### PR TITLE
fix: optimize frontend icon loading

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
     </style>
     <link rel="preload" as="style" href="style.css">
     <link rel="modulepreload" href="script.js">
-    <link rel="preload" as="script" href="scripts/sillybunny-tabs.js?v=20260505a">
+    <link rel="preload" as="script" href="scripts/sillybunny-tabs.js?v=20260505b">
     <link rel="manifest" crossorigin="use-credentials" href="manifest.json">
     <link href="webfonts/Figtree/stylesheet.css?v=20260422b" rel="stylesheet">
     <link href="webfonts/NotoSans/stylesheet.css" rel="stylesheet">
@@ -32,7 +32,7 @@
     <link href="css/cropper.min.css" rel="stylesheet">
     <link href="css/toastr.min.css" rel="stylesheet">
     <link href="css/select2.min.css" rel="stylesheet">
-    <link rel="icon" href="favicon.ico" sizes="any">
+    <link rel="icon" type="image/png" sizes="256x256" href="img/sillybunny-pixel-logo-og.png">
     <link rel="icon" type="image/png" sizes="16x16" href="img/icon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="img/icon-32x32.png">
     <link rel="icon" type="image/png" sizes="48x48" href="img/icon-48x48.png">
@@ -8707,7 +8707,7 @@
     <script type="module" src="lib/eventemitter.js"></script>
     <script type="module" src="scripts/i18n.js"></script>
     <script type="module" src="script.js"></script>
-    <script src="scripts/sillybunny-tabs.js?v=20260505a" defer></script>
+    <script src="scripts/sillybunny-tabs.js?v=20260505b" defer></script>
     <script>
         window.addEventListener('load', (event) => {
             const documentHeight = () => {

--- a/public/login.html
+++ b/public/login.html
@@ -16,7 +16,7 @@
         }
     </style>
     <link rel="preload" as="style" href="style.css">
-    <link rel="icon" href="favicon.ico" sizes="any">
+    <link rel="icon" type="image/png" sizes="256x256" href="img/sillybunny-pixel-logo-og.png">
     <link rel="icon" type="image/png" sizes="16x16" href="img/icon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="img/icon-32x32.png">
     <link rel="icon" type="image/png" sizes="48x48" href="img/icon-48x48.png">

--- a/public/script.js
+++ b/public/script.js
@@ -466,6 +466,7 @@ const SILLYBUNNY_FRONTEND_ICONS = Object.freeze({
     pixel: 'img/sillybunny-pixel-logo-og.png',
     badge: 'img/sillybunny-badge.svg',
 });
+let appliedSillyBunnyFrontendIconId = '';
 
 function normalizeSillyBunnyFrontendIcon(iconId) {
     return Object.hasOwn(SILLYBUNNY_FRONTEND_ICONS, String(iconId)) ? String(iconId) : SILLYBUNNY_FRONTEND_ICON_DEFAULT;
@@ -493,18 +494,25 @@ function applySillyBunnyFrontendIcon(iconId = getStoredSillyBunnyFrontendIcon())
     const normalizedIconId = normalizeSillyBunnyFrontendIcon(iconId);
     const src = SILLYBUNNY_FRONTEND_ICONS[normalizedIconId];
     const absoluteSrc = `/${src}`;
+    const iconAlreadyApplied = appliedSillyBunnyFrontendIconId === normalizedIconId;
     system_avatar = src;
 
     document.documentElement.dataset.sbFrontendIcon = normalizedIconId;
 
     for (const image of document.querySelectorAll('img[data-sb-frontend-icon]')) {
-        image.setAttribute('src', absoluteSrc);
+        if (image.getAttribute('src') !== absoluteSrc) {
+            image.setAttribute('src', absoluteSrc);
+        }
     }
 
-    for (const link of document.querySelectorAll('link[rel~="icon"]')) {
-        link.setAttribute('href', absoluteSrc);
-        link.setAttribute('type', normalizedIconId === 'badge' ? 'image/svg+xml' : 'image/png');
+    if (!iconAlreadyApplied) {
+        for (const link of document.querySelectorAll('link[rel~="icon"]')) {
+            link.setAttribute('href', absoluteSrc);
+            link.setAttribute('type', normalizedIconId === 'badge' ? 'image/svg+xml' : 'image/png');
+        }
     }
+
+    appliedSillyBunnyFrontendIconId = normalizedIconId;
 }
 
 window.SillyBunnyFrontendIcon = Object.assign(window.SillyBunnyFrontendIcon || {}, {

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -1864,10 +1864,16 @@ function setShellTheme(themeId, { persist = true } = {}) {
 
 function applyFrontendIcon(iconId = sbState.frontendIcon) {
     const normalizedIconId = normalizeFrontendIcon(iconId);
+    const iconController = window.SillyBunnyFrontendIcon;
+
+    if (iconController?.apply) {
+        iconController.apply(normalizedIconId);
+        return;
+    }
+
     const iconSrc = getFrontendIconSrc(normalizedIconId);
 
     document.documentElement.dataset.sbFrontendIcon = normalizedIconId;
-    window.SillyBunnyFrontendIcon?.apply?.(normalizedIconId);
 
     for (const image of document.querySelectorAll('img[data-sb-frontend-icon]')) {
         image.setAttribute('src', iconSrc);


### PR DESCRIPTION
## What?
This PR optimizes frontend icon loading by starting index/login favicon discovery with the transparent bunny PNG instead of the large ICO. It avoids redundant favicon writes after the current icon is already applied, delegates shell icon updates through the shared icon bridge, and cache-busts the changed shell script preload/load URL.

## Why?
The frontend should avoid unnecessary icon work and large icon fetches while still keeping the SillyBunny icon surfaces up to date.

## How?
The favicon discovery path now prefers the small transparent PNG. The shell icon update path uses the shared bridge, and repeated writes are skipped once the active icon is already correct.

## Testing?
- `npx eslint public/script.js public/scripts/sillybunny-tabs.js`
- `git diff --check -- public/script.js public/scripts/sillybunny-tabs.js public/index.html public/login.html`
- HTTP check confirmed `/img/sillybunny-pixel-logo-og.png` serves as `image/png` with `Content-Length: 1597`

## Screenshots (optional)
Screenshots were not included. The change was verified with lint, diff checks, and HTTP asset checks.

## Anything Else?
None.