### PR TITLE
feat: optimize SillyBunny UI and fix preset persistence

### DIFF
--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -259,7 +259,6 @@ body.sb-topbar-compact #sb-chatbar-layer {
     width: 100%;
     transform: translate(var(--sb-topbar-offset-x, 0px), var(--sb-topbar-offset-y, 0px));
     transition: transform 180ms ease;
-    will-change: transform;
     contain: layout style;
 }
 
@@ -548,7 +547,7 @@ body.sb-topbar-compact #sb-chatbar-layer {
     min-height: 0 !important;
     line-height: 1;
     box-sizing: border-box;
-    transition: transform 160ms ease, border-color 160ms ease, background-color 160ms ease, opacity 160ms ease, box-shadow 160ms ease;
+    transition: transform 160ms ease, border-color 160ms ease, background-color 160ms ease, opacity 160ms ease;
 }
 
 .sb-chatbar-button::before,
@@ -587,6 +586,15 @@ body.sb-topbar-compact #sb-chatbar-layer {
 .sb-chatbar-button.is-active {
     border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 42%, var(--sb-shell-border) 58%);
     box-shadow: 0 8px 16px color-mix(in srgb, var(--SmartThemeShadowColor) 14%, transparent);
+}
+
+.sb-chatbar-button:focus-visible,
+.sb-connection-strip-connect:focus-visible,
+.sb-bottom-chat-btn:focus-visible,
+.sb-mobile-chat-close:focus-visible {
+    outline: none;
+    border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 46%, var(--sb-shell-border) 54%);
+    box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--sb-focus-ring) 70%, transparent);
 }
 
 #sb-chatbar-visibility-toggle {
@@ -741,7 +749,7 @@ body.sb-topbar-compact #sb-chatbar-layer {
     font: inherit;
     white-space: nowrap;
     cursor: pointer;
-    transition: transform 160ms ease, border-color 160ms ease, opacity 160ms ease, box-shadow 160ms ease;
+    transition: transform 160ms ease, border-color 160ms ease, opacity 160ms ease;
 }
 
 .sb-connection-strip-connect::before {
@@ -1059,7 +1067,7 @@ body:not(.movingUI) .drawer-content.maximized {
     color: var(--SmartThemeBodyColor);
     background: transparent;
     cursor: pointer;
-    transition: transform 180ms ease, background-color 180ms ease, border-color 180ms ease, opacity 180ms ease, box-shadow 180ms ease;
+    transition: transform 180ms ease, background-color 180ms ease, border-color 180ms ease, opacity 180ms ease;
     opacity: 0.82;
 }
 
@@ -1092,6 +1100,13 @@ body:not(.movingUI) .drawer-content.maximized {
 .sb-proxy-button:hover {
     opacity: 1;
     transform: translateY(-1px);
+}
+
+.sb-proxy-button:focus-visible {
+    outline: none;
+    opacity: 1;
+    border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 42%, var(--sb-shell-border) 58%);
+    box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--sb-focus-ring) 64%, transparent);
 }
 
 .sb-proxy-button.is-open,
@@ -1573,7 +1588,7 @@ body.sb-shell-resizing * {
     flex-shrink: 1;
     min-width: 0;
     overflow: hidden;
-    transition: transform 180ms ease, background-color 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+    transition: transform 180ms ease, background-color 180ms ease, border-color 180ms ease;
 }
 
 .sb-shell-tab:hover {
@@ -1979,6 +1994,27 @@ body.sb-shell-resizing * {
     display: flex;
 }
 
+.sb-search-result-group {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.sb-search-result-group + .sb-search-result-group {
+    padding-top: 4px;
+    border-top: 1px solid color-mix(in srgb, var(--sb-shell-border) 64%, transparent);
+}
+
+.sb-search-result-group-label {
+    padding: 0 4px;
+    color: color-mix(in srgb, var(--SmartThemeBodyColor) 72%, transparent);
+    font-size: var(--sb-type-caption);
+    font-weight: var(--sb-weight-title);
+    letter-spacing: var(--sb-tracking-kicker);
+    line-height: var(--sb-line-compact);
+    text-transform: uppercase;
+}
+
 .sb-search-result,
 .sb-search-empty {
     border-radius: var(--sb-radius-md, 16px);
@@ -2017,8 +2053,26 @@ body.sb-shell-resizing * {
     transition: transform 160ms ease, border-color 160ms ease, background-color 160ms ease;
 }
 
-.sb-search-result:hover {
+.sb-search-result:hover,
+.sb-search-result.is-active,
+.sb-search-result:focus-visible {
     transform: translateY(-1px);
+    border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 42%, var(--sb-shell-border) 58%);
+}
+
+.sb-search-result.is-active,
+.sb-search-result:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--sb-focus-ring) 58%, transparent);
+}
+
+.sb-search-result.is-active::before,
+.sb-search-result:focus-visible::before {
+    background: color-mix(
+        in srgb,
+        rgb(from var(--SmartThemeChatTintColor) r g b / 1) 88%,
+        rgb(from var(--SmartThemeBodyColor) r g b / 1) 12%
+    );
 }
 
 .sb-search-result span,
@@ -2888,7 +2942,7 @@ body.sb-shell-resizing * {
     color: var(--SmartThemeBodyColor);
     font: inherit;
     cursor: pointer;
-    transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
+    transition: transform 160ms ease, border-color 160ms ease, background-color 160ms ease;
 }
 
 :root[data-sb-compact-mode='true'] .sb-theme-option {
@@ -2913,6 +2967,13 @@ body.sb-shell-resizing * {
 
 .sb-theme-option.is-selected {
     box-shadow: 0 14px 28px color-mix(in srgb, var(--SmartThemeShadowColor) 16%, transparent);
+}
+
+.sb-theme-option:focus-visible,
+.sb-compact-mode-option:focus-visible {
+    outline: none;
+    border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 46%, var(--sb-shell-border) 54%);
+    box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--sb-focus-ring) 62%, transparent);
 }
 
 .sb-theme-option.is-selected::before {
@@ -3021,7 +3082,7 @@ body.sb-shell-resizing * {
     color: var(--SmartThemeBodyColor);
     cursor: pointer;
     box-sizing: border-box;
-    transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
+    transition: transform 160ms ease, border-color 160ms ease, background-color 160ms ease;
 }
 
 .sb-compact-mode-option::before {

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -275,6 +275,17 @@ body::before {
     scroll-padding-bottom: 8px;
 }
 
+/*
+ * Experimental SillyBunny chat rendering prototype. The setting is off by
+ * default because extensions may read message layout directly. This keeps .mes
+ * nodes mounted and relies on browser content-visibility instead of fixed-height
+ * virtualization or DOM removal.
+ */
+body.sb-chat-virtualization-enabled #chat.sb-chat-virtualization-active .mes {
+    content-visibility: auto;
+    contain-intrinsic-size: auto var(--sb-virtual-message-height, 180px);
+}
+
 #top-bar {
     position: relative;
     isolation: isolate;

--- a/public/index.html
+++ b/public/index.html
@@ -5732,6 +5732,11 @@
                                     <input id="auto_scroll_chat_to_bottom" type="checkbox" />
                                     <small data-i18n="Auto-scroll Chat">Auto-scroll Chat</small>
                                 </label>
+                                <label class="checkbox_label" for="experimental_chat_virtualization" title="Experimental prototype. Keeps messages in the DOM but asks the browser to skip off-screen rendering. Some extensions that inspect message layout may be affected.">
+                                    <input id="experimental_chat_virtualization" type="checkbox" />
+                                    <small>Experimental chat rendering</small>
+                                    <i class="fa-solid fa-flask" title="Prototype. Off by default because extensions may depend on full message layout."></i>
+                                </label>
                                 <label class="checkbox_label" for="auto_save_msg_edits" title="Save edits to messages without confirmation as you type." data-i18n="[title]Save edits to messages without confirmation as you type">
                                     <input id="auto_save_msg_edits" type="checkbox" />
                                     <small data-i18n="Auto-save Message Edits">Auto-save Message Edits</small>

--- a/public/script.js
+++ b/public/script.js
@@ -539,6 +539,8 @@ const messageTemplate = $('#message_template .mes');
 export const chatElement = $('#chat');
 const MOBILE_CHAT_RENDER_MEDIA_QUERY = '(max-width: 1000px)';
 const MOBILE_CHAT_RENDER_BATCH_SIZE = 8;
+const SB_CHAT_VIRTUALIZATION_MIN_MESSAGES = 160;
+const SB_CHAT_VIRTUALIZATION_PLACEHOLDER_HEIGHT = 180;
 const MOBILE_MESSAGE_UPDATE_DELAY_MS = 24;
 const MOBILE_MEDIA_SCROLL_MAX_DELAY_MS = 300;
 const MOBILE_SEND_SCROLL_IMMUNITY_MS = 1500;
@@ -1109,7 +1111,12 @@ function getCharacterBlock(item, id) {
     // Populate the template
     const template = $('#character_template .character_select').clone();
     template.attr({ 'data-chid': id, 'id': `CharID${id}` });
-    template.find('img').attr('src', this_avatar).attr('alt', item.name);
+    template.find('img').attr({
+        src: this_avatar,
+        alt: item.name,
+        loading: 'lazy',
+        decoding: 'async',
+    });
     template.find('.avatar').attr('title', `[Character] ${item.name}\nFile: ${item.avatar}`);
     template.find('.ch_name').text(item.name).attr('title', `[Character] ${item.name}`);
     if (power_user.show_card_avatar_urls) {
@@ -1469,13 +1476,7 @@ export async function getCharacters() {
         for (let i = 0; i < getData.length; i++) {
             characters[i] = getData[i];
             characters[i].name = DOMPurify.sanitize(characters[i].name);
-
-            // For dropped-in cards
-            if (!characters[i].chat) {
-                characters[i].chat = `${characters[i].name} - ${humanizedDateTime()}`;
-            }
-
-            characters[i].chat = String(characters[i].chat);
+            characters[i].chat = characters[i].chat ? String(characters[i].chat) : '';
         }
 
         if (previousAvatar) {
@@ -1498,6 +1499,56 @@ export async function getCharacters() {
             await Popup.show.text(t`Character data length limit reached`, t`To resolve this, set "performance.lazyLoadCharacters" to "true" in config.yaml and restart the server.`);
         }
     }
+}
+
+async function getExistingCharacterChats(characterId) {
+    const character = characters[characterId];
+    if (!character?.avatar) {
+        return [];
+    }
+
+    const response = await fetch('/api/characters/chats', {
+        method: 'POST',
+        headers: getRequestHeaders(),
+        body: JSON.stringify({ avatar_url: character.avatar }),
+    });
+
+    if (!response.ok) {
+        return [];
+    }
+
+    const data = await response.json();
+    if (typeof data === 'object' && data?.error === true) {
+        return [];
+    }
+
+    const chats = Object.values(data);
+    chats.sort((a, b) => sortMoments(timestampToMoment(a.last_mes), timestampToMoment(b.last_mes)));
+    return chats.filter(chatInfo => typeof chatInfo?.file_name === 'string');
+}
+
+async function resolveCharacterChatForLoad(characterId, { allowCreate = false } = {}) {
+    const character = characters[characterId];
+    if (!character) {
+        return { chatName: '', created: false };
+    }
+
+    const persistedChat = String(character.chat || '').trim();
+    const existingChats = await getExistingCharacterChats(characterId);
+    const persistedExists = persistedChat && existingChats.some(chatInfo => chatInfo.file_name === `${persistedChat}.jsonl`);
+    const latestChat = persistedExists ? '' : existingChats[0]?.file_name?.replace('.jsonl', '') || '';
+    const nextChatName = persistedExists ? persistedChat : (latestChat || (allowCreate ? `${character.name} - ${humanizedDateTime()}` : ''));
+
+    if (nextChatName && nextChatName !== persistedChat) {
+        await updateRemoteChatName(characterId, nextChatName);
+    } else {
+        character.chat = nextChatName;
+    }
+
+    return {
+        chatName: nextChatName,
+        created: Boolean(!persistedExists && !latestChat && allowCreate && nextChatName),
+    };
 }
 
 async function delChat(chatfile) {
@@ -1890,7 +1941,9 @@ export async function redisplayChat({ targetChat = chat, startIndex = 0, fade = 
         const shouldYieldBetweenBatches = batchSize < messages.length;
 
         for (let offset = 0; offset < messages.length; offset += batchSize) {
-            const newMessageElements = messages.slice(offset, offset + batchSize).map((message, batchOffset) => {
+            const batchMessages = messages.slice(offset, offset + batchSize);
+            const fragment = document.createDocumentFragment();
+            const newMessageElements = batchMessages.map((message, batchOffset) => {
                 const i = startIndex + offset + batchOffset;
                 const messageElement = updateMessageElement(message, { messageId: i });
 
@@ -1903,7 +1956,10 @@ export async function redisplayChat({ targetChat = chat, startIndex = 0, fade = 
             }
 
             //Append each batch in one DOM update.
-            chatElement.append(newMessageElements);
+            for (const messageElement of newMessageElements) {
+                fragment.appendChild(messageElement);
+            }
+            chatElement[0].appendChild(fragment);
 
             if (shouldYieldBetweenBatches && offset + batchSize < messages.length) {
                 await waitForNextFrame();
@@ -1913,11 +1969,50 @@ export async function redisplayChat({ targetChat = chat, startIndex = 0, fade = 
         applyCharacterTagsToMessageDivs({ mesIds: renderedMessageIds });
     }
 
+    applyExperimentalChatVirtualization(targetChat.length);
     refreshSwipeButtons(false, fade);
     applyStylePins();
     updateEditArrowClasses();
 
     console.info(`Rendered ${targetChat.length - startIndex} messages in ${((performance.now() - t1) / 1000).toFixed(3)} seconds.`);
+}
+
+function applyExperimentalChatVirtualization(messageCount = chat.length) {
+    const chatNode = chatElement[0];
+    const enabled = Boolean(power_user?.experimental_chat_virtualization)
+        && messageCount >= SB_CHAT_VIRTUALIZATION_MIN_MESSAGES
+        && CSS.supports?.('content-visibility', 'auto');
+
+    if (!chatNode) {
+        return;
+    }
+
+    if (!enabled) {
+        document.body.classList.remove('sb-chat-virtualization-enabled');
+        chatNode.classList.remove('sb-chat-virtualization-active');
+    }
+    const shouldMeasureHeights = enabled && !chatNode.classList.contains('sb-chat-virtualization-active');
+
+    // SillyBunny prototype: keep .mes nodes mounted for extension compatibility and let
+    // the browser skip off-screen layout/paint. This does not assume fixed message heights.
+    for (const message of chatNode.querySelectorAll('.mes')) {
+        if (!(message instanceof HTMLElement)) {
+            continue;
+        }
+
+        if (enabled) {
+            const measuredHeight = shouldMeasureHeights ? Math.ceil(message.getBoundingClientRect().height) : 0;
+            const placeholderHeight = Math.max(SB_CHAT_VIRTUALIZATION_PLACEHOLDER_HEIGHT, measuredHeight || 0);
+            message.style.setProperty('--sb-virtual-message-height', `${placeholderHeight}px`);
+        } else {
+            message.style.removeProperty('--sb-virtual-message-height');
+        }
+    }
+
+    if (enabled) {
+        document.body.classList.add('sb-chat-virtualization-enabled');
+        chatNode.classList.add('sb-chat-virtualization-active');
+    }
 }
 
 export function scrollOnMediaLoad({ force = false } = {}) {
@@ -2725,8 +2820,12 @@ export function appendMediaToMessage(mes, messageElement, scrollBehavior = SCROL
         template.attr('data-index', index);
 
         const image = template.find('.mes_img');
-        image.attr('src', attachment.url);
-        image.attr('title', attachment.title || mes.extra.title || '');
+        image.attr({
+            src: attachment.url,
+            title: attachment.title || mes.extra.title || '',
+            loading: 'lazy',
+            decoding: 'async',
+        });
         mediaPromises.push(new Promise((resolve) => {
             function onLoad() {
                 image.removeAttr('alt');
@@ -2761,8 +2860,11 @@ export function appendMediaToMessage(mes, messageElement, scrollBehavior = SCROL
         template.attr('data-index', index);
 
         const video = template.find('.mes_video');
-        video.attr('src', attachment.url);
-        video.attr('title', attachment.title || mes.extra.title || '');
+        video.attr({
+            src: attachment.url,
+            title: attachment.title || mes.extra.title || '',
+            preload: 'metadata',
+        });
         mediaPromises.push(new Promise((resolve) => {
             function onLoad() {
                 resolve();
@@ -3033,6 +3135,7 @@ export function addOneMessage(mes, { type = undefined, insertAfter = null, scrol
     const shouldPinMobileBottom = !insertAfter && !insertBefore && scroll && shouldPinMobileChatToBottom();
 
     let messageElement;
+    let insertedElement = null;
 
     if (type === 'swipe') {
         // Forbidden black magic
@@ -3042,8 +3145,10 @@ export function addOneMessage(mes, { type = undefined, insertAfter = null, scrol
         //This keeps listeners intact.
         messageElement = chatElement.find(`[mesid="${messageId}"]`);
         updateMessageElement(mes, { messageId, messageElement, adjustMediaScroll: scroll ? SCROLL_BEHAVIOR.ADJUST : SCROLL_BEHAVIOR.NONE });
+        insertedElement = messageElement[0] ?? null;
     } else {
         messageElement = updateMessageElement(mes, { messageId, adjustMediaScroll: scroll ? SCROLL_BEHAVIOR.ADJUST : SCROLL_BEHAVIOR.NONE });
+        insertedElement = messageElement[0] ?? null;
         if (typeof insertAfter === 'number' && insertAfter >= 0) {
             const target = chatElement.find(`.mes[mesid="${insertAfter}"]`);
             $(messageElement).insertAfter(target);
@@ -3057,8 +3162,14 @@ export function addOneMessage(mes, { type = undefined, insertAfter = null, scrol
 
 
     //last_mes should always be updated.
-    chatElement.find('.mes').removeClass('last_mes');
-    chatElement.find('.mes').last().addClass('last_mes');
+    const chatNode = chatElement[0];
+    chatNode?.querySelector('.mes.last_mes')?.classList.remove('last_mes');
+    const canUseInsertedAsLast = type !== 'swipe' && !insertAfter && !insertBefore && insertedElement instanceof HTMLElement;
+    const lastMessageElement = canUseInsertedAsLast
+        ? insertedElement
+        : Array.from(chatNode?.querySelectorAll('.mes') ?? []).at(-1);
+    lastMessageElement?.classList.add('last_mes');
+    applyExperimentalChatVirtualization(chat.length);
 
     if (showSwipes) refreshSwipeButtons();
     // Don't scroll if not inserting last
@@ -3140,7 +3251,12 @@ export function updateMessageElement(mes, { messageId = chat.length - 1, message
         messageElement[0].style.setProperty('--mes-avatar-original-url', originalAvatarCssUrl);
     }
 
-    messageElement.find('.avatar img').attr('src', originalAvatarImg).attr('data-thumbnail-src', avatarImg);
+    messageElement.find('.avatar img').attr({
+        src: originalAvatarImg,
+        'data-thumbnail-src': avatarImg,
+        decoding: 'async',
+        loading: messageId > 8 ? 'lazy' : 'eager',
+    });
     messageElement.find('.ch_name .name_text').text(mes.name);
     messageElement.find('.timestamp').text(timestamp).attr('title', `${mes.extra?.api ? mes.extra.api + ' - ' : ''}${mes.extra?.model ?? ''}`);
     messageElement.find('.mesIDDisplay').text(`#${messageId}`);
@@ -8485,7 +8601,12 @@ export function buildAvatarList(block, entities, { templateId = 'inline_avatar_t
 
         avatarTemplate.attr('data-type', entity.type);
         avatarTemplate.attr('data-chid', id);
-        avatarTemplate.find('img').attr('src', this_avatar).attr('alt', entity.item.name);
+        avatarTemplate.find('img').attr({
+            src: this_avatar,
+            alt: entity.item.name,
+            loading: 'lazy',
+            decoding: 'async',
+        });
         avatarTemplate.attr('title', `[Character] ${entity.item.name}\nFile: ${entity.item.avatar}`);
         if (highlightFavs) {
             avatarTemplate.toggleClass('is_fav', entity.item.fav || entity.item.fav == 'true');
@@ -8503,7 +8624,11 @@ export function buildAvatarList(block, entities, { templateId = 'inline_avatar_t
             avatarTemplate.attr('title', `[Group] ${entity.item.name}`);
         } else if (entity.type === 'persona') {
             avatarTemplate.attr({ 'data-pid': id, 'data-chid': null });
-            avatarTemplate.find('img').attr('src', getThumbnailUrl('persona', entity.item.avatar));
+            avatarTemplate.find('img').attr({
+                src: getThumbnailUrl('persona', entity.item.avatar),
+                loading: 'lazy',
+                decoding: 'async',
+            });
             avatarTemplate.attr('title', `[Persona] ${entity.item.name}\nFile: ${entity.item.avatar}`);
         }
 
@@ -8552,6 +8677,7 @@ export async function unshallowCharacter(characterId) {
 export async function getChat() {
     try {
         await unshallowCharacter(this_chid);
+        const resolvedChat = await resolveCharacterChatForLoad(this_chid, { allowCreate: true });
 
         const response = await fetch('/api/chats/get', {
             method: 'POST',
@@ -8559,7 +8685,7 @@ export async function getChat() {
             cache: 'no-cache',
             body: JSON.stringify({
                 ch_name: characters[this_chid].name,
-                file_name: characters[this_chid].chat,
+                file_name: resolvedChat.chatName,
                 avatar_url: characters[this_chid].avatar,
             }),
         });
@@ -8583,7 +8709,7 @@ export async function getChat() {
         if (!chat_metadata.integrity) {
             chat_metadata.integrity = uuidv4();
         }
-        await getChatResult();
+        await getChatResult({ emitCreated: resolvedChat.created });
         eventSource.emit(event_types.CHAT_LOADED, { detail: { id: this_chid, character: characters[this_chid] } });
 
         // Focus on the textarea if not already focused on a visible text input
@@ -8599,7 +8725,7 @@ export async function getChat() {
     }
 }
 
-async function getChatResult() {
+async function getChatResult({ emitCreated = false } = {}) {
     name2 = characters[this_chid].name;
     let freshChat = false;
     if (chat.length === 0) {
@@ -8616,7 +8742,7 @@ async function getChatResult() {
     select_selected_character(this_chid);
 
     await eventSource.emit(event_types.CHAT_CHANGED, (getCurrentChatId()));
-    if (freshChat) await eventSource.emit(event_types.CHAT_CREATED);
+    if (freshChat && emitCreated) await eventSource.emit(event_types.CHAT_CREATED);
 
     if (chat.length === 1) {
         const chat_id = (chat.length - 1);

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -813,7 +813,11 @@ function updateGroupSpeakerControls() {
             const hasUnreadDm = Boolean(unreadState[getGroupDmUnreadKey(group.id, avatarId)]);
             item.toggleClass('selected', avatarId === selectedGroupSpeakerAvatar);
             item.toggleClass('has-unread-dm', hasUnreadDm);
-            item.append($('<img alt="">').attr('src', getThumbnailUrl('avatar', avatarId)));
+            item.append($('<img alt="">').attr({
+                src: getThumbnailUrl('avatar', avatarId),
+                loading: 'lazy',
+                decoding: 'async',
+            }));
             item.append($('<span></span>').text(character.name));
             if (hasUnreadDm) {
                 item.attr('title', `${character.name}: unread DM — tap to open`);
@@ -1170,10 +1174,8 @@ async function validateGroup(group) {
         }
     }
 
-    if ((!Array.isArray(group.chats) || !group.chats.length) && !group.chat_id) {
-        const freshChatId = humanizedDateTime();
-        group.chat_id = freshChatId;
-        group.chats = [freshChatId];
+    if (!Array.isArray(group.chats)) {
+        group.chats = [];
         dirty = true;
     }
 
@@ -1199,10 +1201,21 @@ export async function getGroupChat(groupId, reload = false) {
     await validateGroup(group);
     await unshallowGroupMembers(groupId);
 
+    let createdChat = false;
+
+    if (!group.chat_id) {
+        const freshChatId = humanizedDateTime();
+        group.chat_id = freshChatId;
+        group.chats = Array.isArray(group.chats) ? group.chats : [];
+        group.chats.push(freshChatId);
+        await editGroup(group.id, true, false);
+        createdChat = true;
+    }
+
     const chat_id = group.chat_id;
     const data = await loadGroupChat(chat_id);
     const metadata = data?.[0]?.chat_metadata ?? {};
-    const freshChat = !metadata.tainted && (!Array.isArray(data) || !data.length);
+    const freshChat = createdChat && !metadata.tainted && (!Array.isArray(data) || !data.length);
 
     // Remove chat file header if present
     if (Array.isArray(data) && data.length && Object.hasOwn(data[0], 'chat_metadata')) {
@@ -1789,7 +1802,11 @@ function getGroupAvatar(group) {
         const groupAvatar = $(`#group_avatars_template .collage_${avatarCount}`).clone();
 
         for (let i = 0; i < avatarCount; i++) {
-            groupAvatar.find(`.img_${i + 1}`).attr('src', memberAvatars[i]);
+            groupAvatar.find(`.img_${i + 1}`).attr({
+                src: memberAvatars[i],
+                loading: 'lazy',
+                decoding: 'async',
+            });
         }
 
         groupAvatar.attr('title', `[Group] ${group.name}`);
@@ -1803,7 +1820,11 @@ function getGroupAvatar(group) {
 
     // default avatar
     const groupAvatar = $('#group_avatars_template .collage_1').clone();
-    groupAvatar.find('.img_1').attr('src', group.avatar_url || system_avatar);
+    groupAvatar.find('.img_1').attr({
+        src: group.avatar_url || system_avatar,
+        loading: 'lazy',
+        decoding: 'async',
+    });
     groupAvatar.attr('title', `[Group] ${group.name}`);
     return groupAvatar;
 }

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -279,6 +279,7 @@ export const power_user = {
     auto_swipe_blacklist: [],
     auto_swipe_blacklist_threshold: 2,
     auto_scroll_chat_to_bottom: true,
+    experimental_chat_virtualization: false,
     auto_fix_generated_markdown: true,
     auto_clear_cache_on_update: true,
     send_on_enter: send_on_enter_options.AUTO,
@@ -1783,6 +1784,7 @@ export async function loadPowerUserSettings(settings, data) {
     $('#auto_fix_generated_markdown').prop('checked', power_user.auto_fix_generated_markdown);
     $('#auto_clear_cache_on_update').prop('checked', power_user.auto_clear_cache_on_update);
     $('#auto_scroll_chat_to_bottom').prop('checked', power_user.auto_scroll_chat_to_bottom);
+    $('#experimental_chat_virtualization').prop('checked', !!power_user.experimental_chat_virtualization);
     $('#bogus_folders').prop('checked', power_user.bogus_folders);
     $('#zoomed_avatar_magnification').prop('checked', power_user.zoomed_avatar_magnification);
     $(`#tokenizer option[value="${power_user.tokenizer}"]`).prop('selected', true);
@@ -3761,6 +3763,13 @@ jQuery(async () => {
     $('#auto_scroll_chat_to_bottom').on('input', function () {
         power_user.auto_scroll_chat_to_bottom = !!$(this).prop('checked');
         saveSettingsDebounced();
+    });
+
+    $('#experimental_chat_virtualization').on('input', function () {
+        power_user.experimental_chat_virtualization = !!$(this).prop('checked');
+        document.body.classList.toggle('sb-chat-virtualization-enabled', power_user.experimental_chat_virtualization);
+        saveSettingsDebounced();
+        reloadCurrentChat();
     });
 
     $('#tokenizer').on('change', function () {

--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -109,6 +109,26 @@ function registerPresetManagers() {
     });
 }
 
+function injectRestoreDefaultPresetButtons() {
+    $('[data-preset-manager-restore]').each((_, element) => {
+        const apiId = $(element).data('preset-manager-restore');
+        if (!apiId || $(element).siblings(`[data-preset-manager-restore-defaults="${apiId}"]`).length) {
+            return;
+        }
+
+        const button = $('<div></div>', {
+            class: 'menu_button menu_button_icon',
+            title: t`Restore default presets`,
+            'aria-label': t`Restore default presets`,
+            'data-i18n': '[title]Restore default presets',
+            'data-preset-manager-restore-defaults': apiId,
+            html: '<i class="fa-solid fa-box-open" aria-hidden="true"></i>',
+        });
+
+        $(element).after(button);
+    });
+}
+
 class PresetManager {
     constructor(select, apiId) {
         this.select = select;
@@ -464,7 +484,7 @@ class PresetManager {
      * @param {object} [options] Options for saving the preset
      * @param {boolean} [options.skipUpdate=false] If true, skips updating the preset list after saving.
      */
-    async savePreset(name, settings, { skipUpdate = false } = {}) {
+    async savePreset(name, settings, { skipUpdate = false, restoreDefault = false } = {}) {
         if (this.apiId === 'instruct' && settings) {
             await checkForSystemPromptInInstructTemplate(name, settings);
         }
@@ -478,11 +498,15 @@ class PresetManager {
         const response = await fetch('/api/presets/save', {
             method: 'POST',
             headers: getRequestHeaders(),
-            body: JSON.stringify({ preset, name, apiId: this.apiId }),
+            body: JSON.stringify({ preset, name, apiId: this.apiId, restoreDefault }),
         });
 
         if (!response.ok) {
-            toastr.error(t`Check the server connection and reload the page to prevent data loss.`, t`Preset could not be saved`);
+            const responseData = await response.json().catch(() => ({}));
+            const errorMessage = responseData?.isDeletedDefault
+                ? t`This bundled default was deleted. Use Restore default presets to bring it back.`
+                : t`Check the server connection and reload the page to prevent data loss.`;
+            toastr.error(errorMessage, t`Preset could not be saved`);
             console.error('Preset could not be saved', response);
             throw new Error('Preset could not be saved');
         }
@@ -910,6 +934,59 @@ class PresetManager {
     }
 
     /**
+     * Restores all bundled default presets for this API.
+     * @returns {Promise<any>} Restore result from the server
+     */
+    async restoreDefaultPresets() {
+        const response = await fetch('/api/presets/restore-defaults', {
+            method: 'POST',
+            headers: getRequestHeaders(),
+            body: JSON.stringify({ apiId: this.apiId }),
+        });
+
+        if (!response.ok) {
+            const errorToast = !this.isAdvancedFormatting() ? t`Failed to restore default presets` : t`Failed to restore default templates`;
+            toastr.error(errorToast);
+            return null;
+        }
+
+        return await response.json();
+    }
+
+    /**
+     * Adds restored presets to the select and in-memory preset list without selecting them.
+     * @param {string[]} filenames Restored preset filenames
+     */
+    async refreshRestoredDefaultOptions(filenames = []) {
+        const { preset_names, presets } = this.getPresetList();
+        const names = filenames
+            .map(filename => String(filename || '').replace(/\.[^.]+$/, '').split(/[\\/]/).pop())
+            .filter(Boolean);
+
+        for (const name of names) {
+            if (this.findPreset(name) !== undefined) {
+                continue;
+            }
+
+            const data = await this.getDefaultPreset(name);
+            if (!data?.isDefault || !data.preset || Object.keys(data.preset).length === 0) {
+                continue;
+            }
+
+            if (this.isKeyedApi()) {
+                presets.push(data.preset);
+                preset_names.push(name);
+                $(this.select).append($('<option></option>', { value: name, text: name }));
+            } else if (!Object.hasOwn(preset_names, name)) {
+                const value = presets.length;
+                presets.push(data.preset);
+                preset_names[name] = value;
+                $(this.select).append($('<option></option>', { value, text: name }));
+            }
+        }
+    }
+
+    /**
      * Reads a preset extension field from the preset.
      * @param {object} options
      * @param {string} [options.name] Name of the preset. If not provided, uses the currently selected preset name.
@@ -1057,6 +1134,7 @@ async function waitForConnection() {
 export async function initPresetManager() {
     eventSource.on(event_types.CHAT_CHANGED, autoSelectPreset);
     registerPresetManagers();
+    injectRestoreDefaultPresetButtons();
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name: 'preset',
         callback: presetCommandCallback,
@@ -1303,7 +1381,7 @@ export async function initPresetManager() {
             }
 
             await presetManager.deletePreset();
-            await presetManager.savePreset(name, data.preset);
+            await presetManager.savePreset(name, data.preset, { restoreDefault: true });
             const option = presetManager.findPreset(name);
             presetManager.selectPreset(option);
             const successToast = !presetManager.isAdvancedFormatting() ? t`Default preset restored` : t`Default template restored`;
@@ -1322,6 +1400,35 @@ export async function initPresetManager() {
             const successToast = !presetManager.isAdvancedFormatting() ? t`Preset restored` : t`Template restored`;
             toastr.success(successToast);
         }
+    });
+
+    $(document).on('click', '[data-preset-manager-restore-defaults]', async function () {
+        const apiId = $(this).data('preset-manager-restore-defaults');
+        const presetManager = getPresetManager(apiId);
+
+        if (!presetManager) {
+            console.warn(`Preset Manager not found for API: ${apiId}`);
+            return;
+        }
+
+        const noun = presetManager.isAdvancedFormatting() ? t`templates` : t`presets`;
+        const confirm = await Popup.show.confirm(
+            t`Restore default presets?`,
+            t`Deleted bundled default ${noun} for this section will be restored. Custom ${noun} are kept.`,
+        );
+
+        if (!confirm) {
+            return;
+        }
+
+        const result = await presetManager.restoreDefaultPresets();
+        if (!result) {
+            return;
+        }
+
+        await presetManager.refreshRestoredDefaultOptions(result.restored);
+        toastr.success(t`Restored ${result.restored.length} default ${noun}.`);
+        saveSettingsDebounced();
     });
 
     $('#af_master_import').on('click', () => {

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -58,10 +58,16 @@ const SB_FRONTEND_ICONS = Object.freeze([
 ]);
 const SB_ACCOUNT_STORAGE_READY_MARKER = '__migrated';
 const SB_INLINE_DRAWER_CUSTOM_PERSISTENCE_SELECTOR = '.sb-openai-settings-drawer, .sb-openai-settings-subdrawer, [id$="prompt_manager_drawer"]';
+const SB_STORAGE_PREFIX = 'sb-';
+const SB_STORAGE_WRITE_DEBOUNCE_MS = 120;
 
 let sbInlineDrawerPersistenceObserver = null;
 let sbInlineDrawerPersistenceQueued = false;
 let sbChatScriptModulePromise = null;
+let sbStorageFlushTimer = 0;
+let sbStorageFlushEventsBound = false;
+const sbStorageCache = new Map();
+const sbStoragePendingWrites = new Map();
 
 function getShortcutTarget(side) {
     const stored = safeGetItem(side === 'left' ? SB_STORAGE_KEYS.shortcutLeft : SB_STORAGE_KEYS.shortcutRight);
@@ -103,21 +109,105 @@ function activateShortcutTarget(target) {
     }
 }
 
+function isSillyBunnyStorageKey(key) {
+    return typeof key === 'string' && key.startsWith(SB_STORAGE_PREFIX);
+}
+
+function scheduleSbStorageFlush() {
+    if (sbStorageFlushTimer) {
+        return;
+    }
+
+    sbStorageFlushTimer = window.setTimeout(flushSbStorageWrites, SB_STORAGE_WRITE_DEBOUNCE_MS);
+}
+
+function flushSbStorageWrites() {
+    if (sbStorageFlushTimer) {
+        window.clearTimeout(sbStorageFlushTimer);
+        sbStorageFlushTimer = 0;
+    }
+
+    if (!sbStoragePendingWrites.size) {
+        return;
+    }
+
+    const pendingWrites = Array.from(sbStoragePendingWrites.entries());
+    sbStoragePendingWrites.clear();
+
+    for (const [key, write] of pendingWrites) {
+        try {
+            if (write?.remove) {
+                localStorage.removeItem(key);
+            } else {
+                localStorage.setItem(key, write.value);
+            }
+        } catch {
+            // Keep the previous safe localStorage semantics: storage failures are non-fatal.
+        }
+    }
+}
+
+function bindSbStorageFlushEvents() {
+    if (sbStorageFlushEventsBound || typeof window === 'undefined') {
+        return;
+    }
+
+    window.addEventListener('pagehide', flushSbStorageWrites);
+    window.addEventListener('beforeunload', flushSbStorageWrites);
+    document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'hidden') {
+            flushSbStorageWrites();
+        }
+    });
+    sbStorageFlushEventsBound = true;
+}
+
 function safeGetItem(key) {
-    try { return localStorage.getItem(key); } catch { return null; }
+    if (!isSillyBunnyStorageKey(key)) {
+        try { return localStorage.getItem(key); } catch { return null; }
+    }
+
+    if (sbStorageCache.has(key)) {
+        return sbStorageCache.get(key);
+    }
+
+    try {
+        const value = localStorage.getItem(key);
+        sbStorageCache.set(key, value);
+        return value;
+    } catch {
+        return null;
+    }
 }
 
 function safeSetItem(key, value) {
-    try { localStorage.setItem(key, value); } catch {
-        // Ignore storage write failures.
+    if (!isSillyBunnyStorageKey(key)) {
+        try { localStorage.setItem(key, value); } catch {
+            // Ignore storage write failures.
+        }
+        return;
     }
+
+    const stringValue = String(value);
+    sbStorageCache.set(key, stringValue);
+    sbStoragePendingWrites.set(key, { value: stringValue, remove: false });
+    scheduleSbStorageFlush();
 }
 
 function safeRemoveItem(key) {
-    try { localStorage.removeItem(key); } catch {
-        // Ignore storage removal failures.
+    if (!isSillyBunnyStorageKey(key)) {
+        try { localStorage.removeItem(key); } catch {
+            // Ignore storage removal failures.
+        }
+        return;
     }
+
+    sbStorageCache.set(key, null);
+    sbStoragePendingWrites.set(key, { remove: true });
+    scheduleSbStorageFlush();
 }
+
+bindSbStorageFlushEvents();
 
 const SB_IDLE_BRAND_LABEL = 'SillyBunny';
 const SB_MOBILE_MEDIA_QUERY = '(max-width: 768px)';
@@ -409,6 +499,7 @@ const sbState = {
         results: null,
         expanded: false,
         dismissBound: false,
+        activeIndex: -1,
     },
     shellSizing: {
         overrides: {
@@ -1018,6 +1109,7 @@ function setUniversalSearchOpenState(isOpen, { focusInput = false } = {}) {
     root?.setAttribute('aria-expanded', String(nextOpenState));
     if (input instanceof HTMLInputElement) {
         input.tabIndex = nextOpenState ? 0 : -1;
+        input.setAttribute('aria-expanded', String(nextOpenState));
     }
 
     if (!nextOpenState) {
@@ -1048,6 +1140,8 @@ function clearUniversalSearch({ blur = false } = {}) {
         searchState.results.classList.remove('is-visible');
     }
 
+    searchState.activeIndex = -1;
+    searchState.input?.removeAttribute('aria-activedescendant');
     setUniversalSearchOpenState(false);
 }
 
@@ -4730,10 +4824,14 @@ function buildUniversalSearchRow() {
             autocomplete: 'off',
             enterkeyhint: 'search',
             spellcheck: 'false',
+            role: 'combobox',
+            'aria-expanded': 'false',
+            'aria-controls': 'sb-universal-search-results',
         },
     });
     const panel = createElement('div', { className: 'sb-universal-search-panel' });
     const searchResults = createElement('div', {
+        id: 'sb-universal-search-results',
         className: 'sb-search-results',
         attrs: {
             role: 'listbox',
@@ -4771,8 +4869,22 @@ function buildUniversalSearchRow() {
     });
 
     searchInput.addEventListener('keydown', event => {
+        const resultButtons = Array.from(searchResults.querySelectorAll('.sb-search-result'));
+
+        if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+            event.preventDefault();
+            if (!resultButtons.length) {
+                return;
+            }
+
+            const direction = event.key === 'ArrowDown' ? 1 : -1;
+            const nextIndex = (sbState.universalSearch.activeIndex + direction + resultButtons.length) % resultButtons.length;
+            setUniversalSearchActiveIndex(nextIndex);
+            return;
+        }
+
         if (event.key === 'Enter') {
-            const firstMatch = searchResults.querySelector('.sb-search-result');
+            const firstMatch = resultButtons[sbState.universalSearch.activeIndex] ?? resultButtons[0];
             if (firstMatch instanceof HTMLButtonElement) {
                 event.preventDefault();
                 firstMatch.click();
@@ -5802,6 +5914,7 @@ async function requestServerAdmin(endpoint, body = {}) {
             : data?.error || data?.message || text || `Request failed with status ${response.status}.`;
         const error = new Error(message);
         error.status = response.status;
+        error.data = data;
         throw error;
     }
 
@@ -5869,6 +5982,18 @@ function setServerAdminButtonLabel(button, isBusy, busyLabel) {
     }
 
     button.textContent = isBusy ? busyLabel : button.dataset.idleLabel;
+}
+
+function describeAutoStashState(result) {
+    if (!result?.stashed) {
+        return '';
+    }
+
+    if (result?.stashPopWarning) {
+        return result.stashPopWarning;
+    }
+
+    return 'Local tracked and untracked changes were auto-stashed and restored.';
 }
 
 function getThumbnailSettingsFromRefs(refs = getServerAdminRefs()) {
@@ -6486,15 +6611,22 @@ async function handleServerAdminUpdate() {
 
         if (!result?.updated) {
             renderServerAdminStatus(nextStatus);
-            setServerAdminMessage(refs.updateNote, result?.message || 'Already up to date.', 'good');
+            const stashMessage = describeAutoStashState(result);
+            setServerAdminMessage(refs.updateNote, [result?.message || 'Already up to date.', stashMessage].filter(Boolean).join('\n'), stashMessage ? 'warn' : 'good');
+            if (stashMessage) {
+                toastr.info(stashMessage, 'Auto-stash');
+            }
             toastr.success(result?.message || 'Already up to date.', 'Server update');
             return;
         }
 
         renderServerAdminStatus(nextStatus);
 
+        const stashMessage = describeAutoStashState(result);
         if (result?.stashPopWarning) {
-            toastr.warning(result.stashPopWarning, 'Auto-stash warning', { timeOut: 10000 });
+            toastr.warning(stashMessage, 'Auto-stash warning', { timeOut: 10000 });
+        } else if (stashMessage) {
+            toastr.info(stashMessage, 'Auto-stash');
         }
 
         if (result?.install?.stdout || result?.install?.stderr) {
@@ -6522,7 +6654,11 @@ async function handleServerAdminUpdate() {
     } catch (error) {
         console.error('Failed to update SillyBunny.', error);
         state.busy = false;
-        setServerAdminMessage(refs.updateNote, error.message || 'Failed to update SillyBunny.', 'danger');
+        const stashMessage = describeAutoStashState(error?.data);
+        if (stashMessage) {
+            toastr.warning(stashMessage, 'Auto-stash warning', { timeOut: 10000 });
+        }
+        setServerAdminMessage(refs.updateNote, [error.message || 'Failed to update SillyBunny.', stashMessage].filter(Boolean).join('\n'), 'danger');
         toastr.error(error.message || 'Failed to update SillyBunny.', 'Server update');
     } finally {
         setServerAdminButtonLabel(refs.updateButton, false, 'Updating…');
@@ -8174,6 +8310,8 @@ function renderUniversalSearchResults(query) {
     }
 
     results.replaceChildren();
+    searchState.activeIndex = -1;
+    searchState.input?.removeAttribute('aria-activedescendant');
 
     if (!searchState.expanded) {
         results.classList.remove('is-visible');
@@ -8189,37 +8327,61 @@ function renderUniversalSearchResults(query) {
     }
 
     const matches = collectGlobalSearchMatches(trimmedQuery);
-
+    const groupedMatches = new Map();
     for (const match of matches) {
-        const button = createElement('button', {
-            className: 'sb-search-result',
+        const groupLabel = `${match.shellLabel} · ${match.tabLabel}`;
+        if (!groupedMatches.has(groupLabel)) {
+            groupedMatches.set(groupLabel, []);
+        }
+        groupedMatches.get(groupLabel).push(match);
+    }
+
+    for (const [groupLabel, groupMatches] of groupedMatches.entries()) {
+        const group = createElement('div', {
+            className: 'sb-search-result-group',
             attrs: {
-                type: 'button',
+                role: 'group',
+                'aria-label': groupLabel,
             },
         });
-        const detailText = normalizeText(match.displayText) === normalizeText(match.sectionLabel)
-            ? `Jump straight to this item in ${match.tabLabel}.`
-            : match.displayText;
-        const sectionDisplay = match.sectionLabel === match.tabLabel
-            ? match.displayText || match.tabLabel
-            : match.sectionLabel;
+        group.appendChild(createElement('div', { className: 'sb-search-result-group-label', text: groupLabel }));
 
-        button.appendChild(createElement('strong', { text: sectionDisplay }));
+        for (const match of groupMatches) {
+            const button = createElement('button', {
+                className: 'sb-search-result',
+                attrs: {
+                    type: 'button',
+                    role: 'option',
+                    id: `sb-search-result-${results.querySelectorAll('.sb-search-result').length}`,
+                    'aria-selected': 'false',
+                },
+            });
+            const detailText = normalizeText(match.displayText) === normalizeText(match.sectionLabel)
+                ? `Jump straight to this item in ${match.tabLabel}.`
+                : match.displayText;
+            const sectionDisplay = match.sectionLabel === match.tabLabel
+                ? match.displayText || match.tabLabel
+                : match.sectionLabel;
 
-        if (sectionDisplay !== match.displayText) {
-            button.appendChild(createElement('span', { text: detailText }));
+            button.appendChild(createElement('strong', { text: sectionDisplay }));
+
+            if (sectionDisplay !== match.displayText) {
+                button.appendChild(createElement('span', { text: detailText }));
+            }
+
+            button.appendChild(createElement('small', {
+                text: typeof match.action === 'function' ? 'Quick action' : 'Jump to setting',
+            }));
+
+            button.addEventListener('click', () => {
+                clearUniversalSearch({ blur: true });
+                revealSearchMatch(match.shellKey, match);
+            });
+
+            group.appendChild(button);
         }
 
-        button.appendChild(createElement('small', {
-            text: `${match.shellLabel} · ${match.tabLabel}`,
-        }));
-
-        button.addEventListener('click', () => {
-            clearUniversalSearch({ blur: true });
-            revealSearchMatch(match.shellKey, match);
-        });
-
-        results.appendChild(button);
+        results.appendChild(group);
     }
 
     if (!results.childElementCount) {
@@ -8231,6 +8393,35 @@ function renderUniversalSearchResults(query) {
     }
 
     results.classList.add('is-visible');
+    setUniversalSearchActiveIndex(results.querySelector('.sb-search-result') ? 0 : -1);
+}
+
+function setUniversalSearchActiveIndex(index) {
+    const searchState = getUniversalSearchState();
+    const results = searchState.results;
+    const input = searchState.input;
+
+    if (!(results instanceof HTMLElement)) {
+        return;
+    }
+
+    const buttons = Array.from(results.querySelectorAll('.sb-search-result'));
+    searchState.activeIndex = buttons.length ? Math.min(Math.max(index, 0), buttons.length - 1) : -1;
+
+    for (let i = 0; i < buttons.length; i++) {
+        const button = buttons[i];
+        const active = i === searchState.activeIndex;
+        button.classList.toggle('is-active', active);
+        button.setAttribute('aria-selected', String(active));
+        if (active) {
+            input?.setAttribute('aria-activedescendant', button.id);
+            button.scrollIntoView({ block: 'nearest' });
+        }
+    }
+
+    if (searchState.activeIndex === -1) {
+        input?.removeAttribute('aria-activedescendant');
+    }
 }
 
 function expandHiddenAccordions(target) {

--- a/src/endpoints/content-manager.js
+++ b/src/endpoints/content-manager.js
@@ -18,6 +18,7 @@ const contentDirectory = path.join(serverDirectory, 'default/content');
 const scaffoldDirectory = path.join(serverDirectory, 'default/scaffold');
 const contentIndexPath = path.join(contentDirectory, 'index.json');
 const scaffoldIndexPath = path.join(scaffoldDirectory, 'index.json');
+const DEFAULT_PRESET_DELETIONS_FILE = 'default-preset-deletions.json';
 
 const WHITELIST_GENERIC_URL_DOWNLOAD_SOURCES = getConfigValue('whitelistImportDomains', []);
 const USER_AGENT = 'SillyTavern';
@@ -83,6 +84,126 @@ function isPresetContentType(type) {
     return PRESET_CONTENT_TYPES.includes(type);
 }
 
+function getDefaultPresetDeletionPath(directories) {
+    return path.join(directories.root, DEFAULT_PRESET_DELETIONS_FILE);
+}
+
+function getDefaultPresetDeletionKey(contentItem) {
+    return `${contentItem.type}::${contentItem.filename}`;
+}
+
+function normalizePresetDeletionData(data) {
+    const normalized = { version: 1, deleted: {} };
+
+    if (!data || typeof data !== 'object') {
+        return normalized;
+    }
+
+    const source = data.deleted && typeof data.deleted === 'object' ? data.deleted : data;
+
+    if (Array.isArray(source)) {
+        for (const item of source) {
+            if (!item || typeof item !== 'object' || !item.type || !item.filename) {
+                continue;
+            }
+
+            normalized.deleted[getDefaultPresetDeletionKey(item)] = {
+                type: String(item.type),
+                filename: String(item.filename),
+                deletedAt: Number(item.deletedAt) || Date.now(),
+            };
+        }
+
+        return normalized;
+    }
+
+    for (const [key, value] of Object.entries(source)) {
+        if (value === true) {
+            const [type, filename] = key.split('::');
+            if (type && filename) {
+                normalized.deleted[key] = { type, filename, deletedAt: Date.now() };
+            }
+            continue;
+        }
+
+        if (!value || typeof value !== 'object' || !value.type || !value.filename) {
+            continue;
+        }
+
+        normalized.deleted[getDefaultPresetDeletionKey(value)] = {
+            type: String(value.type),
+            filename: String(value.filename),
+            deletedAt: Number(value.deletedAt) || Date.now(),
+        };
+    }
+
+    return normalized;
+}
+
+export function getDefaultPresetDeletions(directories) {
+    try {
+        const deletionPath = getDefaultPresetDeletionPath(directories);
+        if (!fs.existsSync(deletionPath)) {
+            return { version: 1, deleted: {} };
+        }
+
+        return normalizePresetDeletionData(JSON.parse(fs.readFileSync(deletionPath, 'utf8')));
+    } catch (error) {
+        console.warn('Failed to read default preset deletions', error);
+        return { version: 1, deleted: {} };
+    }
+}
+
+function writeDefaultPresetDeletions(directories, deletions) {
+    const normalized = normalizePresetDeletionData(deletions);
+    const deletionPath = getDefaultPresetDeletionPath(directories);
+
+    fs.mkdirSync(path.dirname(deletionPath), { recursive: true });
+    writeFileAtomicSync(deletionPath, `${JSON.stringify(normalized, null, 4)}\n`, 'utf8');
+}
+
+export function isDefaultPresetDeleted(directories, contentItem) {
+    if (!contentItem || !isPresetContentType(contentItem.type)) {
+        return false;
+    }
+
+    const deletions = getDefaultPresetDeletions(directories);
+    return Object.hasOwn(deletions.deleted, getDefaultPresetDeletionKey(contentItem));
+}
+
+export function recordDefaultPresetDeletion(directories, contentItem) {
+    if (!contentItem || !isPresetContentType(contentItem.type)) {
+        return false;
+    }
+
+    const deletions = getDefaultPresetDeletions(directories);
+    const key = getDefaultPresetDeletionKey(contentItem);
+    deletions.deleted[key] = {
+        type: contentItem.type,
+        filename: contentItem.filename,
+        deletedAt: Date.now(),
+    };
+    writeDefaultPresetDeletions(directories, deletions);
+    return true;
+}
+
+export function clearDefaultPresetDeletion(directories, contentItem) {
+    if (!contentItem || !isPresetContentType(contentItem.type)) {
+        return false;
+    }
+
+    const deletions = getDefaultPresetDeletions(directories);
+    const key = getDefaultPresetDeletionKey(contentItem);
+
+    if (!Object.hasOwn(deletions.deleted, key)) {
+        return false;
+    }
+
+    delete deletions.deleted[key];
+    writeDefaultPresetDeletions(directories, deletions);
+    return true;
+}
+
 /**
  * @enum {string}
  */
@@ -109,16 +230,23 @@ function getScopeByType(type) {
  * @param {import('../users.js').UserDirectoryList} directories User directories
  * @returns {object[]} Array of default presets
  */
-export function getDefaultPresets(directories) {
+export function getDefaultPresets(directories, { includeDeleted = true } = {}) {
     try {
         const contentIndex = getContentIndex(CONTENT_SCOPE.USER);
         const presets = [];
 
         for (const contentItem of contentIndex) {
             if (isPresetContentType(contentItem.type)) {
-                contentItem.name = path.parse(contentItem.filename).name;
-                contentItem.folder = getUserTargetByType(contentItem.type, directories);
-                presets.push(contentItem);
+                if (!includeDeleted && isDefaultPresetDeleted(directories, contentItem)) {
+                    continue;
+                }
+
+                presets.push({
+                    ...contentItem,
+                    name: path.parse(contentItem.filename).name,
+                    folder: getUserTargetByType(contentItem.type, directories),
+                    sourceFolder: contentItem.folder,
+                });
             }
         }
 
@@ -127,6 +255,63 @@ export function getDefaultPresets(directories) {
         console.warn('Failed to get default presets', err);
         return [];
     }
+}
+
+/**
+ * Finds a bundled default preset by target folder and display name.
+ * @param {import('../users.js').UserDirectoryList} directories User directories
+ * @param {object} options Lookup options
+ * @param {string} options.folder Target folder
+ * @param {string} options.name Preset name without extension
+ * @returns {ContentItem|null} Default preset item
+ */
+export function findDefaultPreset(directories, { folder, name }) {
+    if (!folder || !name) {
+        return null;
+    }
+
+    const defaultPresets = getDefaultPresets(directories, { includeDeleted: true });
+    return defaultPresets.find(preset => preset.folder === folder && preset.name === name) || null;
+}
+
+/**
+ * Restores bundled default preset files for a user.
+ * @param {import('../users.js').UserDirectoryList} directories User directories
+ * @param {string[]|null} types Content types to restore, or null for all preset types
+ * @returns {{restored: string[], failed: {filename: string, error: string}[]}}
+ */
+export function restoreDefaultPresetFiles(directories, types = null) {
+    const allowedTypes = Array.isArray(types) && types.length ? new Set(types) : null;
+    const defaultPresets = getDefaultPresets(directories, { includeDeleted: true })
+        .filter(preset => !allowedTypes || allowedTypes.has(preset.type));
+    const restored = [];
+    const failed = [];
+
+    for (const preset of defaultPresets) {
+        try {
+            const sourceFolder = preset.sourceFolder || contentDirectory;
+            const sourcePath = path.join(sourceFolder, preset.filename);
+            const targetFolder = preset.folder;
+            const targetPath = path.join(targetFolder, path.parse(preset.filename).base);
+
+            if (!targetFolder || !fs.existsSync(sourcePath)) {
+                throw new Error('Default preset source is missing.');
+            }
+
+            fs.mkdirSync(targetFolder, { recursive: true });
+            fs.cpSync(sourcePath, targetPath, { recursive: true, force: true });
+            setPermissionsSync(targetPath);
+            clearDefaultPresetDeletion(directories, preset);
+            restored.push(preset.filename);
+        } catch (error) {
+            failed.push({
+                filename: preset.filename,
+                error: error.message || String(error),
+            });
+        }
+    }
+
+    return { restored, failed };
 }
 
 /**
@@ -261,7 +446,15 @@ async function seedContentForUser(contentIndex, directories, forceCategories) {
     const contentLog = getContentLog(contentLogPath);
     removeObsoleteContent(contentLog, directories);
     writeFileAtomicSync(contentLogPath, contentLog.join('\n'));
-    return seedContent(contentIndex, contentLogPath, (type) => getUserTargetByType(type, directories), forceCategories);
+    const filteredContentIndex = contentIndex.filter(contentItem => {
+        if (!isPresetContentType(contentItem.type)) {
+            return true;
+        }
+
+        return !isDefaultPresetDeleted(directories, contentItem);
+    });
+
+    return seedContent(filteredContentIndex, contentLogPath, (type) => getUserTargetByType(type, directories), forceCategories);
 }
 
 /**

--- a/src/endpoints/presets.js
+++ b/src/endpoints/presets.js
@@ -5,7 +5,15 @@ import express from 'express';
 import sanitize from 'sanitize-filename';
 import { sync as writeFileAtomicSync } from 'write-file-atomic';
 
-import { getDefaultPresetFile, getDefaultPresets } from './content-manager.js';
+import {
+    clearDefaultPresetDeletion,
+    findDefaultPreset,
+    getDefaultPresetFile,
+    getDefaultPresets,
+    isDefaultPresetDeleted,
+    recordDefaultPresetDeletion,
+    restoreDefaultPresetFiles,
+} from './content-manager.js';
 
 /**
  * Gets the folder and extension for the preset settings based on the API source ID.
@@ -37,6 +45,27 @@ function getPresetSettingsByAPI(apiId, directories) {
     }
 }
 
+function getPresetContentTypeByAPI(apiId) {
+    switch (apiId) {
+        case 'kobold':
+        case 'koboldhorde':
+            return 'kobold_preset';
+        case 'novel':
+            return 'novel_preset';
+        case 'textgenerationwebui':
+            return 'textgen_preset';
+        case 'openai':
+            return 'openai_preset';
+        case 'instruct':
+        case 'context':
+        case 'sysprompt':
+        case 'reasoning':
+            return apiId;
+        default:
+            return null;
+    }
+}
+
 export const router = express.Router();
 
 router.post('/save', function (request, response) {
@@ -53,6 +82,21 @@ router.post('/save', function (request, response) {
     }
 
     const fullpath = path.join(settings.folder, filename);
+    const defaultPreset = findDefaultPreset(request.user.directories, { folder: settings.folder, name });
+    const explicitDefaultRestore = Boolean(request.body.restoreDefault);
+
+    if (defaultPreset && isDefaultPresetDeleted(request.user.directories, defaultPreset) && !explicitDefaultRestore) {
+        return response.status(409).send({
+            error: 'This bundled default preset was deleted by the user and will not be recreated unless defaults are explicitly restored.',
+            isDeletedDefault: true,
+            name,
+        });
+    }
+
+    if (defaultPreset && explicitDefaultRestore) {
+        clearDefaultPresetDeletion(request.user.directories, defaultPreset);
+    }
+
     writeFileAtomicSync(fullpath, JSON.stringify(request.body.preset, null, 4), 'utf-8');
     return response.send({ name });
 });
@@ -72,12 +116,23 @@ router.post('/delete', function (request, response) {
 
     const fullpath = path.join(settings.folder, filename);
 
+    const defaultPreset = findDefaultPreset(request.user.directories, { folder: settings.folder, name });
+
     if (fs.existsSync(fullpath)) {
+        if (defaultPreset) {
+            recordDefaultPresetDeletion(request.user.directories, defaultPreset);
+        }
+
         fs.unlinkSync(fullpath);
         return response.sendStatus(200);
-    } else {
-        return response.sendStatus(404);
     }
+
+    if (defaultPreset) {
+        recordDefaultPresetDeletion(request.user.directories, defaultPreset);
+        return response.sendStatus(200);
+    }
+
+    return response.sendStatus(404);
 });
 
 router.post('/restore', function (request, response) {
@@ -88,14 +143,38 @@ router.post('/restore', function (request, response) {
 
         const defaultPreset = defaultPresets.find(p => p.name === name && p.folder === settings.folder);
 
-        const result = { isDefault: false, preset: {} };
+        const result = { isDefault: false, preset: {}, tombstoneCleared: false };
 
         if (defaultPreset) {
             result.isDefault = true;
             result.preset = getDefaultPresetFile(defaultPreset.filename) || {};
+            if (request.body.clearTombstone === true) {
+                result.tombstoneCleared = clearDefaultPresetDeletion(request.user.directories, defaultPreset);
+            }
         }
 
         return response.send(result);
+    } catch (error) {
+        console.error(error);
+        return response.sendStatus(500);
+    }
+});
+
+router.post('/restore-defaults', function (request, response) {
+    try {
+        const apiId = request.body.apiId ? String(request.body.apiId) : '';
+        const contentType = apiId ? getPresetContentTypeByAPI(apiId) : null;
+
+        if (apiId && !contentType) {
+            return response.sendStatus(400);
+        }
+
+        const result = restoreDefaultPresetFiles(request.user.directories, contentType ? [contentType] : null);
+
+        return response.send({
+            ok: result.failed.length === 0,
+            ...result,
+        });
     } catch (error) {
         console.error(error);
         return response.sendStatus(500);

--- a/src/endpoints/server-admin.js
+++ b/src/endpoints/server-admin.js
@@ -290,6 +290,7 @@ function getRestartPayload() {
         cwd: serverDirectory,
         command: [process.argv[0], ...process.argv.slice(1)],
         envPatch: isNativeTermuxEnvironment() ? { SILLYBUNNY_SKIP_BROWSER_AUTO_LAUNCH: '1' } : {},
+        visibleRelaunch: process.platform === 'win32',
     };
 
     return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64');
@@ -314,10 +315,14 @@ function scheduleRestart(response) {
     const helper = spawn(process.argv[0], [helperScriptPath, getRestartPayload()], {
         cwd: serverDirectory,
         detached: true,
-        stdio: 'ignore',
+        stdio: process.platform === 'win32' ? ['ignore', 'inherit', 'inherit'] : 'ignore',
         env: process.env,
+        windowsHide: false,
     });
 
+    helper.once('error', (error) => {
+        console.error('Failed to start restart helper.', error);
+    });
     helper.unref();
 
     response.once('finish', () => {
@@ -329,6 +334,18 @@ function scheduleRestart(response) {
             }
         }, RESTART_RESPONSE_DELAY_MS);
     });
+}
+
+async function restoreAutoStash(git, { reason = 'after update failure' } = {}) {
+    try {
+        await git.stash(['pop']);
+        console.info(`Auto-stashed changes restored ${reason}.`);
+        return null;
+    } catch (error) {
+        const warning = `Auto-stashed changes could not be restored ${reason}: ${error.message}. Your changes remain in git stash.`;
+        console.warn(warning);
+        return warning;
+    }
 }
 
 async function runCommand(command, args, options = {}) {
@@ -704,6 +721,8 @@ router.post('/restart', requireAdminMiddleware, async (_request, response) => {
 });
 
 router.post('/update', requireAdminMiddleware, async (_request, response) => {
+    let git = null;
+    let stashed = false;
     try {
         const repository = await getRepositoryStatus();
 
@@ -720,8 +739,7 @@ router.post('/update', requireAdminMiddleware, async (_request, response) => {
         }
 
         const autoStash = getConfigValue('autoStashBeforePull', false, 'boolean');
-        const git = simpleGit({ baseDir: serverDirectory, ...GIT_OPTIONS });
-        let stashed = false;
+        git = simpleGit({ baseDir: serverDirectory, ...GIT_OPTIONS });
         let stashPopWarning = null;
 
         if (repository.hasLocalChanges) {
@@ -729,9 +747,9 @@ router.post('/update', requireAdminMiddleware, async (_request, response) => {
                 return response.status(409).json({ error: repository.message || 'Local changes are present, so auto-update is blocked.', repository });
             }
             try {
-                await git.stash(['push', '-m', 'SillyBunny auto-stash before update']);
+                await git.stash(['push', '-u', '-m', 'SillyBunny auto-stash before update']);
                 stashed = true;
-                console.info('Local changes stashed before update.');
+                console.info('Local changes, including untracked files, stashed before update.');
             } catch (stashError) {
                 console.error('Failed to stash local changes.', stashError);
                 return response.status(500).json({ error: 'Failed to stash local changes: ' + stashError.message });
@@ -739,16 +757,21 @@ router.post('/update', requireAdminMiddleware, async (_request, response) => {
         }
 
         if (repository.ahead > 0 && repository.behind > 0) {
-            return response.status(409).json({ error: repository.message || 'This branch has diverged from upstream.', repository });
+            if (stashed) {
+                stashPopWarning = await restoreAutoStash(git, { reason: 'after diverged-branch update stop' });
+            }
+            return response.status(409).json({ error: repository.message || 'This branch has diverged from upstream.', repository, stashed, stashPopWarning });
         }
 
         if (repository.behind === 0) {
             if (stashed) {
-                try { await git.stash(['pop']); } catch (_) { /* nothing to worry about */ }
+                stashPopWarning = await restoreAutoStash(git, { reason: 'after no-op update' });
             }
             return response.json({
                 updated: false,
                 restarting: false,
+                stashed,
+                stashPopWarning,
                 message: `Already up to date on ${repository.branch || 'current branch'} tracking ${repository.trackingBranch}.`,
                 repository,
             });
@@ -758,13 +781,7 @@ router.post('/update', requireAdminMiddleware, async (_request, response) => {
         await git.raw(['merge', '--ff-only', repository.trackingBranch]);
 
         if (stashed) {
-            try {
-                await git.stash(['pop']);
-                console.info('Stashed changes restored after update.');
-            } catch (popError) {
-                stashPopWarning = 'Update succeeded, but local changes could not be restored: ' + popError.message + '. Your changes remain in git stash.';
-                console.warn(stashPopWarning);
-            }
+            stashPopWarning = await restoreAutoStash(git, { reason: 'after update' });
         }
 
         const installCommand = getInstallCommand();
@@ -804,8 +821,14 @@ router.post('/update', requireAdminMiddleware, async (_request, response) => {
         });
     } catch (error) {
         console.error('Failed to update SillyBunny.', error);
+        let stashPopWarning = null;
+        if (stashed && git) {
+            stashPopWarning = await restoreAutoStash(git, { reason: 'after update failure' });
+        }
         response.status(500).json({
             error: error.message || 'Failed to update SillyBunny.',
+            stashed,
+            stashPopWarning,
         });
     }
 });

--- a/src/restart-helper.js
+++ b/src/restart-helper.js
@@ -16,6 +16,26 @@ function isProcessAlive(pid) {
     }
 }
 
+function buildVisibleWindowsCommand(command, cwd) {
+    const quoted = command.map(value => `"${String(value).replace(/"/g, '\\"')}"`).join(' ');
+    const title = 'SillyBunny Server';
+    return [
+        'cmd.exe',
+        [
+            '/d',
+            '/s',
+            '/c',
+            'start',
+            `"${title}"`,
+            '/D',
+            `"${cwd}"`,
+            'cmd.exe',
+            '/k',
+            quoted,
+        ],
+    ];
+}
+
 async function waitForParentExit(pid) {
     while (isProcessAlive(pid)) {
         await delay(250);
@@ -28,6 +48,7 @@ async function main() {
     const command = Array.isArray(payload?.command) ? payload.command : [];
     const cwd = String(payload?.cwd ?? process.cwd());
     const envPatch = payload?.envPatch && typeof payload.envPatch === 'object' ? payload.envPatch : {};
+    const visibleRelaunch = Boolean(payload?.visibleRelaunch);
 
     if (!Number.isFinite(parentPid) || command.length < 2) {
         process.exit(1);
@@ -36,11 +57,16 @@ async function main() {
     await waitForParentExit(parentPid);
     await delay(800);
 
-    const child = spawn(command[0], command.slice(1), {
+    const relaunch = visibleRelaunch && process.platform === 'win32'
+        ? buildVisibleWindowsCommand(command, cwd)
+        : [command[0], command.slice(1)];
+
+    const child = spawn(relaunch[0], relaunch[1], {
         cwd,
         detached: true,
-        stdio: 'ignore',
+        stdio: visibleRelaunch && process.platform === 'win32' ? ['ignore', 'inherit', 'inherit'] : 'ignore',
         env: { ...process.env, ...envPatch },
+        windowsHide: false,
     });
 
     child.unref();

--- a/tests/default-preset-deletions.test.js
+++ b/tests/default-preset-deletions.test.js
@@ -1,0 +1,105 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, afterEach, beforeAll, describe, expect, jest, test } from '@jest/globals';
+
+jest.unstable_mockModule('../src/util.js', () => ({
+    color: {
+        blue: value => value,
+        yellow: value => value,
+    },
+    getConfigValue: jest.fn((_key, defaultValue) => defaultValue),
+    isValidUrl: jest.fn(() => false),
+    setPermissionsSync: jest.fn(),
+}));
+
+/** @type {import('../src/endpoints/content-manager.js')} */
+let contentManager;
+
+const tempRoots = [];
+
+function makeTempUserDirectories() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'sb-default-presets-'));
+    tempRoots.push(root);
+
+    const directories = {
+        root,
+        openAI_Settings: path.join(root, 'presets', 'openai'),
+        sysprompt: path.join(root, 'presets', 'sysprompt'),
+    };
+
+    fs.mkdirSync(directories.openAI_Settings, { recursive: true });
+    fs.mkdirSync(directories.sysprompt, { recursive: true });
+
+    return directories;
+}
+
+beforeAll(async () => {
+    contentManager = await import('../src/endpoints/content-manager.js');
+});
+
+afterEach(() => {
+    for (const root of tempRoots.splice(0)) {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+afterAll(() => {
+    jest.restoreAllMocks();
+});
+
+describe('bundled default preset deletion tombstones', () => {
+    test('records and filters deleted bundled presets', () => {
+        const directories = makeTempUserDirectories();
+        const defaultPreset = contentManager.findDefaultPreset(directories, {
+            folder: directories.openAI_Settings,
+            name: 'Default',
+        });
+
+        expect(defaultPreset).toBeTruthy();
+        expect(contentManager.recordDefaultPresetDeletion(directories, defaultPreset)).toBe(true);
+        expect(contentManager.isDefaultPresetDeleted(directories, defaultPreset)).toBe(true);
+
+        const visibleDefaults = contentManager.getDefaultPresets(directories, { includeDeleted: false });
+        expect(visibleDefaults).not.toContainEqual(expect.objectContaining({
+            type: defaultPreset.type,
+            filename: defaultPreset.filename,
+        }));
+    });
+
+    test('single restore clears a matching tombstone', () => {
+        const directories = makeTempUserDirectories();
+        const defaultPreset = contentManager.findDefaultPreset(directories, {
+            folder: directories.sysprompt,
+            name: 'Neutral - Chat',
+        });
+
+        expect(defaultPreset).toBeTruthy();
+        contentManager.recordDefaultPresetDeletion(directories, defaultPreset);
+
+        expect(contentManager.clearDefaultPresetDeletion(directories, defaultPreset)).toBe(true);
+        expect(contentManager.isDefaultPresetDeleted(directories, defaultPreset)).toBe(false);
+    });
+
+    test('bulk restore copies deleted defaults and clears only restored tombstones', () => {
+        const directories = makeTempUserDirectories();
+        const defaultPreset = contentManager.findDefaultPreset(directories, {
+            folder: directories.openAI_Settings,
+            name: 'Default',
+        });
+
+        expect(defaultPreset).toBeTruthy();
+        contentManager.recordDefaultPresetDeletion(directories, defaultPreset);
+
+        const targetPath = path.join(directories.openAI_Settings, path.basename(defaultPreset.filename));
+        expect(fs.existsSync(targetPath)).toBe(false);
+
+        const result = contentManager.restoreDefaultPresetFiles(directories, [defaultPreset.type]);
+
+        expect(result.failed).toHaveLength(0);
+        expect(result.restored).toContain(defaultPreset.filename);
+        expect(fs.existsSync(targetPath)).toBe(true);
+        expect(contentManager.isDefaultPresetDeleted(directories, defaultPreset)).toBe(false);
+    });
+});


### PR DESCRIPTION
## What?
This PR optimizes SillyBunny shell/theme UI hot paths and focus states, adds safer chat rendering and media performance improvements, fixes hard-refresh chat resume, improves Windows in-app restart/update behavior, and adds bundled default preset deletion tombstones and restore-default actions.

## Why?
The UI needed better performance without redesigning the app, and preset deletion needed to persist instead of silently recreating defaults. Restart/update handling also needed to be safer on Windows.

## How?
The implementation batches `sb-*` localStorage writes, adds safer chat render batching, lazy media hints, grouped universal search, and an off-by-default experimental chat rendering prototype using `content-visibility` while keeping `.mes` nodes mounted. It also reuses existing character/group chats on hard refresh, improves restart/update auto-stash and relaunch status handling, and guards Guided Generations preset recreation with deletion tombstones and restore-default actions.

## Testing?
- `npm run lint`
- `npm run test:unit --prefix tests -- default-preset-deletions.test.js`
- `npm run test:unit --prefix tests`

The full unit command failed only on the existing `tests/tokenizers-runtime.test.js` 5s timeout; 19 suites passed.

## Screenshots (optional)
Screenshots were not included. The PR focused on performance, persistence, and restart behavior rather than a specific visual state.

## Anything Else?
Local branches were cleaned up, preserving only `main`, `staging`, and the feature branch. Remote branches were left untouched. No tracked `data/default-user/**` files were changed.