### PR TITLE
fix: improve mobile UI accessibility polish

### DIFF
--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -46,7 +46,7 @@
     --sb-proxy-label-scale-base: 0.76;
     --sb-proxy-underline-inset-base: 12px;
     --sb-proxy-underline-bottom-base: 5px;
-    --sb-mobile-toggle-size-base: 40px;
+    --sb-mobile-toggle-size-base: 44px;
     --sb-home-toggle-min-width-base: 92px;
     --sb-topbar-compact-icon-scale-base: 0.84;
     --sb-mobile-tools-padding-top-base: 10px;
@@ -101,8 +101,8 @@
     --sb-proxy-label-size: calc(var(--mainFontSize) * var(--sb-proxy-label-scale-base));
     --sb-proxy-underline-inset: var(--sb-proxy-underline-inset-base);
     --sb-proxy-underline-bottom: var(--sb-proxy-underline-bottom-base);
-    --sb-mobile-toggle-size: calc(var(--sb-mobile-toggle-size-base) * var(--sb-mobile-button-scale));
-    --sb-home-toggle-min-width: calc(var(--sb-home-toggle-min-width-base) * var(--sb-mobile-button-scale));
+    --sb-mobile-toggle-size: max(44px, calc(var(--sb-mobile-toggle-size-base) * var(--sb-mobile-button-scale)));
+    --sb-home-toggle-min-width: max(44px, calc(var(--sb-home-toggle-min-width-base) * var(--sb-mobile-button-scale)));
     --sb-topbar-compact-icon-size: calc(var(--mainFontSize) * var(--sb-topbar-compact-icon-scale-base));
     --sb-topbar-primary-min-height: max(var(--sb-proxy-button-height), var(--sb-mobile-toggle-size));
     --sb-topbar-primary-height: max(calc(var(--sb-topbar-primary-height-base) * var(--sb-topbar-scale-active)), var(--sb-topbar-primary-min-height));
@@ -113,9 +113,9 @@
     --sb-mobile-tools-gap: calc(var(--sb-mobile-tools-gap-base) * var(--sb-topbar-scale-active));
     --sb-mobile-tools-header-gap: calc(var(--sb-mobile-tools-header-gap-base) * var(--sb-topbar-scale-active));
     --sb-mobile-tools-actions-gap: calc(var(--sb-mobile-tools-actions-gap-base) * var(--sb-topbar-scale-active));
-    --sb-mobile-tools-button-size: calc(var(--sb-mobile-tools-button-size-base) * var(--sb-topbar-scale-active) * var(--sb-mobile-button-scale));
+    --sb-mobile-tools-button-size: max(44px, calc(var(--sb-mobile-tools-button-size-base) * var(--sb-topbar-scale-active) * var(--sb-mobile-button-scale)));
     --sb-mobile-tools-button-radius: calc(var(--sb-mobile-tools-button-radius-base) * var(--sb-topbar-scale-active) * var(--sb-mobile-button-scale));
-    --sb-mobile-tools-field-height: calc(var(--sb-mobile-tools-field-height-base) * var(--sb-topbar-scale-active));
+    --sb-mobile-tools-field-height: max(44px, calc(var(--sb-mobile-tools-field-height-base) * var(--sb-topbar-scale-active)));
     --sb-mobile-tools-field-padding-x: calc(var(--sb-mobile-tools-field-padding-x-base) * var(--sb-topbar-scale-active));
     --sb-mobile-tools-field-icon-size: calc(var(--mainFontSize) * var(--sb-mobile-tools-field-icon-scale-base) * var(--sb-topbar-scale-active));
     --sb-mobile-tools-input-height: calc(var(--sb-mobile-tools-input-height-base) * var(--sb-topbar-scale-active));
@@ -144,22 +144,22 @@
     --sb-chatbar-gap-base: 4px;
     --sb-chatbar-padding-y-base: 3px;
     --sb-chatbar-padding-x-base: 5px;
-    --sb-chatbar-button-size-base: 26px;
-    --sb-chatbar-field-height-base: 26px;
+    --sb-chatbar-button-size-base: 30px;
+    --sb-chatbar-field-height-base: 30px;
     --sb-chatbar-field-padding-x-base: 7px;
     --sb-chatbar-input-font-scale-base: 0.66;
     --sb-proxy-button-padding-x-base: 11px;
-    --sb-proxy-button-height-base: 34px;
+    --sb-proxy-button-height-base: 40px;
     --sb-proxy-button-min-width-base: 88px;
     --sb-proxy-button-gap-base: 6px;
-    --sb-mobile-toggle-size-base: 34px;
+    --sb-mobile-toggle-size-base: 44px;
     --sb-home-toggle-min-width-base: 78px;
     --sb-mobile-tools-padding-top-base: 7px;
     --sb-mobile-tools-padding-x-base: 7px;
     --sb-mobile-tools-padding-bottom-base: 8px;
     --sb-mobile-tools-gap-base: 6px;
-    --sb-mobile-tools-button-size-base: 26px;
-    --sb-mobile-tools-field-height-base: 26px;
+    --sb-mobile-tools-button-size-base: 30px;
+    --sb-mobile-tools-field-height-base: 30px;
     --sb-shell-panel-bottom-padding: clamp(30px, 4vh, 52px);
 }
 
@@ -1373,6 +1373,12 @@ body.movingUI #right-nav-panel.openDrawer > .sb-shell-resize-handle {
 .sb-shell-root.sb-shell-resize-active .sb-shell-resize-handle,
 #right-nav-panel.sb-shell-resize-active > .sb-shell-resize-handle,
 .sb-shell-resize-handle:hover {
+    opacity: 1;
+}
+
+.sb-shell-resize-handle:focus-visible {
+    outline: 2px solid var(--color-focus-ring, var(--color-primary, var(--sb-accent)));
+    outline-offset: 3px;
     opacity: 1;
 }
 
@@ -3036,7 +3042,7 @@ body.sb-shell-resizing * {
     border-radius: var(--sb-radius-xl, 22px);
     background: var(--sb-composer-surface-bg, var(--sb-chat-surface-bg, color-mix(in srgb, var(--SmartThemeBlurTintColor) 92%, var(--SmartThemeChatTintColor) 8%)));
     box-shadow: 0 10px 26px color-mix(in srgb, var(--SmartThemeShadowColor) 12%, transparent);
-    min-height: calc(34px * var(--sb-bottom-bar-scale));
+    min-height: max(44px, calc(34px * var(--sb-bottom-bar-scale)));
     overflow: hidden;
 }
 
@@ -3047,7 +3053,8 @@ body.sb-shell-resizing * {
 #sb-bottom-chat-select {
     flex: 1;
     min-width: 0;
-    height: calc(28px * var(--sb-bottom-bar-scale));
+    height: max(44px, calc(28px * var(--sb-bottom-bar-scale)));
+    min-height: max(44px, calc(28px * var(--sb-bottom-bar-scale)));
     margin: 0;
     padding: 0 calc(12px * var(--sb-bottom-bar-scale));
     box-sizing: border-box;
@@ -3081,7 +3088,8 @@ body.sb-shell-resizing * {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-height: calc(28px * var(--sb-bottom-bar-scale));
+    min-width: max(44px, calc(28px * var(--sb-bottom-bar-scale)));
+    min-height: max(44px, calc(28px * var(--sb-bottom-bar-scale)));
     margin: 0;
     padding: calc(4px * var(--sb-bottom-bar-scale)) calc(8px * var(--sb-bottom-bar-scale));
     box-sizing: border-box;
@@ -3108,22 +3116,22 @@ body.sb-shell-resizing * {
         gap: calc(4px * var(--sb-bottom-bar-scale));
         margin: 0 max(12px, env(safe-area-inset-right)) 6px max(12px, env(safe-area-inset-left));
         padding: calc(4px * var(--sb-bottom-bar-scale)) calc(6px * var(--sb-bottom-bar-scale));
-        min-height: calc(42px * var(--sb-bottom-bar-scale));
+        min-height: max(52px, calc(42px * var(--sb-bottom-bar-scale)));
         border-radius: calc(14px * var(--sb-bottom-bar-scale));
     }
 
     #sb-bottom-chat-select {
         flex: 1 1 72px;
-        height: calc(34px * var(--sb-bottom-bar-scale));
-        min-height: calc(34px * var(--sb-bottom-bar-scale));
+        height: max(44px, calc(34px * var(--sb-bottom-bar-scale)));
+        min-height: max(44px, calc(34px * var(--sb-bottom-bar-scale)));
         padding: 0 calc(8px * var(--sb-bottom-bar-scale));
         font-size: calc(var(--mainFontSize) * 0.78 * var(--sb-bottom-bar-scale));
         border-radius: calc(11px * var(--sb-bottom-bar-scale));
     }
 
     .sb-bottom-chat-btn {
-        min-width: calc(34px * var(--sb-bottom-bar-scale));
-        min-height: calc(34px * var(--sb-bottom-bar-scale));
+        min-width: max(44px, calc(34px * var(--sb-bottom-bar-scale)));
+        min-height: max(44px, calc(34px * var(--sb-bottom-bar-scale)));
         padding: 0 calc(6px * var(--sb-bottom-bar-scale));
         border-radius: calc(9px * var(--sb-bottom-bar-scale));
         font-size: calc(var(--mainFontSize) * 0.78 * var(--sb-bottom-bar-scale));
@@ -3134,22 +3142,22 @@ body.sb-shell-resizing * {
     #sb-bottom-chat-bar {
         gap: calc(3px * var(--sb-bottom-bar-scale));
         padding: calc(3px * var(--sb-bottom-bar-scale)) calc(5px * var(--sb-bottom-bar-scale));
-        min-height: calc(38px * var(--sb-bottom-bar-scale));
+        min-height: max(52px, calc(38px * var(--sb-bottom-bar-scale)));
         border-radius: calc(13px * var(--sb-bottom-bar-scale));
     }
 
     #sb-bottom-chat-select {
         flex-basis: 58px;
-        height: calc(30px * var(--sb-bottom-bar-scale));
-        min-height: calc(30px * var(--sb-bottom-bar-scale));
+        height: max(44px, calc(30px * var(--sb-bottom-bar-scale)));
+        min-height: max(44px, calc(30px * var(--sb-bottom-bar-scale)));
         padding: 0 calc(6px * var(--sb-bottom-bar-scale));
         font-size: calc(var(--mainFontSize) * 0.72 * var(--sb-bottom-bar-scale));
         border-radius: calc(10px * var(--sb-bottom-bar-scale));
     }
 
     .sb-bottom-chat-btn {
-        min-width: calc(30px * var(--sb-bottom-bar-scale));
-        min-height: calc(30px * var(--sb-bottom-bar-scale));
+        min-width: max(44px, calc(30px * var(--sb-bottom-bar-scale)));
+        min-height: max(44px, calc(30px * var(--sb-bottom-bar-scale)));
         padding: 0 calc(5px * var(--sb-bottom-bar-scale));
         font-size: calc(var(--mainFontSize) * 0.72 * var(--sb-bottom-bar-scale));
     }
@@ -3339,10 +3347,10 @@ body.sb-shell-resizing * {
 
 /* Persona quick-access bubble */
 #sb-persona-bubble {
-    width: 32px;
-    height: 32px;
-    min-width: 32px;
-    min-height: 32px;
+    width: 44px;
+    height: 44px;
+    min-width: 44px;
+    min-height: 44px;
     aspect-ratio: 1;
     border-radius: 50%;
     border: 2px solid color-mix(in srgb, var(--SmartThemeBorderColor) 50%, transparent);
@@ -3361,20 +3369,20 @@ body.sb-shell-resizing * {
 
 @media screen and (max-width: 768px) {
     #sb-persona-bubble {
-        width: 34px;
-        height: 34px;
-        min-width: 34px;
-        min-height: 34px;
+        width: 44px;
+        height: 44px;
+        min-width: 44px;
+        min-height: 44px;
         border-width: 1px;
     }
 }
 
 @media screen and (max-width: 420px) {
     #sb-persona-bubble {
-        width: 30px;
-        height: 30px;
-        min-width: 30px;
-        min-height: 30px;
+        width: 44px;
+        height: 44px;
+        min-width: 44px;
+        min-height: 44px;
     }
 }
 
@@ -3397,23 +3405,44 @@ body.sb-shell-resizing * {
 }
 
 .sb-persona-option {
+    appearance: none;
+    width: 100%;
+    border: 0;
+    background: transparent;
     display: flex;
     align-items: center;
     gap: 8px;
     padding: 6px 10px;
     border-radius: 8px;
     cursor: pointer;
+    text-align: left;
     transition: background-color 150ms ease;
     font-size: calc(var(--mainFontSize) * 0.85);
     color: var(--SmartThemeBodyColor);
+    min-height: 44px;
 }
 
-.sb-persona-option:hover {
+.sb-persona-option:hover,
+.sb-persona-option:focus-visible {
     background: color-mix(in srgb, var(--SmartThemeBodyColor) 10%, transparent);
+}
+
+.sb-persona-option:focus-visible {
+    outline: 2px solid var(--color-focus-ring, var(--color-primary, var(--sb-accent)));
+    outline-offset: 2px;
 }
 
 .sb-persona-option.is-active {
     background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 20%, transparent);
+}
+
+.sb-persona-option-empty {
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    padding: 6px 10px;
+    color: color-mix(in srgb, var(--SmartThemeBodyColor) 64%, transparent);
+    font-size: calc(var(--mainFontSize) * 0.85);
 }
 
 .sb-persona-option-avatar {
@@ -3921,8 +3950,8 @@ body.sb-shell-resizing * {
         --sb-chatbar-field-radius-base: 12px;
         --sb-chatbar-field-icon-scale-base: 0.60;
         --sb-chatbar-input-font-scale-base: 0.66;
-        --sb-mobile-toggle-size-base: 34px;
-        --sb-home-toggle-min-width-base: 34px;
+        --sb-mobile-toggle-size-base: 44px;
+        --sb-home-toggle-min-width-base: 44px;
         --sb-proxy-underline-inset-base: 8px;
         --sb-proxy-underline-bottom-base: 4px;
     }
@@ -5305,5 +5334,15 @@ body.sb-shell-resizing * {
 
     .sb-search-hit {
         animation: none;
+    }
+
+    .sb-bottom-chat-btn,
+    #sb-bottom-chat-select,
+    #sb-persona-bubble,
+    #sb-persona-picker,
+    .sb-persona-option,
+    .sb-shell-resize-handle {
+        animation: none !important;
+        transition-duration: 0.01ms !important;
     }
 }

--- a/public/script.js
+++ b/public/script.js
@@ -11944,7 +11944,10 @@ function openAlternateGreetings() {
         }
 
         field.focus({ preventScroll: true });
-        field.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+        field.scrollIntoView({
+            block: 'nearest',
+            behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth',
+        });
     });
 }
 

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -1034,6 +1034,10 @@ function isMobileViewport() {
     return window.matchMedia(SB_MOBILE_MEDIA_QUERY).matches;
 }
 
+function prefersReducedMotion() {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
 function isTouchOnlyDesktopViewport() {
     const hasHover = window.matchMedia('(hover: hover), (any-hover: hover)').matches;
     const hasFinePointer = window.matchMedia('(pointer: fine), (any-pointer: fine)').matches;
@@ -1309,6 +1313,7 @@ function syncDesktopShellSizing() {
         if (isMobileViewport()) {
             clearDesktopShellSize(root);
             root.classList.remove('sb-shell-can-resize');
+            syncShellResizeHandleValue(shellKey, null);
             continue;
         }
 
@@ -1318,6 +1323,7 @@ function syncDesktopShellSizing() {
             }
 
             root.classList.remove('sb-shell-can-resize');
+            syncShellResizeHandleValue(shellKey, null);
             continue;
         }
 
@@ -1343,6 +1349,7 @@ function syncDesktopShellSizing() {
 
         applyDesktopShellSize(root, sizeToApply);
         root.classList.toggle('sb-shell-can-resize', resizingEnabled);
+        syncShellResizeHandleValue(shellKey, sizeToApply);
     }
 
     syncCharacterDrawerLockPosition();
@@ -1366,6 +1373,7 @@ function isPrimaryShellResizeStart(event) {
 
 function bindShellResizeHandle(handle, shellKey) {
     stopProxyPointerPropagation(handle);
+    configureShellResizeHandle(handle, shellKey);
     handle.addEventListener('pointerdown', event => beginShellResize(shellKey, event));
     handle.addEventListener('mousedown', event => {
         if (event.defaultPrevented || sbState.shellSizing.activeResize) {
@@ -1374,6 +1382,94 @@ function bindShellResizeHandle(handle, shellKey) {
 
         beginShellResize(shellKey, event);
     });
+    handle.addEventListener('keydown', event => handleShellResizeKeydown(shellKey, event));
+}
+
+function configureShellResizeHandle(handle, shellKey) {
+    const bounds = getDesktopShellResizeBounds(shellKey);
+    const currentSize = getShellSizeOverride(shellKey) ?? {
+        width: bounds.defaultWidth,
+        height: bounds.defaultHeight,
+    };
+    const label = shellKey === 'characters' ? 'Characters' : getShellConfig(shellKey)?.title || 'panel';
+
+    handle.setAttribute('role', 'separator');
+    handle.setAttribute('aria-orientation', 'horizontal');
+    handle.setAttribute('aria-label', `Resize ${label} panel`);
+    handle.setAttribute('aria-valuemin', String(bounds.minWidth));
+    handle.setAttribute('aria-valuemax', String(bounds.maxWidth));
+    handle.setAttribute('aria-valuenow', String(Math.round(currentSize.width)));
+    handle.setAttribute('aria-valuetext', `${Math.round(currentSize.width)} pixels wide, ${Math.round(currentSize.height)} pixels tall`);
+    handle.tabIndex = canResizeDesktopShells() ? 0 : -1;
+}
+
+function syncShellResizeHandleValue(shellKey, size) {
+    const root = getResizableShellRoot(shellKey);
+    const shellState = getShellState(shellKey);
+    const handle = shellState?.resizeHandle ?? root?.querySelector(':scope > .sb-shell-resize-handle, .sb-shell-resize-handle');
+    if (!(handle instanceof HTMLElement)) {
+        return;
+    }
+
+    if (!size) {
+        configureShellResizeHandle(handle, shellKey);
+        return;
+    }
+
+    configureShellResizeHandle(handle, shellKey);
+    handle.setAttribute('aria-valuenow', String(Math.round(size.width)));
+    handle.setAttribute('aria-valuetext', `${Math.round(size.width)} pixels wide, ${Math.round(size.height)} pixels tall`);
+}
+
+function handleShellResizeKeydown(shellKey, event) {
+    if (!canResizeDesktopShells() || !isDesktopResizableShell(shellKey)) {
+        return;
+    }
+
+    const root = getResizableShellRoot(shellKey);
+    if (!(root instanceof HTMLElement) || !root.classList.contains('openDrawer')) {
+        return;
+    }
+
+    const bounds = getDesktopShellResizeBounds(shellKey);
+    const currentRect = root.getBoundingClientRect();
+    const currentSize = clampShellSize({
+        width: currentRect.width || bounds.defaultWidth,
+        height: currentRect.height || bounds.defaultHeight,
+    }, bounds);
+
+    if (!currentSize) {
+        return;
+    }
+
+    const step = event.shiftKey ? 72 : 24;
+    let nextSize = currentSize;
+
+    if (event.key === 'ArrowLeft') {
+        nextSize = { ...currentSize, width: currentSize.width - step };
+    } else if (event.key === 'ArrowRight') {
+        nextSize = { ...currentSize, width: currentSize.width + step };
+    } else if (event.key === 'ArrowUp') {
+        nextSize = { ...currentSize, height: currentSize.height - step };
+    } else if (event.key === 'ArrowDown') {
+        nextSize = { ...currentSize, height: currentSize.height + step };
+    } else if (event.key === 'Home') {
+        nextSize = { ...currentSize, width: bounds.minWidth };
+    } else if (event.key === 'End') {
+        nextSize = { ...currentSize, width: bounds.maxWidth };
+    } else {
+        return;
+    }
+
+    const clampedSize = clampShellSize(nextSize, bounds);
+    if (!clampedSize) {
+        return;
+    }
+
+    event.preventDefault();
+    setShellSizeOverride(shellKey, clampedSize);
+    applyDesktopShellSize(root, clampedSize);
+    syncShellResizeHandleValue(shellKey, clampedSize);
 }
 
 function beginShellResize(shellKey, event) {
@@ -1457,6 +1553,7 @@ function beginShellResize(shellKey, event) {
 
         sbState.shellSizing.overrides[getShellSizingKey(shellKey)] = nextSize;
         applyDesktopShellSize(root, nextSize);
+        syncShellResizeHandleValue(shellKey, nextSize);
     };
 
     const onPointerUp = endEvent => {
@@ -1467,6 +1564,7 @@ function beginShellResize(shellKey, event) {
         const activeSize = getShellSizeOverride(shellKey) ?? startSize;
         cleanup();
         setShellSizeOverride(shellKey, activeSize);
+        syncShellResizeHandleValue(shellKey, activeSize);
         syncDesktopShellSizing();
     };
 
@@ -4338,9 +4436,6 @@ function ensureCharacterResizeHandle() {
     handle = createElement('div', {
         className: 'sb-shell-resize-handle',
         attrs: {
-            role: 'separator',
-            'aria-orientation': 'both',
-            'aria-label': 'Resize Characters panel',
             title: 'Resize Characters panel',
         },
     });
@@ -8103,7 +8198,7 @@ function setActiveTab(shellKey, tabId, { focusButton = false } = {}) {
     activeTab.button?.scrollIntoView({
         block: 'nearest',
         inline: 'nearest',
-        behavior: focusButton ? 'smooth' : 'auto',
+        behavior: focusButton && !prefersReducedMotion() ? 'smooth' : 'auto',
     });
     shellState.updateNavScrollIndicators?.();
 
@@ -8233,7 +8328,7 @@ function buildShell(shellKey) {
     const scrollNavByPage = direction => {
         nav.scrollBy({
             left: direction * Math.max(nav.clientWidth * 0.72, 160),
-            behavior: 'smooth',
+            behavior: prefersReducedMotion() ? 'auto' : 'smooth',
         });
     };
 
@@ -8271,7 +8366,6 @@ function buildShell(shellKey) {
     const resizeHandle = createElement('div', {
         className: 'sb-shell-resize-handle',
         attrs: {
-            'aria-hidden': 'true',
             title: `Resize ${shellConfig.title}`,
         },
     });
@@ -9480,6 +9574,7 @@ function togglePersonaPicker() {
     const existing = document.getElementById('sb-persona-picker');
     if (existing) {
         existing.remove();
+        document.getElementById('sb-persona-bubble')?.focus({ preventScroll: true });
         return;
     }
 
@@ -9488,7 +9583,13 @@ function togglePersonaPicker() {
 
     const { personas, currentAvatarId } = getCurrentPersonaSelection(context);
     const personaDescriptions = context?.powerUserSettings?.persona_descriptions ?? {};
-    const picker = createElement('div', { id: 'sb-persona-picker' });
+    const picker = createElement('div', {
+        id: 'sb-persona-picker',
+        attrs: {
+            role: 'listbox',
+            'aria-label': 'Choose persona',
+        },
+    });
 
     const keys = Object.keys(personas).filter(avatarId => {
         const name = personas[avatarId];
@@ -9498,7 +9599,7 @@ function togglePersonaPicker() {
     });
 
     if (!keys.length) {
-        const empty = createElement('div', { className: 'sb-persona-option' });
+        const empty = createElement('div', { className: 'sb-persona-option-empty' });
         empty.textContent = 'No personas defined';
         picker.appendChild(empty);
     } else {
@@ -9514,6 +9615,9 @@ function togglePersonaPicker() {
     if (bubble instanceof HTMLElement) {
         document.body.appendChild(picker);
         positionPersonaPicker(picker, bubble);
+        const activeOption = picker.querySelector('.sb-persona-option.is-active');
+        const firstOption = picker.querySelector('.sb-persona-option');
+        (activeOption ?? firstOption)?.focus({ preventScroll: true });
     }
 }
 
@@ -9543,9 +9647,66 @@ function positionPersonaPicker(picker, bubble) {
     });
 }
 
+function closePersonaPicker({ restoreFocus = false } = {}) {
+    const picker = document.getElementById('sb-persona-picker');
+    if (picker) {
+        picker.remove();
+    }
+
+    if (restoreFocus) {
+        document.getElementById('sb-persona-bubble')?.focus({ preventScroll: true });
+    }
+}
+
+function focusPersonaOption(picker, offset) {
+    const options = Array.from(picker.querySelectorAll('.sb-persona-option'));
+    const currentIndex = options.indexOf(document.activeElement);
+    const nextIndex = currentIndex === -1
+        ? 0
+        : (currentIndex + offset + options.length) % options.length;
+    options[nextIndex]?.focus({ preventScroll: true });
+}
+
+async function selectPersonaOption(option, picker, avatarId, context) {
+    picker.querySelectorAll('.sb-persona-option').forEach(element => {
+        element.classList.toggle('is-active', element === option);
+        element.setAttribute('aria-selected', String(element === option));
+    });
+    closePersonaPicker();
+    const execSlash = context?.executeSlashCommandsWithOptions;
+    let switched = false;
+    if (typeof execSlash === 'function') {
+        try {
+            await execSlash(`/persona-set ${quoteSlashCommandArgument(avatarId)}`);
+            switched = true;
+        } catch (error) {
+            console.warn('[SillyBunny] Persona switch via slash command failed, falling back to DOM selection.', error);
+        }
+    }
+
+    if (!switched) {
+        // Fallback: try clicking the DOM avatar
+        const avatarBlock = document.getElementById('user_avatar_block');
+        const domAvatar = avatarBlock?.querySelector(`.avatar-container[title="${CSS.escape(avatarId)}"]`);
+        if (domAvatar instanceof HTMLElement) {
+            domAvatar.click();
+        } else {
+            openShell('right', 'persona');
+        }
+    }
+
+    updatePersonaBubble();
+    document.getElementById('sb-persona-bubble')?.focus({ preventScroll: true });
+}
+
 function addPersonaOption(picker, avatarId, name, title, isActive, context) {
-    const option = createElement('div', {
+    const option = createElement('button', {
         className: `sb-persona-option${isActive ? ' is-active' : ''}`,
+        attrs: {
+            type: 'button',
+            role: 'option',
+            'aria-selected': String(isActive),
+        },
     });
 
     const img = createElement('img', {
@@ -9571,30 +9732,24 @@ function addPersonaOption(picker, avatarId, name, title, isActive, context) {
         option.append(img, label);
     }
 
-    option.addEventListener('click', async () => {
-        picker.remove();
-        const execSlash = context?.executeSlashCommandsWithOptions;
-        let switched = false;
-        if (typeof execSlash === 'function') {
-            try {
-                await execSlash(`/persona-set ${quoteSlashCommandArgument(avatarId)}`);
-                switched = true;
-            } catch (error) {
-                console.warn('[SillyBunny] Persona switch via slash command failed, falling back to DOM selection.', error);
-            }
+    option.addEventListener('click', () => { void selectPersonaOption(option, picker, avatarId, context); });
+    option.addEventListener('keydown', event => {
+        if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
+            event.preventDefault();
+            focusPersonaOption(picker, 1);
+        } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
+            event.preventDefault();
+            focusPersonaOption(picker, -1);
+        } else if (event.key === 'Home') {
+            event.preventDefault();
+            picker.querySelector('.sb-persona-option')?.focus({ preventScroll: true });
+        } else if (event.key === 'End') {
+            event.preventDefault();
+            Array.from(picker.querySelectorAll('.sb-persona-option')).at(-1)?.focus({ preventScroll: true });
+        } else if (event.key === 'Escape') {
+            event.preventDefault();
+            closePersonaPicker({ restoreFocus: true });
         }
-
-        if (!switched) {
-            // Fallback: try clicking the DOM avatar
-            const avatarBlock = document.getElementById('user_avatar_block');
-            const domAvatar = avatarBlock?.querySelector(`.avatar-container[title="${CSS.escape(avatarId)}"]`);
-            if (domAvatar instanceof HTMLElement) {
-                domAvatar.click();
-            } else {
-                openShell('right', 'persona');
-            }
-        }
-        updatePersonaBubble();
     });
 
     picker.appendChild(option);

--- a/public/style.css
+++ b/public/style.css
@@ -7408,18 +7408,18 @@ body:not(.movingUI) .drawer-content.maximized {
 }
 
 .ica-transform-diff-part--ins {
-    background: rgba(50, 200, 80, 0.24);
-    color: #90ee90;
+    background: color-mix(in srgb, var(--color-success, var(--success, var(--SmartThemeQuoteColor))) 24%, transparent);
+    color: color-mix(in srgb, var(--color-success, var(--success, var(--SmartThemeQuoteColor))) 86%, var(--SmartThemeBodyColor));
     text-decoration: none;
     border-radius: 2px;
     padding: 0 1px;
 }
 
 .ica-transform-diff-part--del {
-    background: rgba(220, 50, 50, 0.28);
-    color: #ff9090;
+    background: color-mix(in srgb, var(--color-danger, var(--SmartThemeUnderlineColor)) 28%, transparent);
+    color: color-mix(in srgb, var(--color-danger, var(--SmartThemeUnderlineColor)) 88%, var(--SmartThemeBodyColor));
     text-decoration: line-through;
-    text-decoration-color: rgba(220, 80, 80, 0.6);
+    text-decoration-color: color-mix(in srgb, var(--color-danger, var(--SmartThemeUnderlineColor)) 62%, transparent);
     border-radius: 2px;
     padding: 0 1px;
 }
@@ -7517,6 +7517,14 @@ body:not(.movingUI) .drawer-content.maximized {
     50% {
         opacity: 0.98;
         transform: scale(1.08);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .group_speaker_avatar.has-unread-dm::after {
+        animation: none;
+        opacity: 0.72;
+        transform: none;
     }
 }
 


### PR DESCRIPTION
## What?
This PR improves mobile and keyboard accessibility across SillyBunny shell controls. It enforces 44px mobile touch targets, makes the persona picker keyboard-operable with listbox/option semantics and focus return, makes shell resize handles keyboard-adjustable separators, respects reduced-motion preferences, and routes in-chat agent diff colors through semantic theme tokens.

## Why?
Mobile users and keyboard users needed reliable controls that meet touch target expectations, expose useful accessibility semantics, and avoid motion that conflicts with user preferences.

## How?
The UI wiring adds ARIA roles and synchronized resize values where the shell already exposes interactive controls. The styling updates normalize touch target sizing and route visual states through existing semantic tokens.

## Testing?
- `git diff --check`
- `npm run lint`
- Live Chrome 390x844 measurement confirmed visible topbar and bottom toolbar controls are at least 44px with no horizontal overflow.
- Live Chrome desktop probe confirmed keyboard resize updated Workspace width and `aria-valuenow`.
- Mocked SillyTavern persona context probe confirmed listbox/options, arrow navigation, persona selection, close, and focus return.

## Screenshots (optional)
Screenshots were not included. Live Chrome and mocked-context browser probes were used for the accessibility and layout checks.

## Anything Else?
3SR was run locally before PR creation, and PR metadata/checks were pulled after creation.