### PR TITLE
fix: harden webpack lib cache lifecycle

### DIFF
--- a/src/middleware/webpack-serve.js
+++ b/src/middleware/webpack-serve.js
@@ -1,12 +1,59 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import webpack from 'webpack';
-import getPublicLibConfig from '../../webpack.config.js';
+import getPublicLibConfig, {
+    getPublicLibCacheInfo,
+    prunePublicLibCache,
+} from '../../webpack.config.js';
 import { isBunRuntime } from '../runtime.js';
 
 export default function getWebpackServeMiddleware({ forceDist = false } = {}) {
     const resolvePublicLibConfig = ({ forceDist: overrideForceDist = forceDist, pruneCache = false } = {}) =>
         getPublicLibConfig({ forceDist: overrideForceDist, pruneCache });
+    /** @type {import('webpack').Configuration | null} */
+    let activePublicLibConfig = null;
+    /** @type {Promise<void> | null} */
+    let compilePromise = null;
+
+    function getCompiledOutputPath(publicLibConfig) {
+        const outputPath = publicLibConfig.output?.path;
+        const outputFile = publicLibConfig.output?.filename;
+
+        return typeof outputPath === 'string' && typeof outputFile === 'string'
+            ? path.join(outputPath, outputFile)
+            : null;
+    }
+
+    function cleanupTemporaryOutput(temporaryOutputPath) {
+        try {
+            fs.rmSync(temporaryOutputPath, { recursive: true, force: true });
+        } catch (error) {
+            console.error('Failed to remove temporary Webpack output directory.', error);
+        }
+    }
+
+    function sendPublicLib(publicLibConfig, res, next, { recoverMissing = true } = {}) {
+        const outputPath = publicLibConfig.output?.path;
+        const outputFile = publicLibConfig.output?.filename;
+
+        res.setHeader('Cache-Control', 'no-cache');
+        return res.sendFile(outputFile, { root: outputPath }, (error) => {
+            if (!error) {
+                return;
+            }
+
+            if (error.code !== 'ENOENT' || !recoverMissing || res.headersSent) {
+                return next(error);
+            }
+
+            console.warn(`Frontend library bundle was missing at ${path.join(outputPath, outputFile)}. Rebuilding...`);
+            runWebpackCompiler({ forceDist, pruneCache: true })
+                .then(() => {
+                    sendPublicLib(activePublicLibConfig ?? resolvePublicLibConfig(), res, next, { recoverMissing: false });
+                })
+                .catch(next);
+        });
+    }
 
     /**
      * A very spartan recreation of webpack-dev-middleware.
@@ -16,13 +63,12 @@ export default function getWebpackServeMiddleware({ forceDist = false } = {}) {
      * @type {import('express').RequestHandler}
      */
     function devMiddleware(req, res, next) {
-        const publicLibConfig = resolvePublicLibConfig();
-        const outputPath = publicLibConfig.output?.path;
+        const publicLibConfig = activePublicLibConfig ?? resolvePublicLibConfig();
         const outputFile = publicLibConfig.output?.filename;
         const parsedPath = path.parse(req.path);
 
         if (req.method === 'GET' && parsedPath.dir === '/' && parsedPath.base === outputFile) {
-            return res.sendFile(outputFile, { root: outputPath });
+            return sendPublicLib(publicLibConfig, res, next);
         }
 
         next();
@@ -35,37 +81,93 @@ export default function getWebpackServeMiddleware({ forceDist = false } = {}) {
      * @param {boolean} [param.pruneCache=false] Whether to prune old cache directories before compiling.
      * @returns {Promise<void>}
      */
-    devMiddleware.runWebpackCompiler = ({ forceDist: overrideForceDist = forceDist, pruneCache = false } = {}) => {
-        const publicLibConfig = resolvePublicLibConfig({ forceDist: overrideForceDist, pruneCache });
-        const outputPath = publicLibConfig.output?.path;
-        const outputFile = publicLibConfig.output?.filename;
-        const compiledOutputPath = typeof outputPath === 'string' && typeof outputFile === 'string'
-            ? path.join(outputPath, outputFile)
-            : null;
+    function compilePublicLib({ forceDist: overrideForceDist = forceDist, pruneCache = false } = {}) {
+        const cacheInfo = getPublicLibCacheInfo({ forceDist: overrideForceDist });
+        const publicLibConfig = resolvePublicLibConfig({ forceDist: overrideForceDist });
+        const compiledOutputPath = getCompiledOutputPath(publicLibConfig);
 
         if (isBunRuntime() && compiledOutputPath && fs.existsSync(compiledOutputPath)) {
             console.log();
             console.log('Reusing precompiled frontend libraries...');
+            activePublicLibConfig = publicLibConfig;
+            if (pruneCache) {
+                prunePublicLibCache({ forceDist: overrideForceDist, currentCacheVersion: cacheInfo.cacheVersion });
+            }
             return Promise.resolve();
         }
+
+        const temporaryOutputPath = path.join(cacheInfo.webpackRoot, cacheInfo.cacheVersion, `output.${process.pid}.${Date.now()}.tmp`);
+        const temporaryOutputFilePath = path.join(temporaryOutputPath, cacheInfo.outputFile);
+        const temporaryPublicLibConfig = getPublicLibConfig({
+            forceDist: overrideForceDist,
+            outputPath: temporaryOutputPath,
+        });
 
         console.log();
         console.log('Compiling frontend libraries...');
 
-        const compiler = webpack(publicLibConfig);
+        const compiler = webpack(temporaryPublicLibConfig);
 
-        return new Promise((resolve) => {
-            compiler.run((_error, stats) => {
-                const output = stats?.toString(publicLibConfig.stats);
+        return new Promise((resolve, reject) => {
+            compiler.run((error, stats) => {
+                const output = stats?.toString(temporaryPublicLibConfig.stats);
                 if (output) {
                     console.log(output);
                     console.log();
                 }
-                compiler.close(() => {
-                    resolve();
+
+                compiler.close((closeError) => {
+                    try {
+                        const compileError = error ?? closeError;
+                        if (compileError) {
+                            cleanupTemporaryOutput(temporaryOutputPath);
+                            reject(compileError);
+                            return;
+                        }
+
+                        if (stats?.hasErrors()) {
+                            cleanupTemporaryOutput(temporaryOutputPath);
+                            reject(new Error('Webpack failed to compile frontend libraries.'));
+                            return;
+                        }
+
+                        if (!fs.existsSync(temporaryOutputFilePath)) {
+                            cleanupTemporaryOutput(temporaryOutputPath);
+                            reject(new Error(`Webpack did not produce ${cacheInfo.outputFile}.`));
+                            return;
+                        }
+
+                        fs.rmSync(cacheInfo.outputDirectory, { recursive: true, force: true });
+                        fs.mkdirSync(path.dirname(cacheInfo.outputDirectory), { recursive: true });
+                        fs.renameSync(temporaryOutputPath, cacheInfo.outputDirectory);
+
+                        activePublicLibConfig = publicLibConfig;
+                        if (pruneCache) {
+                            prunePublicLibCache({ forceDist: overrideForceDist, currentCacheVersion: cacheInfo.cacheVersion });
+                        }
+                        resolve();
+                    } catch (error) {
+                        cleanupTemporaryOutput(temporaryOutputPath);
+                        reject(error);
+                    }
                 });
             });
         });
+    }
+
+    function runWebpackCompiler({ forceDist: overrideForceDist = forceDist, pruneCache = false } = {}) {
+        if (!compilePromise) {
+            compilePromise = compilePublicLib({ forceDist: overrideForceDist, pruneCache })
+                .finally(() => {
+                    compilePromise = null;
+                });
+        }
+
+        return compilePromise;
+    }
+
+    devMiddleware.runWebpackCompiler = ({ forceDist: overrideForceDist = forceDist, pruneCache = false } = {}) => {
+        return runWebpackCompiler({ forceDist: overrideForceDist, pruneCache });
     };
 
     return devMiddleware;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,8 @@ import { serverDirectory } from './src/server-directory.js';
 import { getVersion, color } from './src/util.js';
 
 const BUN_LIB_BUNDLE_SIGNATURE = 'bun-no-minify-v1';
+const WEBPACK_CACHE_KEEP_COUNT = 3;
+const PUBLIC_LIB_FILENAME = 'lib.js';
 
 function hashFileIfPresent(hasher, filePath) {
     if (!fs.existsSync(filePath)) {
@@ -50,8 +52,10 @@ function getWebpackCacheVersion() {
  * Prune old Webpack cache directories that do not match the current cache version.
  * @param {string} webpackRoot The root directory where Webpack caches are stored.
  * @param {string} currentCacheVersion The current cache version to keep.
+ * @param {object} options Options.
+ * @param {number} [options.keepCount=WEBPACK_CACHE_KEEP_COUNT] Number of recent cache directories to keep.
  */
-function pruneWebpackCache(webpackRoot, currentCacheVersion) {
+function pruneWebpackCache(webpackRoot, currentCacheVersion, { keepCount = WEBPACK_CACHE_KEEP_COUNT } = {}) {
     try {
         if (!fs.existsSync(webpackRoot)) {
             return;
@@ -59,16 +63,32 @@ function pruneWebpackCache(webpackRoot, currentCacheVersion) {
 
         const cacheDirectories = fs.readdirSync(webpackRoot, { withFileTypes: true })
             .filter(dirent => dirent.isDirectory())
-            .map(dirent => dirent.name);
+            .map((dirent) => {
+                const dirPath = path.join(webpackRoot, dirent.name);
+                return {
+                    name: dirent.name,
+                    path: dirPath,
+                    mtimeMs: fs.statSync(dirPath).mtimeMs,
+                };
+            })
+            .sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+        const keepDirectories = new Set([currentCacheVersion]);
+        for (const dir of cacheDirectories) {
+            if (keepDirectories.size >= keepCount) {
+                break;
+            }
+
+            keepDirectories.add(dir.name);
+        }
 
         for (const dir of cacheDirectories) {
-            const dirPath = path.join(webpackRoot, dir);
-            if (dir !== currentCacheVersion) {
+            if (!keepDirectories.has(dir.name)) {
                 try {
-                    fs.rmSync(dirPath, { recursive: true, force: true });
-                    console.debug(`Removed outdated cache directory: ${color.yellow(dir)}`);
+                    fs.rmSync(dir.path, { recursive: true, force: true });
+                    console.debug(`Removed outdated cache directory: ${color.yellow(dir.name)}`);
                 } catch (error) {
-                    console.error(`Failed to remove Webpack cache directory: ${color.red(dir)}`, error);
+                    console.error(`Failed to remove Webpack cache directory: ${color.red(dir.name)}`, error);
                 }
             }
         }
@@ -79,6 +99,64 @@ function pruneWebpackCache(webpackRoot, currentCacheVersion) {
 
 const appVersion = await getVersion();
 
+function getWebpackRoot({ forceDist = false } = {}) {
+    if (forceDist || isDocker()) {
+        return path.resolve(process.cwd(), 'dist', '_webpack');
+    }
+
+    if (typeof globalThis.DATA_ROOT === 'string') {
+        return path.resolve(globalThis.DATA_ROOT, '_webpack');
+    }
+
+    throw new Error('DATA_ROOT variable is not set.');
+}
+
+function getCacheDirectory(webpackRoot, cacheVersion) {
+    return path.join(webpackRoot, cacheVersion, 'cache');
+}
+
+function getOutputDirectory(webpackRoot, cacheVersion) {
+    return path.join(webpackRoot, cacheVersion, 'output');
+}
+
+/**
+ * Get the resolved output paths for the public lib bundle.
+ * @param {object} options Configuration options.
+ * @param {boolean} [options.forceDist=false] Whether to force the use the /dist folder.
+ * @returns {{ webpackRoot: string, cacheVersion: string, cacheDirectory: string, outputDirectory: string, outputFile: string, outputFilePath: string }}
+ */
+export function getPublicLibCacheInfo({ forceDist = false } = {}) {
+    const webpackRoot = getWebpackRoot({ forceDist });
+    const cacheVersion = getWebpackCacheVersion();
+    const cacheDirectory = getCacheDirectory(webpackRoot, cacheVersion);
+    const outputDirectory = getOutputDirectory(webpackRoot, cacheVersion);
+    const outputFile = PUBLIC_LIB_FILENAME;
+    const outputFilePath = path.join(outputDirectory, outputFile);
+
+    return {
+        webpackRoot,
+        cacheVersion,
+        cacheDirectory,
+        outputDirectory,
+        outputFile,
+        outputFilePath,
+    };
+}
+
+/**
+ * Prune older public lib cache directories after a successful compile.
+ * @param {object} options Options.
+ * @param {boolean} [options.forceDist=false] Whether to force the use the /dist folder.
+ * @param {string} [options.currentCacheVersion] Cache version to preserve.
+ * @param {number} [options.keepCount=WEBPACK_CACHE_KEEP_COUNT] Number of recent cache directories to keep.
+ * @returns {void}
+ */
+export function prunePublicLibCache({ forceDist = false, currentCacheVersion = undefined, keepCount = WEBPACK_CACHE_KEEP_COUNT } = {}) {
+    const webpackRoot = getWebpackRoot({ forceDist });
+    const cacheVersion = currentCacheVersion ?? getWebpackCacheVersion();
+    pruneWebpackCache(webpackRoot, cacheVersion, { keepCount });
+}
+
 /**
  * Get the Webpack configuration for the public/lib.js file.
  * 1. Docker has got cache and the output file pre-baked.
@@ -86,34 +164,17 @@ const appVersion = await getVersion();
  * @param {object} options Configuration options.
  * @param {boolean} [options.forceDist=false] Whether to force the use the /dist folder.
  * @param {boolean} [options.pruneCache=false] Whether to prune old cache directories.
+ * @param {string} [options.outputPath] Override for the Webpack output directory.
  * @returns {import('webpack').Configuration}
  * @throws {Error} If the DATA_ROOT variable is not set.
  * */
-export default function getPublicLibConfig({ forceDist = false, pruneCache = false } = {}) {
-    function getWebpackRoot() {
-        if (forceDist || isDocker()) {
-            return path.resolve(process.cwd(), 'dist', '_webpack');
-        }
-
-        if (typeof globalThis.DATA_ROOT === 'string') {
-            return path.resolve(globalThis.DATA_ROOT, '_webpack');
-        }
-
-        throw new Error('DATA_ROOT variable is not set.');
-    }
-
-    function getCacheDirectory() {
-        return path.join(webpackRoot, cacheVersion, 'cache');
-    }
-
-    function getOutputDirectory() {
-        return path.join(webpackRoot, cacheVersion, 'output');
-    }
-
-    const webpackRoot = getWebpackRoot();
-    const cacheVersion = getWebpackCacheVersion();
-    const cacheDirectory = getCacheDirectory();
-    const outputDirectory = getOutputDirectory();
+export default function getPublicLibConfig({ forceDist = false, pruneCache = false, outputPath = undefined } = {}) {
+    const {
+        webpackRoot,
+        cacheVersion,
+        cacheDirectory,
+        outputDirectory,
+    } = getPublicLibCacheInfo({ forceDist });
 
     if (pruneCache) {
         pruneWebpackCache(webpackRoot, cacheVersion);
@@ -152,8 +213,8 @@ export default function getPublicLibConfig({ forceDist = false, pruneCache = fal
             minimize,
         },
         output: {
-            path: outputDirectory,
-            filename: 'lib.js',
+            path: outputPath ?? outputDirectory,
+            filename: PUBLIC_LIB_FILENAME,
             libraryTarget: 'module',
         },
     };


### PR DESCRIPTION
## What?
This PR hardens the generated `/lib.js` bundle lifecycle by compiling transactionally before promotion, keeping recent webpack cache directories, serving `/lib.js` with no-cache headers, adding one-shot rebuild recovery for missing `/lib.js`, and deduplicating concurrent rebuilds behind a shared compiler promise.

## Why?
The server should not promote incomplete vendor bundles or leave users stuck after a missing `/lib.js`. Cache cleanup also needed to be less aggressive so recent compiled outputs remain available.

## How?
Webpack output is compiled into a safe intermediate state before promotion. Cache pruning keeps a small set of recent hashes, missing bundle requests can trigger one recovery rebuild, and concurrent rebuilds share a single compiler promise.

## Testing?
- `npm run lint -- --quiet`
- `node -e "globalThis.DATA_ROOT='D:/AIStuff/SillyBunny/data'; const { default: getWebpackServeMiddleware } = await import('./src/middleware/webpack-serve.js'); const middleware = getWebpackServeMiddleware(); await middleware.runWebpackCompiler({ pruneCache: true }); console.log('node-compile-ok');"`

`npm run test:unit --prefix tests -- frontend-assets.test.js` was attempted, but this staging base did not contain `tests/frontend-assets.test.js`.

## Screenshots (optional)
Screenshots were not applicable for this server middleware/cache lifecycle change.

## Anything Else?
None.