### PR TITLE
chore: typeset shell typography

### DIFF
--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -881,19 +881,22 @@ body:not(.movingUI) .drawer-content.maximized {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    font-size: calc(var(--mainFontSize) * 0.86);
+    font-size: var(--sb-type-control);
+    font-weight: var(--sb-weight-title);
+    line-height: var(--sb-line-title);
 }
 
 .sb-chat-file-head small,
 .sb-chat-file-meta small {
     opacity: 0.62;
-    font-size: calc(var(--mainFontSize) * 0.7);
+    font-size: var(--sb-type-caption);
+    line-height: var(--sb-line-compact);
 }
 
 .sb-chat-file-preview {
     opacity: 0.76;
-    line-height: 1.35;
-    font-size: calc(var(--mainFontSize) * 0.76);
+    font-size: var(--sb-type-meta);
+    line-height: var(--sb-line-body);
 }
 
 .sb-chat-files-empty {
@@ -908,7 +911,8 @@ body:not(.movingUI) .drawer-content.maximized {
 .sb-chat-files-empty p {
     margin-top: 4px;
     opacity: 0.7;
-    font-size: calc(var(--mainFontSize) * 0.76);
+    font-size: var(--sb-type-meta);
+    line-height: var(--sb-line-body);
 }
 
 #sb-mobile-chat-tools {
@@ -982,7 +986,7 @@ body:not(.movingUI) .drawer-content.maximized {
 
 .sb-mobile-chat-section-title {
     font-size: var(--sb-mobile-tools-section-title-size);
-    letter-spacing: 0.12em;
+    letter-spacing: var(--sb-tracking-kicker);
     text-transform: uppercase;
     opacity: 0.66;
 }
@@ -997,26 +1001,27 @@ body:not(.movingUI) .drawer-content.maximized {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    font-size: calc(var(--mainFontSize) * 1);
-    font-weight: 800;
-    letter-spacing: 0.03em;
+    font-size: var(--sb-type-body);
+    font-weight: var(--sb-weight-title);
+    line-height: var(--sb-line-title);
+    letter-spacing: 0;
 }
 
 .sb-brand-title.is-chat {
-    font-size: calc(var(--mainFontSize) * 0.92);
-    font-weight: 700;
-    letter-spacing: 0.015em;
+    font-size: var(--sb-type-control);
+    font-weight: var(--sb-weight-title);
+    letter-spacing: 0;
 }
 
 .sb-brand-subtitle {
-    font-size: calc(var(--mainFontSize) * 0.72);
-    letter-spacing: 0.16em;
+    font-size: var(--sb-type-caption);
+    letter-spacing: var(--sb-tracking-kicker);
     text-transform: uppercase;
     opacity: 0.7;
 }
 
 .sb-brand-badge {
-    font-size: calc(var(--mainFontSize) * 0.68);
+    font-size: var(--sb-type-caption);
     opacity: 0.72;
     white-space: nowrap;
 }
@@ -1052,7 +1057,7 @@ body:not(.movingUI) .drawer-content.maximized {
 
 .sb-proxy-button span {
     font-size: var(--sb-proxy-label-size);
-    font-weight: 600;
+    font-weight: var(--sb-weight-control);
     white-space: nowrap;
     transition: transform 180ms ease, opacity 180ms ease;
 }
@@ -1724,9 +1729,9 @@ body.sb-shell-resizing * {
 }
 
 .sb-shell-kicker {
-    font-size: calc(var(--mainFontSize) * 0.7);
-    font-weight: 700;
-    letter-spacing: 0.14em;
+    font-size: var(--sb-type-caption);
+    font-weight: var(--sb-weight-title);
+    letter-spacing: var(--sb-tracking-kicker);
     text-transform: uppercase;
     opacity: 0.74;
     text-align: left;
@@ -1734,8 +1739,9 @@ body.sb-shell-resizing * {
 
 .sb-shell-title {
     margin: 0;
-    font-size: calc(var(--mainFontSize) * 1.45);
-    line-height: 1.08;
+    font-size: var(--sb-type-headline);
+    font-weight: var(--sb-weight-title);
+    line-height: var(--sb-line-title);
     text-align: left;
 }
 
@@ -1746,15 +1752,17 @@ body.sb-shell-resizing * {
 }
 
 .sb-shell-subtitle {
-    font-size: calc(var(--mainFontSize) * 0.88);
-    line-height: 1.45;
+    font-size: var(--sb-type-control);
+    line-height: var(--sb-line-body);
     opacity: 0.9;
+    max-width: 68ch;
 }
 
 .sb-shell-description {
-    font-size: calc(var(--mainFontSize) * 0.78);
-    line-height: 1.5;
+    font-size: var(--sb-type-meta);
+    line-height: var(--sb-line-body);
     opacity: 0.66;
+    max-width: 72ch;
 }
 
 .sb-shell-search {
@@ -1798,8 +1806,8 @@ body.sb-shell-resizing * {
 
 .sb-shell-search-note {
     margin: 0 2px;
-    font-size: calc(var(--mainFontSize) * 0.72);
-    line-height: 1.5;
+    font-size: var(--sb-type-caption);
+    line-height: var(--sb-line-body);
     opacity: 0.72;
     text-wrap: balance;
     max-width: 72ch;
@@ -1828,8 +1836,8 @@ body.sb-shell-resizing * {
 }
 
 .sb-agent-state-label {
-    font-size: calc(var(--mainFontSize) * 0.68);
-    letter-spacing: 0.08em;
+    font-size: var(--sb-type-caption);
+    letter-spacing: var(--sb-tracking-label);
     text-transform: uppercase;
     opacity: 0.68;
 }
@@ -1842,7 +1850,7 @@ body.sb-shell-resizing * {
 }
 
 .sb-agent-state-value {
-    line-height: 1.45;
+    line-height: var(--sb-line-body);
 }
 
 .sb-agent-state-list {
@@ -2130,7 +2138,9 @@ body.sb-shell-resizing * {
 
 .sb-admin-card-copy strong {
     display: block;
-    font-size: calc(var(--mainFontSize) * 0.92);
+    font-size: var(--sb-type-control);
+    font-weight: var(--sb-weight-title);
+    line-height: var(--sb-line-title);
 }
 
 .sb-server-card {
@@ -2155,15 +2165,15 @@ body.sb-shell-resizing * {
 }
 
 .sb-server-stat-label {
-    font-size: calc(var(--mainFontSize) * 0.68);
-    letter-spacing: 0.08em;
+    font-size: var(--sb-type-caption);
+    letter-spacing: var(--sb-tracking-label);
     text-transform: uppercase;
     opacity: 0.68;
 }
 
 .sb-server-stat-value {
-    font-size: calc(var(--mainFontSize) * 0.82);
-    line-height: 1.4;
+    font-size: var(--sb-type-control);
+    line-height: var(--sb-line-body);
     overflow-wrap: anywhere;
 }
 
@@ -2175,9 +2185,9 @@ body.sb-shell-resizing * {
     min-height: 32px;
     padding: 0 12px;
     border-radius: 999px;
-    font-size: calc(var(--mainFontSize) * 0.7);
-    font-weight: 700;
-    letter-spacing: 0.04em;
+    font-size: var(--sb-type-caption);
+    font-weight: var(--sb-weight-title);
+    letter-spacing: var(--sb-tracking-label);
     text-transform: uppercase;
     background: color-mix(in srgb, var(--SmartThemeBodyColor) 8%, transparent);
     color: var(--SmartThemeBodyColor);
@@ -2206,8 +2216,8 @@ body.sb-shell-resizing * {
     border-radius: var(--sb-radius-md, 16px);
     border: 1px solid color-mix(in srgb, var(--sb-shell-border) 72%, transparent);
     background: color-mix(in srgb, var(--SmartThemeBodyColor) 4%, transparent);
-    font-size: calc(var(--mainFontSize) * 0.76);
-    line-height: 1.5;
+    font-size: var(--sb-type-meta);
+    line-height: var(--sb-line-body);
     white-space: pre-wrap;
     overflow-wrap: anywhere;
 }

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -341,7 +341,7 @@ hr {
 .standoutHeader,
 h3:not(.popup h3):not(#chat h3),
 .inline-drawer-header {
-    letter-spacing: 0.02em;
+    letter-spacing: 0;
 }
 
 .standoutHeader,
@@ -351,6 +351,9 @@ h3:not(.popup h3):not(#chat h3) {
     padding: 10px 14px;
     background: color-mix(in srgb, var(--SmartThemeBodyColor) 4%, transparent);
     box-sizing: border-box;
+    font-size: var(--sb-type-title);
+    font-weight: var(--sb-weight-title);
+    line-height: var(--sb-line-title);
 }
 
 .inline-drawer-header {
@@ -389,7 +392,7 @@ h3:not(.popup h3):not(#chat h3) {
     box-sizing: border-box;
     min-width: var(--sb-control-min-height);
     min-height: var(--sb-control-min-height);
-    line-height: 1.2;
+    line-height: var(--sb-line-compact);
 }
 
 .menu_button,
@@ -400,6 +403,9 @@ h3:not(.popup h3):not(#chat h3) {
     gap: 6px;
     margin-block: 0;
     min-width: var(--sb-control-min-height);
+    font-size: var(--sb-type-control);
+    font-weight: var(--sb-weight-control);
+    letter-spacing: 0;
 }
 
 .menu_button > :is(.fa, .fa-solid, .fa-regular, .fa-brands, i, svg, img),
@@ -449,7 +455,8 @@ h3:not(.popup h3):not(#chat h3) {
 
 .checkbox_label {
     min-height: var(--sb-control-min-height);
-    line-height: 1.45;
+    font-size: var(--sb-type-control);
+    line-height: var(--sb-line-body);
     display: flex;
     align-items: center;
     gap: var(--sb-row-gap);
@@ -482,7 +489,8 @@ h3:not(.popup h3):not(#chat h3) {
 
 .floating_prompt_radio_group label {
     min-height: var(--sb-control-min-height);
-    line-height: 1.45;
+    font-size: var(--sb-type-control);
+    line-height: var(--sb-line-body);
     display: flex;
     align-items: center;
     gap: var(--sb-row-gap);
@@ -501,7 +509,7 @@ h3:not(.popup h3):not(#chat h3) {
 
 .floating_prompt_radio_group label > span,
 .floating_prompt_radio_group label > small {
-    line-height: 1.45;
+    line-height: var(--sb-line-body);
     min-width: 0;
     white-space: normal;
     overflow-wrap: anywhere;
@@ -509,7 +517,7 @@ h3:not(.popup h3):not(#chat h3) {
 
 .checkbox_label small,
 .checkbox_label span {
-    line-height: 1.45;
+    line-height: var(--sb-line-body);
     min-width: 0;
     white-space: normal;
     overflow-wrap: anywhere;
@@ -631,7 +639,8 @@ h3:not(.popup h3):not(#chat h3) {
 .standoutHeader > strong,
 .standoutHeader > span {
     min-width: 0;
-    line-height: 1.25;
+    font-weight: var(--sb-weight-title);
+    line-height: var(--sb-line-title);
 }
 
 .custom-drawer-icon,
@@ -668,7 +677,8 @@ input.text_pole {
     border-radius: var(--sb-radius-button);
     color: var(--SmartThemeBodyColor);
     caret-color: var(--color-primary, var(--sb-accent));
-    line-height: 1.45;
+    font-size: var(--sb-type-control);
+    line-height: var(--sb-line-body);
     transition: border-color var(--sb-transition-fast), box-shadow var(--sb-transition-fast), background-color var(--sb-transition-fast);
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -41,7 +41,7 @@
     <link rel="apple-touch-icon" sizes="114x114" href="img/apple-icon-114x114.png" />
     <link rel="apple-touch-icon" sizes="144x144" href="img/apple-icon-144x144.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="img/apple-icon-180x180.png" />
-    <link rel="stylesheet" type="text/css" href="style.css">
+    <link rel="stylesheet" type="text/css" href="style.css?v=20260505b">
     <link rel="stylesheet" type="text/css" href="css/st-tailwind.css">
     <link rel="stylesheet" type="text/css" href="css/rm-groups.css">
     <link rel="stylesheet" type="text/css" href="css/group-avatars.css">
@@ -50,8 +50,8 @@
     <link rel="stylesheet" type="text/css" href="css/extensions-panel.css?v=20260425a">
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css">
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260505a" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260505a">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260505a">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260505b">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260505b">
     <link rel="stylesheet" type="text/css" href="css/macros.css">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->

--- a/public/style.css
+++ b/public/style.css
@@ -114,6 +114,22 @@
     --mainFontSize: calc(var(--fontScale) * 15px);
     --mainFontFamily: 'Figtree', 'Noto Sans', sans-serif;
     --monoFontFamily: 'Red Hat Mono', 'Noto Sans Mono', 'Courier New', Consolas, monospace;
+    --sb-type-caption: calc(var(--mainFontSize) * 0.72);
+    --sb-type-meta: calc(var(--mainFontSize) * 0.78);
+    --sb-type-control: calc(var(--mainFontSize) * 0.86);
+    --sb-type-body: var(--mainFontSize);
+    --sb-type-title: calc(var(--mainFontSize) * 1.08);
+    --sb-type-headline: calc(var(--mainFontSize) * 1.35);
+    --sb-type-display: calc(var(--mainFontSize) * 1.62);
+    --sb-line-compact: 1.2;
+    --sb-line-title: 1.18;
+    --sb-line-body: 1.55;
+    --sb-line-prose: 1.65;
+    --sb-weight-body: 400;
+    --sb-weight-control: 600;
+    --sb-weight-title: 700;
+    --sb-tracking-label: 0.06em;
+    --sb-tracking-kicker: 0.1em;
     /* Compatibility aliases for older imported themes and extension-style presets. */
     --mainFont: var(--mainFontFamily);
     --headerFont: var(--mainFontFamily);


### PR DESCRIPTION
## What?
This PR adds semantic typography tokens for SillyBunny UI roles, retunes shell headings, labels, controls, metadata, and status text around the new scale, and cache-busts the changed shell stylesheets.

## Why?
The shell needed more consistent type hierarchy so dense UI surfaces stayed readable without redesigning the application.

## How?
The styling introduces role-based typography tokens and applies them across existing shell UI selectors. The changed stylesheet URLs are cache-busted so users receive the updated type scale.

## Testing?
- `node D:\AIStuff\SillyBunny\node_modules\eslint\bin\eslint.js "src/**/*.js" "public/**/*.js" "scripts/**/*.js" ./*.js --quiet --resolve-plugins-relative-to D:\AIStuff\SillyBunny`
- `git diff --check`
- Playwright/Chrome visual check against `http://127.0.0.1:4444`

## Screenshots (optional)
Screenshots were not included. A Playwright/Chrome visual check was used against the local app.

## Anything Else?
None.