### PR TITLE
fix: harden getSillyTavernContext against TDZ during slow boot

### DIFF
--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -1402,7 +1402,14 @@ function updateThemeBadge() {
 }
 
 function getSillyTavernContext() {
-    return globalThis.SillyTavern?.getContext?.() ?? null;
+    // SillyTavern.getContext() throws a TDZ ReferenceError on slow boots when
+    // it is called before script.js finishes initializing its module-level
+    // `chat` binding. Treat that the same as "context not ready yet".
+    try {
+        return globalThis.SillyTavern?.getContext?.() ?? null;
+    } catch {
+        return null;
+    }
 }
 
 function hasActiveTopBarChat(context = getSillyTavernContext()) {


### PR DESCRIPTION
## Problem

On slow VPS-style setups (e.g. EasyPanel cold starts), the top bar fails to render on the first load and only appears after a manual refresh. The T5 safety-net added in c99b2d5 (`APP_READY event fallback for shell init on slow VPS environments`) does not fire in this case.

## Root cause

`SillyTavern.getContext()` in `public/scripts/st-context.js` reads module-level bindings from `script.js` — including `chat`. `script.js` is loaded as `<script type="module">`, while `sillybunny-tabs.js` is loaded as a classic `defer` script. On slow boots, the classic defer body runs while the module graph is still resolving, so `chat` is in the Temporal Dead Zone.

`getContext()` therefore throws `ReferenceError: Cannot access 'chat' before initialization`. `getSillyTavernContext()` in `sillybunny-tabs.js` did not wrap the call, so the error propagated and aborted whichever callsite triggered it — including `bindTopBarBrand()` inside `buildTopBar()`, and the T5 `APP_READY` listener registration at the bottom of the file.

Confirmed at runtime with temporary debug logs:

```
[SB-DEBUG script-parse]   ReferenceError: Cannot access 'chat' before initialization at Object.getContext (st-context.js:117:9)
[SB-DEBUG setTimeout-120] ReferenceError: Cannot access 'chat' before initialization at Object.getContext (st-context.js:117:9)
[SB-DEBUG initAll-entry]  ReferenceError: Cannot access 'chat' before initialization at Object.getContext (st-context.js:117:9)
```

## Fix

Wrap `getSillyTavernContext()` in `try/catch`. A TDZ throw is treated as "context not ready yet" — the same null value the function already returns when `globalThis.SillyTavern` is undefined. Downstream callers already handle the null case (`bindTopBarBrand` retries via `scheduleTopBarBrandBindingRetry`, the T5 APP_READY registration guards on `ctx?.eventSource`), so they resume working as intended.

## Verification

Deployed to a slow-boot EasyPanel instance that reliably reproduced the original bug (top bar blank on first load, required refresh). After this change the top bar renders correctly on every cold load across multiple hard refreshes. No regressions observed on fast setups (the `try` succeeds on the first attempt).

Scope is intentionally minimal — a single three-line `try/catch` in one function, no behavioural change on the happy path.