### PR TITLE
fix: harden mobile extension settings forms

### DIFF
--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -5977,6 +5977,169 @@ body.sb-shell-resizing * {
     }
 }
 
+/* SillyBunny mobile settings/extensions forms: keep dense extension UIs touch-safe. */
+@media screen and (max-width: 1000px) {
+    #user-settings-block.openDrawer #rm_extensions_block {
+        min-height: 0 !important;
+        height: auto !important;
+        overflow: visible !important;
+    }
+
+    #user-settings-block.openDrawer #rm_extensions_block .extensions_block {
+        gap: 10px !important;
+    }
+
+    #user-settings-block.openDrawer #extensions_settings,
+    #user-settings-block.openDrawer #extensions_settings2 {
+        display: flex !important;
+        flex-direction: column !important;
+        gap: 8px !important;
+        width: 100% !important;
+        min-width: 0 !important;
+        height: auto !important;
+        min-height: 0 !important;
+        overflow: visible !important;
+    }
+
+    #user-settings-block.openDrawer #rm_extensions_block .extension_container {
+        width: 100% !important;
+        min-width: 0 !important;
+        margin: 0 !important;
+    }
+
+    #user-settings-block.openDrawer #rm_extensions_block .sb-mobile-extension-summary {
+        display: flex !important;
+        align-items: center !important;
+        justify-content: space-between !important;
+        gap: 10px !important;
+        width: 100% !important;
+        min-height: 48px !important;
+        margin: 0 !important;
+        padding: 10px 12px !important;
+        border-radius: 12px !important;
+        border: 1px solid color-mix(in srgb, var(--sb-shell-border) 74%, transparent) !important;
+        background: color-mix(in srgb, var(--SmartThemeBodyColor) 5%, transparent) !important;
+        color: var(--SmartThemeBodyColor) !important;
+        box-sizing: border-box !important;
+        text-align: left !important;
+    }
+
+    #user-settings-block.openDrawer #rm_extensions_block .sb-mobile-extension-summary-label {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-weight: 700;
+    }
+
+    #user-settings-block.openDrawer #rm_extensions_block .sb-mobile-extension-summary i {
+        flex: 0 0 auto;
+        transition: transform 160ms ease;
+    }
+
+    #user-settings-block.openDrawer #rm_extensions_block .sb-mobile-extension-summary.is-expanded i {
+        transform: rotate(180deg);
+    }
+
+    #user-settings-block.openDrawer #rm_extensions_block .sb-mobile-extension-direct-root[hidden] {
+        display: none !important;
+    }
+
+    #user-settings-block.openDrawer #rm_extensions_block .inline-drawer {
+        border-radius: 12px !important;
+        overflow: hidden !important;
+    }
+
+    #user-settings-block.openDrawer #rm_extensions_block .inline-drawer-toggle,
+    #user-settings-block.openDrawer #rm_extensions_block .inline-drawer-header {
+        min-height: 48px !important;
+        margin: 0 !important;
+        padding: 10px 12px !important;
+        align-items: center !important;
+        box-sizing: border-box !important;
+    }
+
+    #user-settings-block.openDrawer #rm_extensions_block .inline-drawer-content {
+        padding: 10px !important;
+        overflow: hidden !important;
+    }
+
+    #user-settings-block.openDrawer #rm_extensions_block :is(button, .menu_button, .menu_button_icon, input[type='button'], input[type='submit'], input[type='reset'], select, textarea),
+    #user-settings-block.openDrawer #rm_extensions_block input:not([type='checkbox']):not([type='radio']) {
+        min-height: 46px !important;
+        height: auto !important;
+        max-height: none !important;
+        box-sizing: border-box !important;
+        font-size: max(16px, var(--mainFontSize)) !important;
+    }
+
+    #user-settings-block.openDrawer #rm_extensions_block :is(input:not([type='checkbox']):not([type='radio']), select, textarea) {
+        width: 100% !important;
+        min-width: 0 !important;
+        padding: 10px 12px !important;
+    }
+
+    #user-settings-block.openDrawer #rm_extensions_block :is(input[type='checkbox'], input[type='radio']) {
+        width: 22px !important;
+        min-width: 22px !important;
+        height: 22px !important;
+        min-height: 22px !important;
+        margin: 0 !important;
+        flex: 0 0 22px !important;
+    }
+
+    #user-settings-block.openDrawer #rm_extensions_block label {
+        min-width: 0 !important;
+        line-height: 1.35 !important;
+    }
+
+    #user-settings-block.openDrawer #rm_extensions_block label:has(input[type='checkbox']),
+    #user-settings-block.openDrawer #rm_extensions_block label:has(input[type='radio']),
+    #user-settings-block.openDrawer #rm_extensions_block .checkbox_label,
+    #user-settings-block.openDrawer #rm_extensions_block .qig-row:has(input[type='checkbox']),
+    #user-settings-block.openDrawer #rm_extensions_block .qig-row:has(input[type='radio']) {
+        display: flex !important;
+        align-items: center !important;
+        gap: 10px !important;
+        width: 100% !important;
+        min-height: 46px !important;
+        margin: 0 !important;
+        padding: 8px 10px !important;
+        border-radius: 10px !important;
+        box-sizing: border-box !important;
+    }
+
+    #user-settings-block.openDrawer #rm_extensions_block .qig-row {
+        display: grid !important;
+        grid-template-columns: repeat(auto-fit, minmax(min(100%, 96px), 1fr)) !important;
+        gap: 8px !important;
+        align-items: end !important;
+        width: 100% !important;
+        min-width: 0 !important;
+    }
+
+    #user-settings-block.openDrawer #rm_extensions_block .qig-row > * {
+        min-width: 0 !important;
+    }
+
+    #user-settings-block.openDrawer #rm_extensions_block #qig-profile-del {
+        width: 46px !important;
+        min-width: 46px !important;
+        min-height: 46px !important;
+        padding: 0 !important;
+    }
+
+    #user-settings-block.openDrawer #rm_extensions_block .extensions_block > .alignitemscenter.flex-container.wide100p > label[for='extensions_notify_updates'] {
+        min-height: 46px !important;
+    }
+
+    #user-settings-block.openDrawer .sb-shell-close {
+        width: 44px !important;
+        min-width: 44px !important;
+    }
+}
+
 @media (prefers-reduced-motion: reduce) {
     .sb-proxy-button,
     .sb-shell-tab,

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -76,6 +76,8 @@ const SB_MOBILE_NAV_OPEN_GRACE_MS = 450;
 let sbInlineDrawerPersistenceObserver = null;
 let sbInlineDrawerPersistenceQueued = false;
 let sbChatScriptModulePromise = null;
+let sbMobileExtensionSyncObserver = null;
+let sbMobileExtensionSyncFrame = 0;
 let sbStorageFlushTimer = 0;
 let sbStorageFlushEventsBound = false;
 const sbStorageCache = new Map();
@@ -9670,6 +9672,128 @@ function getInlineDrawers(root = document) {
     return drawers;
 }
 
+function isExtensionSettingsDrawer(drawer) {
+    return drawer instanceof HTMLElement
+        && drawer.closest('#rm_extensions_block')
+        && drawer.closest('.extension_container');
+}
+
+function getMobileExtensionRootLabel(root) {
+    if (!(root instanceof HTMLElement)) {
+        return 'Extension settings';
+    }
+
+    const labelSource = root.querySelector('.extension_name, .inline-drawer-header, .inline-drawer-toggle, h1, h2, h3, h4, strong, b')
+        ?? root;
+    const label = String(labelSource.textContent ?? '')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+    return clampText(label || root.id.replace(/[-_]+/g, ' ') || 'Extension settings', 48);
+}
+
+function getMobileExtensionDirectRoots() {
+    const hosts = [
+        document.getElementById('extensions_settings'),
+        document.getElementById('extensions_settings2'),
+    ].filter(element => element instanceof HTMLElement);
+
+    return hosts.flatMap(host => Array.from(host.children))
+        .filter(root => root instanceof HTMLElement)
+        .filter(root => !root.classList.contains('sb-mobile-extension-summary'))
+        .filter(root => root.id !== 'assets_container')
+        .filter(root => root.textContent?.trim())
+        .filter(root => !root.classList.contains('extension_container') || !root.querySelector(':scope > .inline-drawer'));
+}
+
+function setMobileExtensionRootExpanded(root, expanded) {
+    if (!(root instanceof HTMLElement)) {
+        return;
+    }
+
+    const summary = root.previousElementSibling instanceof HTMLButtonElement
+        && root.previousElementSibling.classList.contains('sb-mobile-extension-summary')
+        ? root.previousElementSibling
+        : null;
+
+    root.hidden = !expanded;
+    root.dataset.sbMobileExtensionExpanded = String(expanded);
+    root.setAttribute('aria-hidden', String(!expanded));
+
+    if ('inert' in root) {
+        root.inert = !expanded;
+    }
+
+    if (summary) {
+        summary.setAttribute('aria-expanded', String(expanded));
+        summary.classList.toggle('is-expanded', expanded);
+    }
+}
+
+function queueMobileExtensionDrawerStateSync() {
+    if (sbMobileExtensionSyncFrame) {
+        return;
+    }
+
+    sbMobileExtensionSyncFrame = window.requestAnimationFrame(() => {
+        sbMobileExtensionSyncFrame = 0;
+        syncMobileExtensionDrawerState();
+    });
+}
+
+function ensureMobileExtensionSyncObserver() {
+    const root = document.getElementById('rm_extensions_block');
+    if (!(root instanceof HTMLElement) || sbMobileExtensionSyncObserver) {
+        return;
+    }
+
+    sbMobileExtensionSyncObserver = new MutationObserver(() => queueMobileExtensionDrawerStateSync());
+    sbMobileExtensionSyncObserver.observe(root, { childList: true, subtree: true });
+}
+
+function ensureMobileExtensionSummaries() {
+    ensureMobileExtensionSyncObserver();
+
+    for (const root of getMobileExtensionDirectRoots()) {
+        if (!(root instanceof HTMLElement)) {
+            continue;
+        }
+
+        root.classList.add('sb-mobile-extension-direct-root');
+
+        const existingSummary = root.previousElementSibling instanceof HTMLButtonElement
+            && root.previousElementSibling.classList.contains('sb-mobile-extension-summary')
+            ? root.previousElementSibling
+            : null;
+
+        if (existingSummary) {
+            const label = existingSummary.querySelector('.sb-mobile-extension-summary-label');
+            if (label instanceof HTMLElement) {
+                label.textContent = getMobileExtensionRootLabel(root);
+            }
+            continue;
+        }
+
+        const summary = createElement('button', {
+            className: 'sb-mobile-extension-summary',
+            attrs: {
+                type: 'button',
+                'aria-expanded': 'false',
+            },
+        });
+        summary.innerHTML = `
+            <span class="sb-mobile-extension-summary-label"></span>
+            <i class="fa-solid fa-chevron-down" aria-hidden="true"></i>
+        `;
+        summary.querySelector('.sb-mobile-extension-summary-label').textContent = getMobileExtensionRootLabel(root);
+        summary.addEventListener('click', () => {
+            setMobileExtensionRootExpanded(root, root.hidden);
+        });
+
+        root.before(summary);
+    }
+}
+
 function bindInlineDrawerPersistence(root = document) {
     for (const drawer of getInlineDrawers(root)) {
         if (!(drawer instanceof HTMLElement) || !shouldPersistInlineDrawer(drawer)) {
@@ -9677,7 +9801,9 @@ function bindInlineDrawerPersistence(root = document) {
         }
 
         const storedExpanded = getStoredInlineDrawerExpanded(drawer);
-        if (storedExpanded !== null) {
+        if (isExtensionSettingsDrawer(drawer) && isMobileViewport()) {
+            setInlineDrawerExpanded(drawer, false);
+        } else if (storedExpanded !== null) {
             setInlineDrawerExpanded(drawer, storedExpanded);
         }
 
@@ -9749,6 +9875,42 @@ function applyDefaultDrawerStates() {
     ensureInlineDrawerPersistenceObserver();
 }
 
+function syncMobileExtensionDrawerState() {
+    ensureMobileExtensionSummaries();
+
+    if (!isMobileViewport()) {
+        for (const root of getMobileExtensionDirectRoots()) {
+            root.hidden = false;
+            root.removeAttribute('aria-hidden');
+            delete root.dataset.sbMobileExtensionExpanded;
+
+            if ('inert' in root) {
+                root.inert = false;
+            }
+        }
+
+        return;
+    }
+
+    for (const drawer of getInlineDrawers(document.getElementById('rm_extensions_block') ?? document)) {
+        if (isExtensionSettingsDrawer(drawer)) {
+            setInlineDrawerExpanded(drawer, false);
+        }
+    }
+
+    for (const root of getMobileExtensionDirectRoots()) {
+        if (root.dataset.sbMobileExtensionExpanded !== 'true') {
+            setMobileExtensionRootExpanded(root, false);
+        }
+    }
+}
+
+document.addEventListener('sb:shell-tab-activated', event => {
+    if (event?.detail?.shellKey === 'right' && event.detail.tabId === 'extensions') {
+        queueMobileExtensionDrawerStateSync();
+    }
+});
+
 function syncMobileViewportState() {
     if (!isMobileViewport()) {
         closeMobileNav();
@@ -9762,6 +9924,7 @@ function syncMobileViewportState() {
     scheduleTopbarContextRefresh(0);
     syncMobileModalState();
     syncMobileCharacterListMode();
+    syncMobileExtensionDrawerState();
 }
 
 function reinitSelect2AfterShell() {


### PR DESCRIPTION
## What?
This PR collapses injected mobile extension setting roots behind touch-safe summary rows, makes the active settings shell body own extension scrolling instead of the page or drawer, and normalizes mobile settings controls, labels, checkboxes, and close affordances to touch-safe sizing.

## Why?
Extension settings on mobile needed to be easier to scan and operate without page-level scroll conflicts or undersized controls.

## How?
Injected extension roots are paired with generated summary rows, and the active settings shell body becomes the scroll owner. The mobile settings styling normalizes controls and labels around touch-safe sizes.

## Testing?
- `npm run lint -- --quiet`
- `git diff --check -- public/scripts/sillybunny-tabs.js public/css/sillybunny-tabs.css`
- Playwright mobile probe at 393x852 for collapsed and expanded extension settings

## Screenshots (optional)
Screenshots were not included. A 393x852 Playwright mobile probe verified collapsed and expanded extension settings.

## Anything Else?
This PR was based on `codex/mobile-shell-foundation`, which included PR #31 at the time. It was originally marked as stacked until the stack was reviewed.