### PR TITLE
fix: polish SillyBunny UI followups

### DIFF
--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -94,12 +94,12 @@
     }
 
     #right-nav-panel #CharListButtonAndHotSwaps :is(#rm_button_characters, #sb-character-right-lock, #sb-character-back-to-list, #sb-character-mobile-close) {
-        width: 36px;
-        min-width: 36px;
-        max-width: 36px;
-        height: 36px;
-        min-height: 36px;
-        max-height: 36px;
+        width: var(--sb-mobile-touch-target, 44px);
+        min-width: var(--sb-mobile-touch-target, 44px);
+        max-width: var(--sb-mobile-touch-target, 44px);
+        height: var(--sb-mobile-touch-target, 44px);
+        min-height: var(--sb-mobile-touch-target, 44px);
+        max-height: var(--sb-mobile-touch-target, 44px);
         margin: 0;
         padding: 0 !important;
         box-sizing: border-box;
@@ -1746,11 +1746,11 @@
 
     .group_speaker_controls {
         display: grid !important;
-        grid-template-columns: minmax(0, 1fr) repeat(4, 32px) !important;
+        grid-template-columns: minmax(0, 1fr) repeat(4, var(--sb-mobile-touch-target, 44px)) !important;
         grid-template-areas: "avatars speak dm chat auto" !important;
-        gap: 4px !important;
+        gap: 5px !important;
         align-items: center !important;
-        min-height: 40px !important;
+        min-height: calc(var(--sb-mobile-touch-target, 44px) + 8px) !important;
         padding: 4px 6px !important;
         margin-bottom: 2px !important;
         border-radius: 9px !important;
@@ -1771,7 +1771,7 @@
         text-overflow: ellipsis !important;
         white-space: nowrap !important;
         font-size: 14px !important;
-        line-height: 32px !important;
+        line-height: var(--sb-mobile-touch-target, 44px) !important;
         pointer-events: none !important;
     }
 
@@ -1782,8 +1782,8 @@
         justify-content: space-evenly !important;
         gap: 0 !important;
         min-width: 0 !important;
-        min-height: 32px !important;
-        max-height: 32px !important;
+        min-height: var(--sb-mobile-touch-target, 44px) !important;
+        max-height: var(--sb-mobile-touch-target, 44px) !important;
         overflow-x: auto !important;
         overflow-y: hidden !important;
         scrollbar-width: none !important;
@@ -1804,15 +1804,15 @@
     }
 
     .group_speaker_avatar {
-        width: 30px !important;
-        min-width: 30px !important;
-        max-width: 30px !important;
+        width: var(--sb-mobile-touch-target, 44px) !important;
+        min-width: var(--sb-mobile-touch-target, 44px) !important;
+        max-width: var(--sb-mobile-touch-target, 44px) !important;
         margin-inline: 1px !important;
-        height: 30px !important;
-        min-height: 30px !important;
-        max-height: 30px !important;
-        flex: 0 0 30px !important;
-        padding: 1px !important;
+        height: var(--sb-mobile-touch-target, 44px) !important;
+        min-height: var(--sb-mobile-touch-target, 44px) !important;
+        max-height: var(--sb-mobile-touch-target, 44px) !important;
+        flex: 0 0 var(--sb-mobile-touch-target, 44px) !important;
+        padding: 4px !important;
         gap: 0 !important;
         justify-content: center !important;
         border-radius: 999px !important;
@@ -1820,8 +1820,8 @@
     }
 
     .group_speaker_avatar img {
-        width: 26px !important;
-        height: 26px !important;
+        width: 34px !important;
+        height: 34px !important;
     }
 
     .group-dm-unread-dot {
@@ -1835,8 +1835,8 @@
     }
 
     .group_speaker_avatar.has-unread-dm {
-        border-color: #ff3b3b !important;
-        box-shadow: 0 0 0 1px color-mix(in srgb, #ff3b3b 42%, transparent) !important;
+        border-color: var(--sb-state-attention, var(--color-danger, #fb7185)) !important;
+        box-shadow: 0 0 0 1px var(--sb-state-attention-border, color-mix(in srgb, var(--color-danger, #fb7185) 42%, transparent)) !important;
         animation: none !important;
     }
 
@@ -1858,12 +1858,12 @@
     #group_speaker_dm_consolidate,
     #group_speaker_auto_dm,
     .group_speaker_toggle {
-        width: 32px !important;
-        min-width: 32px !important;
-        max-width: 32px !important;
-        height: 32px !important;
-        min-height: 32px !important;
-        max-height: 32px !important;
+        width: var(--sb-mobile-touch-target, 44px) !important;
+        min-width: var(--sb-mobile-touch-target, 44px) !important;
+        max-width: var(--sb-mobile-touch-target, 44px) !important;
+        height: var(--sb-mobile-touch-target, 44px) !important;
+        min-height: var(--sb-mobile-touch-target, 44px) !important;
+        max-height: var(--sb-mobile-touch-target, 44px) !important;
         padding: 0 !important;
         margin: 0 !important;
         display: inline-flex !important;

--- a/public/css/promptmanager.css
+++ b/public/css/promptmanager.css
@@ -560,10 +560,10 @@
 
     #completion_prompt_manager #completion_prompt_manager_list li.completion_prompt_manager_prompt .prompt_manager_prompt_controls span,
     #completion_prompt_manager #completion_prompt_manager_list li.completion_prompt_manager_prompt span span span {
-        height: 24px;
-        width: 24px;
-        flex-basis: 24px;
-        border-radius: 7px;
+        height: var(--sb-mobile-touch-target, 44px);
+        width: var(--sb-mobile-touch-target, 44px);
+        flex-basis: var(--sb-mobile-touch-target, 44px);
+        border-radius: var(--sb-icon-control-radius, 10px);
     }
 
     #completion_prompt_manager #completion_prompt_manager_list li.completion_prompt_manager_prompt span span span {
@@ -659,13 +659,13 @@
         min-height: 0;
         height: clamp(360px, 58vh, 820px);
         max-height: clamp(360px, 58vh, 820px);
-        padding: 16px;
-        border-radius: 22px;
-        border: 1px solid color-mix(in srgb, var(--SmartThemeBorderColor) 78%, transparent);
+        padding: 18px;
+        border-radius: var(--sb-radius-md, 16px);
+        border: 1px solid color-mix(in srgb, var(--SmartThemeBorderColor) 64%, transparent);
         background:
-            linear-gradient(180deg, color-mix(in srgb, var(--SmartThemeBodyColor) 6%, transparent), transparent 24%),
-            color-mix(in srgb, var(--SmartThemeBodyColor) 3%, transparent);
-        box-shadow: 0 18px 36px color-mix(in srgb, var(--SmartThemeShadowColor) 14%, transparent);
+            linear-gradient(180deg, color-mix(in srgb, var(--SmartThemeBodyColor) 4%, transparent), transparent 24%),
+            color-mix(in srgb, var(--SmartThemeBodyColor) 2%, transparent);
+        box-shadow: none;
         overflow: hidden;
     }
 

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1393,8 +1393,8 @@ body.sb-shell-resizing * {
     position: absolute;
     top: 50%;
     z-index: 3;
-    width: 28px;
-    height: 28px;
+    width: 34px;
+    height: 34px;
     display: none;
     align-items: center;
     justify-content: center;
@@ -1402,7 +1402,7 @@ body.sb-shell-resizing * {
     border-radius: 999px;
     background: color-mix(in srgb, var(--sb-surface-strong) 84%, transparent);
     color: var(--SmartThemeBodyColor);
-    box-shadow: 0 10px 24px color-mix(in srgb, var(--SmartThemeShadowColor) 24%, transparent);
+    box-shadow: 0 8px 18px color-mix(in srgb, var(--SmartThemeShadowColor) 14%, transparent);
     opacity: 0;
     pointer-events: none;
     transform: translateY(-50%);
@@ -1468,7 +1468,7 @@ body.sb-shell-resizing * {
     flex-direction: row;
     flex-wrap: nowrap;
     justify-content: center;
-    gap: 6px;
+    gap: 8px;
     padding: 12px 24px;
     background: transparent;
     border-bottom: 1px solid color-mix(in srgb, var(--sb-shell-border) 88%, transparent);
@@ -1537,7 +1537,7 @@ body.sb-shell-resizing * {
 
 .sb-shell-tab:hover {
     transform: none;
-    background: color-mix(in srgb, var(--sb-button-hover) 52%, transparent);
+    background: color-mix(in srgb, var(--sb-button-hover) 72%, transparent);
 }
 
 .sb-shell-tab i {
@@ -1573,7 +1573,7 @@ body.sb-shell-resizing * {
     border-color: color-mix(in srgb, var(--sb-shell-border) 85%, transparent);
     box-shadow:
         inset 0 0 0 1px color-mix(in srgb, var(--sb-shell-border) 78%, transparent),
-        inset 0 -2px 0 color-mix(in srgb, var(--color-primary, var(--sb-accent)) 34%, transparent);
+        inset 0 -2px 0 color-mix(in srgb, var(--color-primary, var(--sb-accent)) 42%, transparent);
     transform: none;
 }
 
@@ -2021,7 +2021,7 @@ body.sb-shell-resizing * {
     overflow-x: hidden;
     overscroll-behavior: contain;
     -webkit-overflow-scrolling: touch;
-    padding: 20px 24px var(--sb-shell-panel-bottom-padding);
+    padding: 22px 28px var(--sb-shell-panel-bottom-padding);
 }
 
 :root[data-sb-compact-mode='true'] .sb-shell-panel-scroller {
@@ -2031,7 +2031,7 @@ body.sb-shell-resizing * {
 .sb-shell-column {
     display: flex;
     flex-direction: column;
-    gap: 18px;
+    gap: 20px;
 }
 
 :root[data-sb-compact-mode='true'] .sb-shell-column {
@@ -2063,9 +2063,9 @@ body.sb-shell-resizing * {
 .sb-admin-card,
 .sb-theme-card {
     border-radius: var(--sb-radius-lg, 22px);
-    border: 1px solid color-mix(in srgb, var(--sb-shell-border) 84%, transparent);
+    border: 1px solid color-mix(in srgb, var(--sb-shell-border) 72%, transparent);
     background: transparent;
-    box-shadow: 0 18px 36px color-mix(in srgb, var(--SmartThemeShadowColor) 16%, transparent);
+    box-shadow: 0 10px 22px color-mix(in srgb, var(--SmartThemeShadowColor) 8%, transparent);
 }
 
 .sb-shell-callout::before,
@@ -2087,7 +2087,7 @@ body.sb-shell-resizing * {
 .sb-agent-hero,
 .sb-admin-card,
 .sb-theme-card {
-    padding: 20px;
+    padding: 18px;
 }
 
 :root[data-sb-compact-mode='true'] .sb-shell-callout,
@@ -4689,7 +4689,7 @@ body.sb-shell-resizing * {
         flex-basis: clamp(150px, 64vw, 204px);
         min-width: clamp(150px, 64vw, 204px);
         max-width: calc(100vw - 36px);
-        min-height: 42px;
+        min-height: var(--sb-mobile-touch-target, 44px);
         padding: 8px 12px;
         gap: 6px;
         align-items: center;
@@ -4852,9 +4852,9 @@ body.sb-shell-resizing * {
     #right-nav-panel.openDrawer > #CharListButtonAndHotSwaps {
         flex: 0 0 auto;
         display: grid;
-        grid-template-columns: 36px minmax(0, 1fr) 36px 36px;
+        grid-template-columns: var(--sb-mobile-touch-target, 44px) minmax(0, 1fr) var(--sb-mobile-touch-target, 44px) var(--sb-mobile-touch-target, 44px);
         align-items: center;
-        gap: 6px;
+        gap: 8px;
         width: 100%;
         min-width: 0;
         margin: 0;
@@ -4864,9 +4864,9 @@ body.sb-shell-resizing * {
     }
 
     #right-nav-panel.openDrawer > #CharListButtonAndHotSwaps > .flexFlowColumn.flex-container {
-        width: 36px;
-        min-width: 36px;
-        max-width: 36px;
+        width: var(--sb-mobile-touch-target, 44px);
+        min-width: var(--sb-mobile-touch-target, 44px);
+        max-width: var(--sb-mobile-touch-target, 44px);
         align-items: center;
         justify-content: center;
     }
@@ -4887,12 +4887,12 @@ body.sb-shell-resizing * {
     }
 
     #right-nav-panel.openDrawer :is(#rm_button_characters, #sb-character-right-lock, #sb-character-back-to-list, #sb-character-mobile-close) {
-        width: 36px;
-        min-width: 36px;
-        max-width: 36px;
-        height: 36px;
-        min-height: 36px;
-        max-height: 36px;
+        width: var(--sb-mobile-touch-target, 44px);
+        min-width: var(--sb-mobile-touch-target, 44px);
+        max-width: var(--sb-mobile-touch-target, 44px);
+        height: var(--sb-mobile-touch-target, 44px);
+        min-height: var(--sb-mobile-touch-target, 44px);
+        max-height: var(--sb-mobile-touch-target, 44px);
         margin: 0;
         padding: 0 !important;
         border-radius: 10px;
@@ -4912,8 +4912,8 @@ body.sb-shell-resizing * {
     }
 
     #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) > #CharListButtonAndHotSwaps {
-        grid-template-columns: 36px minmax(0, 1fr) 36px 36px 36px;
-        min-height: 46px;
+        grid-template-columns: var(--sb-mobile-touch-target, 44px) minmax(0, 1fr) var(--sb-mobile-touch-target, 44px) var(--sb-mobile-touch-target, 44px) var(--sb-mobile-touch-target, 44px);
+        min-height: 54px;
         padding-block: 5px;
     }
 
@@ -4948,13 +4948,13 @@ body.sb-shell-resizing * {
     #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) #right-nav-panel-tabs {
         position: relative;
         display: grid;
-        grid-template-columns: minmax(0, 1fr) 34px;
+        grid-template-columns: minmax(0, 1fr) var(--sb-mobile-touch-target, 44px);
         grid-template-areas:
             'title close'
             'meta meta';
         align-items: center;
         gap: 2px 6px;
-        min-height: 0;
+        min-height: var(--sb-mobile-touch-target, 44px);
         padding: 5px 8px;
         border: 1px solid color-mix(in srgb, var(--sb-shell-border) 72%, transparent);
         border-radius: 10px;
@@ -4963,10 +4963,10 @@ body.sb-shell-resizing * {
 
     #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) #rm_button_selected_ch {
         grid-area: title;
-        min-height: 30px;
+        min-height: var(--sb-mobile-touch-target, 44px);
         display: flex;
         align-items: center;
-        padding: 0 6px;
+        padding: 0 8px;
         border-radius: 8px;
     }
 
@@ -4978,11 +4978,11 @@ body.sb-shell-resizing * {
     #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) #result_info {
         grid-area: meta;
         display: grid !important;
-        grid-template-columns: minmax(0, 1fr) 32px 32px 32px;
+        grid-template-columns: minmax(0, 1fr) repeat(3, var(--sb-mobile-touch-target, 44px));
         align-items: center;
         justify-content: stretch;
-        gap: 3px;
-        min-height: 32px;
+        gap: 4px;
+        min-height: var(--sb-mobile-touch-target, 44px);
         padding: 0;
         font-size: calc(var(--mainFontSize) * 0.74);
     }
@@ -4994,12 +4994,12 @@ body.sb-shell-resizing * {
 
     #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) #result_info .right_menu_button,
     #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) #sb_character_editor_exit {
-        width: 32px;
-        min-width: 32px;
-        max-width: 32px;
-        height: 32px;
-        min-height: 32px;
-        max-height: 32px;
+        width: var(--sb-mobile-touch-target, 44px);
+        min-width: var(--sb-mobile-touch-target, 44px);
+        max-width: var(--sb-mobile-touch-target, 44px);
+        height: var(--sb-mobile-touch-target, 44px);
+        min-height: var(--sb-mobile-touch-target, 44px);
+        max-height: var(--sb-mobile-touch-target, 44px);
         margin: 0;
         padding: 0 !important;
         border-radius: 8px;

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -8,9 +8,9 @@
     --sb-radius-lg: 22px;
     --sb-radius-xl: 28px;
     --sb-radius-button: 14px;
-    --sb-transition-fast: 180ms ease;
-    --sb-transition: 240ms ease;
-    --sb-transition-slow: 360ms ease;
+    --sb-transition-fast: 180ms cubic-bezier(0.22, 1, 0.36, 1);
+    --sb-transition: 240ms cubic-bezier(0.22, 1, 0.36, 1);
+    --sb-transition-slow: 360ms cubic-bezier(0.22, 1, 0.36, 1);
     --sb-icon-control-size: 2rem;
     --sb-icon-control-radius: 10px;
     --sb-inline-drawer-icon-size: 2rem;
@@ -57,8 +57,8 @@
     --sb-shell-main-bg: color-mix(in srgb, var(--SmartThemeBlurTintColor) 93%, transparent);
     --sb-shell-nav-bg: color-mix(in srgb, var(--SmartThemeBlurTintColor) 88%, transparent);
     --sb-shell-header-bg: color-mix(in srgb, var(--SmartThemeBlurTintColor) 90%, transparent);
-    --sb-shell-header-glow: color-mix(in srgb, var(--SmartThemeQuoteColor) 18%, transparent);
-    --sb-shell-tab-active-bg: linear-gradient(135deg, color-mix(in srgb, var(--SmartThemeQuoteColor) 18%, transparent), color-mix(in srgb, var(--SmartThemeBodyColor) 4%, transparent));
+    --sb-shell-header-glow: color-mix(in srgb, var(--SmartThemeQuoteColor) 8%, transparent);
+    --sb-shell-tab-active-bg: color-mix(in srgb, var(--SmartThemeBodyColor) 7%, var(--SmartThemeBlurTintColor) 93%);
     --sb-shell-border: color-mix(in srgb, var(--SmartThemeBorderColor) 96%, transparent);
     --sb-shell-shadow: 0 32px 90px color-mix(in srgb, var(--SmartThemeShadowColor) 34%, transparent);
     --sb-chat-surface-source: color-mix(in srgb, var(--SmartThemeBlurTintColor) 92%, var(--SmartThemeChatTintColor) 8%);
@@ -71,7 +71,7 @@
     --sb-composer-input-bg: color-mix(in srgb, var(--SmartThemeBodyColor) 4%, var(--sb-composer-surface-base));
     --sb-card-bg: linear-gradient(180deg, color-mix(in srgb, var(--SmartThemeBodyColor) 6%, var(--SmartThemeBlurTintColor)), color-mix(in srgb, var(--SmartThemeBlurTintColor) 92%, transparent));
     --sb-button-bg: color-mix(in srgb, var(--SmartThemeBlurTintColor) 84%, transparent);
-    --sb-button-hover: color-mix(in srgb, var(--SmartThemeQuoteColor) 14%, transparent);
+    --sb-button-hover: color-mix(in srgb, var(--SmartThemeQuoteColor) 8%, var(--SmartThemeBodyColor) 4%);
     --sb-topbar-surface-bg: var(--sb-fixed-surface-bg);
     --sb-chatbar-surface-bg: var(--sb-fixed-surface-bg);
     --sb-mobile-overlay-bg: color-mix(in srgb, var(--sb-shell-main-bg) 96%, transparent);
@@ -80,6 +80,12 @@
     --sb-positive-bg: color-mix(in srgb, var(--SmartThemeQuoteColor) 22%, transparent);
     --sb-muted-fg: color-mix(in srgb, var(--SmartThemeBodyColor) 74%, transparent);
     --sb-muted-bg: color-mix(in srgb, var(--SmartThemeBodyColor) 7%, transparent);
+    --sb-state-favorite: color-mix(in srgb, var(--color-warning, var(--warning, #facc15)) 82%, var(--SmartThemeBodyColor) 18%);
+    --sb-state-favorite-bg: color-mix(in srgb, var(--sb-state-favorite) 14%, var(--sb-button-bg));
+    --sb-state-favorite-border: color-mix(in srgb, var(--sb-state-favorite) 40%, var(--sb-shell-border));
+    --sb-state-attention: color-mix(in srgb, var(--color-danger, var(--danger, #fb7185)) 86%, var(--SmartThemeBodyColor) 14%);
+    --sb-state-attention-bg: color-mix(in srgb, var(--sb-state-attention) 18%, transparent);
+    --sb-state-attention-border: color-mix(in srgb, var(--sb-state-attention) 44%, transparent);
     --sb-on-accent: rgb(0, 0, 0);
     --sb-on-solid-accent: var(--sb-on-accent);
     --sb-warning-fg: color-mix(in srgb, var(--warning, #ff6b6b) 72%, var(--SmartThemeBodyColor) 28%);
@@ -115,6 +121,16 @@
     --sb-chat-composer-edge-gap: 6px;
     --sb-icon-control-size: 1.85rem;
     --sb-inline-drawer-icon-size: 1.85rem;
+}
+
+@media (pointer: coarse), screen and (max-width: 760px) {
+    :root,
+    :root[data-sb-compact-mode='true'] {
+        --sb-control-min-height: var(--sb-mobile-touch-target);
+        --sb-control-icon-physical-size: var(--sb-mobile-touch-target);
+        --sb-icon-control-size: var(--sb-mobile-touch-target);
+        --sb-inline-drawer-icon-size: var(--sb-mobile-touch-target);
+    }
 }
 
 @supports (color: rgb(from black r g b / 1)) {
@@ -330,9 +346,10 @@ h3:not(.popup h3):not(#chat h3),
 
 .standoutHeader,
 h3:not(.popup h3):not(#chat h3) {
-    border-left: 3px solid color-mix(in srgb, var(--color-primary, var(--sb-accent)) 82%, transparent);
-    padding-left: 12px;
-    padding-right: 12px;
+    border: 1px solid color-mix(in srgb, var(--sb-shell-border) 74%, transparent);
+    border-radius: var(--sb-radius-md);
+    padding: 10px 14px;
+    background: color-mix(in srgb, var(--SmartThemeBodyColor) 4%, transparent);
     box-sizing: border-box;
 }
 
@@ -350,8 +367,8 @@ h3:not(.popup h3):not(#chat h3) {
 
 .inline-drawer-header:hover {
     background: var(--color-surface-hover, color-mix(in srgb, var(--SmartThemeBlurTintColor) 84%, var(--SmartThemeBodyColor) 16%));
-    border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 34%, transparent);
-    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-primary, var(--sb-accent)) 16%, transparent);
+    border-color: color-mix(in srgb, var(--sb-shell-border) 94%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--SmartThemeBodyColor) 8%, transparent);
 }
 
 .menu_button,
@@ -1323,14 +1340,18 @@ body.bubblechat .mes[is_user='true']::before {
 }
 
 .mes[is_user='true'] .mes_block {
-    border-left: 2px solid color-mix(in srgb, var(--color-primary, var(--sb-accent)) 60%, transparent);
-    padding-left: 10px;
+    box-sizing: border-box;
+    border: 1px solid color-mix(in srgb, var(--color-primary, var(--sb-accent)) 24%, transparent);
+    border-radius: var(--sb-radius-md);
+    padding: 10px 12px;
+    background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 4%, transparent);
 }
 
 body.flatchat .mes[is_user='true'] .mes_block,
 body.bubblechat .mes[is_user='true'] .mes_block {
-    border-left: 0;
-    padding-left: 10px;
+    border: 0;
+    padding: 0 0 0 10px;
+    background: transparent;
 }
 
 @media screen and (max-width: 1000px) {
@@ -2362,9 +2383,9 @@ input[type='range']::-moz-range-thumb {
 }
 
 #model_openai_favorite_toggle.is-favorite {
-    color: #f4c95d;
-    border-color: color-mix(in srgb, #f4c95d 48%, var(--sb-shell-border));
-    background: color-mix(in srgb, #f4c95d 16%, var(--sb-button-bg));
+    color: var(--sb-state-favorite);
+    border-color: var(--sb-state-favorite-border);
+    background: var(--sb-state-favorite-bg);
 }
 
 #openai_model_picker_hint {

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -200,15 +200,15 @@ const SB_SHELLS = Object.freeze({
         proxyIcon: 'fa-bars',
         proxyLabel: 'Workspace',
         title: 'Workspace',
-        subtitle: 'Back end modifications, model setup, presets, lorebooks, and formatting tools live here.',
-        searchPlaceholder: 'Quick find presets, samplers, lorebooks...',
+        subtitle: 'Set up models, prompts, lore, and helpers, then get back to the scene.',
+        searchPlaceholder: 'Find presets, samplers, lore, or tools...',
         storageKey: SB_STORAGE_KEYS.leftTab,
         defaultTabId: 'presets',
         baseTab: {
             id: 'presets',
             label: 'Presets',
             icon: 'fa-sliders',
-            description: 'Change presets, edit system prompts, and modify other output settings here.',
+            description: 'Choose presets and tune the prompts that shape each reply.',
         },
         embeddedTabs: [
             {
@@ -216,21 +216,21 @@ const SB_SHELLS = Object.freeze({
                 drawerId: 'sys-settings-button',
                 label: 'API',
                 icon: 'fa-plug',
-                description: 'Connect providers, select models, and manage backend-specific options here.',
+                description: 'Connect a provider, pick a model, and test the connection.',
             },
             {
                 id: 'advanced-formatting',
                 drawerId: 'advanced-formatting-button',
                 label: 'Formatting',
                 icon: 'fa-text-height',
-                description: 'Tune context and instruction formatting tools here.',
+                description: 'Adjust how context, instructions, and reasoning are formatted.',
             },
             {
                 id: 'world-info',
                 drawerId: 'WI-SP-button',
                 label: 'World Info',
                 icon: 'fa-book-atlas',
-                description: 'Edit and access lorebooks and world entries here.',
+                description: 'Manage lorebooks and world details for the current story.',
             },
         ],
         customTabs: [
@@ -238,7 +238,7 @@ const SB_SHELLS = Object.freeze({
                 id: 'sampling',
                 label: 'Sampling',
                 icon: 'fa-wave-square',
-                description: 'Control model sampling, seeds, and banned logits/tokens here.',
+                description: 'Tune generation style, randomness, seeds, and token controls.',
                 searchPlaceholder: 'Search temperature, top p, repetition penalty, or backend samplers',
                 searchExamples: ['temperature', 'top p', 'repetition penalty'],
             },
@@ -246,7 +246,7 @@ const SB_SHELLS = Object.freeze({
                 id: 'agents',
                 label: 'Agents',
                 icon: 'fa-robot',
-                description: 'Configure in-chat agent helpers.',
+                description: 'Manage helpers that can assist during the conversation.',
             },
         ],
     },
@@ -4406,15 +4406,6 @@ function closeAllDropdowns({ except = '' } = {}) {
     document.getElementById('sb-persona-picker')?.remove();
 }
 
-function closeNonShellDropdowns({ except = '' } = {}) {
-    if (except !== 'characters') closeCharacterPanel();
-    if (except !== 'search') setUniversalSearchOpenState(false);
-    closeMobileNav();
-    closeMobileChatTools();
-    setConnectionStripOpenState(false);
-    document.getElementById('sb-persona-picker')?.remove();
-}
-
 function toggleShellPanel(shellKey, tabId = null) {
     if (!ensureShellReady(shellKey)) {
         return;
@@ -4429,7 +4420,7 @@ function toggleShellPanel(shellKey, tabId = null) {
         return;
     }
 
-    closeNonShellDropdowns();
+    closeAllDropdowns({ except: shellKey });
     window.requestAnimationFrame(() => openShell(shellKey, tabId));
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -2784,7 +2784,10 @@ textarea::placeholder {
     width: 100%;
     margin: 5px 0;
     height: fit-content;
-    transition: all 0.5s ease;
+    transition:
+        border-color var(--sb-transition-fast, 180ms cubic-bezier(0.22, 1, 0.36, 1)),
+        background-color var(--sb-transition-fast, 180ms cubic-bezier(0.22, 1, 0.36, 1)),
+        box-shadow var(--sb-transition-fast, 180ms cubic-bezier(0.22, 1, 0.36, 1));
 }
 
 .text_pole:hover {
@@ -7215,7 +7218,7 @@ body:not(.movingUI) .drawer-content.maximized {
     padding: 10px 1em;
     margin: 1em 0;
     border-radius: 10px;
-    border-left: 5px solid;
+    border: 1px solid;
     background-color: var(--SmartThemeBlurTintColor);
     color: var(--SmartThemeBodyColor);
     backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)));
@@ -7486,8 +7489,8 @@ body:not(.movingUI) .drawer-content.maximized {
 }
 
 .group_speaker_avatar.has-unread-dm {
-    border-color: #ff3b3b;
-    box-shadow: 0 0 0 1px color-mix(in srgb, #ff3b3b 42%, transparent);
+    border-color: var(--sb-state-attention, var(--color-danger, #fb7185));
+    box-shadow: 0 0 0 1px var(--sb-state-attention-border, color-mix(in srgb, var(--color-danger, #fb7185) 42%, transparent));
 }
 
 .group_speaker_avatar.has-unread-dm::after {
@@ -7496,8 +7499,8 @@ body:not(.movingUI) .drawer-content.maximized {
     inset: -4px;
     z-index: -1;
     border-radius: inherit;
-    background: color-mix(in srgb, #ff3b3b 24%, transparent);
-    box-shadow: 0 0 10px color-mix(in srgb, #ff3b3b 55%, transparent);
+    background: var(--sb-state-attention-bg, color-mix(in srgb, var(--color-danger, #fb7185) 24%, transparent));
+    box-shadow: 0 0 10px color-mix(in srgb, var(--sb-state-attention, var(--color-danger, #fb7185)) 42%, transparent);
     opacity: 0.78;
     pointer-events: none;
     transform: scale(1);
@@ -7678,9 +7681,11 @@ body:not(.movingUI) .drawer-content.maximized {
     min-height: 10px;
     padding: 0;
     border-radius: 50%;
-    background: #ff3b3b;
+    background: var(--sb-state-attention, var(--color-danger, #fb7185));
     border: 2px solid var(--SmartThemeBlurTintColor);
-    box-shadow: 0 0 0 1px color-mix(in srgb, #ff3b3b 65%, transparent), 0 0 7px color-mix(in srgb, #ff3b3b 75%, transparent);
+    box-shadow:
+        0 0 0 1px var(--sb-state-attention-border, color-mix(in srgb, var(--color-danger, #fb7185) 65%, transparent)),
+        0 0 7px color-mix(in srgb, var(--sb-state-attention, var(--color-danger, #fb7185)) 58%, transparent);
     pointer-events: none;
 }
 


### PR DESCRIPTION
## What?
This PR makes the Workspace and Customize shells mutually exclusive so menus cannot overlap. It also completes UI polish follow-ups for theme tokens, mobile touch targets, calmer shell surfaces, and keeps OOC/status accents on semantic tokens.

## Why?
The shell needed clearer state boundaries so users could not end up with overlapping menus, especially on mobile. The follow-up polish keeps the UI consistent while preserving the safer OOC rendering behavior from the prior work.

## How?
The shell state now coordinates Workspace and Customize visibility as exclusive modes. The styling changes continue using semantic theme tokens and touch-safe sizing rather than introducing a separate visual system.

## Testing?
- `npm run lint`
- `npm run test:unit --prefix tests -- tests/ooc-blocks.test.js`
- `npm run test:unit --prefix tests`
- `git diff --check`
- Chromium drawer mutual-exclusion check

## Screenshots (optional)
Screenshots were not included. A Chromium drawer probe verified the mutual-exclusion behavior.

## Anything Else?
3SR was run locally; no correctness or security blockers were found. Residual risk was normal CSS/UI breadth.