### PR TITLE
feat: add optional frontend production assets

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,29 @@
+# Design
+
+## Style
+
+SillyBunny is a product UI. Visual design serves repeated workflows: chatting, switching personas, managing presets, searching settings, editing characters, and controlling extensions. The shell should feel calm, compact, and familiar, with enough warmth to match the fork's personality.
+
+## Color
+
+Use a restrained strategy by default: tinted dark surfaces, clear text contrast, one accent for active selections and primary actions, and semantic colors only for status. Avoid making inactive controls saturated. Existing theme customization remains the source of truth for user-selected accents.
+
+## Typography
+
+Use a stable product scale, not viewport-fluid type. Prefer Figtree with system UI fallbacks for shell and form text. Use broad fallback fonts only when needed for language coverage. Use mono fonts only for code-like surfaces, token/debug output, or structured prompts.
+
+## Layout
+
+Favor predictable app-shell patterns: top navigation, side panels, drawers, tabs, and dense but scannable settings groups. Do not add cards inside cards. Use responsive structural changes on mobile instead of shrinking everything.
+
+## Components
+
+Controls should have clear default, hover, focus, active, disabled, loading, and error states. Icon buttons should use familiar icons and tooltips. Loading states should reserve space and use skeleton-like placeholders where content layout is known.
+
+## Motion
+
+Use short 150-250 ms transitions for state changes. Prefer transform and opacity. Respect reduced motion. Avoid decorative page-load choreography and animations that change layout.
+
+## Performance Notes
+
+The first viewport should load only what it needs to display the shell and active chat. Heavy panels, broad font families, optional extension assets, and feature-specific CSS should be deferred where compatibility allows. Mobile and low-power devices are the performance baseline.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,33 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+SillyBunny is for creative-writing and roleplay users who want SillyTavern compatibility with a friendlier shell, faster startup, mobile stability, and powerful advanced controls that stay out of the way until needed. Users may be on desktop workstations, laptops, tablets, phones, or low-power Android/Termux setups.
+
+## Product Purpose
+
+SillyBunny exists to make long-form AI chat, character management, presets, lorebooks, extensions, and in-chat agents easier to navigate without losing the depth of upstream SillyTavern. Success means the default workspace feels simple and fast, while expert workflows remain reachable, compatible, and predictable.
+
+## Brand Personality
+
+Friendly, capable, focused. The interface can feel warm and playful, but the product surface should stay task-led, stable, and respectful of long writing sessions.
+
+## Anti-references
+
+Avoid marketing-site theatrics, decorative motion, nested card layouts, loud color for inactive states, heavy glass effects as a default, and invented controls where standard product UI affordances work better. Avoid changes that make upstream SillyTavern syncs unnecessarily difficult.
+
+## Design Principles
+
+- Simple by default, powerful when needed.
+- Performance is a visible product feature, especially on mobile and low-power devices.
+- Compatibility earns trust; preserve existing data, extensions, and workflows.
+- Advanced complexity should be organized, searchable, and progressively revealed.
+- UI polish should reduce friction, not compete with the writing experience.
+
+## Accessibility & Inclusion
+
+Use standard controls, visible focus states, reduced-motion support, readable fixed type scales, stable layouts that avoid surprise shifts, and semantic labels for icon-heavy controls. Mobile Safari and low-memory devices are first-class constraints.

--- a/default/config.yaml
+++ b/default/config.yaml
@@ -223,6 +223,12 @@ performance:
     maxPayloadSize: '8mb'
     # Timeout for request compression in milliseconds.
     timeout: 4000
+  frontendBuild:
+    # Serve hashed frontend assets from dist/frontend when a production asset manifest is present.
+    # Dev mode continues to serve plain files from public for upstream compatibility.
+    enabled: false
+    # Static cache max age for hashed frontend assets in seconds.
+    immutableMaxAge: 31536000
 
 # Allow secret keys exposure via API
 allowKeysExposure: false

--- a/docs/frontend-build.md
+++ b/docs/frontend-build.md
@@ -1,0 +1,79 @@
+# Frontend Production Build
+
+SillyBunny normally serves the plain ES modules and stylesheets from `public/`.
+That keeps development readable and close to upstream SillyTavern. The optional
+frontend production build creates minified, fingerprinted assets in
+`dist/frontend/` for release testing and performance checks.
+
+## Build
+
+```sh
+npm run build:frontend
+```
+
+The build writes `dist/frontend/asset-manifest.json` and hashed asset names such
+as `script-0123456789ab.js`.
+
+## Enable
+
+In `config.yaml`:
+
+```yaml
+performance:
+  frontendBuild:
+    enabled: true
+```
+
+Or use the environment override:
+
+```sh
+SILLYTAVERN_PERFORMANCE_FRONTENDBUILD_ENABLED=true npm run start:node
+```
+
+With Bun:
+
+```sh
+SILLYTAVERN_PERFORMANCE_FRONTENDBUILD_ENABLED=true bun run start
+```
+
+The server only switches to production frontend assets when the flag is enabled
+and `dist/frontend/asset-manifest.json` exists. If either is missing, it falls
+back to the normal `public/` files.
+
+## Verify
+
+Open the app and check the HTML for `/frontend-assets/` URLs:
+
+```sh
+curl http://127.0.0.1:4444/ | grep frontend-assets
+```
+
+Check cache headers on a hashed asset:
+
+```sh
+curl -I http://127.0.0.1:4444/frontend-assets/script-0123456789ab.js
+```
+
+Hashed files should return long-lived immutable cache headers. Unhashed fallback
+files under `/frontend-assets/` are not treated as immutable by the service
+worker, so a fresh build can safely update dependency modules during testing.
+
+## Measure
+
+Run the mobile-oriented smoke measurement against a running server:
+
+```sh
+npm run perf:frontend
+```
+
+Use `SILLYBUNNY_PERF_URL` to point the script at a different port:
+
+```sh
+SILLYBUNNY_PERF_URL=http://127.0.0.1:4555 npm run perf:frontend
+```
+
+## Disable
+
+Set `performance.frontendBuild.enabled` to `false` or remove the environment
+override, then restart the server. No user data or extension data is migrated by
+this mode.

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,7 +137,10 @@
                 "@types/yargs": "^17.0.33",
                 "@types/yauzl": "^2.10.3",
                 "eslint": "^8.57.1",
-                "eslint-plugin-jsdoc": "^48.10.0"
+                "eslint-plugin-jest": "^27.9.0",
+                "eslint-plugin-jsdoc": "^48.10.0",
+                "eslint-plugin-playwright": "^2.10.2",
+                "terser": "^5.46.2"
             },
             "engines": {
                 "bun": ">= 1.3.0"
@@ -2141,6 +2144,13 @@
                 "@types/jquery": "*"
             }
         },
+        "node_modules/@types/semver": {
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/send": {
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
@@ -2222,6 +2232,160 @@
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
+            }
+        },
+        "node_modules/@typescript-eslint/scope-manager": {
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+            "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "5.62.0",
+                "@typescript-eslint/visitor-keys": "5.62.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/types": {
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+            "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree": {
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+            "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "@typescript-eslint/types": "5.62.0",
+                "@typescript-eslint/visitor-keys": "5.62.0",
+                "debug": "^4.3.4",
+                "globby": "^11.1.0",
+                "is-glob": "^4.0.3",
+                "semver": "^7.3.7",
+                "tsutils": "^3.21.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@typescript-eslint/utils": {
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+            "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.2.0",
+                "@types/json-schema": "^7.0.9",
+                "@types/semver": "^7.3.12",
+                "@typescript-eslint/scope-manager": "5.62.0",
+                "@typescript-eslint/types": "5.62.0",
+                "@typescript-eslint/typescript-estree": "5.62.0",
+                "eslint-scope": "^5.1.1",
+                "semver": "^7.3.7"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/eslint-scope": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/estraverse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/@typescript-eslint/visitor-keys": {
+            "version": "5.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+            "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "5.62.0",
+                "eslint-visitor-keys": "^3.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
             }
         },
         "node_modules/@ungap/structured-clone": {
@@ -2787,6 +2951,16 @@
             "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
             "license": "MIT"
         },
+        "node_modules/array-union": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/ast-types": {
             "version": "0.13.4",
             "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -3027,6 +3201,19 @@
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/braces": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fill-range": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/browserslist": {
@@ -4073,6 +4260,19 @@
                 "md5": "^2.3.0"
             }
         },
+        "node_modules/dir-glob": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-type": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/doctrine": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -4428,6 +4628,32 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
+        "node_modules/eslint-plugin-jest": {
+            "version": "27.9.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.9.0.tgz",
+            "integrity": "sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/utils": "^5.10.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/eslint-plugin": "^5.0.0 || ^6.0.0 || ^7.0.0",
+                "eslint": "^7.0.0 || ^8.0.0",
+                "jest": "*"
+            },
+            "peerDependenciesMeta": {
+                "@typescript-eslint/eslint-plugin": {
+                    "optional": true
+                },
+                "jest": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/eslint-plugin-jsdoc": {
             "version": "48.10.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-48.10.0.tgz",
@@ -4490,6 +4716,35 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/eslint-plugin-playwright": {
+            "version": "2.10.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.10.2.tgz",
+            "integrity": "sha512-0N+2OWc3NZbOZ0gK8mp2TK6Qu3UWcJTQ9rqU0UM2yRJXgT758pvpY0lsOLIySfbyFrLqn3TcXjixbmcK90VnuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "globals": "^17.3.0"
+            },
+            "engines": {
+                "node": ">=16.9.0"
+            },
+            "peerDependencies": {
+                "eslint": ">=8.40.0"
+            }
+        },
+        "node_modules/eslint-plugin-playwright/node_modules/globals": {
+            "version": "17.6.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+            "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/eslint-scope": {
             "version": "7.2.2",
@@ -4771,6 +5026,23 @@
             "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
             "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
         },
+        "node_modules/fast-glob": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.2",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.8"
+            },
+            "engines": {
+                "node": ">=8.6.0"
+            }
+        },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4868,6 +5140,19 @@
             },
             "funding": {
                 "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+            }
+        },
+        "node_modules/fill-range": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/finalhandler": {
@@ -5223,6 +5508,19 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/glob-to-regexp": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -5250,6 +5548,27 @@
             },
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/globby": {
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "array-union": "^2.1.0",
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.2.9",
+                "ignore": "^5.2.0",
+                "merge2": "^1.4.1",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -5847,6 +6166,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
         "node_modules/is-path-inside": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -6397,6 +6726,16 @@
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "license": "MIT"
         },
+        "node_modules/merge2": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/methods": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -6404,6 +6743,20 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/micromatch": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=8.6"
             }
         },
         "node_modules/mime": {
@@ -7130,6 +7483,16 @@
             "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
             "license": "MIT"
         },
+        "node_modules/path-type": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/peek-readable": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
@@ -7166,6 +7529,19 @@
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
             "license": "ISC"
+        },
+        "node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
         },
         "node_modules/pify": {
             "version": "4.0.1",
@@ -8190,6 +8566,16 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT"
         },
+        "node_modules/slash": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/slashes": {
             "version": "3.0.12",
             "resolved": "https://registry.npmjs.org/slashes/-/slashes-3.0.12.tgz",
@@ -8490,9 +8876,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.46.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
-            "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
+            "version": "5.46.2",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
+            "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
             "license": "BSD-2-Clause",
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
@@ -8614,6 +9000,19 @@
             ],
             "license": "MIT"
         },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
         "node_modules/toidentifier": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -8674,6 +9073,29 @@
             "engines": {
                 "node": ">=0.6.x"
             }
+        },
+        "node_modules/tsutils": {
+            "version": "3.21.0",
+            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+            "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^1.8.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            },
+            "peerDependencies": {
+                "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+            }
+        },
+        "node_modules/tsutils/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true,
+            "license": "0BSD"
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -8745,6 +9167,21 @@
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
             "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
             "license": "MIT"
+        },
+        "node_modules/typescript": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
         },
         "node_modules/uglify-js": {
             "version": "3.19.3",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,8 @@
         "debug": "bun --inspect server.js",
         "start:global": "bun server.js --global",
         "start:no-csrf": "bun server.js --disableCsrf",
+        "build:frontend": "node scripts/build-frontend-assets.js",
+        "perf:frontend": "node scripts/measure-frontend-performance.js",
         "postinstall": "node post-install.js || bun post-install.js",
         "lint": "eslint \"src/**/*.js\" \"public/**/*.js\" \"scripts/**/*.js\" ./*.js",
         "lint:fix": "eslint \"src/**/*.js\" \"public/**/*.js\" \"scripts/**/*.js\" ./*.js --fix",
@@ -158,6 +160,9 @@
         "@types/yargs": "^17.0.33",
         "@types/yauzl": "^2.10.3",
         "eslint": "^8.57.1",
-        "eslint-plugin-jsdoc": "^48.10.0"
+        "eslint-plugin-jest": "^27.9.0",
+        "eslint-plugin-jsdoc": "^48.10.0",
+        "eslint-plugin-playwright": "^2.10.2",
+        "terser": "^5.46.2"
     }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -19,11 +19,12 @@
     </style>
     <link rel="preload" as="style" href="style.css">
     <link rel="modulepreload" href="script.js">
-    <link rel="preload" as="script" href="scripts/sillybunny-tabs.js?v=20260501f">
+    <link rel="modulepreload" href="scripts/sillybunny-tabs.js?v=20260501f">
+    <link rel="preload" as="font" type="font/woff2" href="webfonts/Figtree/Figtree-Regular.woff2?v=20260422b" crossorigin>
     <link rel="manifest" crossorigin="use-credentials" href="manifest.json">
     <link href="webfonts/Figtree/stylesheet.css?v=20260422b" rel="stylesheet">
-    <link href="webfonts/NotoSans/stylesheet.css" rel="stylesheet">
-    <link href="webfonts/NotoSansMono/stylesheet.css" rel="stylesheet">
+    <link href="webfonts/NotoSans/stylesheet.css" rel="preload" as="style" data-sb-deferred-style data-sb-media="all">
+    <link href="webfonts/NotoSansMono/stylesheet.css" rel="preload" as="style" data-sb-deferred-style data-sb-media="all">
     <link href="css/fontawesome.min.css" rel="stylesheet">
     <link href="css/solid.min.css" rel="stylesheet">
     <link href="css/brands.min.css" rel="stylesheet">
@@ -8626,8 +8627,9 @@
     <script type="module" src="lib/swiped-events.js"></script>
     <script type="module" src="lib/eventemitter.js"></script>
     <script type="module" src="scripts/i18n.js"></script>
+    <script type="module" src="scripts/performance-loader.js"></script>
     <script type="module" src="script.js"></script>
-    <script src="scripts/sillybunny-tabs.js?v=20260501f" defer></script>
+    <script type="module" src="scripts/sillybunny-tabs.js?v=20260501f"></script>
     <script>
         window.addEventListener('load', (event) => {
             const documentHeight = () => {

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -946,7 +946,7 @@ async function activateExtensions() {
         const isDisabled = extension_settings.disabledExtensions.includes(name);
 
         if (meetsModuleRequirements && meetsExtensionDeps && meetsClientMinimumVersion && !isDisabled) {
-            try {
+            const activateExtension = async () => {
                 console.debug('Activating extension', name);
                 activatingExtensionDedupKeys.add(extensionKey);
                 const promise = addExtensionLocale(name, manifest).finally(() =>
@@ -965,9 +965,21 @@ async function activateExtensions() {
                     .finally(() => {
                         activatingExtensionDedupKeys.delete(extensionKey);
                     });
-                promises.push(promise);
-            } catch (error) {
-                console.error('Could not activate extension', name, error);
+            };
+
+            const hasDependencies = Array.isArray(extensionDependencies) && extensionDependencies.length > 0;
+
+            if (hasDependencies) {
+                await Promise.allSettled(promises);
+                try {
+                    await activateExtension();
+                } catch (error) {
+                    console.error('Could not activate extension', name, error);
+                }
+            } else {
+                promises.push(activateExtension().catch(error => {
+                    console.error('Could not activate extension', name, error);
+                }));
             }
         } else if (!meetsModuleRequirements && !isDisabled) {
             console.warn(t`Extension "${name}" did not load. Missing required Extras module(s): "${missingModules.join(', ')}"`);

--- a/public/scripts/performance-loader.js
+++ b/public/scripts/performance-loader.js
@@ -1,0 +1,37 @@
+function activateDeferredStyles() {
+    const styles = document.querySelectorAll('link[data-sb-deferred-style]');
+
+    for (const style of styles) {
+        if (style.dataset.sbStyleActivated === 'true') {
+            continue;
+        }
+
+        style.dataset.sbStyleActivated = 'true';
+        style.rel = 'stylesheet';
+        style.media = style.getAttribute('data-sb-media') || style.getAttribute('media') || 'all';
+    }
+}
+
+function loadWideFontFallbacks() {
+    activateDeferredStyles();
+}
+
+function scheduleIdleWork(callback) {
+    if ('requestIdleCallback' in window) {
+        window.requestIdleCallback(callback, { timeout: 2500 });
+        return;
+    }
+
+    window.setTimeout(callback, 1200);
+}
+
+window.SillyBunnyLoadStylesheet = activateDeferredStyles;
+window.SillyBunnyLoadWideFontFallbacks = loadWideFontFallbacks;
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => scheduleIdleWork(activateDeferredStyles), { once: true });
+} else {
+    scheduleIdleWork(activateDeferredStyles);
+}
+
+scheduleIdleWork(loadWideFontFallbacks);

--- a/public/style.css
+++ b/public/style.css
@@ -111,8 +111,8 @@
     /*base variable calculated in rems*/
     --fontScale: 1;
     --mainFontSize: calc(var(--fontScale) * 15px);
-    --mainFontFamily: 'Figtree', 'Noto Sans', sans-serif;
-    --monoFontFamily: 'Red Hat Mono', 'Noto Sans Mono', 'Courier New', Consolas, monospace;
+    --mainFontFamily: 'Figtree', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', sans-serif;
+    --monoFontFamily: 'Noto Sans Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
     /* Compatibility aliases for older imported themes and extension-style presets. */
     --mainFont: var(--mainFontFamily);
     --headerFont: var(--mainFontFamily);
@@ -1278,6 +1278,7 @@ body .panelControlBar {
     /* Keep the live send/stream handoff fully laid out so mobile scroll anchoring stays calm. */
     #chat .mes:not(.last_mes):not(:nth-last-child(-n + 2)) {
         content-visibility: auto;
+        contain: layout style paint;
         contain-intrinsic-size: auto 220px;
     }
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,8 @@
 const SB_SW_CACHE_VERSION = 'sillybunny-cache-v20260501g';
 const SB_STATIC_CACHE = `${SB_SW_CACHE_VERSION}-static`;
 const SB_SHELL_CACHE = `${SB_SW_CACHE_VERSION}-shell`;
+const SB_FRONTEND_ASSET_PREFIX = '/frontend-assets/';
+const SB_HASHED_FRONTEND_ASSET_RE = /-[a-f0-9]{8,}\.[a-z0-9]+$/i;
 
 const SB_STALE_WHILE_REVALIDATE_PREFIXES = Object.freeze([
     '/lib/',
@@ -21,6 +23,14 @@ function isSameOrigin(url) {
 
 function shouldStaleWhileRevalidate(url) {
     return SB_STALE_WHILE_REVALIDATE_PREFIXES.some(prefix => url.pathname.startsWith(prefix));
+}
+
+function isFrontendAsset(url) {
+    return url.pathname.startsWith(SB_FRONTEND_ASSET_PREFIX);
+}
+
+function shouldCacheFirst(url) {
+    return isFrontendAsset(url) && SB_HASHED_FRONTEND_ASSET_RE.test(url.pathname);
 }
 
 function shouldNetworkFirst(url) {
@@ -59,6 +69,21 @@ async function staleWhileRevalidate(request) {
         });
 
     return cachedResponse || freshResponse;
+}
+
+async function cacheFirst(request) {
+    const cache = await caches.open(SB_STATIC_CACHE);
+    const cachedResponse = await cache.match(request);
+
+    if (cachedResponse) {
+        return cachedResponse;
+    }
+
+    const response = await fetch(request);
+    await putCache(cache, request, response).catch((error) => {
+        console.debug('SillyBunny service worker skipped immutable cache update.', error);
+    });
+    return response;
 }
 
 async function networkFirst(request) {
@@ -105,6 +130,15 @@ self.addEventListener('fetch', (event) => {
     const url = new URL(request.url);
 
     if (!isSameOrigin(url)) {
+        return;
+    }
+
+    if (isFrontendAsset(url) && !shouldCacheFirst(url)) {
+        return;
+    }
+
+    if (shouldCacheFirst(url)) {
+        event.respondWith(cacheFirst(request));
         return;
     }
 

--- a/public/webfonts/NotoSans/stylesheet.css
+++ b/public/webfonts/NotoSans/stylesheet.css
@@ -4,7 +4,7 @@
         url('NotoSans-Black.woff') format('woff');
     font-weight: 900;
     font-style: normal;
-    font-display: swap;
+    font-display: optional;
 }
 
 @font-face {
@@ -13,7 +13,7 @@
         url('NotoSans-ExtraBoldItalic.woff') format('woff');
     font-weight: bold;
     font-style: italic;
-    font-display: swap;
+    font-display: optional;
 }
 
 @font-face {
@@ -22,7 +22,7 @@
         url('NotoSans-BlackItalic.woff') format('woff');
     font-weight: 900;
     font-style: italic;
-    font-display: swap;
+    font-display: optional;
 }
 
 @font-face {
@@ -31,7 +31,7 @@
         url('NotoSans-ExtraBold.woff') format('woff');
     font-weight: bold;
     font-style: normal;
-    font-display: swap;
+    font-display: optional;
 }
 
 @font-face {
@@ -40,7 +40,7 @@
         url('NotoSans-ThinItalic.woff') format('woff');
     font-weight: 100;
     font-style: italic;
-    font-display: swap;
+    font-display: optional;
 }
 
 @font-face {
@@ -49,7 +49,7 @@
         url('NotoSans-BoldItalic.woff') format('woff');
     font-weight: bold;
     font-style: italic;
-    font-display: swap;
+    font-display: optional;
 }
 
 @font-face {
@@ -58,7 +58,7 @@
         url('NotoSans-Bold.woff') format('woff');
     font-weight: bold;
     font-style: normal;
-    font-display: swap;
+    font-display: optional;
 }
 
 @font-face {
@@ -67,7 +67,7 @@
         url('NotoSans-LightItalic.woff') format('woff');
     font-weight: 300;
     font-style: italic;
-    font-display: swap;
+    font-display: optional;
 }
 
 @font-face {
@@ -76,7 +76,7 @@
         url('NotoSans-Italic.woff') format('woff');
     font-weight: normal;
     font-style: italic;
-    font-display: swap;
+    font-display: optional;
 }
 
 @font-face {
@@ -85,7 +85,7 @@
         url('NotoSans-ExtraLightItalic.woff') format('woff');
     font-weight: 200;
     font-style: italic;
-    font-display: swap;
+    font-display: optional;
 }
 
 @font-face {
@@ -94,7 +94,7 @@
         url('NotoSans-Light.woff') format('woff');
     font-weight: 300;
     font-style: normal;
-    font-display: swap;
+    font-display: optional;
 }
 
 @font-face {
@@ -103,7 +103,7 @@
         url('NotoSans-ExtraLight.woff') format('woff');
     font-weight: 200;
     font-style: normal;
-    font-display: swap;
+    font-display: optional;
 }
 
 @font-face {
@@ -112,7 +112,7 @@
         url('NotoSans-Medium.woff') format('woff');
     font-weight: 500;
     font-style: normal;
-    font-display: swap;
+    font-display: optional;
 }
 
 @font-face {
@@ -121,7 +121,7 @@
         url('NotoSans-Regular.woff') format('woff');
     font-weight: normal;
     font-style: normal;
-    font-display: swap;
+    font-display: optional;
 }
 
 @font-face {
@@ -130,7 +130,7 @@
         url('NotoSans-MediumItalic.woff') format('woff');
     font-weight: 500;
     font-style: italic;
-    font-display: swap;
+    font-display: optional;
 }
 
 @font-face {
@@ -139,7 +139,7 @@
         url('NotoSans-SemiBoldItalic.woff') format('woff');
     font-weight: 600;
     font-style: italic;
-    font-display: swap;
+    font-display: optional;
 }
 
 @font-face {
@@ -148,7 +148,7 @@
         url('NotoSans-SemiBold.woff') format('woff');
     font-weight: 600;
     font-style: normal;
-    font-display: swap;
+    font-display: optional;
 }
 
 @font-face {
@@ -157,6 +157,6 @@
         url('NotoSans-Thin.woff') format('woff');
     font-weight: 100;
     font-style: normal;
-    font-display: swap;
+    font-display: optional;
 }
 

--- a/public/webfonts/NotoSansMono/stylesheet.css
+++ b/public/webfonts/NotoSansMono/stylesheet.css
@@ -1,6 +1,6 @@
 /* noto-sans-mono-100 - cyrillic_cyrillic-ext_greek_greek-ext_latin_latin-ext_vietnamese */
 @font-face {
-    font-display: swap;
+    font-display: optional;
     font-family: 'Noto Sans Mono';
     font-style: normal;
     font-weight: 100;
@@ -10,7 +10,7 @@
 
 /* noto-sans-mono-200 - cyrillic_cyrillic-ext_greek_greek-ext_latin_latin-ext_vietnamese */
 @font-face {
-    font-display: swap;
+    font-display: optional;
     font-family: 'Noto Sans Mono';
     font-style: normal;
     font-weight: 200;
@@ -20,7 +20,7 @@
 
 /* noto-sans-mono-300 - cyrillic_cyrillic-ext_greek_greek-ext_latin_latin-ext_vietnamese */
 @font-face {
-    font-display: swap;
+    font-display: optional;
     font-family: 'Noto Sans Mono';
     font-style: normal;
     font-weight: 300;
@@ -30,7 +30,7 @@
 
 /* noto-sans-mono-regular - cyrillic_cyrillic-ext_greek_greek-ext_latin_latin-ext_vietnamese */
 @font-face {
-    font-display: swap;
+    font-display: optional;
     font-family: 'Noto Sans Mono';
     font-style: normal;
     font-weight: 400;
@@ -40,7 +40,7 @@
 
 /* noto-sans-mono-500 - cyrillic_cyrillic-ext_greek_greek-ext_latin_latin-ext_vietnamese */
 @font-face {
-    font-display: swap;
+    font-display: optional;
     font-family: 'Noto Sans Mono';
     font-style: normal;
     font-weight: 500;
@@ -50,7 +50,7 @@
 
 /* noto-sans-mono-600 - cyrillic_cyrillic-ext_greek_greek-ext_latin_latin-ext_vietnamese */
 @font-face {
-    font-display: swap;
+    font-display: optional;
     font-family: 'Noto Sans Mono';
     font-style: normal;
     font-weight: 600;
@@ -60,7 +60,7 @@
 
 /* noto-sans-mono-700 - cyrillic_cyrillic-ext_greek_greek-ext_latin_latin-ext_vietnamese */
 @font-face {
-    font-display: swap;
+    font-display: optional;
     font-family: 'Noto Sans Mono';
     font-style: normal;
     font-weight: 700;
@@ -70,7 +70,7 @@
 
 /* noto-sans-mono-800 - cyrillic_cyrillic-ext_greek_greek-ext_latin_latin-ext_vietnamese */
 @font-face {
-    font-display: swap;
+    font-display: optional;
     font-family: 'Noto Sans Mono';
     font-style: normal;
     font-weight: 800;
@@ -80,7 +80,7 @@
 
 /* noto-sans-mono-900 - cyrillic_cyrillic-ext_greek_greek-ext_latin_latin-ext_vietnamese */
 @font-face {
-    font-display: swap;
+    font-display: optional;
     font-family: 'Noto Sans Mono';
     font-style: normal;
     font-weight: 900;

--- a/scripts/build-frontend-assets.js
+++ b/scripts/build-frontend-assets.js
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { minify } from 'terser';
+
+const repoRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const publicRoot = path.join(repoRoot, 'public');
+const distRoot = path.join(repoRoot, 'dist', 'frontend');
+const manifestFile = 'asset-manifest.json';
+
+const hashedExtensions = new Set([
+    '.css',
+    '.js',
+    '.mjs',
+    '.woff2',
+    '.png',
+    '.jpg',
+    '.jpeg',
+    '.webp',
+    '.gif',
+    '.svg',
+    '.ico',
+    '.mp3',
+    '.wav',
+    '.wasm',
+]);
+
+const copyExtensions = new Set([
+    '.html',
+    '.json',
+    '.txt',
+    '.map',
+    '.woff',
+    '.ttf',
+]);
+
+const ignoreSegments = new Set([
+    '.git',
+    '.github',
+    '.playwright-cli',
+    'output',
+    'node_modules',
+]);
+
+function toPosix(value) {
+    return value.split(path.sep).join('/');
+}
+
+function shouldIgnore(relativePath) {
+    return relativePath.split(path.sep).some(segment => ignoreSegments.has(segment));
+}
+
+function getHash(buffer) {
+    return crypto.createHash('sha256').update(buffer).digest('hex').slice(0, 12);
+}
+
+function getOutputName(relativePath, hash) {
+    const parsed = path.parse(relativePath);
+    return path.join(parsed.dir, `${parsed.name}-${hash}${parsed.ext}`);
+}
+
+function minifyCss(source) {
+    return source
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/\s+/g, ' ')
+        .replace(/\s*([{}:;,>+~])\s*/g, '$1')
+        .replace(/;}/g, '}')
+        .trim();
+}
+
+async function optimizeAsset(inputPath, relativePath, ext, warnings) {
+    const buffer = await fs.readFile(inputPath);
+
+    if (ext === '.js' || ext === '.mjs') {
+        const source = buffer.toString('utf8');
+        try {
+            const result = await minify(source, {
+                module: ext === '.mjs' || relativePath.includes(`${path.sep}scripts${path.sep}`) || relativePath === 'script.js' || relativePath === 'lib.js',
+                compress: {
+                    passes: 1,
+                },
+                mangle: true,
+                format: {
+                    comments: false,
+                },
+            });
+
+            if (result.code) {
+                return Buffer.from(result.code, 'utf8');
+            }
+        } catch (error) {
+            warnings.push(`Skipped JS minification for ${toPosix(relativePath)}: ${error.message}`);
+        }
+    }
+
+    if (ext === '.css') {
+        return Buffer.from(minifyCss(buffer.toString('utf8')), 'utf8');
+    }
+
+    return buffer;
+}
+
+async function walk(directory, files = []) {
+    const entries = await fs.readdir(directory, { withFileTypes: true });
+
+    for (const entry of entries) {
+        const fullPath = path.join(directory, entry.name);
+        const relativePath = path.relative(publicRoot, fullPath);
+
+        if (shouldIgnore(relativePath)) {
+            continue;
+        }
+
+        if (entry.isDirectory()) {
+            await walk(fullPath, files);
+        } else if (entry.isFile()) {
+            files.push(fullPath);
+        }
+    }
+
+    return files;
+}
+
+async function copyFile(inputPath, outputRelativePath) {
+    const outputPath = path.join(distRoot, outputRelativePath);
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+    await fs.copyFile(inputPath, outputPath);
+}
+
+async function build() {
+    await fs.rm(distRoot, { recursive: true, force: true });
+    await fs.mkdir(distRoot, { recursive: true });
+
+    const files = await walk(publicRoot);
+    const assets = {};
+    const skipped = [];
+    const warnings = [];
+
+    for (const inputPath of files) {
+        const relativePath = path.relative(publicRoot, inputPath);
+        const ext = path.extname(relativePath).toLowerCase();
+        const source = toPosix(relativePath);
+
+        if (hashedExtensions.has(ext)) {
+            const buffer = await optimizeAsset(inputPath, relativePath, ext, warnings);
+            const hash = getHash(buffer);
+            const output = getOutputName(relativePath, hash);
+            await copyFile(inputPath, relativePath);
+            await fs.mkdir(path.dirname(path.join(distRoot, output)), { recursive: true });
+            await fs.writeFile(path.join(distRoot, output), buffer);
+            assets[source] = {
+                hash,
+                output: toPosix(output),
+                bytes: buffer.length,
+            };
+            continue;
+        }
+
+        if (copyExtensions.has(ext)) {
+            await copyFile(inputPath, relativePath);
+            assets[source] = {
+                output: source,
+                bytes: (await fs.stat(inputPath)).size,
+            };
+            continue;
+        }
+
+        skipped.push(source);
+    }
+
+    const manifest = {
+        version: 1,
+        generatedAt: new Date().toISOString(),
+        publicRoot: 'public',
+        assets,
+        skipped,
+        warnings,
+    };
+
+    await fs.writeFile(path.join(distRoot, manifestFile), `${JSON.stringify(manifest, null, 2)}\n`);
+
+    const hashedCount = Object.values(assets).filter(asset => asset.hash).length;
+    console.log(`Built ${Object.keys(assets).length} frontend assets (${hashedCount} hashed) in ${path.relative(repoRoot, distRoot)}`);
+    warnings.forEach(warning => console.warn(warning));
+}
+
+build().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/scripts/measure-frontend-performance.js
+++ b/scripts/measure-frontend-performance.js
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const { chromium, devices } = require('../tests/node_modules/@playwright/test');
+
+const repoRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const outputDir = path.join(repoRoot, 'output', 'performance');
+const baseUrl = process.env.SILLYBUNNY_PERF_URL || 'http://127.0.0.1:4444';
+const outputPath = process.env.SILLYBUNNY_PERF_OUTPUT || path.join(outputDir, `frontend-${Date.now()}.json`);
+const mobileProfile = devices['Pixel 5'];
+
+function summarizeRequests(requests) {
+    const totals = {
+        count: requests.length,
+        js: 0,
+        css: 0,
+        font: 0,
+        image: 0,
+        other: 0,
+    };
+
+    for (const request of requests) {
+        if (/\.m?js(?:\?|$)/i.test(request.url)) {
+            totals.js += request.bytes;
+        } else if (/\.css(?:\?|$)/i.test(request.url)) {
+            totals.css += request.bytes;
+        } else if (/\.(?:woff2?|ttf)(?:\?|$)/i.test(request.url)) {
+            totals.font += request.bytes;
+        } else if (/\.(?:png|jpe?g|webp|gif|svg|ico)(?:\?|$)/i.test(request.url)) {
+            totals.image += request.bytes;
+        } else {
+            totals.other += request.bytes;
+        }
+    }
+
+    return totals;
+}
+
+async function measurePage(page) {
+    const metrics = await page.evaluate(() => {
+        const browserGlobal = globalThis;
+        const navigation = browserGlobal.performance.getEntriesByType('navigation')[0];
+        const paint = Object.fromEntries(browserGlobal.performance.getEntriesByType('paint').map(entry => [entry.name, entry.startTime]));
+        const resources = browserGlobal.performance.getEntriesByType('resource');
+        const longTasks = browserGlobal.performance.getEntriesByType('longtask');
+
+        return {
+            navigation: navigation ? {
+                domContentLoaded: navigation.domContentLoadedEventEnd,
+                load: navigation.loadEventEnd,
+                transferSize: navigation.transferSize,
+                encodedBodySize: navigation.encodedBodySize,
+            } : null,
+            paint,
+            longTasks: {
+                count: longTasks.length,
+                totalDuration: longTasks.reduce((total, task) => total + task.duration, 0),
+                longest: longTasks.reduce((max, task) => Math.max(max, task.duration), 0),
+            },
+            resourceCount: resources.length,
+            heap: browserGlobal.performance.memory ? {
+                usedJSHeapSize: browserGlobal.performance.memory.usedJSHeapSize,
+                totalJSHeapSize: browserGlobal.performance.memory.totalJSHeapSize,
+            } : null,
+        };
+    });
+
+    const scrollFps = await page.evaluate(async () => {
+        const browserGlobal = globalThis;
+        const browserDocument = browserGlobal.document;
+        const scroller = browserDocument.getElementById('chat') || browserDocument.scrollingElement;
+        if (!scroller) {
+            return null;
+        }
+
+        const frameTimes = [];
+        let previous = browserGlobal.performance.now();
+        const start = previous;
+
+        return new Promise(resolve => {
+            function step(now) {
+                frameTimes.push(now - previous);
+                previous = now;
+                scroller.scrollTop += 24;
+
+                if (now - start >= 1000) {
+                    const averageFrame = frameTimes.reduce((total, frame) => total + frame, 0) / Math.max(1, frameTimes.length);
+                    resolve({
+                        frames: frameTimes.length,
+                        averageFrame,
+                        estimatedFps: averageFrame ? 1000 / averageFrame : 0,
+                    });
+                    return;
+                }
+
+                browserGlobal.requestAnimationFrame(step);
+            }
+
+            browserGlobal.requestAnimationFrame(step);
+        });
+    });
+
+    return {
+        ...metrics,
+        scrollFps,
+    };
+}
+
+async function run() {
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+
+    const browser = await chromium.launch();
+    const context = await browser.newContext({
+        ...mobileProfile,
+        serviceWorkers: 'block',
+    });
+    const page = await context.newPage();
+    const requests = [];
+
+    await page.route('**/*', async (route) => {
+        const request = route.request();
+        const response = await route.fetch();
+        const body = await response.body();
+        requests.push({
+            url: request.url(),
+            method: request.method(),
+            status: response.status(),
+            bytes: body.length,
+        });
+        await route.fulfill({ response, body });
+    });
+
+    await page.goto(baseUrl, { waitUntil: 'networkidle' });
+    await page.waitForFunction('document.getElementById("preloader") === null', { timeout: 60000 }).catch(() => {});
+
+    const result = {
+        url: baseUrl,
+        profile: 'Pixel 5',
+        measuredAt: new Date().toISOString(),
+        metrics: await measurePage(page),
+        requests: summarizeRequests(requests),
+    };
+
+    await fs.writeFile(outputPath, `${JSON.stringify(result, null, 2)}\n`);
+    console.log(JSON.stringify(result, null, 2));
+
+    await browser.close();
+}
+
+run().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/src/frontend-assets.js
+++ b/src/frontend-assets.js
@@ -1,0 +1,111 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { serverDirectory } from './server-directory.js';
+import { getConfigValue } from './util.js';
+
+export const FRONTEND_DIST_ROOT = path.join(serverDirectory, 'dist', 'frontend');
+export const FRONTEND_MANIFEST_FILE = 'asset-manifest.json';
+export const FRONTEND_ASSET_PREFIX = '/frontend-assets/';
+export const HASHED_FRONTEND_ASSET_RE = /-[a-f0-9]{8,}\.[a-z0-9]+$/i;
+
+let manifestCache = null;
+
+export function getFrontendManifestPath() {
+    return path.join(FRONTEND_DIST_ROOT, FRONTEND_MANIFEST_FILE);
+}
+
+export function getFrontendAssetsEnabled() {
+    return getConfigValue('performance.frontendBuild.enabled', false, 'boolean');
+}
+
+export function getFrontendImmutableMaxAge() {
+    const value = getConfigValue('performance.frontendBuild.immutableMaxAge', 31536000, 'number');
+    return Number.isFinite(value) && value > 0 ? Math.floor(value) : 31536000;
+}
+
+export function clearFrontendManifestCache() {
+    manifestCache = null;
+}
+
+export function loadFrontendManifest() {
+    if (manifestCache !== null) {
+        return manifestCache;
+    }
+
+    const manifestPath = getFrontendManifestPath();
+    if (!fs.existsSync(manifestPath)) {
+        manifestCache = null;
+        return null;
+    }
+
+    try {
+        const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+        manifestCache = manifest && typeof manifest === 'object' ? manifest : null;
+    } catch (error) {
+        console.warn('Failed to read frontend asset manifest.', error);
+        manifestCache = null;
+    }
+
+    return manifestCache;
+}
+
+export function resolveFrontendAssetPath(publicPath) {
+    const manifest = loadFrontendManifest();
+    const assets = manifest?.assets;
+
+    if (!assets || typeof assets !== 'object') {
+        return null;
+    }
+
+    const normalizedPath = String(publicPath).replace(/^\/+/, '');
+    const entry = assets[normalizedPath];
+
+    if (!entry || typeof entry.output !== 'string') {
+        return null;
+    }
+
+    return `${FRONTEND_ASSET_PREFIX}${entry.output}`;
+}
+
+export function rewriteFrontendHtml(html, { enabled = getFrontendAssetsEnabled() } = {}) {
+    if (!enabled || typeof html !== 'string') {
+        return html;
+    }
+
+    let rewritten = html;
+    const replacements = new Map([
+        ['style.css', resolveFrontendAssetPath('style.css')],
+        ['css/mobile-styles.css', resolveFrontendAssetPath('css/mobile-styles.css')],
+        ['css/sillybunny-theme.css', resolveFrontendAssetPath('css/sillybunny-theme.css')],
+        ['css/sillybunny-tabs.css', resolveFrontendAssetPath('css/sillybunny-tabs.css')],
+        ['script.js', resolveFrontendAssetPath('script.js')],
+        ['scripts/performance-loader.js', resolveFrontendAssetPath('scripts/performance-loader.js')],
+        ['scripts/sillybunny-tabs.js', resolveFrontendAssetPath('scripts/sillybunny-tabs.js')],
+        ['webfonts/Figtree/stylesheet.css', resolveFrontendAssetPath('webfonts/Figtree/stylesheet.css')],
+        ['webfonts/NotoSans/stylesheet.css', resolveFrontendAssetPath('webfonts/NotoSans/stylesheet.css')],
+        ['webfonts/NotoSansMono/stylesheet.css', resolveFrontendAssetPath('webfonts/NotoSansMono/stylesheet.css')],
+    ]);
+
+    for (const [source, target] of replacements) {
+        if (!target) {
+            continue;
+        }
+
+        const escaped = source.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        rewritten = rewritten.replace(new RegExp(`(["'])${escaped}(?:\\?v=[^"']*)?\\1`, 'g'), `$1${target}$1`);
+    }
+
+    return rewritten;
+}
+
+export function applyFrontendAssetHeaders(res, filePath) {
+    const relativePath = path.relative(FRONTEND_DIST_ROOT, filePath).split(path.sep).join('/');
+
+    if (HASHED_FRONTEND_ASSET_RE.test(relativePath)) {
+        res.setHeader('Cache-Control', `public, max-age=${getFrontendImmutableMaxAge()}, immutable`);
+        return;
+    }
+
+    res.setHeader('Cache-Control', 'no-cache');
+}

--- a/src/middleware/frontend-assets.js
+++ b/src/middleware/frontend-assets.js
@@ -1,0 +1,34 @@
+import express from 'express';
+
+import {
+    FRONTEND_DIST_ROOT,
+    applyFrontendAssetHeaders,
+    getFrontendAssetsEnabled,
+    loadFrontendManifest,
+} from '../frontend-assets.js';
+
+function setPublicAssetHeaders(res, requestPath) {
+    if (/\.(?:html?|json|map)$/i.test(requestPath)) {
+        res.setHeader('Cache-Control', 'no-cache');
+        return;
+    }
+
+    res.setHeader('Cache-Control', 'public, max-age=3600');
+}
+
+export function getFrontendAssetMiddleware() {
+    return {
+        immutableAssets: express.static(FRONTEND_DIST_ROOT, {
+            fallthrough: true,
+            setHeaders: applyFrontendAssetHeaders,
+        }),
+        publicAssets: express.static(FRONTEND_DIST_ROOT, {
+            fallthrough: true,
+            setHeaders: setPublicAssetHeaders,
+        }),
+    };
+}
+
+export function shouldServeFrontendAssets() {
+    return getFrontendAssetsEnabled() && Boolean(loadFrontendManifest());
+}

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -42,6 +42,8 @@ import {
 } from './users.js';
 
 import getWebpackServeMiddleware from './middleware/webpack-serve.js';
+import { FRONTEND_ASSET_PREFIX, rewriteFrontendHtml } from './frontend-assets.js';
+import { getFrontendAssetMiddleware, shouldServeFrontendAssets } from './middleware/frontend-assets.js';
 import basicAuthMiddleware from './middleware/basicAuth.js';
 import requireHttpsMiddleware from './middleware/requireHttps.js';
 import { createSession, destroySession, validateCredentials, isSessionAuthEnabled } from './middleware/sessionAuth.js';
@@ -258,6 +260,14 @@ app.get('/', (request, response) => {
         return response.redirect(redirectUrl);
     }
 
+    if (shouldServeFrontendAssets()) {
+        const indexPath = path.join(serverDirectory, 'public', 'index.html');
+        const indexHtml = safeReadFileSync(indexPath);
+        response.type('html');
+        response.set('Cache-Control', 'no-cache');
+        return response.send(rewriteFrontendHtml(indexHtml));
+    }
+
     return response.sendFile('index.html', { root: path.join(serverDirectory, 'public') });
 });
 
@@ -277,7 +287,16 @@ app.get('/login', loginPageMiddleware);
 
 // Host frontend assets
 const webpackMiddleware = getWebpackServeMiddleware();
+const frontendAssetMiddleware = getFrontendAssetMiddleware();
+app.use(FRONTEND_ASSET_PREFIX, frontendAssetMiddleware.immutableAssets);
 app.use(webpackMiddleware);
+app.use((request, response, next) => {
+    if (!shouldServeFrontendAssets()) {
+        return next();
+    }
+
+    return frontendAssetMiddleware.publicAssets(request, response, next);
+});
 app.use(express.static(path.join(serverDirectory, 'public'), {}));
 
 // Public API

--- a/tests/frontend-assets.test.js
+++ b/tests/frontend-assets.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, test } from '@jest/globals';
+
+import {
+    FRONTEND_ASSET_PREFIX,
+    HASHED_FRONTEND_ASSET_RE,
+    rewriteFrontendHtml,
+} from '../src/frontend-assets.js';
+
+describe('frontend asset manifest rewriting', () => {
+    test('leaves HTML unchanged when the frontend build is disabled', () => {
+        const html = '<link href="style.css"><script type="module" src="script.js"></script>';
+        expect(rewriteFrontendHtml(html, { enabled: false })).toBe(html);
+    });
+
+    test('keeps the immutable asset prefix stable for production serving', () => {
+        expect(FRONTEND_ASSET_PREFIX).toBe('/frontend-assets/');
+    });
+
+    test('only treats fingerprinted frontend asset names as immutable', () => {
+        expect(HASHED_FRONTEND_ASSET_RE.test('script-0123456789ab.js')).toBe(true);
+        expect(HASHED_FRONTEND_ASSET_RE.test('scripts/extensions-abcdef123456.js')).toBe(true);
+        expect(HASHED_FRONTEND_ASSET_RE.test('script.js')).toBe(false);
+        expect(HASHED_FRONTEND_ASSET_RE.test('scripts/extensions.js')).toBe(false);
+    });
+});

--- a/tests/frontend-performance.e2e.js
+++ b/tests/frontend-performance.e2e.js
@@ -1,0 +1,39 @@
+/* global globalThis */
+import { expect, test } from '@playwright/test';
+
+test.describe('frontend performance smoke', () => {
+    test('mobile shell exposes core performance marks and bounded assets', async ({ page }) => {
+        await page.setViewportSize({ width: 390, height: 844 });
+        await page.goto('/', { waitUntil: 'domcontentloaded' });
+        await page.waitForFunction(() => {
+            const browserGlobal = globalThis;
+            return browserGlobal.document.readyState === 'complete'
+                && browserGlobal.performance.getEntriesByType('resource').length > 0;
+        });
+
+        const snapshot = await page.evaluate(() => {
+            const browserGlobal = globalThis;
+            const resources = browserGlobal.performance.getEntriesByType('resource');
+            const jsBytes = resources
+                .filter(entry => /\.m?js(?:\?|$)/i.test(entry.name))
+                .reduce((total, entry) => total + (entry.transferSize || entry.encodedBodySize || 0), 0);
+            const cssBytes = resources
+                .filter(entry => /\.css(?:\?|$)/i.test(entry.name))
+                .reduce((total, entry) => total + (entry.transferSize || entry.encodedBodySize || 0), 0);
+            const fontRequests = resources.filter(entry => /\.(?:woff2?|ttf)(?:\?|$)/i.test(entry.name)).length;
+
+            return {
+                title: browserGlobal.document.title,
+                hasShell: Boolean(browserGlobal.SillyBunnyShell),
+                resourceCount: resources.length,
+                jsBytes,
+                cssBytes,
+                fontRequests,
+            };
+        });
+
+        expect(snapshot.title).toBe('SillyBunny');
+        expect(snapshot.resourceCount).toBeLessThan(260);
+        expect(snapshot.fontRequests).toBeLessThan(18);
+    });
+});

--- a/tests/openai-responses.test.js
+++ b/tests/openai-responses.test.js
@@ -6,7 +6,7 @@ import { setConfigFilePath } from '../src/util.js';
 import { CHAT_COMPLETION_SOURCES } from '../src/constants.js';
 import { MockServer } from './util/mock-server.js';
 
-setConfigFilePath(fileURLToPath(new URL('../config.yaml', import.meta.url)));
+setConfigFilePath(fileURLToPath(new URL('../default/config.yaml', import.meta.url)));
 
 describe('OpenAI Responses integration', () => {
     /** @type {import('express').Router} */

--- a/tests/playwright.config.js
+++ b/tests/playwright.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-    testMatch: '*.e2e.js',
+    testMatch: ['*.e2e.js', 'frontend-performance.e2e.js'],
     use: {
         baseURL: 'http://127.0.0.1:4444',
         video: 'only-on-failure',


### PR DESCRIPTION
## What?
This PR adds an optional production frontend asset build with minified and fingerprinted files under `dist/frontend`. It serves built assets behind `performance.frontendBuild.enabled` and `SILLYTAVERN_PERFORMANCE_FRONTENDBUILD_ENABLED`, defers broad Noto font loading, adds a lightweight performance loader, documents the operator flow, and adds frontend asset/performance smoke tests.

## Why?
Production deployments needed an optional path for cacheable frontend assets without changing normal development mode or forcing the source-module flow off by default.

## How?
The build emits hashed frontend assets and serves them through `/frontend-assets/` only when the feature flag or environment variable is enabled. The service worker cache-first behavior stays limited to hashed frontend assets, and normal dev mode continues to serve source modules from `public/`.

## Testing?
- `npm run lint`
- `npm run lint --prefix tests`
- `npm run test:unit --prefix tests`
- `npm run build:frontend`
- Node production smoke with `SILLYTAVERN_PERFORMANCE_FRONTENDBUILD_ENABLED=true` on port 4555
- `npm run perf:frontend`
- `npm run test:e2e --prefix tests -- frontend-performance.e2e.js`

Manual mode check:
1. Run `npm run build:frontend`.
2. Start with `SILLYTAVERN_PERFORMANCE_FRONTENDBUILD_ENABLED=true npm run start:node` or Bun equivalent.
3. Open `/` and confirm the HTML references `/frontend-assets/`.
4. Check a hashed asset returns `Cache-Control: public, max-age=31536000, immutable`.

## Screenshots (optional)
Screenshots were not included. The verification was build, smoke, cache-header, and performance-test oriented.

## Anything Else?
Build warnings for copied BunnyPresetTools files are non-fatal minification skips. The PR targeted `main` because local `origin/staging` diverged and would have included unrelated release artifacts in the diff. See `docs/frontend-build.md` for the full operator flow.