### PR TITLE
chore: defer secondary frontend stylesheets

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,8 +28,6 @@
     <link href="css/solid.min.css" rel="stylesheet">
     <link href="css/brands.min.css" rel="stylesheet">
     <link href="css/jquery-ui.min.css" rel="stylesheet">
-    <link href="css/bright.min.css" rel="stylesheet">
-    <link href="css/cropper.min.css" rel="stylesheet">
     <link href="css/toastr.min.css" rel="stylesheet">
     <link href="css/select2.min.css" rel="stylesheet">
     <link rel="icon" type="image/png" sizes="256x256" href="img/sillybunny-pixel-logo-og.png">

--- a/public/script.js
+++ b/public/script.js
@@ -305,6 +305,8 @@ import { bindIOSFastTapSendButton, isIOSWebKitPlatform } from './scripts/mobile-
 import { getStreamingUpdateInterval } from './scripts/mobile-streaming.js';
 
 const DEFERRED_STARTUP_STYLESHEETS = Object.freeze([
+    { href: 'css/bright.min.css', id: 'deferred-highlight-theme-css' },
+    { href: 'css/cropper.min.css', id: 'deferred-cropper-css' },
     { href: 'css/rm-groups.css', id: 'deferred-rm-groups-css' },
     { href: 'css/group-avatars.css', id: 'deferred-group-avatars-css' },
     { href: 'css/macros.css', id: 'deferred-macros-css' },

--- a/scripts/check-frontend-budgets.js
+++ b/scripts/check-frontend-budgets.js
@@ -10,8 +10,8 @@ const indexPath = path.join(repoRoot, 'public', 'index.html');
 const publicRoot = path.join(repoRoot, 'public');
 
 const budgets = Object.freeze({
-    blockingStylesheetCount: 23,
-    blockingStylesheetBytes: 770 * 1024,
+    blockingStylesheetCount: 16,
+    blockingStylesheetBytes: 690 * 1024,
     startupScriptCount: 23,
     startupScriptBytes: 3_600 * 1024,
     extensionLargeAssetBytes: 2_250 * 1024,


### PR DESCRIPTION
## What?
This PR defers syntax highlight and cropper stylesheets through the existing idle stylesheet loader, and tightens the frontend budget to preserve the reduced blocking stylesheet count and byte total.

## Why?
The frontend performance gains from deferring noncritical assets needed to be preserved and extended to secondary stylesheets that do not need to block initial render.

## How?
The secondary stylesheet loading path now uses the existing idle loader instead of adding another loading mechanism. The budget thresholds are adjusted so regressions in blocking stylesheet count or bytes are caught.

## Testing?
- `npm run check:frontend-budgets`
- `npx eslint public/script.js scripts/check-frontend-budgets.js --quiet`
- `npm run test:unit --prefix tests -- --testTimeout=30000`

## Screenshots (optional)
Screenshots were not applicable for this stylesheet loading and budget change.

## Anything Else?
None.