### PR TITLE
fix: reset mobile shell drawers

### DIFF
--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -5481,6 +5481,159 @@ body.sb-shell-resizing * {
     }
 }
 
+/* SillyBunny mobile shell foundation: final sheet contract for modal drawers.
+ * Keep this at the end of the shell sheet so it beats older mobile drawer rules. */
+@media screen and (max-width: 1000px) {
+    body.sb-mobile-modal-open {
+        overflow: hidden !important;
+    }
+
+    #left-nav-panel.openDrawer,
+    #user-settings-block.openDrawer,
+    .sb-shell-root.openDrawer,
+    .sb-shell-root.fillLeft.openDrawer,
+    .sb-shell-root.fillRight.openDrawer,
+    #right-nav-panel.openDrawer,
+    :root[data-sb-character-drawer-lock='right'] #right-nav-panel.openDrawer,
+    #top-settings-holder #right-nav-panel.openDrawer {
+        position: fixed !important;
+        inset-inline: 0 !important;
+        top: var(--sb-topbar-layout-offset) !important;
+        bottom: 0 !important;
+        width: 100vw !important;
+        width: 100dvw !important;
+        max-width: 100dvw !important;
+        min-width: 0 !important;
+        height: calc(100dvh - var(--sb-topbar-layout-offset)) !important;
+        max-height: calc(100dvh - var(--sb-topbar-layout-offset)) !important;
+        margin: 0 !important;
+        padding: 0 !important;
+        border-radius: 0 !important;
+        overflow: hidden !important;
+        transform: translateZ(0) !important;
+        box-sizing: border-box !important;
+    }
+
+    #left-nav-panel.openDrawer,
+    #user-settings-block.openDrawer,
+    .sb-shell-root.openDrawer,
+    .sb-shell-root.fillLeft.openDrawer,
+    .sb-shell-root.fillRight.openDrawer {
+        display: flex !important;
+        flex-direction: column !important;
+    }
+
+    #right-nav-panel.openDrawer {
+        display: flex !important;
+        flex-direction: column !important;
+    }
+
+    #left-nav-panel.openDrawer .sb-shell-frame,
+    #user-settings-block.openDrawer .sb-shell-frame,
+    .sb-shell-root.openDrawer .sb-shell-frame,
+    .sb-shell-root.fillLeft.openDrawer .sb-shell-frame,
+    .sb-shell-root.fillRight.openDrawer .sb-shell-frame {
+        flex: 1 1 auto !important;
+        min-height: 0 !important;
+        height: 100% !important;
+        overflow: hidden !important;
+    }
+
+    #left-nav-panel.openDrawer .sb-shell-main,
+    #user-settings-block.openDrawer .sb-shell-main,
+    .sb-shell-root.openDrawer .sb-shell-main,
+    .sb-shell-root.fillLeft.openDrawer .sb-shell-main,
+    .sb-shell-root.fillRight.openDrawer .sb-shell-main {
+        flex: 1 1 auto !important;
+        min-height: 0 !important;
+        overflow: hidden !important;
+    }
+
+    #left-nav-panel.openDrawer .sb-shell-body,
+    #user-settings-block.openDrawer .sb-shell-body,
+    .sb-shell-root.openDrawer .sb-shell-body,
+    .sb-shell-root.fillLeft.openDrawer .sb-shell-body,
+    .sb-shell-root.fillRight.openDrawer .sb-shell-body {
+        flex: 1 1 auto !important;
+        min-height: 0 !important;
+        height: auto !important;
+        overflow: hidden !important;
+        padding-bottom: 0 !important;
+    }
+
+    #left-nav-panel.openDrawer .sb-shell-panel,
+    #user-settings-block.openDrawer .sb-shell-panel,
+    .sb-shell-root.openDrawer .sb-shell-panel,
+    .sb-shell-root.fillLeft.openDrawer .sb-shell-panel,
+    .sb-shell-root.fillRight.openDrawer .sb-shell-panel {
+        min-height: 0 !important;
+        height: 100% !important;
+        overflow: hidden !important;
+    }
+
+    #left-nav-panel.openDrawer .sb-shell-panel-active,
+    #user-settings-block.openDrawer .sb-shell-panel-active,
+    .sb-shell-root.openDrawer .sb-shell-panel-active,
+    .sb-shell-root.fillLeft.openDrawer .sb-shell-panel-active,
+    .sb-shell-root.fillRight.openDrawer .sb-shell-panel-active {
+        display: flex !important;
+        flex-direction: column !important;
+    }
+
+    #left-nav-panel.openDrawer .sb-shell-panel-scroller,
+    #user-settings-block.openDrawer .sb-shell-panel-scroller,
+    .sb-shell-root.openDrawer .sb-shell-panel-scroller,
+    .sb-shell-root.fillLeft.openDrawer .sb-shell-panel-scroller,
+    .sb-shell-root.fillRight.openDrawer .sb-shell-panel-scroller {
+        flex: 1 1 auto !important;
+        min-height: 0 !important;
+        height: auto !important;
+        max-height: none !important;
+        overflow-y: auto !important;
+        overflow-x: hidden !important;
+        overscroll-behavior: contain !important;
+        -webkit-overflow-scrolling: touch !important;
+        padding-bottom: max(24px, var(--sb-mobile-safe-area-bottom, env(safe-area-inset-bottom, 0px))) !important;
+    }
+
+    #right-nav-panel.openDrawer > .scrollableInner,
+    #right-nav-panel.openDrawer > .scrollableInnerFull {
+        flex: 1 1 auto !important;
+        min-height: 0 !important;
+        height: auto !important;
+        max-height: none !important;
+        overflow-y: auto !important;
+        overflow-x: hidden !important;
+        overscroll-behavior: contain !important;
+        -webkit-overflow-scrolling: touch !important;
+        padding-bottom: max(24px, var(--sb-mobile-safe-area-bottom, env(safe-area-inset-bottom, 0px))) !important;
+    }
+
+    #right-nav-panel.openDrawer .sb-shell-panel-scroller {
+        min-height: 0 !important;
+        overflow-y: auto !important;
+        overflow-x: hidden !important;
+        -webkit-overflow-scrolling: touch !important;
+    }
+}
+
+@supports (-webkit-touch-callout: none) {
+    @media screen and (max-width: 1000px) {
+        #left-nav-panel.openDrawer,
+        #user-settings-block.openDrawer,
+        .sb-shell-root.openDrawer,
+        .sb-shell-root.fillLeft.openDrawer,
+        .sb-shell-root.fillRight.openDrawer,
+        #right-nav-panel.openDrawer,
+        :root[data-sb-character-drawer-lock='right'] #right-nav-panel.openDrawer,
+        #top-settings-holder #right-nav-panel.openDrawer {
+            overflow: hidden !important;
+            padding-bottom: 0 !important;
+            -webkit-overflow-scrolling: auto !important;
+        }
+    }
+}
+
 @media (prefers-reduced-motion: reduce) {
     .sb-proxy-button,
     .sb-shell-tab,

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -71,6 +71,7 @@ const SB_ACCOUNT_STORAGE_READY_MARKER = '__migrated';
 const SB_INLINE_DRAWER_CUSTOM_PERSISTENCE_SELECTOR = '.sb-openai-settings-drawer, .sb-openai-settings-subdrawer, [id$="prompt_manager_drawer"]';
 const SB_STORAGE_PREFIX = 'sb-';
 const SB_STORAGE_WRITE_DEBOUNCE_MS = 120;
+const SB_MOBILE_NAV_OPEN_GRACE_MS = 450;
 
 let sbInlineDrawerPersistenceObserver = null;
 let sbInlineDrawerPersistenceQueued = false;
@@ -521,6 +522,12 @@ const sbState = {
     },
     characterDrawer: {
         rightLocked: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.characterDrawerRightLocked), false),
+    },
+    mobileModal: {
+        syncFrame: 0,
+    },
+    mobileNav: {
+        lastOpenedAt: 0,
     },
     chatbar: {
         desktop: null,
@@ -3816,6 +3823,8 @@ function setMobileChatToolsOpenState(shouldOpen) {
         refs.overlay.inert = !isOpen;
     }
 
+    queueMobileModalStateSync();
+
     if (isOpen) {
         scheduleChatbarRefresh(0);
     }
@@ -4481,6 +4490,167 @@ function isDrawerActuallyOpen(drawerRootOrId) {
         && el.getClientRects().length > 0;
 }
 
+function isMobileOverlayActuallyOpen(overlayRootOrId, openClass) {
+    const el = getDrawerRoot(overlayRootOrId);
+
+    if (!(el instanceof HTMLElement) || !el.classList.contains(openClass)) {
+        return false;
+    }
+
+    const isExplicitlyHidden = el.hidden || el.getAttribute('aria-hidden') === 'true';
+    if (isExplicitlyHidden) {
+        return false;
+    }
+
+    const styles = getComputedStyle(el);
+    return styles.display !== 'none'
+        && styles.visibility !== 'hidden'
+        && styles.pointerEvents !== 'none'
+        && el.getClientRects().length > 0;
+}
+
+function getMobileModalRootCandidates() {
+    const chatTools = getChatbarState().mobileTools?.overlay ?? document.getElementById('sb-mobile-chat-tools');
+    return [
+        document.getElementById(getShellConfig('left').rootPanelId),
+        document.getElementById(getShellConfig('right').rootPanelId),
+        document.getElementById('right-nav-panel'),
+        document.getElementById('sb-mobile-nav'),
+        chatTools,
+    ].filter(element => element instanceof HTMLElement);
+}
+
+function isMobileModalRootOpen(root) {
+    if (!(root instanceof HTMLElement)) {
+        return false;
+    }
+
+    if (root.id === 'sb-mobile-nav') {
+        return isMobileOverlayActuallyOpen(root, 'sb-nav-open');
+    }
+
+    if (root.id === 'sb-mobile-chat-tools') {
+        return isMobileOverlayActuallyOpen(root, 'sb-chat-tools-open');
+    }
+
+    return isDrawerActuallyOpen(root);
+}
+
+function getActiveMobileModalRoots() {
+    if (!isMobileViewport()) {
+        return [];
+    }
+
+    return getMobileModalRootCandidates().filter(root => isMobileModalRootOpen(root));
+}
+
+function setElementInertForMobileModal(element, shouldInert) {
+    if (!(element instanceof HTMLElement)) {
+        return;
+    }
+
+    if (shouldInert) {
+        if (!element.hasAttribute('data-sb-mobile-modal-prev-aria-hidden')) {
+            element.setAttribute(
+                'data-sb-mobile-modal-prev-aria-hidden',
+                element.getAttribute('aria-hidden') ?? '',
+            );
+        }
+
+        element.setAttribute('aria-hidden', 'true');
+        if ('inert' in element) {
+            element.inert = true;
+        }
+        return;
+    }
+
+    const previousAriaHidden = element.getAttribute('data-sb-mobile-modal-prev-aria-hidden');
+    if (previousAriaHidden !== null) {
+        if (previousAriaHidden) {
+            element.setAttribute('aria-hidden', previousAriaHidden);
+        } else {
+            element.removeAttribute('aria-hidden');
+        }
+        element.removeAttribute('data-sb-mobile-modal-prev-aria-hidden');
+    }
+
+    if ('inert' in element) {
+        element.inert = false;
+    }
+}
+
+function setMobileModalRootA11y(root, isActiveRoot) {
+    if (!(root instanceof HTMLElement)) {
+        return;
+    }
+
+    const hasManagedAriaState = root.id === 'sb-mobile-nav' || root.id === 'sb-mobile-chat-tools';
+
+    if (isActiveRoot) {
+        if (hasManagedAriaState) {
+            root.setAttribute('aria-hidden', 'false');
+            if ('inert' in root) {
+                root.inert = false;
+            }
+            return;
+        }
+
+        if (!root.hasAttribute('data-sb-mobile-modal-root-prev-aria-hidden')) {
+            root.setAttribute(
+                'data-sb-mobile-modal-root-prev-aria-hidden',
+                root.getAttribute('aria-hidden') ?? '',
+            );
+        }
+
+        root.setAttribute('aria-hidden', 'false');
+        if ('inert' in root) {
+            root.inert = false;
+        }
+        return;
+    }
+
+    if (hasManagedAriaState) {
+        return;
+    }
+
+    const previousAriaHidden = root.getAttribute('data-sb-mobile-modal-root-prev-aria-hidden');
+    if (previousAriaHidden !== null) {
+        if (previousAriaHidden) {
+            root.setAttribute('aria-hidden', previousAriaHidden);
+        } else {
+            root.removeAttribute('aria-hidden');
+        }
+        root.removeAttribute('data-sb-mobile-modal-root-prev-aria-hidden');
+    }
+}
+
+function syncMobileModalState() {
+    const activeRoots = getActiveMobileModalRoots();
+    const hasActiveMobileModal = activeRoots.length > 0;
+    const activeRootSet = new Set(activeRoots);
+    const shouldInertTopBar = activeRoots.some(root => root.id !== 'sb-mobile-nav');
+
+    document.body?.classList.toggle('sb-mobile-modal-open', hasActiveMobileModal);
+
+    for (const root of getMobileModalRootCandidates()) {
+        setMobileModalRootA11y(root, activeRootSet.has(root));
+    }
+
+    setElementInertForMobileModal(document.getElementById('sheld'), hasActiveMobileModal);
+    setElementInertForMobileModal(document.getElementById('top-bar'), shouldInertTopBar);
+}
+
+function queueMobileModalStateSync() {
+    if (sbState.mobileModal.syncFrame) {
+        return;
+    }
+
+    sbState.mobileModal.syncFrame = window.requestAnimationFrame(() => {
+        sbState.mobileModal.syncFrame = 0;
+        syncMobileModalState();
+    });
+}
+
 function forceDrawerState(drawerRootOrId, shouldOpen, drawerIconOrSelector = null) {
     const el = typeof drawerRootOrId === 'string'
         ? document.getElementById(drawerRootOrId)
@@ -4489,6 +4659,7 @@ function forceDrawerState(drawerRootOrId, shouldOpen, drawerIconOrSelector = nul
     el.classList.toggle('openDrawer', Boolean(shouldOpen));
     el.classList.toggle('closedDrawer', !shouldOpen);
     syncDrawerIconState(drawerIconOrSelector, shouldOpen);
+    queueMobileModalStateSync();
 }
 
 function isShellOpen(shellKey) {
@@ -4594,6 +4765,7 @@ function closeCharacterPanel() {
     }
 
     syncChatbarVisibilityState();
+    queueMobileModalStateSync();
 }
 
 function ensureCharacterResizeHandle() {
@@ -4659,6 +4831,7 @@ function toggleCharacterPanel() {
 
         syncChatbarVisibilityState();
         syncDesktopShellSizing();
+        queueMobileModalStateSync();
     });
 }
 
@@ -8752,10 +8925,12 @@ function buildShell(shellKey) {
             activeTab?.onActivate?.();
             dispatchShellTabActivated(shellKey, activeTab);
             updateNavScrollIndicators();
+            queueMobileModalStateSync();
             return;
         }
 
         shellState.tabs.get(shellState.activeTabId)?.onDeactivate?.();
+        queueMobileModalStateSync();
     }).observe(shellRoot, { attributes: true, attributeFilter: ['class'] });
 
     const basePanel = createShellPanel(shellConfig.baseTab);
@@ -9121,6 +9296,14 @@ function buildMobileNav() {
             return;
         }
 
+        if (!event.isTrusted) {
+            return;
+        }
+
+        if (performance.now() - sbState.mobileNav.lastOpenedAt < SB_MOBILE_NAV_OPEN_GRACE_MS) {
+            return;
+        }
+
         // Don't close if clicking the hamburger button itself
         if (target.closest('#sb-hamburger')) {
             return;
@@ -9150,6 +9333,10 @@ function setMobileNavOpenState(isOpen) {
         return;
     }
 
+    if (shouldOpen) {
+        sbState.mobileNav.lastOpenedAt = performance.now();
+    }
+
     overlay.hidden = !shouldOpen;
     overlay.classList.toggle('sb-nav-open', shouldOpen);
     overlay.setAttribute('aria-hidden', String(!shouldOpen));
@@ -9163,6 +9350,8 @@ function setMobileNavOpenState(isOpen) {
     button.innerHTML = shouldOpen
         ? '<i class="fa-solid fa-xmark" aria-hidden="true"></i>'
         : '<i class="fa-solid fa-bars" aria-hidden="true"></i>';
+
+    queueMobileModalStateSync();
 }
 
 function toggleMobileNav() {
@@ -9523,6 +9712,7 @@ function syncMobileViewportState() {
     syncChatbarVisibilityState();
     updateTopBarBrand();
     scheduleTopbarContextRefresh(0);
+    syncMobileModalState();
 }
 
 function reinitSelect2AfterShell() {


### PR DESCRIPTION
## What?
This PR establishes one mobile modal state coordinator for shell drawers, the character drawer, mobile nav, and chat tools. It makes mobile drawers full-width safe-area-aware fixed panels with a single internal scroll owner, and marks chat/background chrome inert while modal drawers are open without trapping the hamburger close path.

## Why?
Mobile drawer states needed to stop overlapping, leaking background interaction, and creating competing page/drawer scroll behavior.

## How?
The shell uses one coordinator for mobile modal state and applies inert/ARIA background state consistently. Drawer layout becomes fixed, safe-area-aware, and internally scrollable so the shell body does not become the scroll owner.

## Testing?
- `npm run lint -- --quiet`
- `git diff --check -- public/scripts/sillybunny-tabs.js public/css/sillybunny-tabs.css`
- Playwright probe at 393x852 against `http://127.0.0.1:4444`:
  - Character drawer rect: `x=0 y=40 w=393 h=812`, scroller overflow `auto`, chat/top bar inert.
  - Customize drawer rect: `x=0 y=40 w=393 h=812`, shell body overflow hidden, panel scroller overflow `auto`, scrollHeight `3757` / clientHeight `670`.
  - Closing drawers clears `sb-mobile-modal-open` and restores inert/aria-hidden state.
  - Mobile nav keeps hamburger reachable while chat background is inert.

## Screenshots (optional)
Screenshots were not included. A 393x852 Playwright mobile probe verified layout, scrolling, and inert-state behavior.

## Anything Else?
None.