### PR TITLE
fix: stop Quick Reply init/render duplicates by breaking circular imports

### DIFF
--- a/public/scripts/extensions/quick-reply/index.js
+++ b/public/scripts/extensions/quick-reply/index.js
@@ -230,7 +230,18 @@ const finalizeInit = async () => {
     isReady = true;
     debug('READY');
 };
-await init();
+// Fire-and-forget init — using top-level await here creates a circular
+// top-level-await deadlock on slow boots: init() awaits a dynamic import of
+// ./src/QuickReply.js, but that module statically imports from this file via
+// `import { log, quickReplyApi, warn } from '../index.js'`. With top-level
+// await the module resolver must wait for this file to finish evaluating
+// before QuickReply.js can resolve — while this file is waiting on that
+// import. The isReady flag + executeQueue pattern below already handles the
+// case where event handlers fire before init completes.
+init().catch(err => {
+    console.error('[QR2] init failed:', err);
+    try { toastr?.error(err?.message ?? String(err), 'Quick Reply init failed'); } catch { /* noop */ }
+});
 
 const purgeCharacterQuickReplySets = ({ character }) => {
     // Remove the character's Quick Reply Sets from the settings.

--- a/public/scripts/extensions/quick-reply/index.js
+++ b/public/scripts/extensions/quick-reply/index.js
@@ -9,15 +9,12 @@ import { QuickReplySettings } from './src/QuickReplySettings.js';
 import { SlashCommandHandler } from './src/SlashCommandHandler.js';
 import { ButtonUi } from './src/ui/ButtonUi.js';
 import { SettingsUi } from './src/ui/SettingsUi.js';
-import { debounceAsync } from '../../utils.js';
 import { selected_group } from '../../group-chats.js';
-export { debounceAsync };
-
-
-const _VERBOSE = true;
-export const debug = (...msg) => _VERBOSE ? console.debug('[QR2]', ...msg) : null;
-export const log = (...msg) => _VERBOSE ? console.log('[QR2]', ...msg) : null;
-export const warn = (...msg) => _VERBOSE ? console.warn('[QR2]', ...msg) : null;
+import { debounceAsync, debug, log, warn } from './src/shared.js';
+// Re-exported so that any existing `from '.../quick-reply/index.js'` imports
+// keep working. Internally the other src/ modules should import from
+// './shared.js' directly to avoid a circular back-edge — see shared.js.
+export { debounceAsync, debug, log, warn };
 
 
 const defaultConfig = {

--- a/public/scripts/extensions/quick-reply/src/AutoExecuteHandler.js
+++ b/public/scripts/extensions/quick-reply/src/AutoExecuteHandler.js
@@ -1,4 +1,4 @@
-import { warn } from '../index.js';
+import { warn } from './shared.js';
 import { QuickReply } from './QuickReply.js';
 import { QuickReplySettings } from './QuickReplySettings.js';
 

--- a/public/scripts/extensions/quick-reply/src/QuickReply.js
+++ b/public/scripts/extensions/quick-reply/src/QuickReply.js
@@ -12,7 +12,7 @@ import { SlashCommandParserError } from '../../../slash-commands/SlashCommandPar
 import { SlashCommandScope } from '../../../slash-commands/SlashCommandScope.js';
 import { accountStorage } from '../../../util/AccountStorage.js';
 import { debounce, delay, getSortableDelay, showFontAwesomePicker } from '../../../utils.js';
-import { log, quickReplyApi, warn } from '../index.js';
+import { log, warn } from './shared.js';
 import { QuickReplyContextLink } from './QuickReplyContextLink.js';
 import { QuickReplySet } from './QuickReplySet.js';
 import { ContextMenu } from './ui/ctx/ContextMenu.js';
@@ -443,12 +443,12 @@ export class QuickReply {
                             setItem.classList.add('qr--modal-switcherItem');
                             setItem.addEventListener('click', () => {
                                 list.innerHTML = '';
-                                for (const qrs of quickReplyApi.listSets()) {
+                                for (const qrs of globalThis.quickReplyApi.listSets()) {
                                     const item = document.createElement('li'); {
                                         item.classList.add('qr--modal-switcherItem');
                                         item.addEventListener('click', () => {
                                             list.innerHTML = '';
-                                            makeList(quickReplyApi.getSetByName(qrs));
+                                            makeList(globalThis.quickReplyApi.getSetByName(qrs));
                                         });
                                         const lbl = document.createElement('div'); {
                                             lbl.classList.add('qr--label');
@@ -478,7 +478,7 @@ export class QuickReply {
                         const addItem = document.createElement('li'); {
                             addItem.classList.add('qr--modal-switcherItem');
                             addItem.addEventListener('click', () => {
-                                const qr = quickReplyApi.getSetByQr(this).addQuickReply();
+                                const qr = globalThis.quickReplyApi.getSetByQr(this).addQuickReply();
                                 this.editorPopup.completeAffirmative();
                                 qr.showEditor();
                             });
@@ -525,7 +525,7 @@ export class QuickReply {
                             }
                         }
                     };
-                    makeList(quickReplyApi.getSetByQr(this));
+                    makeList(globalThis.quickReplyApi.getSetByQr(this));
                 }
                 label.parentElement.append(list);
             });

--- a/public/scripts/extensions/quick-reply/src/QuickReplySet.js
+++ b/public/scripts/extensions/quick-reply/src/QuickReplySet.js
@@ -3,7 +3,7 @@ import { Popup, POPUP_RESULT, POPUP_TYPE } from '../../../popup.js';
 import { executeSlashCommandsOnChatInput, executeSlashCommandsWithOptions } from '../../../slash-commands.js';
 import { SlashCommandScope } from '../../../slash-commands/SlashCommandScope.js';
 import { SlashCommandParser } from '../../../slash-commands/SlashCommandParser.js';
-import { debounceAsync, warn } from '../index.js';
+import { debounceAsync, warn } from './shared.js';
 import { QuickReply } from './QuickReply.js';
 
 export class QuickReplySet {

--- a/public/scripts/extensions/quick-reply/src/shared.js
+++ b/public/scripts/extensions/quick-reply/src/shared.js
@@ -1,0 +1,15 @@
+// Shared utilities for the Quick Reply extension.
+//
+// Having a dedicated module under src/ lets the other src/*.js files avoid
+// importing back into ../index.js. That back-edge was the source of a
+// duplicate-drawer bug: the extension loader tags index.js with a cache-
+// busting ?v=<version> query, so children that did `from '../index.js'`
+// resolved to the bare URL and the browser treated them as a second
+// module instance. Two evaluations meant two init() calls, two SettingsUi
+// renders, and every eventSource handler getting registered twice.
+export { debounceAsync } from '../../../utils.js';
+
+const _VERBOSE = true;
+export const debug = (...msg) => _VERBOSE ? console.debug('[QR2]', ...msg) : null;
+export const log = (...msg) => _VERBOSE ? console.log('[QR2]', ...msg) : null;
+export const warn = (...msg) => _VERBOSE ? console.warn('[QR2]', ...msg) : null;

--- a/public/scripts/extensions/quick-reply/src/ui/SettingsUi.js
+++ b/public/scripts/extensions/quick-reply/src/ui/SettingsUi.js
@@ -1,6 +1,6 @@
 import { Popup } from '../../../../popup.js';
 import { getSortableDelay } from '../../../../utils.js';
-import { log, warn } from '../../index.js';
+import { log, warn } from '../shared.js';
 import { QuickReply } from '../QuickReply.js';
 import { QuickReplySet } from '../QuickReplySet.js';
 import { QuickReplySettings } from '../QuickReplySettings.js';


### PR DESCRIPTION
## Problem

Two closely related failure modes in the bundled Quick Reply extension, both caused by the same circular import shape.

1. **Slow-boot mount failure.** On cold-starting VPS environments (e.g. EasyPanel) the Extensions tab shows no QR settings panel and no QR bar above the chat input. The extension is enabled and active according to the loader; `quick-reply/index.js` simply never finishes evaluating.
2. **Duplicate drawer.** On fast-booting environments with the first fix in place, the Extensions tab shows *two* \"Quick Reply\" drawers. Both are fully rendered SettingsUi trees, and every \`eventSource\` handler registered at module scope gets registered twice (chat change, message received, auto-exec triggers, etc.) — meaning auto-execute-on-user-message actually fires twice per message once two drawers are present.

## Root cause

`public/scripts/extensions/quick-reply/index.js` participates in a cycle with its own `src/` files:

- `src/AutoExecuteHandler.js`, `src/QuickReply.js`, `src/QuickReplySet.js`, `src/ui/SettingsUi.js` all did `import { ... } from '../index.js'`.
- `index.js` originally ended with `await init();`, and inside `init()` → `loadSets()` did `await import('./src/QuickReply.js')` to break TDZ.

Two things fall out of this cycle:

**(A) Top-level-await deadlock.** Under ES module TLA semantics, `QuickReply.js`'s static import of `../index.js` can't resolve until `index.js` finishes async-evaluation, but `index.js` can't finish until the dynamic import of `QuickReply.js` resolves. Deadlock. Timing lets this resolve on fast boots but it's latent on slow ones.

**(B) Duplicate module evaluation.** `addExtensionScript` injects `<script type=\"module\" src=\"/scripts/extensions/quick-reply/index.js?v=<CLIENT_VERSION>\">`. The \`?v=\` cache-buster makes that URL distinct from the bare path. The children's \`from '../index.js'\` specifier resolves relative to the child's URL and produces the **bare** URL, which the browser treats as a different module than the queried one. So `index.js` gets evaluated **twice**, once under each URL, and every top-level side effect — including the \`init()\` call and all the \`eventSource.on(...)\` registrations — runs twice.

With `await init()` (old code) both evaluations deadlock and nothing renders. With fire-and-forget init (first commit) both evaluations succeed, producing the duplicate drawer.

Verified on a reproducing deployment by stack-tracing each \`init\` call:

```
#1: at init (.../quick-reply/index.js:177:27)
#2: at init (.../quick-reply/index.js?v=SillyBunny%3A1.3.7%3Afork:177:27)
```

Two distinct \`index.js\` module URLs, each running their own top-level \`init()\`.

## Fix

Two commits in this branch:

1. Stop awaiting `init()` at module scope — keep the existing `isReady` + `executeQueue` machinery that already handles handlers firing before init completes. This makes boot deterministic and logs/reports failures instead of hanging.
2. Introduce `src/shared.js` holding \`log\`, \`warn\`, \`debug\`, and a re-export of \`debounceAsync\`. Every `src/*.js` now imports those from its **sibling** instead of climbing back to `../index.js`. `index.js` re-exports the same names so any external consumer of `.../quick-reply/index.js` (including `QuickReplyApi` callers and type imports) keeps working. `QuickReply.js` reaches the API via `globalThis.quickReplyApi` so it no longer needs a live-binding import into `index.js`.

No more cycle → no more second module instance → no more duplicate drawer, and the TLA deadlock path can't regress.

## Verification

Deployed to the EasyPanel instance that reproduced both symptoms.

- QR settings panel renders exactly once in the Extensions tab (`find()` reports a single \`Enable Quick Replies\` checkbox, versus two on the broken build).
- QR bar renders above the chat input.
- `eventSource` handlers fire once per event.
- No regressions on the happy path; slash commands, import/export, rename/delete all still work.

## Scope

Three files edited, one file added. No touches outside \`public/scripts/extensions/quick-reply/\`.