### PR TITLE
fix: tune character avatar density

### DIFF
--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -3892,7 +3892,7 @@ body.sb-shell-resizing * {
 @media screen and (min-width: 1001px) {
     body.charListGrid #right-nav-panel.openDrawer #rm_print_characters_block:not(.group_overlay_mode_select) {
         display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(min(100%, 148px), 1fr));
+        grid-template-columns: repeat(auto-fill, minmax(min(100%, 160px), 1fr));
         gap: 10px;
         align-content: flex-start;
         justify-content: stretch;
@@ -3910,8 +3910,8 @@ body.sb-shell-resizing * {
         max-width: none;
         min-width: 0;
         height: auto !important;
-        min-height: 160px;
-        padding: 12px 10px;
+        min-height: 178px;
+        padding: 14px 12px;
         box-sizing: border-box;
         border: 1px solid color-mix(in srgb, var(--sb-shell-border) 72%, transparent);
         border-radius: 12px;
@@ -3921,14 +3921,14 @@ body.sb-shell-resizing * {
     }
 
     body.charListGrid #right-nav-panel.openDrawer #rm_print_characters_block:not(.group_overlay_mode_select) > :is(.character_select, .group_select, .bogus_folder_select):not(.inline_avatar) > :is(.avatar, .missing-avatar) {
-        width: 88px !important;
-        min-width: 88px !important;
-        max-width: 88px !important;
-        height: 88px !important;
-        min-height: 88px !important;
-        max-height: 88px !important;
-        flex: 0 0 88px !important;
-        margin: 0 auto 8px !important;
+        width: 104px !important;
+        min-width: 104px !important;
+        max-width: 104px !important;
+        height: 104px !important;
+        min-height: 104px !important;
+        max-height: 104px !important;
+        flex: 0 0 104px !important;
+        margin: 0 auto 10px !important;
         aspect-ratio: 1 / 1 !important;
         overflow: hidden;
     }
@@ -5831,23 +5831,27 @@ body.sb-shell-resizing * {
 
     body.sb-mobile-character-list:not(.sb-mobile-character-gallery) #right-nav-panel.openDrawer #rm_print_characters_block,
     body.charListGrid.sb-mobile-character-list:not(.sb-mobile-character-gallery) #right-nav-panel.openDrawer #rm_print_characters_block {
-        display: flex !important;
-        flex-direction: column !important;
-        gap: 6px !important;
+        display: grid !important;
+        grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+        gap: 7px !important;
         padding: 6px 0 14px !important;
+        overflow-x: hidden !important;
+        align-content: flex-start !important;
     }
 
     body.sb-mobile-character-list:not(.sb-mobile-character-gallery) #right-nav-panel.openDrawer #rm_print_characters_block:not(.group_overlay_mode_select) > :is(.character_select, .group_select, .bogus_folder_select):not(.inline_avatar),
     body.charListGrid.sb-mobile-character-list:not(.sb-mobile-character-gallery) #right-nav-panel.openDrawer #rm_print_characters_block:not(.group_overlay_mode_select) > :is(.character_select, .group_select, .bogus_folder_select):not(.inline_avatar) {
-        --sb-character-list-avatar-size: 48px;
+        --sb-character-list-avatar-size: 58px;
         display: grid !important;
         grid-template-columns: var(--sb-character-list-avatar-size) minmax(0, 1fr) !important;
-        gap: 4px 10px !important;
+        gap: 4px 8px !important;
         align-items: center !important;
         width: 100% !important;
-        min-height: 62px !important;
-        padding: 7px 8px !important;
+        min-width: 0 !important;
+        min-height: 70px !important;
+        padding: 6px !important;
         border-radius: 10px !important;
+        box-sizing: border-box !important;
     }
 
     body.sb-mobile-character-list:not(.sb-mobile-character-gallery) #right-nav-panel.openDrawer #rm_print_characters_block:not(.group_overlay_mode_select) > :is(.character_select, .group_select, .bogus_folder_select):not(.inline_avatar) > :is(.avatar, .missing-avatar),
@@ -5874,22 +5878,24 @@ body.sb-shell-resizing * {
         gap: 1px;
         width: 100% !important;
         min-width: 0 !important;
+        overflow: hidden !important;
     }
 
     body.sb-mobile-character-list:not(.sb-mobile-character-gallery) #right-nav-panel.openDrawer #rm_print_characters_block :is(.ch_name, .group_select_counter, .bogus_folder_counter),
     body.charListGrid.sb-mobile-character-list:not(.sb-mobile-character-gallery) #right-nav-panel.openDrawer #rm_print_characters_block :is(.ch_name, .group_select_counter, .bogus_folder_counter) {
-        font-size: calc(var(--mainFontSize) * 0.9) !important;
+        font-size: calc(var(--mainFontSize) * 0.86) !important;
         line-height: 1.16 !important;
         text-align: left !important;
+        white-space: normal !important;
+        overflow-wrap: anywhere !important;
+        display: -webkit-box !important;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
     }
 
     body.sb-mobile-character-list:not(.sb-mobile-character-gallery) #right-nav-panel.openDrawer #rm_print_characters_block :is(.character_name_block_sub_line, .ch_description, .group_select_block_list),
     body.charListGrid.sb-mobile-character-list:not(.sb-mobile-character-gallery) #right-nav-panel.openDrawer #rm_print_characters_block :is(.character_name_block_sub_line, .ch_description, .group_select_block_list) {
-        max-height: 1.25em;
-        font-size: calc(var(--mainFontSize) * 0.76) !important;
-        line-height: 1.22 !important;
-        opacity: 0.78;
-        text-align: left !important;
+        display: none !important;
     }
 
     body.sb-mobile-character-list:not(.sb-mobile-character-gallery) #right-nav-panel.openDrawer #rm_print_characters_block .tags_inline,
@@ -5900,7 +5906,74 @@ body.sb-shell-resizing * {
     body.sb-mobile-character-list.sb-mobile-character-gallery #right-nav-panel.openDrawer #rm_print_characters_block {
         display: grid !important;
         grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
-        gap: 8px !important;
+        gap: 10px !important;
+        padding: 8px 0 18px !important;
+        overflow-x: hidden !important;
+        align-content: flex-start !important;
+    }
+
+    body.sb-mobile-character-list.sb-mobile-character-gallery #right-nav-panel.openDrawer #rm_print_characters_block:not(.group_overlay_mode_select) > :is(.character_select, .group_select, .bogus_folder_select):not(.inline_avatar) {
+        --sb-character-gallery-avatar-size: min(124px, calc((100vw - 54px) / 2));
+        display: flex !important;
+        flex-direction: column !important;
+        align-items: center !important;
+        justify-content: flex-start !important;
+        width: 100% !important;
+        min-width: 0 !important;
+        min-height: calc(var(--sb-character-gallery-avatar-size) + 52px) !important;
+        padding: 10px 8px !important;
+        border-radius: 12px !important;
+        box-sizing: border-box !important;
+    }
+
+    body.sb-mobile-character-list.sb-mobile-character-gallery #right-nav-panel.openDrawer #rm_print_characters_block:not(.group_overlay_mode_select) > :is(.character_select, .group_select, .bogus_folder_select):not(.inline_avatar) > :is(.avatar, .missing-avatar) {
+        width: var(--sb-character-gallery-avatar-size) !important;
+        min-width: var(--sb-character-gallery-avatar-size) !important;
+        max-width: var(--sb-character-gallery-avatar-size) !important;
+        height: var(--sb-character-gallery-avatar-size) !important;
+        min-height: var(--sb-character-gallery-avatar-size) !important;
+        max-height: var(--sb-character-gallery-avatar-size) !important;
+        flex: 0 0 var(--sb-character-gallery-avatar-size) !important;
+        margin: 0 0 8px !important;
+        aspect-ratio: 1 / 1 !important;
+        overflow: hidden !important;
+    }
+
+    body.sb-mobile-character-list.sb-mobile-character-gallery #right-nav-panel.openDrawer #rm_print_characters_block:not(.group_overlay_mode_select) > :is(.character_select, .group_select, .bogus_folder_select):not(.inline_avatar) > :is(.character_select_container, .group_select_container) {
+        display: grid !important;
+        grid-template-columns: minmax(0, 1fr);
+        align-items: start;
+        justify-items: center;
+        width: 100% !important;
+        min-width: 0 !important;
+        overflow: hidden !important;
+    }
+
+    body.sb-mobile-character-list.sb-mobile-character-gallery #right-nav-panel.openDrawer #rm_print_characters_block :is(.character_name_block, .group_name_block) {
+        width: 100% !important;
+        min-width: 0 !important;
+        justify-items: center;
+    }
+
+    body.sb-mobile-character-list.sb-mobile-character-gallery #right-nav-panel.openDrawer #rm_print_characters_block :is(.ch_name, .group_select_counter, .bogus_folder_counter) {
+        width: 100% !important;
+        max-width: 100% !important;
+        min-width: 0 !important;
+        margin: 0 !important;
+        font-size: calc(var(--mainFontSize) * 0.86) !important;
+        line-height: 1.18 !important;
+        text-align: center !important;
+        white-space: normal !important;
+        overflow-wrap: anywhere !important;
+        display: -webkit-box !important;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+    }
+
+    body.sb-mobile-character-list.sb-mobile-character-gallery #right-nav-panel.openDrawer #rm_print_characters_block :is(.character_name_block_sub_line, .ch_description, .group_select_block_list, .tags_inline),
+    body.sb-mobile-character-list.sb-mobile-character-gallery #right-nav-panel.openDrawer #rm_print_characters_block .tags_inline *,
+    body.sb-mobile-character-list.sb-mobile-character-gallery #right-nav-panel.openDrawer #rm_print_characters_block .tag {
+        display: none !important;
     }
 }
 


### PR DESCRIPTION
## What?
This PR increases desktop character grid avatar/card sizing, changes the mobile compact character list into a dense two-column layout with 58px thumbnails, and makes mobile gallery mode more image-forward with 124px thumbnails while hiding tiny per-card tag chips.

## Why?
Character browsing needed better scanability on desktop and denser, more legible avatar presentation on mobile.

## How?
The CSS retunes desktop grid card/avatar dimensions and mobile compact/gallery layouts. Mobile gallery mode emphasizes larger thumbnails and removes small tag chips that do not fit the tighter card format.

## Testing?
- `npm run lint -- --quiet`
- `git diff --check -- public/css/sillybunny-tabs.css`
- Playwright probe at 393x852 against `http://127.0.0.1:4444`:
  - Mobile compact list: first item at `y=268`, two `184px` columns, avatar `58x58`, drawer small controls: `0`.
  - Mobile gallery: two `182.5px` columns, avatar `124x124`, drawer small controls: `0`.
- Playwright probe at 1280x900:
  - Desktop grid: six `161.5px` columns, cards `162x178`, avatars `104x104`.

## Screenshots (optional)
Screenshots were not included. Playwright probes at mobile and desktop viewports verified the layout dimensions.

## Anything Else?
This PR was stacked via `codex/mobile-shell-foundation` and opened separately because PR #30 was already merged while this density follow-up was being verified locally.