### PR TITLE
Fix upstream-safe reasoning, agent UI, bottom-bar, and World Info regressions

### DIFF
--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -540,6 +540,16 @@
         flex: 0 0 auto;
     }
 
+    .checkbox_label {
+        align-items: flex-start;
+        column-gap: 8px;
+    }
+
+    .checkbox_label > input[type="checkbox"] {
+        flex: 0 0 auto;
+        margin-top: 0.2em;
+    }
+
     :is(#kobold_api-presets, #novel_api-presets, #openai_api-presets, #textgenerationwebui_api-presets) .menu_button,
     :is(#kobold_api-presets, #novel_api-presets, #openai_api-presets, #textgenerationwebui_api-presets) .menu_button_icon {
         min-height: 44px;

--- a/public/css/world-info.css
+++ b/public/css/world-info.css
@@ -19,7 +19,7 @@
     flex-direction: column;
     z-index: 3010;
     overflow-y: hidden;
-    gap: 14px;
+    gap: 10px;
 }
 
 #WorldInfo.sb-shell-embedded-content {
@@ -117,8 +117,8 @@
 
 #wiTopBlock {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 12px;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 10px;
     align-items: start;
 }
 
@@ -151,8 +151,8 @@
 
 #wiSliders {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: 12px;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 10px;
 }
 
 #wiSliders > .alignitemscenter.flex-container.flexFlowColumn {
@@ -779,30 +779,30 @@ select.keyselect+span.select2-container .select2-selection--multiple {
 @media screen and (min-width: 961px) {
     #world_popup_workspace {
         display: grid;
-        grid-template-columns: minmax(380px, 0.98fr) minmax(460px, 1.2fr);
+        grid-template-columns: minmax(340px, 0.92fr) minmax(0, 1.08fr);
         align-items: start;
-        gap: 16px;
+        gap: 14px;
         min-height: 0;
     }
 
     #world_popup_entries_column {
         display: flex;
         flex-direction: column;
-        min-height: clamp(420px, 62vh, 920px);
+        min-height: clamp(360px, 58vh, 820px);
     }
 
     #world_popup_entries_list {
         min-height: 0;
         height: 100%;
-        max-height: clamp(420px, 62vh, 920px);
+        max-height: clamp(360px, 58vh, 820px);
         padding-right: 4px;
     }
 
     #world_popup_editor_pane {
         display: flex;
         flex-direction: column;
-        min-height: clamp(420px, 62vh, 920px);
-        padding: 16px;
+        min-height: clamp(360px, 58vh, 820px);
+        padding: 14px;
         border-radius: 22px;
         border: 1px solid color-mix(in srgb, var(--SmartThemeBorderColor) 78%, transparent);
         background:

--- a/public/index.html
+++ b/public/index.html
@@ -2113,9 +2113,16 @@
                                             <span data-i18n="Allows the model to return its thinking process.">
                                                 Allows the model to return its thinking process.
                                             </span>
-                                            <strong data-i18n="This setting affects visibility only." data-source-mode="except" data-source="zai,moonshot,openrouter">
-                                                This setting affects visibility only.
+                                            <strong data-source-mode="except" data-source="zai,moonshot,openrouter">
+                                                Provider support varies. Use "Show thought in chat" to control UI visibility separately.
                                             </strong>
+                                        </div>
+                                        <label for="openai_show_thoughts_ui" class="checkbox_label widthFreeExpand">
+                                            <input id="openai_show_thoughts_ui" type="checkbox" />
+                                            <span>Show thought in chat</span>
+                                        </label>
+                                        <div class="toggle-description justifyLeft">
+                                            <span>Controls whether returned thought text is shown in chat. Thought tokens and signatures remain available separately.</span>
                                         </div>
                                     </div>
                                     <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai,custom,claude,xai,makersuite,vertexai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes,nanogpt">
@@ -7576,6 +7583,7 @@
                                 <div title="Generate Image" class="mes_button sd_message_gen fa-solid fa-paintbrush" data-i18n="[title]Generate Image"></div>
                                 <div title="Narrate" class="mes_button mes_narrate fa-solid fa-bullhorn" data-i18n="[title]Narrate"></div>
                                 <div title="Prompt" class="mes_button mes_prompt fa-solid fa-square-poll-horizontal " data-i18n="[title]Prompt" style="display: none;"></div>
+                                <div title="View agent changes" class="mes_button mes_view_agent_changes fa-solid fa-file-lines" data-i18n="[title]View agent changes" style="display: none;"></div>
                                 <div title="Exclude message from prompts" class="mes_button mes_hide fa-solid fa-eye" data-i18n="[title]Exclude message from prompts"></div>
                                 <div title="Include message in prompts" class="mes_button mes_unhide fa-solid fa-eye-slash" data-i18n="[title]Include message in prompts"></div>
                                 <div title="Toggle media display style" class="mes_button mes_media_gallery fa-solid fa-photo-film" data-i18n="[title]Toggle media display style"></div>

--- a/public/script.js
+++ b/public/script.js
@@ -2101,30 +2101,7 @@ export function updateMessageBlock(messageId, message, { rerenderMessage = true 
         const text = message?.extra?.display_text ?? message.mes;
         messageElement.find('.mes_text').html(messageFormatting(text, message.name, message.is_system, message.is_user, messageId, {}, false));
     }
-
-    // Update reasoning tokens badge
-    const reasoningTokens = message?.extra?.reasoning_tokens;
-    if (reasoningTokens && reasoningTokens > 0) {
-        let badge = messageElement.find('.reasoning-tokens-badge');
-        if (!badge.length) {
-            badge = $('<span class="reasoning-tokens-badge"></span>');
-            messageElement.find('.tokenCounterDisplay').after(badge);
-        }
-        badge.text(`💭 ${reasoningTokens}`);
-    } else {
-        messageElement.find('.reasoning-tokens-badge').remove();
-    }
-
-    // Update agent transform badge
-    if (message?.extra?.inChatAgentTransformHistory?.length > 0) {
-        let transformBadge = messageElement.find('.agent-transform-badge');
-        if (!transformBadge.length) {
-            transformBadge = $('<span class="agent-transform-badge" title="Modified by agent(s)">📝</span>');
-            messageElement.find('.tokenCounterDisplay').after(transformBadge);
-        }
-    } else {
-        messageElement.find('.agent-transform-badge').remove();
-    }
+    updateMessageMetaBadges(messageElement, message);
 
     updateReasoningUI(messageElement);
 
@@ -2758,28 +2735,7 @@ export function updateMessageElement(mes, { messageId = chat.length - 1, message
     messageElement.find('.timestamp').text(timestamp).attr('title', `${mes.extra?.api ? mes.extra.api + ' - ' : ''}${mes.extra?.model ?? ''}`);
     messageElement.find('.mesIDDisplay').text(`#${messageId}`);
     tokenCount && messageElement.find('.tokenCounterDisplay').text(`${tokenCount}t`);
-    
-    const reasoningTokens = mes.extra?.reasoning_tokens;
-    if (reasoningTokens && reasoningTokens > 0) {
-        let badge = messageElement.find('.reasoning-tokens-badge');
-        if (!badge.length) {
-            badge = $('<span class="reasoning-tokens-badge"></span>');
-            messageElement.find('.tokenCounterDisplay').after(badge);
-        }
-        badge.text(`💭 ${reasoningTokens}`);
-    } else {
-        messageElement.find('.reasoning-tokens-badge').remove();
-    }
-
-    if (mes.extra?.inChatAgentTransformHistory?.length > 0) {
-        let transformBadge = messageElement.find('.agent-transform-badge');
-        if (!transformBadge.length) {
-            transformBadge = $('<span class="agent-transform-badge" title="Modified by agent(s)">📝</span>');
-            messageElement.find('.tokenCounterDisplay').after(transformBadge);
-        }
-    } else {
-        messageElement.find('.agent-transform-badge').remove();
-    }
+    updateMessageMetaBadges(messageElement, mes);
 
     mes.title && messageElement.attr('title', mes.title);
     timerValue && messageElement.find('.mes_timer').attr('title', timerTitle).text(timerValue);
@@ -2821,6 +2777,45 @@ export function updateMessageElement(mes, { messageId = chat.length - 1, message
     }
 
     return messageElement;
+}
+
+function updateMessageMetaBadges(messageElement, message) {
+    const $messageElement = messageElement?.jquery ? messageElement : $(messageElement);
+    if ($messageElement.length === 0) {
+        return;
+    }
+
+    const $tokenCounter = $messageElement.find('.tokenCounterDisplay').first();
+    if ($tokenCounter.length === 0) {
+        return;
+    }
+
+    const reasoningTokens = Number(message?.extra?.reasoning_tokens ?? 0);
+    if (reasoningTokens > 0) {
+        let badge = $messageElement.find('.reasoning-tokens-badge');
+        if (!badge.length) {
+            badge = $('<span class="reasoning-tokens-badge" title="Thought tokens"></span>');
+            $tokenCounter.after(badge);
+        }
+        badge.html(`<i class="fa-solid fa-brain" aria-hidden="true"></i><span class="reasoning-tokens-count">${reasoningTokens}</span>`);
+    } else {
+        $messageElement.find('.reasoning-tokens-badge').remove();
+    }
+
+    const hasTransformHistory = Array.isArray(message?.extra?.inChatAgentTransformHistory)
+        && message.extra.inChatAgentTransformHistory.length > 0;
+    if (hasTransformHistory) {
+        let transformBadge = $messageElement.find('.agent-transform-badge');
+        if (!transformBadge.length) {
+            transformBadge = $('<button type="button" class="agent-transform-badge" title="View agent changes" aria-label="View agent changes"></button>');
+            transformBadge.html('<i class="fa-solid fa-file-lines" aria-hidden="true"></i>');
+            $tokenCounter.after(transformBadge);
+        }
+    } else {
+        $messageElement.find('.agent-transform-badge').remove();
+    }
+
+    $messageElement.find('.mes_view_agent_changes').toggle(hasTransformHistory);
 }
 
 /**
@@ -6424,6 +6419,66 @@ function parseAndSaveLogprobs(data, continueFrom) {
  * @returns {string} Extracted message
  */
 export function extractMessageFromData(data, activeApi = null) {
+    const stringifyUnknown = (value) => {
+        if (typeof value === 'string') {
+            return value;
+        }
+
+        if (value == null) {
+            return '';
+        }
+
+        try {
+            return JSON.stringify(value);
+        } catch {
+            return String(value);
+        }
+    };
+
+    const normalizeContentText = (value) => {
+        if (typeof value === 'string') {
+            return value;
+        }
+
+        if (Array.isArray(value)) {
+            return value
+                .map(item => {
+                    if (typeof item === 'string') {
+                        return item;
+                    }
+                    if (typeof item?.text === 'string') {
+                        return item.text;
+                    }
+                    if (typeof item?.content === 'string') {
+                        return item.content;
+                    }
+                    if (typeof item?.thinking === 'string') {
+                        return item.thinking;
+                    }
+                    return '';
+                })
+                .filter(Boolean)
+                .join('\n\n');
+        }
+
+        if (typeof value === 'object') {
+            if (typeof value.text === 'string') {
+                return value.text;
+            }
+            if (Array.isArray(value.parts)) {
+                return value.parts
+                    .map(part => typeof part?.text === 'string' ? part.text : '')
+                    .filter(Boolean)
+                    .join('\n\n');
+            }
+            if (Array.isArray(value.content)) {
+                return normalizeContentText(value.content);
+            }
+        }
+
+        return '';
+    };
+
     function getResult() {
         if (typeof data === 'string') {
             return data;
@@ -6439,14 +6494,25 @@ export function extractMessageFromData(data, activeApi = null) {
             case 'novel':
                 return data.output;
             case 'openai':
-                return data?.content?.filter(p => p.type === 'text')?.map(p => p.text)?.join('\n\n') ?? data?.choices?.[0]?.message?.content ?? data?.choices?.[0]?.text ?? data?.text ?? data?.message?.content?.[0]?.text ?? data?.message?.tool_plan ?? '';
+                return normalizeContentText(data?.content?.filter?.(p => p.type === 'text')?.map?.(p => p.text)?.join?.('\n\n'))
+                    || normalizeContentText(data?.choices?.[0]?.message?.content)
+                    || normalizeContentText(data?.choices?.[0]?.text)
+                    || normalizeContentText(data?.text)
+                    || normalizeContentText(data?.message?.content)
+                    || normalizeContentText(data?.message?.tool_plan)
+                    || normalizeContentText(data?.responseContent?.parts)
+                    || normalizeContentText(data?.candidates?.[0]?.content?.parts)
+                    || stringifyUnknown(data?.message?.content);
             default:
                 return '';
         }
     }
 
     const result = getResult();
-    return Array.isArray(result) ? result.map(x => x.text).filter(x => x).join('') : result;
+    if (Array.isArray(result)) {
+        return result.map(x => typeof x?.text === 'string' ? x.text : '').filter(Boolean).join('');
+    }
+    return typeof result === 'string' ? result : stringifyUnknown(result);
 }
 
 /**

--- a/public/scripts/agents.js
+++ b/public/scripts/agents.js
@@ -694,7 +694,11 @@ function summarizeError(error) {
         return error.message;
     }
 
-    return JSON.stringify(error);
+    try {
+        return JSON.stringify(error);
+    } catch {
+        return String(error);
+    }
 }
 
 function toArray(value) {
@@ -1637,7 +1641,19 @@ function normalizeToolCalls(data) {
 }
 
 function toolResultToContent(result) {
-    return typeof result === 'string' ? result : JSON.stringify(result);
+    if (typeof result === 'string') {
+        return result;
+    }
+
+    if (result == null) {
+        return '';
+    }
+
+    try {
+        return JSON.stringify(result);
+    } catch {
+        return String(result);
+    }
 }
 
 async function sendAgentCompletionRequest(agentSettings, messages, customTools, signal) {
@@ -2472,12 +2488,12 @@ export async function runPostGenerationAgents({ depth, generationType = 'normal'
 
 async function runLorebookSyncFromUi() {
     if (!isAgentModeAvailable()) {
-        toastr.info(t`Agent mode only runs in chat-completions mode with an active chat.`, t`Agent`);
+        toastr.info(t`Adventure helpers only run in chat-completions mode with an active chat.`, t`Agent`);
         return;
     }
 
     if (!getAgentChatState().enabled) {
-        toastr.info(t`Enable Agent for this chat first.`, t`Agent`);
+        toastr.info(t`Enable adventure helpers for this chat first.`, t`Agent`);
         return;
     }
 
@@ -2490,7 +2506,7 @@ async function runLorebookSyncFromUi() {
 
 async function applyPendingLoreReviewFromUi() {
     if (!isAgentModeAvailable()) {
-        toastr.info(t`Agent mode only runs in chat-completions mode with an active chat.`, t`Agent`);
+        toastr.info(t`Adventure helpers only run in chat-completions mode with an active chat.`, t`Agent`);
         return;
     }
 
@@ -2942,9 +2958,9 @@ function renderAgentPanel() {
         ? t` Lore updates will stay in review until you apply them.`
         : t` Lore updates auto-apply after validation.`;
     const availabilityText = !hasChat
-        ? t`Open a chat to configure per-chat agent mode.`
+        ? t`Open a chat to configure per-chat adventure helpers.`
         : !available
-            ? t`Agent mode currently runs only through chat-completions providers.`
+            ? t`Adventure helpers currently run only through chat-completions providers.`
             : `${t`The turn director runs retrieval before the next reply, then updates durable memory, story state, and lorebook context after the reply is saved.`}${loreReviewText}`;
     $('#agent_mode_status_hint').text(availabilityText);
     $('#agent_preset_status').text(

--- a/public/scripts/extensions/in-chat-agents/editor.html
+++ b/public/scripts/extensions/in-chat-agents/editor.html
@@ -49,7 +49,7 @@
                 <input type="text" id="ica--editor-modelOverride" class="text_pole" placeholder="Leave empty to use profile default" />
             </label>
         </div>
-        <textarea id="ica--editor-prompt" class="text_pole textarea_compact" rows="8" placeholder="Write your agent prompt here. Supports macros: {{char}}, {{user}}, {{random::a::b::c}}, etc."></textarea>
+        <textarea id="ica--editor-prompt" class="text_pole textarea_compact" rows="8" placeholder="Write your agent prompt here. Supports macros: &#123;&#123;char&#125;&#125;, &#123;&#123;user&#125;&#125;, &#123;&#123;random::a::b::c&#125;&#125;, etc."></textarea>
     </div>
 
     <div class="ica--editor-section" id="ica--injection-section">

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -1,3 +1,4 @@
+import { DiffMatchPatch } from '../../../lib.js';
 import { extension_settings, renderExtensionTemplateAsync, getContext } from '../../extensions.js';
 import { Popup, POPUP_TYPE, POPUP_RESULT } from '../../popup.js';
 import { download, getSortableDelay, uuidv4 } from '../../utils.js';
@@ -2080,8 +2081,75 @@ function handleExportAll() {
  */
 function escapeHtml(str) {
     const div = document.createElement('div');
-    div.textContent = str;
+    div.textContent = str ?? '';
     return div.innerHTML;
+}
+
+function buildPromptTransformDiffMarkup(beforeText, afterText) {
+    const dmp = new DiffMatchPatch();
+    const diffs = dmp.diff_main(String(beforeText ?? ''), String(afterText ?? ''));
+    dmp.diff_cleanupSemantic(diffs);
+
+    return diffs.map(([operation, text]) => {
+        const escapedText = escapeHtml(text);
+        if (operation === 1) {
+            return `<span class="ica-transform-diff-part--ins">${escapedText}</span>`;
+        }
+        if (operation === -1) {
+            return `<span class="ica-transform-diff-part--del">${escapedText}</span>`;
+        }
+        return `<span>${escapedText}</span>`;
+    }).join('');
+}
+
+async function openPromptTransformHistoryPopup(messageIndex) {
+    if (!Number.isInteger(Number(messageIndex)) || !chat[messageIndex]) {
+        return;
+    }
+
+    const message = chat[Number(messageIndex)];
+    const history = message.extra?.[PROMPT_TRANSFORM_HISTORY_KEY];
+    if (!Array.isArray(history) || history.length === 0) {
+        toastr.info('No transform history available.');
+        return;
+    }
+
+    const entries = history.map((entry, i) => {
+        const timestamp = entry.timestamp ? new Date(entry.timestamp).toLocaleString() : '';
+        return `
+            <div class="ica-transform-history-entry" data-index="${i}">
+                <h5>${escapeHtml(entry.agentName || 'Agent')} <small>(${escapeHtml(entry.mode || 'replace')})</small></h5>
+                <small>${timestamp}</small>
+                <div class="ica-transform-diff">${buildPromptTransformDiffMarkup(entry.beforeText ?? '', entry.afterText ?? '')}</div>
+                <div class="ica-transform-actions">
+                    <button class="ica-undo-btn menu_button" data-mesid="${messageIndex}">Undo</button>
+                    <button class="ica-redo-btn menu_button" data-mesid="${messageIndex}">Redo</button>
+                </div>
+            </div>
+        `;
+    }).join('');
+
+    const html = $(`<div class="ica-transform-history">${entries}</div>`);
+
+    html.find('.ica-undo-btn').on('click', function () {
+        const idx = Number($(this).data('mesid'));
+        if (undoPromptTransform(idx)) {
+            toastr.success('Transform undone.');
+        } else {
+            toastr.warning('Could not undo transform.');
+        }
+    });
+
+    html.find('.ica-redo-btn').on('click', function () {
+        const idx = Number($(this).data('mesid'));
+        if (redoPromptTransform(idx)) {
+            toastr.success('Transform redone.');
+        } else {
+            toastr.warning('Could not redo transform.');
+        }
+    });
+
+    await new Popup(html, POPUP_TYPE.TEXT, '', { wide: true }).show();
 }
 
 // ===================== Pathfinder Editor =====================
@@ -2685,67 +2753,9 @@ async function refinePromptWithAI(currentPrompt, category, phase, connectionProf
         }
     });
 
-    // Transform history popup — click the 📝 badge on a message
-    $(document).on('click', '.agent-transform-badge', async function () {
+    $(document).on('click', '.agent-transform-badge, .mes_view_agent_changes', async function () {
         const mesId = $(this).closest('.mes').attr('mesid');
         const messageIndex = Number(mesId);
-        if (isNaN(messageIndex) || !chat[messageIndex]) {
-            return;
-        }
-
-        const message = chat[messageIndex];
-        const history = message.extra?.[PROMPT_TRANSFORM_HISTORY_KEY];
-        if (!Array.isArray(history) || history.length === 0) {
-            toastr.info('No transform history available.');
-            return;
-        }
-
-        const entries = history.map((entry, i) => {
-            const beforePreview = escapeHtml(String(entry.beforeText ?? '').slice(0, 500));
-            const afterPreview = escapeHtml(String(entry.afterText ?? '').slice(0, 500));
-            const beforeEllipsis = entry.beforeText?.length > 500 ? '...' : '';
-            const afterEllipsis = entry.afterText?.length > 500 ? '...' : '';
-            const timestamp = entry.timestamp ? new Date(entry.timestamp).toLocaleString() : '';
-            return `
-                <div class="ica-transform-history-entry" data-index="${i}">
-                    <h5>${escapeHtml(entry.agentName || 'Agent')} <small>(${escapeHtml(entry.mode || 'replace')})</small></h5>
-                    <small>${timestamp}</small>
-                    <div class="ica-diff-original">
-                        <strong>Before:</strong>
-                        <pre>${beforePreview}${beforeEllipsis}</pre>
-                    </div>
-                    <div class="ica-diff-after">
-                        <strong>After:</strong>
-                        <pre>${afterPreview}${afterEllipsis}</pre>
-                    </div>
-                    <div class="ica-transform-actions">
-                        <button class="ica-undo-btn menu_button" data-mesid="${messageIndex}">Undo</button>
-                        <button class="ica-redo-btn menu_button" data-mesid="${messageIndex}">Redo</button>
-                    </div>
-                </div>
-            `;
-        }).join('');
-
-        const html = $(`<div class="ica-transform-history">${entries}</div>`);
-
-        html.find('.ica-undo-btn').on('click', function () {
-            const idx = Number($(this).data('mesid'));
-            if (undoPromptTransform(idx)) {
-                toastr.success('Transform undone.');
-            } else {
-                toastr.warning('Could not undo transform.');
-            }
-        });
-
-        html.find('.ica-redo-btn').on('click', function () {
-            const idx = Number($(this).data('mesid'));
-            if (redoPromptTransform(idx)) {
-                toastr.success('Transform redone.');
-            } else {
-                toastr.warning('Could not redo transform.');
-            }
-        });
-
-        await new Popup(html, POPUP_TYPE.TEXT, '', { wide: true }).show();
+        await openPromptTransformHistoryPopup(messageIndex);
     });
 })();

--- a/public/scripts/extensions/in-chat-agents/style.css
+++ b/public/scripts/extensions/in-chat-agents/style.css
@@ -510,8 +510,9 @@
     display: flex;
     flex-direction: column;
     gap: 14px;
-    max-height: 70vh;
+    max-height: min(82vh, 960px);
     overflow-y: auto;
+    padding-right: 4px;
 }
 
 .ica--editor-section {
@@ -554,7 +555,14 @@
 }
 
 .ica--editor .checkbox_label {
+    align-items: flex-start;
+    column-gap: 8px;
     font-size: calc(var(--mainFontSize) * 0.88);
+}
+
+.ica--editor .checkbox_label > input[type="checkbox"] {
+    flex: 0 0 auto;
+    margin-top: 0.2em;
 }
 
 .ica--regex-note {
@@ -795,6 +803,10 @@
     #ica--templatesCallout {
         width: 100%;
         justify-content: center;
+    }
+
+    .ica--editor-row.flex-container {
+        flex-direction: column;
     }
 }
 

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -395,6 +395,7 @@ export const settingsToUpdate = {
     continue_postfix: ['#continue_postfix', 'continue_postfix', false, false],
     function_calling: ['#openai_function_calling', 'function_calling', true, false],
     show_thoughts: ['#openai_show_thoughts', 'show_thoughts', true, false],
+    show_thoughts_ui: ['#openai_show_thoughts_ui', 'show_thoughts_ui', true, false],
     reasoning_effort: ['#openai_reasoning_effort', 'reasoning_effort', false, false],
     verbosity: ['#openai_verbosity', 'verbosity', false, false],
     enable_web_search: ['#openai_enable_web_search', 'enable_web_search', true, false],
@@ -504,6 +505,7 @@ const default_settings = {
     continue_postfix: continue_postfix_types.SPACE,
     custom_prompt_post_processing: custom_prompt_post_processing_types.NONE,
     show_thoughts: true,
+    show_thoughts_ui: true,
     reasoning_effort: reasoning_effort_types.auto,
     verbosity: verbosity_levels.auto,
     enable_web_search: false,
@@ -8047,6 +8049,13 @@ export function initOpenAI() {
         setToolReasoningControls();
         saveSettingsDebounced();
     });
+
+    $('#openai_show_thoughts_ui').on('input', function () {
+        oai_settings.show_thoughts_ui = !!$(this).prop('checked');
+        $('#chat').attr('data-show-thoughts-ui', oai_settings.show_thoughts_ui === false ? 'false' : 'true');
+        saveSettingsDebounced();
+    });
+    $('#chat').attr('data-show-thoughts-ui', oai_settings.show_thoughts_ui === false ? 'false' : 'true');
 
     $('#openai_reasoning_effort').on('input', function () {
         oai_settings.reasoning_effort = String($(this).val());

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -181,13 +181,14 @@ export function extractReasoningSignatureFromData(data, {
         }
     }
 
-    // Direct Gemini format: Extract from responseContent.parts if available (only text parts)
-    if (isGemini && Array.isArray(data?.responseContent?.parts)) {
-        data.responseContent.parts.forEach((part) => {
+    // Direct Gemini format: Extract from responseContent.parts or candidates[].content.parts if available.
+    const geminiParts = data?.responseContent?.parts ?? data?.candidates?.[0]?.content?.parts;
+    if (isGemini && Array.isArray(geminiParts)) {
+        for (const part of geminiParts) {
             if (part.thoughtSignature && typeof part.text === 'string') {
                 return part.thoughtSignature;
             }
-        });
+        }
     }
 
     return null;

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -7071,22 +7071,7 @@ function buildBottomChatBar() {
         attrs: { title: 'Switch chat' },
     });
     chatSelect.addEventListener('change', () => {
-        const chatName = chatSelect.value;
-        if (!chatName) return;
-        const context = getSillyTavernContext();
-        if (!context) return;
-
-        // Use ST's own chat-load mechanism via the hidden input
-        const chatPole = document.getElementById('selected_chat_pole');
-        if (chatPole) {
-            chatPole.value = chatName;
-            chatPole.dispatchEvent(new Event('change', { bubbles: true }));
-            return;
-        }
-        // Fallback: context API
-        if (typeof context.openCharacterChat === 'function') {
-            void context.openCharacterChat(chatName);
-        }
+        void openChatById(chatSelect.value);
     });
 
     const newBtn = createElement('button', {
@@ -7160,7 +7145,15 @@ function buildBottomChatBar() {
         }
     });
 
-    refreshBottomChatSelect();
+    scheduleBottomChatBarRefresh(0);
+}
+
+function scheduleBottomChatBarRefresh(delay = 0) {
+    window.clearTimeout(sbState.bottomChatBarRefreshTimer || 0);
+    sbState.bottomChatBarRefreshTimer = window.setTimeout(() => {
+        sbState.bottomChatBarRefreshTimer = 0;
+        void refreshBottomChatSelect();
+    }, delay);
 }
 
 async function refreshBottomChatSelect() {
@@ -7169,19 +7162,12 @@ async function refreshBottomChatSelect() {
         return;
     }
 
-    const context = getSillyTavernContext();
-    if (!context) {
+    const chatContext = getChatUiContext();
+    if (!chatContext.context) {
         return;
     }
 
-    const currentChatName = normalizeChatFileName(
-        context.getCurrentChatId?.()
-        ?? context.chatId
-        ?? document.getElementById('selected_chat_pole')?.value
-        ?? '',
-    );
-    const character = context.characters?.[context.characterId];
-
+    const currentChatName = chatContext.chatId;
     chatSelect.replaceChildren();
 
     // Add placeholder option showing the current chat
@@ -7191,29 +7177,12 @@ async function refreshBottomChatSelect() {
     placeholder.selected = true;
     chatSelect.appendChild(placeholder);
 
-    // Fetch the list of available chats for this character
-    if (!character?.avatar) {
+    if (!chatContext.canBrowseChats) {
         return;
     }
 
     try {
-        const headers = await getAuthorizedRequestHeadersOrNull(2000, context);
-        if (!headers) {
-            return;
-        }
-
-        const response = await fetch('/api/characters/chats', {
-            method: 'POST',
-            headers,
-            body: JSON.stringify({ avatar_url: character.avatar, simple: true }),
-        });
-
-        if (!response.ok) return;
-
-        const data = await response.json();
-        const chats = Object.values(data)
-            .sort((a, b) => (b.last_mes || '').localeCompare(a.last_mes || ''))
-            .map(c => normalizeChatFileName(c.file_name));
+        const chats = (await getChatFilesForContext(chatContext)).map(chat => chat.fileName);
 
         chatSelect.replaceChildren();
 
@@ -7233,8 +7202,22 @@ async function refreshBottomChatSelect() {
             fallback.selected = true;
             chatSelect.prepend(fallback);
         }
+
+        if (chatContext.canBrowseChats && chats.length === 0) {
+            const attempts = Number(sbState.bottomChatBarRefreshAttempts ?? 0);
+            if (attempts < 8) {
+                sbState.bottomChatBarRefreshAttempts = attempts + 1;
+                scheduleBottomChatBarRefresh(200);
+            }
+        } else {
+            sbState.bottomChatBarRefreshAttempts = 0;
+        }
     } catch {
-        // Silently keep the placeholder on error
+        const attempts = Number(sbState.bottomChatBarRefreshAttempts ?? 0);
+        if (attempts < 8) {
+            sbState.bottomChatBarRefreshAttempts = attempts + 1;
+            scheduleBottomChatBarRefresh(250);
+        }
     }
 }
 
@@ -7259,10 +7242,16 @@ function updatePersonaBubble(bubble) {
     bubble.setAttribute('title', `Persona: ${currentName}`);
 }
 
+function quoteSlashCommandArgument(value) {
+    return `"${String(value ?? '').replace(/(["\\])/g, '\\$1')}"`;
+}
+
 function getCurrentPersonaSelection(context = getSillyTavernContext()) {
     const personas = context?.powerUserSettings?.personas ?? {};
+    const selectedAvatarId = document.querySelector('#user_avatar_block .avatar-container.selected[data-avatar-id]')?.getAttribute('data-avatar-id')
+        ?? '';
     const currentAvatarId = String(context?.userAvatar ?? '').trim()
-        || Object.entries(personas).find(([, name]) => name === (context?.name1 || ''))?.[0]
+        || String(selectedAvatarId).trim()
         || '';
     const currentName = personas[currentAvatarId] || context?.name1 || 'You';
 
@@ -7346,11 +7335,18 @@ function addPersonaOption(picker, avatarId, name, title, isActive, context) {
 
     option.addEventListener('click', async () => {
         picker.remove();
-        // Use ST's /persona slash command — the most reliable way to switch personas
         const execSlash = context?.executeSlashCommandsWithOptions;
+        let switched = false;
         if (typeof execSlash === 'function') {
-            await execSlash(`/persona ${name}`);
-        } else {
+            try {
+                await execSlash(`/persona-set ${quoteSlashCommandArgument(avatarId)}`);
+                switched = true;
+            } catch (error) {
+                console.warn('[SillyBunny] Persona switch via slash command failed, falling back to DOM selection.', error);
+            }
+        }
+
+        if (!switched) {
             // Fallback: try clicking the DOM avatar
             const avatarBlock = document.getElementById('user_avatar_block');
             const domAvatar = avatarBlock?.querySelector(`.avatar-container[title="${CSS.escape(avatarId)}"]`);
@@ -7428,7 +7424,7 @@ function initAll() {
     // Refresh again after the current JS task — APP_READY may have already
     // fired before this listener was registered, so the initial call in
     // buildBottomChatBar() may have found no active chat yet.
-    setTimeout(() => refreshBottomChatSelect(), 0);
+    scheduleBottomChatBarRefresh(0);
     bindTopbarDragEvents();
     bindChatbarEvents();
     scheduleChatbarRefresh(0);

--- a/public/style.css
+++ b/public/style.css
@@ -519,6 +519,10 @@ input[type='checkbox']:focus-visible {
     display: none;
 }
 
+#chat[data-show-thoughts-ui="false"]:not(:has(.reasoning_edit_textarea)) .mes_reasoning_details {
+    display: none;
+}
+
 .mes_reasoning_details .mes_reasoning_arrow {
     position: absolute;
     top: 50%;
@@ -6920,34 +6924,59 @@ body:not(.movingUI) .drawer-content.maximized {
 }
 
 .reasoning-tokens-badge {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
     margin-left: 4px;
-    padding: 1px 4px;
-    border-radius: 4px;
-    background: rgba(128, 0, 128, 0.15);
-    color: #b080d0;
+    padding: 1px 6px;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--SmartThemeQuoteColor, #8b8) 34%, transparent);
+    background: color-mix(in srgb, var(--SmartThemeQuoteColor, #8b8) 14%, transparent);
+    color: color-mix(in srgb, var(--SmartThemeBodyColor, #ddd) 82%, var(--SmartThemeQuoteColor, #8b8) 18%);
     font-size: 0.75em;
+    font-weight: 600;
     cursor: default;
     white-space: nowrap;
+    box-shadow: 0 1px 3px color-mix(in srgb, #000 12%, transparent);
+}
+
+.reasoning-tokens-badge i {
+    font-size: 0.9em;
+    opacity: 0.85;
 }
 
 .agent-transform-badge {
-    font-size: 0.7em;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
     margin-left: 4px;
-    opacity: 0.7;
+    padding: 0;
+    appearance: none;
+    border: 1px solid color-mix(in srgb, var(--SmartThemeBorderColor, #555) 50%, transparent);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--SmartThemeBlurTintColor, #222) 36%, transparent);
+    color: color-mix(in srgb, var(--SmartThemeBodyColor, #ddd) 88%, var(--SmartThemeQuoteColor, #8b8) 12%);
+    font-size: 0.7em;
+    opacity: 0.78;
+    line-height: 1;
     cursor: pointer;
-    transition: opacity 0.15s;
+    transition: opacity 0.15s, border-color 0.15s, background 0.15s;
 }
 
 .agent-transform-badge:hover {
     opacity: 1;
+    border-color: color-mix(in srgb, var(--SmartThemeQuoteColor, #8b8) 42%, transparent);
+    background: color-mix(in srgb, var(--SmartThemeQuoteColor, #8b8) 14%, transparent);
 }
 
 .ica-transform-history-entry {
     margin-bottom: 12px;
-    padding: 8px;
-    border: 1px solid var(--SmartThemeBorderColor, #444);
-    border-radius: 6px;
+    padding: 12px;
+    border: 1px solid color-mix(in srgb, var(--SmartThemeBorderColor, #444) 55%, transparent);
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--SmartThemeBlurTintColor, #222) 26%, transparent);
 }
 
 .ica-transform-history-entry h5 {
@@ -6955,27 +6984,37 @@ body:not(.movingUI) .drawer-content.maximized {
 }
 
 .ica-transform-history-entry small {
-    opacity: 0.6;
+    display: block;
+    margin-bottom: 8px;
+    opacity: 0.72;
 }
 
-.ica-diff-original,
-.ica-diff-after {
-    margin-top: 6px;
-}
-
-.ica-diff-original pre,
-.ica-diff-after pre {
+.ica-transform-diff {
+    padding: 10px 12px;
+    border-radius: 10px;
+    border: 1px solid color-mix(in srgb, var(--SmartThemeBorderColor, #444) 45%, transparent);
+    background: color-mix(in srgb, var(--SmartThemeBlurTintColor, #222) 22%, transparent);
     white-space: pre-wrap;
-    max-height: 200px;
-    overflow-y: auto;
-    padding: 8px;
-    border: 1px solid var(--SmartThemeBorderColor, #444);
-    border-radius: 4px;
-    font-size: 0.85em;
+    word-break: break-word;
+    line-height: 1.55;
+    font-family: var(--monoFontFamily, monospace);
+    font-size: calc(var(--mainFontSize) * 0.84);
+}
+
+.ica-transform-diff-part--ins {
+    background: color-mix(in srgb, #3bb273 22%, transparent);
+    color: color-mix(in srgb, var(--SmartThemeBodyColor, #ddd) 88%, #3bb273 12%);
+}
+
+.ica-transform-diff-part--del {
+    background: color-mix(in srgb, #d35b5b 20%, transparent);
+    color: color-mix(in srgb, var(--SmartThemeBodyColor, #ddd) 88%, #d35b5b 12%);
+    text-decoration: line-through;
 }
 
 .ica-transform-actions {
-    margin-top: 8px;
     display: flex;
-    gap: 8px;
+    gap: 6px;
+    margin-top: 10px;
+    flex-wrap: wrap;
 }

--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -31,7 +31,9 @@ const GEMINI_MEDIA_RESOLUTION = {
     high: 'media_resolution_high',
 };
 
-const enableThoughtSignatures = !!getConfigValue('gemini.thoughtSignatures', true, 'boolean');
+function isThoughtSignaturesEnabled() {
+    return !!getConfigValue('gemini.thoughtSignatures', true, 'boolean');
+}
 
 /**
  * @typedef {object} PromptNames
@@ -582,7 +584,7 @@ export function convertGooglePrompt(messages, model, useSysPrompt, names) {
             const textSignature = message.signature;
 
             parts.forEach((part) => {
-                if (enableThoughtSignatures && textSignature && typeof part.text === 'string') {
+                if (isThoughtSignaturesEnabled() && textSignature && typeof part.text === 'string') {
                     part.thoughtSignature = textSignature;
                 } else if (/gemini-3/.test(model)) {
                     // Gemini 3: Fall back to bypass magic for function calls (mandatory) and images
@@ -1432,7 +1434,7 @@ export function addOpenRouterSignatures(messages, model) {
             details.push(detail);
         };
         if (typeof message.signature === 'string') {
-            if (enableThoughtSignatures) {
+            if (isThoughtSignaturesEnabled()) {
                 addDetail(message.signature);
             }
             delete message.signature;


### PR DESCRIPTION
## Why this PR exists

This PR fixes a focused set of UI/state regressions in SillyBunny while keeping the fork as close to upstream SillyTavern behavior as possible.

The main goal is to resolve bugs that are already user-facing and repeatedly reported, without introducing new external APIs, widening fork drift, or rewriting legacy systems that may still matter for compatibility.

In short: this is a low-risk, upstream-safe bugfix bundle for reasoning UI, in-chat agent reviewability, provider normalization, bottom-bar identity handling, and World Info layout polish.

## Scope

This PR is intentionally limited to:

- reasoning / thought UI polish and thought-signature fixes
- in-chat agent change review and provider-response normalization
- bottom-bar persona/chat switching reliability
- World Info layout tightening and shared checkbox alignment
- removal of visible `Agent mode` wording where it still surfaced

This PR intentionally does **not**:

- add new server or external API contracts
- remove the legacy adventure-helper runtime outright
- introduce a large maintainability refactor
- redesign upstream data models or persistence formats

## What changed

### Reasoning and thought UI

- replaced hardcoded emoji-style reasoning token badges with theme-native badges
- added a separate `Show thought in chat` UI toggle so request and visibility are no longer coupled
- kept reasoning tokens tied to message metadata so they show whenever the message has them
- fixed Gemini/OpenRouter thought-signature handling by resolving signature enablement live instead of caching it once at module load time
- corrected direct Gemini thought-signature extraction to read both `responseContent.parts` and `candidates[].content.parts`

### In-Chat Agents

- added a message-level `View agent changes` action for prompt-transformed replies
- upgraded transform review from a simple before/after preview to a semantic diff with undo/redo preserved
- escaped the agent prompt placeholder so literal macros like `{{char}}` and `{{user}}` remain visible as authored
- improved agent modal scrolling and checkbox alignment for zoom/mobile ergonomics
- hardened provider-response normalization so nested object-shaped responses stop leaking through as `[object Object]`

### Bottom bar / persona / chat reliability

- routed bottom-bar chat switching through the shared `openChatById()` path instead of a separate ad hoc loader
- changed bottom-bar persona switching to target stable avatar IDs through `persona-set`, avoiding duplicate-name collisions
- fixed current-persona resolution so it does not fall back to the first same-name persona
- added retry-based refresh scheduling for bottom-bar initial load so Node startup races are less brittle

### World Info and UI cleanup

- tightened World Info layout with CSS-first adjustments to reduce width/height sprawl
- improved shared checkbox alignment on mobile and in touched editor surfaces
- removed remaining visible `Agent mode` wording from the shipped UI text in touched paths
- kept the legacy runtime in place to avoid risky compatibility drift while de-branding the user-facing wording

## Compatibility / upstream-safety notes

- no new external API or server contract was introduced
- existing message metadata was reused rather than replaced
- fixes were kept in shared/core paths only where the bug was generic or already leaking into common behavior
- fork-specific behavior remains isolated to SillyBunny shell/UI code where possible

## Verification

Completed:

- `node --check public\\script.js`
- `node --check public\\scripts\\openai.js`
- `node --check public\\scripts\\reasoning.js`
- `node --check public\\scripts\\extensions\\in-chat-agents\\index.js`
- `node --check public\\scripts\\agents.js`
- `node --check public\\scripts\\sillybunny-tabs.js`
- `git diff --check`

Not completed:

- full `bun run lint` is currently blocked by an existing ESLint/AJV toolchain crash in this repo (`Cannot set properties of undefined (setting 'defaultMeta')`), so it could not be used as a validation signal for this PR
- live manual browser smoke validation still recommended for Node mode, mobile width, and 175% zoom

## Recommended review focus

1. reasoning signature behavior for Gemini / OpenRouter Gemini
2. message-level agent diff UX and undo/redo
3. duplicate-name persona switching from the bottom bar
4. bottom-bar chat/branch selection on first load in Node mode
5. World Info layout changes on desktop and narrower widths
