### PR TITLE
chore(sync): align server security with SillyTavern 1.18

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Run npm install
         run: npm ci --ignore-scripts
 
+      - name: Install test lint dependencies
+        run: npm ci --ignore-scripts --prefix tests
+
       - name: Run ESLint
         # Action ESLint
         # https://github.com/marketplace/actions/action-eslint

--- a/src/command-line.js
+++ b/src/command-line.js
@@ -32,6 +32,7 @@ import { initConfig } from './config-init.js';
  * @property {string} keyPassphrase SSL private key passphrase
  * @property {boolean} whitelistMode If enable whitelist mode
  * @property {boolean} basicAuthMode If enable basic authentication
+ * @property {boolean} enableKeepAlive Enable HTTP/HTTPS keep-alive globally
  * @property {boolean} requestProxyEnabled If enable outgoing request proxy
  * @property {string} requestProxyUrl Request proxy URL
  * @property {string[]} requestProxyBypass Request proxy bypass list
@@ -77,6 +78,7 @@ export class CommandLineParser {
             keyPassphrase: '',
             whitelistMode: true,
             basicAuthMode: false,
+            enableKeepAlive: false,
             requestProxyEnabled: false,
             requestProxyUrl: '',
             requestProxyBypass: [],
@@ -218,6 +220,11 @@ export class CommandLineParser {
                 default: null,
                 describe: 'Enables basic authentication',
             })
+            .option('enableKeepAlive', {
+                type: 'boolean',
+                default: null,
+                describe: 'Enable HTTP/HTTPS keep-alive globally',
+            })
             .option('requestProxyEnabled', {
                 type: 'boolean',
                 default: null,
@@ -293,6 +300,7 @@ export class CommandLineParser {
             keyPassphrase: cliArguments.keyPassphrase ?? getConfigValue('ssl.keyPassphrase', defaultConfig.keyPassphrase),
             whitelistMode: cliArguments.whitelist ?? getConfigValue('whitelistMode', defaultConfig.whitelistMode, 'boolean'),
             basicAuthMode: cliArguments.basicAuthMode ?? getConfigValue('basicAuthMode', defaultConfig.basicAuthMode, 'boolean'),
+            enableKeepAlive: cliArguments.enableKeepAlive ?? getConfigValue('enableKeepAlive', defaultConfig.enableKeepAlive, 'boolean'),
             requestProxyEnabled: cliArguments.requestProxyEnabled ?? getConfigValue('requestProxy.enabled', defaultConfig.requestProxyEnabled, 'boolean'),
             requestProxyUrl: cliArguments.requestProxyUrl ?? getConfigValue('requestProxy.url', defaultConfig.requestProxyUrl),
             requestProxyBypass: cliArguments.requestProxyBypass ?? getConfigValue('requestProxy.bypass', defaultConfig.requestProxyBypass),

--- a/src/endpoints/users-public.js
+++ b/src/endpoints/users-public.js
@@ -3,23 +3,23 @@ import crypto from 'node:crypto';
 import storage from 'node-persist';
 import express from 'express';
 import { RateLimiterMemory, RateLimiterRes } from 'rate-limiter-flexible';
-import { getIpFromRequest, getRealIpFromHeader } from '../express-common.js';
+import { getIpAddress, retryAfter } from '../express-common.js';
 import { color, Cache, getConfigValue } from '../util.js';
 import { KEY_PREFIX, getUserAvatar, toKey, getPasswordHash, getPasswordSalt } from '../users.js';
 
 const DISCREET_LOGIN = getConfigValue('enableDiscreetLogin', false, 'boolean');
 const PREFER_REAL_IP_HEADER = getConfigValue('rateLimiting.preferRealIpHeader', false, 'boolean');
+const LOGIN_POINTS = getConfigValue('rateLimiting.accountsLoginMaxAttempts', 5, 'number');
+const RECOVER_POINTS = getConfigValue('rateLimiting.accountsRecoverMaxAttempts', 5, 'number');
 const MFA_CACHE = new Cache(5 * 60 * 1000);
-
-const getIpAddress = (request) => PREFER_REAL_IP_HEADER ? getRealIpFromHeader(request) : getIpFromRequest(request);
 
 export const router = express.Router();
 const loginLimiter = new RateLimiterMemory({
-    points: 5,
+    points: LOGIN_POINTS > 0 ? LOGIN_POINTS : Number.MAX_SAFE_INTEGER,
     duration: 60,
 });
 const recoverLimiter = new RateLimiterMemory({
-    points: 5,
+    points: RECOVER_POINTS > 0 ? RECOVER_POINTS : Number.MAX_SAFE_INTEGER,
     duration: 300,
 });
 
@@ -62,7 +62,7 @@ router.post('/login', async (request, response) => {
             return response.status(400).json({ error: 'Missing required fields' });
         }
 
-        const ip = getIpAddress(request);
+        const ip = getIpAddress(request, PREFER_REAL_IP_HEADER);
         await loginLimiter.consume(ip);
 
         /** @type {import('../users.js').User} */
@@ -94,8 +94,8 @@ router.post('/login', async (request, response) => {
         return response.json({ handle: user.handle });
     } catch (error) {
         if (error instanceof RateLimiterRes) {
-            console.error('Login failed: Rate limited from', getIpAddress(request));
-            return response.status(429).send({ error: 'Too many attempts. Try again later or recover your password.' });
+            console.error('Login failed: Rate limited from', getIpAddress(request, PREFER_REAL_IP_HEADER));
+            return retryAfter(response, error).status(429).send({ error: 'Too many attempts. Try again later or recover your password.' });
         }
 
         console.error('Login failed:', error);
@@ -110,7 +110,7 @@ router.post('/recover-step1', async (request, response) => {
             return response.status(400).json({ error: 'Missing required fields' });
         }
 
-        const ip = getIpAddress(request);
+        const ip = getIpAddress(request, PREFER_REAL_IP_HEADER);
         await recoverLimiter.consume(ip);
 
         /** @type {import('../users.js').User} */
@@ -134,8 +134,8 @@ router.post('/recover-step1', async (request, response) => {
         return response.sendStatus(204);
     } catch (error) {
         if (error instanceof RateLimiterRes) {
-            console.error('Recover step 1 failed: Rate limited from', getIpAddress(request));
-            return response.status(429).send({ error: 'Too many attempts. Try again later or contact your admin.' });
+            console.error('Recover step 1 failed: Rate limited from', getIpAddress(request, PREFER_REAL_IP_HEADER));
+            return retryAfter(response, error).status(429).send({ error: 'Too many attempts. Try again later or contact your admin.' });
         }
 
         console.error('Recover step 1 failed:', error);
@@ -152,7 +152,7 @@ router.post('/recover-step2', async (request, response) => {
 
         /** @type {import('../users.js').User} */
         const user = await storage.getItem(toKey(request.body.handle));
-        const ip = getIpAddress(request);
+        const ip = getIpAddress(request, PREFER_REAL_IP_HEADER);
 
         if (!user) {
             console.error('Recover step 2 failed: User', request.body.handle, 'not found');
@@ -188,8 +188,8 @@ router.post('/recover-step2', async (request, response) => {
         return response.sendStatus(204);
     } catch (error) {
         if (error instanceof RateLimiterRes) {
-            console.error('Recover step 2 failed: Rate limited from', getIpAddress(request));
-            return response.status(429).send({ error: 'Too many attempts. Try again later or contact your admin.' });
+            console.error('Recover step 2 failed: Rate limited from', getIpAddress(request, PREFER_REAL_IP_HEADER));
+            return retryAfter(response, error).status(429).send({ error: 'Too many attempts. Try again later or contact your admin.' });
         }
 
         console.error('Recover step 2 failed:', error);

--- a/src/express-common.js
+++ b/src/express-common.js
@@ -1,4 +1,7 @@
 import ipaddr from 'ipaddr.js';
+import ipMatching from 'ip-matching';
+import { RateLimiterRes } from 'rate-limiter-flexible';
+import { getConfigValue } from './util.js';
 
 /**
  * Gets the IP address of the client from the request object.
@@ -22,17 +25,93 @@ export function getIpFromRequest(req) {
 }
 
 /**
- * Gets the IP address of the client when behind reverse proxy using x-real-ip header, falls back to socket remote address.
- * This function should be used when the application is running behind a reverse proxy (e.g., Nginx, traefik, Caddy...).
+ * Get the client IP address from configured reverse proxy headers.
+ * @param {import('express').Request} req Express request object
+ * @returns {string|undefined} The forwarded client IP address
+ */
+export function getRealOrForwardedIp(req) {
+    const xRealIpEnabled = !!getConfigValue('forwardedHeaders.xRealIp', true, 'boolean');
+    const cfConnectingIpEnabled = !!getConfigValue('forwardedHeaders.cfConnectingIp', false, 'boolean');
+    const xForwardedForEnabled = !!getConfigValue('forwardedHeaders.xForwardedFor', true, 'boolean');
+
+    if (req.headers['x-real-ip'] && xRealIpEnabled) {
+        return req.headers['x-real-ip'].toString();
+    }
+
+    if (req.headers['cf-connecting-ip'] && cfConnectingIpEnabled) {
+        return req.headers['cf-connecting-ip'].toString();
+    }
+
+    if (req.headers['x-forwarded-for'] && xForwardedForEnabled) {
+        const ipList = req.headers['x-forwarded-for'].toString().split(',').map(ip => ip.trim());
+        return ipList[0];
+    }
+
+    return undefined;
+}
+
+/**
+ * Gets the IP address of the client when behind reverse proxy using configured forwarded headers.
  * @param {import('express').Request} req Request object
  * @returns {string} IP address of the client
  */
 export function getRealIpFromHeader(req) {
-    if (req.headers['x-real-ip']) {
-        return req.headers['x-real-ip'].toString();
+    return getRealOrForwardedIp(req) || getIpFromRequest(req);
+}
+
+/**
+ * Gets the IP address of the client, optionally including the real/forwarded IP from headers.
+ * @param {import('express').Request} request Request object
+ * @param {boolean} includeHeaderIp Whether to include the real/forwarded IP from headers
+ * @returns {string} IP address of the client
+ */
+export function getIpAddress(request, includeHeaderIp) {
+    const socketIp = getIpFromRequest(request);
+    const forwardedIp = includeHeaderIp && getRealOrForwardedIp(request);
+    return forwardedIp ? `${socketIp} (forwarded: ${forwardedIp})` : socketIp;
+}
+
+/**
+ * Filters and validates IP patterns.
+ * @param {string[]} entries The list of IP patterns to validate
+ * @param {(entry: string, message: string) => string} formatLog Function to format the warning message
+ * @returns {string[]} The list of valid IP patterns
+ */
+export function filterValidIpPatterns(entries, formatLog) {
+    const validEntries = [];
+
+    if (!Array.isArray(entries)) {
+        return validEntries;
     }
 
-    return getIpFromRequest(req);
+    for (const entry of entries) {
+        try {
+            ipMatching.getMatch(entry);
+            validEntries.push(entry);
+        } catch (e) {
+            if (typeof formatLog === 'function') {
+                console.warn(formatLog(entry, e?.message || 'Unknown error'));
+            }
+        }
+    }
+
+    return validEntries;
+}
+
+/**
+ * Sets the Retry-After header on the response based on rate limit information.
+ * @param {import('express').Response} response Express response object
+ * @param {RateLimiterRes} rateLimit Rate limit information
+ * @returns {import('express').Response} Response object
+ */
+export function retryAfter(response, rateLimit) {
+    if (response.headersSent || !(rateLimit instanceof RateLimiterRes)) {
+        return response;
+    }
+
+    const retryAfter = Math.ceil(rateLimit.msBeforeNext / 1000);
+    response.set('Retry-After', retryAfter.toString());
+    return response;
 }
 
 /**

--- a/src/middleware/accessLogWriter.js
+++ b/src/middleware/accessLogWriter.js
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import fs from 'node:fs';
-import { getRealIpFromHeader } from '../express-common.js';
+import { getIpAddress } from '../express-common.js';
 import { color, getConfigValue } from '../util.js';
 
 const enableAccessLog = getConfigValue('logging.enableAccessLog', true, 'boolean');
@@ -32,7 +32,7 @@ export function migrateAccessLog() {
  */
 export default function accessLoggerMiddleware() {
     return function (req, res, next) {
-        const clientIp = getRealIpFromHeader(req);
+        const clientIp = getIpAddress(req, true);
         const userAgent = req.headers['user-agent'];
 
         if (!knownIPs.has(clientIp)) {

--- a/src/middleware/basicAuth.js
+++ b/src/middleware/basicAuth.js
@@ -4,16 +4,26 @@
  * Also supports session-based Bearer token authentication when sessionAuth is enabled.
  */
 import { Buffer } from 'node:buffer';
+import path from 'node:path';
 import storage from 'node-persist';
+import { RateLimiterMemory, RateLimiterRes } from 'rate-limiter-flexible';
 import { getAllUserHandles, toKey, getPasswordHash } from '../users.js';
 import { getConfigValue, safeReadFileSync } from '../util.js';
+import { getIpAddress, retryAfter } from '../express-common.js';
 import { validateSession, isSessionAuthEnabled } from './sessionAuth.js';
 
 const PER_USER_BASIC_AUTH = getConfigValue('perUserBasicAuth', false, 'boolean');
 const ENABLE_ACCOUNTS = getConfigValue('enableUserAccounts', false, 'boolean');
+const PREFER_REAL_IP_HEADER = getConfigValue('rateLimiting.preferRealIpHeader', false, 'boolean');
+const BASIC_AUTH_ATTEMPTS = getConfigValue('rateLimiting.basicAuthMaxAttempts', 5, 'number');
+
+const basicAuthLimiter = new RateLimiterMemory({
+    points: BASIC_AUTH_ATTEMPTS > 0 ? BASIC_AUTH_ATTEMPTS : Number.MAX_SAFE_INTEGER,
+    duration: 60,
+});
 
 const basicAuthMiddleware = async function (request, response, callback) {
-    const unauthorizedWebpage = safeReadFileSync('./public/error/unauthorized.html') ?? '';
+    const unauthorizedWebpage = safeReadFileSync(path.join(process.cwd(), 'public/error/unauthorized.html')) ?? '';
     const unauthorizedResponse = (res) => {
         res.set({
             'Cache-Control': 'no-store, no-cache, must-revalidate, private',
@@ -43,39 +53,59 @@ const basicAuthMiddleware = async function (request, response, callback) {
         return callback();
     }
 
-    const basicAuthUserName = getConfigValue('basicAuthUser.username');
-    const basicAuthUserPassword = getConfigValue('basicAuthUser.password');
+    try {
+        const ip = getIpAddress(request, PREFER_REAL_IP_HEADER);
+        const basicAuthUserName = getConfigValue('basicAuthUser.username');
+        const basicAuthUserPassword = getConfigValue('basicAuthUser.password');
 
-    if (!authHeader) {
-        return unauthorizedResponse(response);
-    }
+        if (!authHeader) {
+            return unauthorizedResponse(response);
+        }
 
-    const [scheme, credentials] = authHeader.split(' ');
+        const [scheme, credentials] = authHeader.split(' ');
 
-    if (scheme !== 'Basic' || !credentials) {
-        return unauthorizedResponse(response);
-    }
+        if (scheme !== 'Basic' || !credentials) {
+            return unauthorizedResponse(response);
+        }
 
-    const usePerUserAuth = PER_USER_BASIC_AUTH && ENABLE_ACCOUNTS;
-    const [username, ...passwordParts] = Buffer.from(credentials, 'base64')
-        .toString('utf8')
-        .split(':');
-    const password = passwordParts.join(':');
+        const rateLimit = await basicAuthLimiter.get(ip);
 
-    if (!usePerUserAuth && username === basicAuthUserName && password === basicAuthUserPassword) {
-        return callback();
-    } else if (usePerUserAuth) {
-        const userHandles = await getAllUserHandles();
-        for (const userHandle of userHandles) {
-            if (username === userHandle) {
-                const user = await storage.getItem(toKey(userHandle));
-                if (user && user.enabled && (user.password && user.password === getPasswordHash(password, user.salt))) {
-                    return callback();
+        if (rateLimit !== null && rateLimit.consumedPoints > basicAuthLimiter.points) {
+            throw rateLimit;
+        }
+
+        const usePerUserAuth = PER_USER_BASIC_AUTH && ENABLE_ACCOUNTS;
+        const [username, ...passwordParts] = Buffer.from(credentials, 'base64')
+            .toString('utf8')
+            .split(':');
+        const password = passwordParts.join(':');
+
+        if (!usePerUserAuth && username === basicAuthUserName && password === basicAuthUserPassword) {
+            await basicAuthLimiter.delete(ip);
+            return callback();
+        } else if (usePerUserAuth) {
+            const userHandles = await getAllUserHandles();
+            for (const userHandle of userHandles) {
+                if (username === userHandle) {
+                    const user = await storage.getItem(toKey(userHandle));
+                    if (user && user.enabled && (user.password && user.password === getPasswordHash(password, user.salt))) {
+                        await basicAuthLimiter.delete(ip);
+                        return callback();
+                    }
                 }
             }
         }
+
+        await basicAuthLimiter.consume(ip);
+        return unauthorizedResponse(response);
+    } catch (error) {
+        if (error instanceof RateLimiterRes) {
+            console.error('Basic auth failed: Rate limited from', getIpAddress(request, PREFER_REAL_IP_HEADER), request.method, request.originalUrl);
+            return retryAfter(response, error).sendStatus(429);
+        }
+        console.error('Basic auth error:', error);
+        return response.sendStatus(500);
     }
-    return unauthorizedResponse(response);
 };
 
 export default basicAuthMiddleware;

--- a/src/middleware/whitelist.js
+++ b/src/middleware/whitelist.js
@@ -6,7 +6,7 @@ import Handlebars from 'handlebars';
 import ipMatching from 'ip-matching';
 import isDocker from 'is-docker';
 
-import { getIpFromRequest } from '../express-common.js';
+import { filterValidIpPatterns, getIpFromRequest, getRealOrForwardedIp } from '../express-common.js';
 import { color, getConfigValue, safeReadFileSync } from '../util.js';
 
 const whitelistPath = path.join(process.cwd(), './whitelist.txt');
@@ -24,28 +24,7 @@ if (fs.existsSync(whitelistPath)) {
     }
 }
 
-/**
- * Validates and filters the whitelist, removing any invalid entries.
- * @param {string[]} entries - The whitelist entries to validate
- * @returns {string[]} The filtered list of valid whitelist entries
- */
-function validateWhitelist(entries) {
-    const validEntries = [];
-
-    for (const entry of entries) {
-        try {
-            // This will throw if the entry is not a valid IP or CIDR
-            ipMatching.getMatch(entry);
-            validEntries.push(entry);
-        } catch (e) {
-            console.warn(`Whitelist ${color.red('Warning')}: Ignoring invalid entry ${color.yellow(entry)} - ${e.message}`);
-        }
-    }
-
-    return validEntries;
-}
-
-whitelist = validateWhitelist(whitelist);
+whitelist = filterValidIpPatterns(whitelist, (entry, message) => `${color.red('Warning')}: Ignoring invalid whitelist entry ${color.yellow(entry)} - ${message}`);
 
 /**
  * Get the client IP address from the request headers.
@@ -57,19 +36,7 @@ function getForwardedIp(req) {
         return undefined;
     }
 
-    // Check if X-Real-IP is available
-    if (req.headers['x-real-ip']) {
-        return req.headers['x-real-ip'].toString();
-    }
-
-    // Check for X-Forwarded-For and parse if available
-    if (req.headers['x-forwarded-for']) {
-        const ipList = req.headers['x-forwarded-for'].toString().split(',').map(ip => ip.trim());
-        return ipList[0];
-    }
-
-    // If none of the headers are available, return undefined
-    return undefined;
+    return getRealOrForwardedIp(req);
 }
 
 /**

--- a/src/private-request-filter.js
+++ b/src/private-request-filter.js
@@ -1,0 +1,168 @@
+import net from 'node:net';
+import tls from 'node:tls';
+import http from 'node:http';
+import https from 'node:https';
+import dns from 'node:dns';
+import ipMatch from 'ip-matching';
+import ipRegex from 'ip-regex';
+import { Agent } from 'agent-base';
+import { color } from './util.js';
+import { filterValidIpPatterns } from './express-common.js';
+
+const LOG_HEADER = '[Private Request Filter]';
+
+/** @type {import('ip-matching').IPMatch[]} */
+const privateIpRanges = [
+    ipMatch.getMatch('127.0.0.0/8'),
+    ipMatch.getMatch('10.0.0.0/8'),
+    ipMatch.getMatch('172.16.0.0/12'),
+    ipMatch.getMatch('192.168.0.0/16'),
+    ipMatch.getMatch('169.254.0.0/16'),
+    ipMatch.getMatch('::1/128'),
+    ipMatch.getMatch('fc00::/7'),
+    ipMatch.getMatch('fe80::/10'),
+];
+
+/**
+ * HTTP/HTTPS agent that blocks requests resolving to private IP addresses unless explicitly allowed.
+ */
+export class PrivateRequestAgent extends Agent {
+    /** @type {Readonly<import('ip-matching').IPMatch[]>} */
+    privateAddressWhitelist = [];
+
+    logBlocked = true;
+    logAllowed = false;
+    allowUnresolvedHosts = false;
+
+    /**
+     * @param {object} options Agent options
+     * @param {string[]} options.privateAddressWhitelist List of private IP addresses or CIDR ranges to allow
+     * @param {boolean} options.logBlocked Whether to log blocked requests
+     * @param {boolean} options.logAllowed Whether to log allowed requests
+     * @param {boolean} options.allowUnresolvedHosts Whether to allow unresolved hosts
+     * @param {boolean} options.enableKeepAlive Whether to enable keep-alive
+     */
+    constructor(options = { privateAddressWhitelist: [], logBlocked: true, logAllowed: false, allowUnresolvedHosts: false, enableKeepAlive: false }) {
+        super({ keepAlive: options.enableKeepAlive });
+
+        const logEntryWarning = (entry, message) => `${color.red('Warning')}: Ignoring invalid private whitelist entry ${color.yellow(entry)} - ${message}`;
+        const whitelistArray = Array.isArray(options.privateAddressWhitelist) ? options.privateAddressWhitelist : [];
+        this.privateAddressWhitelist = Object.freeze(filterValidIpPatterns(whitelistArray, logEntryWarning).map(pattern => ipMatch.getMatch(pattern)));
+        this.allowUnresolvedHosts = options.allowUnresolvedHosts;
+        this.logBlocked = options.logBlocked;
+        this.logAllowed = options.logAllowed;
+    }
+
+    /**
+     * @param {string} address The IP address to check
+     * @returns {boolean} Whether the IP is private
+     */
+    #isPrivateIp(address) {
+        return privateIpRanges.some(range => range.matches(address));
+    }
+
+    /**
+     * @param {string} address The IP address to check
+     * @returns {boolean} Whether the private IP is allowed
+     */
+    #isAllowedPrivateAddress(address) {
+        return this.privateAddressWhitelist.some(match => match.matches(address));
+    }
+
+    /**
+     * @param {http.ClientRequest} _req HTTP request object
+     * @param {import('agent-base').AgentConnectOpts} options Agent connection options
+     * @returns {Promise<net.Socket|tls.TLSSocket>}
+     */
+    async connect(_req, options) {
+        const raiseError = (message, log = true) => {
+            if (log) {
+                console.error(color.red(LOG_HEADER), message);
+            }
+            throw new Error(message);
+        };
+
+        const connect = (hostOverride = null) => {
+            if (hostOverride) {
+                options.host = hostOverride;
+            }
+            return options.secureEndpoint ? tls.connect(options) : net.connect(options);
+        };
+
+        const validateIpAddress = (ip) => {
+            if (!this.#isPrivateIp(ip)) {
+                return connect(ip);
+            }
+
+            if (this.#isAllowedPrivateAddress(ip)) {
+                if (this.logAllowed) {
+                    console.info(color.green(LOG_HEADER), 'Allowed request to private IP address:', color.blue(ip));
+                }
+                return connect(ip);
+            }
+
+            return raiseError(`Blocked request to private IP address: ${ip}`, this.logBlocked);
+        };
+
+        const lookupHost = async (host) => {
+            try {
+                return (await dns.promises.lookup(host)).address;
+            } catch {
+                return '';
+            }
+        };
+
+        const host = options.host;
+        if (!host) {
+            return raiseError('No host specified in request options', true);
+        }
+
+        const isIp = ipRegex.v4({ exact: true }).test(host) || ipRegex.v6({ exact: true }).test(host);
+        if (isIp) {
+            return validateIpAddress(host);
+        }
+
+        const address = await lookupHost(host);
+        if (!address) {
+            if (this.allowUnresolvedHosts) {
+                return connect();
+            }
+            return raiseError(`Unable to resolve host: ${host}. Set privateAddressWhitelist.allowUnresolvedHosts to true to bypass this check.`, true);
+        }
+
+        return validateIpAddress(address);
+    }
+}
+
+/**
+ * Initialize the private request filter by replacing global HTTP/HTTPS agents.
+ * @param {object} options Initialization options
+ * @param {boolean} options.listen Whether the server listens for incoming requests
+ * @param {boolean} options.enabled Whether the private request filter is enabled
+ * @param {string[]} options.privateAddressWhitelist Allowed private ranges
+ * @param {boolean} options.logBlocked Whether blocked requests are logged
+ * @param {boolean} options.logAllowed Whether allowed requests are logged
+ * @param {boolean} options.allowUnresolvedHosts Whether unresolved hosts are allowed
+ * @param {boolean} options.enableKeepAlive Whether keep-alive is enabled
+ */
+export default function initPrivateRequestFilter({ listen, enabled, privateAddressWhitelist, logBlocked, logAllowed, allowUnresolvedHosts, enableKeepAlive }) {
+    if (!enabled) {
+        if (listen) {
+            console.warn();
+            console.warn(color.yellow('Warning: listen is enabled but private request filter is disabled. This may expose your server to SSRF attacks.'));
+            console.warn(color.blue('To enable, provide trusted addresses in privateAddressWhitelist.allowedRanges and set privateAddressWhitelist.enabled to true in config.yaml and restart the server.'));
+        }
+        return;
+    }
+
+    const agent = new PrivateRequestAgent({ privateAddressWhitelist, logBlocked, logAllowed, allowUnresolvedHosts, enableKeepAlive });
+    http.globalAgent = agent;
+    https.globalAgent = agent;
+
+    console.info();
+    console.info(color.green(LOG_HEADER), 'Enabled');
+    if (agent.privateAddressWhitelist.length > 0) {
+        console.info(color.green(LOG_HEADER), 'Allowed private addresses:', color.blue(agent.privateAddressWhitelist.join(', ')));
+    }
+    console.info();
+}

--- a/src/request-proxy.js
+++ b/src/request-proxy.js
@@ -13,12 +13,19 @@ const LOG_HEADER = '[Request Proxy]';
  * @property {boolean} enabled Whether proxy is enabled.
  * @property {string} url Proxy URL.
  * @property {string[]} bypass List of URLs to bypass proxy.
+ * @property {boolean} enableKeepAlive Enable HTTP/HTTPS keep-alive.
+ * @property {boolean} privateRequestFilterEnabled Whether the private request filter is enabled.
  */
-export default function initRequestProxy({ enabled, url, bypass }) {
+export default function initRequestProxy({ enabled, url, bypass, enableKeepAlive = false, privateRequestFilterEnabled = false }) {
     try {
         // No proxy is enabled, so return
         if (!enabled) {
             return;
+        }
+
+        if (privateRequestFilterEnabled) {
+            console.warn(color.yellow(LOG_HEADER), 'Warning: Request proxy is enabled while private request filter is also enabled. Only URLs that BYPASS the request proxy will be checked.');
+            console.warn(color.yellow(LOG_HEADER), 'To ensure all requests are properly filtered, disable the request proxy.');
         }
 
         if (!url) {
@@ -39,7 +46,9 @@ export default function initRequestProxy({ enabled, url, bypass }) {
             process.env.no_proxy = bypass.join(',');
         }
 
-        const proxyAgent = new ProxyAgent();
+        const httpAgent = http.globalAgent;
+        const httpsAgent = https.globalAgent;
+        const proxyAgent = new ProxyAgent({ httpAgent, httpsAgent, keepAlive: enableKeepAlive });
         http.globalAgent = proxyAgent;
         https.globalAgent = proxyAgent;
 

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -6,6 +6,8 @@ import path from 'node:path';
 import util from 'node:util';
 import dns from 'node:dns';
 import process from 'node:process';
+import http from 'node:http';
+import https from 'node:https';
 
 import cors from 'cors';
 import { csrfSync } from 'csrf-sync';
@@ -49,6 +51,7 @@ import getWhitelistMiddleware from './middleware/whitelist.js';
 import accessLoggerMiddleware, { getAccessLogPath, migrateAccessLog } from './middleware/accessLogWriter.js';
 import multerMonkeyPatch from './middleware/multerMonkeyPatch.js';
 import initRequestProxy from './request-proxy.js';
+import initPrivateRequestFilter from './private-request-filter.js';
 import corsProxyMiddleware from './middleware/corsProxy.js';
 import hostWhitelistMiddleware from './middleware/hostWhitelist.js';
 import {
@@ -88,6 +91,9 @@ if (!cliArgs.enableIPv6 && !cliArgs.enableIPv4) {
     console.error('error: You can\'t disable all internet protocols: at least IPv6 or IPv4 must be enabled.');
     process.exit(1);
 }
+
+http.globalAgent = new http.Agent({ keepAlive: cliArgs.enableKeepAlive });
+https.globalAgent = new https.Agent({ keepAlive: cliArgs.enableKeepAlive });
 
 const app = express();
 app.use(helmet({
@@ -477,8 +483,25 @@ async function preSetupTasks() {
         exitProcess();
     });
 
+    const requestFilterOptions = {
+        listen: cliArgs.listen,
+        enabled: !!getConfigValue('privateAddressWhitelist.enabled', false, 'boolean'),
+        privateAddressWhitelist: getConfigValue('privateAddressWhitelist.allowedRanges', ['127.0.0.0/8', '::1/128']),
+        logBlocked: !!getConfigValue('privateAddressWhitelist.log.blockedRequests', true, 'boolean'),
+        logAllowed: !!getConfigValue('privateAddressWhitelist.log.allowedRequests', false, 'boolean'),
+        allowUnresolvedHosts: !!getConfigValue('privateAddressWhitelist.allowUnresolvedHosts', false, 'boolean'),
+        enableKeepAlive: cliArgs.enableKeepAlive,
+    };
+    initPrivateRequestFilter(requestFilterOptions);
+
     // Add request proxy.
-    initRequestProxy({ enabled: cliArgs.requestProxyEnabled, url: cliArgs.requestProxyUrl, bypass: cliArgs.requestProxyBypass });
+    initRequestProxy({
+        enabled: cliArgs.requestProxyEnabled,
+        url: cliArgs.requestProxyUrl,
+        bypass: cliArgs.requestProxyBypass,
+        enableKeepAlive: cliArgs.enableKeepAlive,
+        privateRequestFilterEnabled: requestFilterOptions.enabled,
+    });
 
     // Wait for frontend libs to compile
     await webpackMiddleware.runWebpackCompiler({ pruneCache: true });

--- a/src/users.js
+++ b/src/users.js
@@ -14,12 +14,14 @@ import archiver from 'archiver';
 import _ from 'lodash';
 import { sync as writeFileAtomicSync } from 'write-file-atomic';
 import sanitize from 'sanitize-filename';
+import ipMatching from 'ip-matching';
 
 import { USER_DIRECTORY_TEMPLATE, DEFAULT_USER, PUBLIC_DIRECTORIES, SETTINGS_FILE, UPLOADS_DIRECTORY } from './constants.js';
 import { getConfigValue, color, delay, generateTimestamp, invalidateFirefoxCache, isPathUnderParent } from './util.js';
 import { allowKeysExposure, readSecret, writeSecret, SECRETS_FILE } from './endpoints/secrets.js';
 import { getContentOfType } from './endpoints/content-manager.js';
 import { serverDirectory } from './server-directory.js';
+import { filterValidIpPatterns, getIpFromRequest } from './express-common.js';
 
 export const KEY_PREFIX = 'user:';
 const AVATAR_PREFIX = 'avatar:';
@@ -27,6 +29,7 @@ const ENABLE_ACCOUNTS = getConfigValue('enableUserAccounts', false, 'boolean');
 const AUTHELIA_AUTH = getConfigValue('sso.autheliaAuth', false, 'boolean');
 const AUTHENTIK_AUTH = getConfigValue('sso.authentikAuth', false, 'boolean');
 const PER_USER_BASIC_AUTH = getConfigValue('perUserBasicAuth', false, 'boolean');
+const TRUSTED_PROXIES = getConfigValue('sso.trustedProxies', ['::1', '127.0.0.1']);
 const ANON_CSRF_SECRET = crypto.randomBytes(64).toString('base64');
 
 /**
@@ -795,6 +798,32 @@ async function authentikUserLogin(request) {
 }
 
 /**
+ * Checks if an SSO header can be trusted based on the request IP and the configured trusted proxies.
+ * @param {string} ip Request socket IP
+ * @returns {boolean} Whether the request came from a trusted proxy
+ */
+function isRequestFromTrustedProxy(ip) {
+    if (!Array.isArray(TRUSTED_PROXIES)) {
+        console.warn(color.yellow('sso.trustedProxies is not an array. Please check your config.yaml. SSO auto-login will not work.'));
+        return false;
+    }
+
+    if (TRUSTED_PROXIES.length === 1 && TRUSTED_PROXIES[0] === '*') {
+        console.warn(color.yellow('sso.trustedProxies is set to accept all IPs. This is not recommended for production environments.'));
+        return true;
+    }
+
+    if (!ip || ip === 'unknown') {
+        return false;
+    }
+
+    const formatWarning = (entry, message) => `SSO trusted proxy ${color.red('Warning')}: Ignoring invalid entry ${color.yellow(entry)} - ${message}`;
+    const trustedProxies = filterValidIpPatterns(TRUSTED_PROXIES, formatWarning);
+
+    return trustedProxies.some(entry => ipMatching.matches(ip, ipMatching.getMatch(entry)));
+}
+
+/**
  * Tries auto-login with a given header.
  * @param {import('express').Request} request Request object
  * @param {string} [header='Remote-User'] The header to use for the trusted user
@@ -810,6 +839,12 @@ async function headerUserLogin(request, header = 'Remote-User') {
         return false;
     }
     console.debug(`Attempting auto-login for user from header ${header}: ${remoteUser}`);
+
+    const ip = getIpFromRequest(request);
+    if (!isRequestFromTrustedProxy(ip)) {
+        console.warn(color.yellow(`Received ${header} header from untrusted IP ${ip}. Ignoring for auto-login.`));
+        return false;
+    }
 
     const userHandles = await getAllUserHandles();
     for (const userHandle of userHandles) {

--- a/tests/security-compat.test.js
+++ b/tests/security-compat.test.js
@@ -1,0 +1,160 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+function withConfigEnv(values) {
+    const previous = {};
+    for (const [key, value] of Object.entries(values)) {
+        previous[key] = process.env[key];
+        process.env[key] = value;
+    }
+
+    return () => {
+        for (const [key, value] of Object.entries(previous)) {
+            if (value === undefined) {
+                delete process.env[key];
+            } else {
+                process.env[key] = value;
+            }
+        }
+    };
+}
+
+function makeRequest(headers = {}, remoteAddress = '::ffff:127.0.0.1') {
+    const normalized = Object.fromEntries(
+        Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]),
+    );
+    return {
+        headers: normalized,
+        socket: { remoteAddress },
+    };
+}
+
+describe('forwarded header helpers', () => {
+    test('uses only configured forwarded headers', async () => {
+        const restore = withConfigEnv({
+            SILLYTAVERN_FORWARDEDHEADERS_XREALIP: 'false',
+            SILLYTAVERN_FORWARDEDHEADERS_CFCONNECTINGIP: 'true',
+            SILLYTAVERN_FORWARDEDHEADERS_XFORWARDEDFOR: 'true',
+        });
+        jest.resetModules();
+
+        try {
+            const { getRealOrForwardedIp, getIpAddress } = await import('../src/express-common.js');
+            const request = makeRequest({
+                'x-real-ip': '198.51.100.10',
+                'cf-connecting-ip': '203.0.113.20',
+                'x-forwarded-for': '192.0.2.30, 192.0.2.31',
+            });
+
+            expect(getRealOrForwardedIp(request)).toBe('203.0.113.20');
+            expect(getIpAddress(request, true)).toBe('127.0.0.1 (forwarded: 203.0.113.20)');
+            expect(getIpAddress(request, false)).toBe('127.0.0.1');
+        } finally {
+            restore();
+        }
+    });
+
+    test('falls through to X-Forwarded-For when higher priority headers are disabled or absent', async () => {
+        const restore = withConfigEnv({
+            SILLYTAVERN_FORWARDEDHEADERS_XREALIP: 'false',
+            SILLYTAVERN_FORWARDEDHEADERS_CFCONNECTINGIP: 'false',
+            SILLYTAVERN_FORWARDEDHEADERS_XFORWARDEDFOR: 'true',
+        });
+        jest.resetModules();
+
+        try {
+            const { getRealOrForwardedIp } = await import('../src/express-common.js');
+            expect(getRealOrForwardedIp(makeRequest({
+                'x-real-ip': '198.51.100.10',
+                'x-forwarded-for': '192.0.2.30, 192.0.2.31',
+            }))).toBe('192.0.2.30');
+        } finally {
+            restore();
+        }
+    });
+});
+
+describe('rate-limit response helpers', () => {
+    test('sets Retry-After in seconds', async () => {
+        const [{ retryAfter }, { RateLimiterRes }] = await Promise.all([
+            import('../src/express-common.js'),
+            import('rate-limiter-flexible'),
+        ]);
+        const response = {
+            headersSent: false,
+            headers: {},
+            set(name, value) {
+                this.headers[name] = value;
+                return this;
+            },
+        };
+
+        expect(retryAfter(response, new RateLimiterRes(0, 2500, 3))).toBe(response);
+        expect(response.headers['Retry-After']).toBe('3');
+    });
+});
+
+describe('command-line keep-alive config', () => {
+    test('parses enableKeepAlive from environment-backed config', async () => {
+        const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-security-'));
+        const configPath = path.join(tempRoot, 'config.yaml');
+        const restore = withConfigEnv({
+            SILLYTAVERN_ENABLEKEEPALIVE: 'true',
+        });
+        jest.resetModules();
+
+        try {
+            const { CommandLineParser } = await import('../src/command-line.js');
+            const parser = new CommandLineParser();
+            const parsed = parser.parse(['node', 'server.js', '--configPath', configPath]);
+
+            expect(parsed.enableKeepAlive).toBe(true);
+        } finally {
+            restore();
+            fs.rmSync(tempRoot, { recursive: true, force: true });
+        }
+    });
+});
+
+describe('private request filter', () => {
+    test('blocks private addresses outside the allowlist', async () => {
+        const { PrivateRequestAgent } = await import('../src/private-request-filter.js');
+        const agent = new PrivateRequestAgent({
+            privateAddressWhitelist: [],
+            logBlocked: false,
+            logAllowed: false,
+            allowUnresolvedHosts: false,
+            enableKeepAlive: true,
+        });
+
+        await expect(agent.connect({}, {
+            host: '127.0.0.1',
+            secureEndpoint: false,
+            port: 80,
+        })).rejects.toThrow('Blocked request to private IP address: 127.0.0.1');
+        expect(agent.options.keepAlive).toBe(true);
+    });
+
+    test('allows allowlisted private addresses', async () => {
+        const { PrivateRequestAgent } = await import('../src/private-request-filter.js');
+        const agent = new PrivateRequestAgent({
+            privateAddressWhitelist: ['127.0.0.0/8'],
+            logBlocked: false,
+            logAllowed: false,
+            allowUnresolvedHosts: false,
+            enableKeepAlive: false,
+        });
+
+        const socket = await agent.connect({}, {
+            host: '127.0.0.1',
+            secureEndpoint: false,
+            port: 80,
+        });
+        socket.on('error', () => {});
+        socket.destroy();
+
+        expect(socket).toBeTruthy();
+    });
+});


### PR DESCRIPTION
## Summary
- wire upstream 1.18.0 server security config into runtime behavior: `enableKeepAlive`, private request filtering, forwarded headers, SSO trusted proxies, and auth rate limits
- add `src/private-request-filter.js` and thread keep-alive/private-filter state through global agents and request proxy setup
- update whitelist, access logging, basic auth, and user login/recovery paths to use upstream-compatible IP helpers and `Retry-After` handling
- add focused security compatibility unit coverage and ensure PR lint installs the existing test lint dependencies before linting changed test files

## Verification
- `npm ci --ignore-scripts`
- `npm ci --ignore-scripts --prefix tests`
- `bun install --frozen-lockfile --ignore-scripts`
- `npm run lint`
- `node node_modules/eslint/bin/eslint.js tests/security-compat.test.js --ignore-path=.gitignore --quiet`
- `npm run test:unit --prefix tests`
- Node startup smoke: `node --no-warnings server.js --port 4456 --browserLaunchEnabled=false --listen=false --disableCsrf`
- Bun startup smoke: `bun server.js --port 4457 --browserLaunchEnabled=false --listen=false --disableCsrf`

## Notes
- Draft PR per migration-series workflow; do not merge until explicitly promoted.
- Preserves SillyBunny session auth and HTTPS middleware behavior.
- Does not include immutable data override migration, provider/model work, extension lifecycle work, or UI polish.
- Existing local edits in `public/css/sillybunny-tabs.css` and `public/css/sillybunny-theme.css` remain unstaged and untouched.