### PR TITLE
fix: stabilize mobile extension summaries

### DIFF
--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -6130,8 +6130,15 @@ body.sb-shell-resizing * {
         padding: 0 !important;
     }
 
-    #user-settings-block.openDrawer #rm_extensions_block .extensions_block > .alignitemscenter.flex-container.wide100p > label[for='extensions_notify_updates'] {
+    #user-settings-block.openDrawer #rm_extensions_block .extensions_block > .alignitemscenter.flex-container.wide100p > label[for='extensions_notify_updates'],
+    #user-settings-block.openDrawer #rm_extensions_block .extensions_block > .alignitemscenter.flex-container.wide100p > .checkbox_label[for='extensions_notify_updates'] {
+        display: flex !important;
+        align-items: center !important;
+        gap: 10px !important;
+        width: 100% !important;
         min-height: 46px !important;
+        padding: 8px 10px !important;
+        box-sizing: border-box !important;
     }
 
     #user-settings-block.openDrawer .sb-shell-close {

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -72,7 +72,7 @@ const extensionLoadErrors = new Set();
 
 // SillyBunny: extensions append settings UI into shared columns; keep that surface resilient.
 const extensionSettingsHostIds = ['extensions_settings', 'extensions_settings2'];
-const ignoredExtensionSettingsSelectors = [];
+const ignoredExtensionSettingsSelectors = ['.sb-mobile-extension-summary'];
 const ignoredExtensionSettingsSelector = ignoredExtensionSettingsSelectors.join(', ');
 const LEGACY_MOONLIT_ECHOES_SETTINGS_KEY = 'SillyTavernMoonlitEchoesTheme';
 const SILLYBUNNY_MOONLIT_ECHOES_EXTENSION_NAME = 'third-party/SillyBunny-MoonlitEchoesTheme';

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -9683,13 +9683,31 @@ function getMobileExtensionRootLabel(root) {
         return 'Extension settings';
     }
 
-    const labelSource = root.querySelector('.extension_name, .inline-drawer-header, .inline-drawer-toggle, h1, h2, h3, h4, strong, b')
+    const containerLabel = {
+        'extension_settings_GuidedGenerations-Extension': 'Guided Generations',
+        'bpt-settings': 'Bunny Preset Tools',
+        'qig-settings': 'Quick Image Gen',
+        qr_container: 'Quick Reply',
+        translation_container: 'Chat Translation',
+        regex_container: 'Regex',
+        vectors_container: 'Vector Storage',
+        'ChatCompletionTabs-drawer': 'Chat Completion Tabs',
+    }[root.id];
+
+    const normalizedId = root.id
+        .replace(/^extension_settings_/, '')
+        .replace(/[-_]+container$/i, '')
+        .replace(/[-_]+settings$/i, '')
+        .replace(/[-_]+/g, ' ')
+        .trim();
+
+    const labelSource = root.querySelector(':scope > .inline-drawer-header, :scope > .inline-drawer-toggle, :scope > .extension_name, :scope > h1, :scope > h2, :scope > h3, :scope > h4')
         ?? root;
     const label = String(labelSource.textContent ?? '')
         .replace(/\s+/g, ' ')
         .trim();
 
-    return clampText(label || root.id.replace(/[-_]+/g, ' ') || 'Extension settings', 48);
+    return clampText(containerLabel || normalizedId || label || 'Extension settings', 48);
 }
 
 function getMobileExtensionDirectRoots() {
@@ -9794,6 +9812,23 @@ function ensureMobileExtensionSummaries() {
     }
 }
 
+function resetMobileExtensionSummaries() {
+    for (const summary of document.querySelectorAll('#extensions_settings > .sb-mobile-extension-summary, #extensions_settings2 > .sb-mobile-extension-summary')) {
+        summary.remove();
+    }
+
+    for (const root of getMobileExtensionDirectRoots()) {
+        root.hidden = false;
+        root.removeAttribute('aria-hidden');
+        root.classList.remove('sb-mobile-extension-direct-root');
+        delete root.dataset.sbMobileExtensionExpanded;
+
+        if ('inert' in root) {
+            root.inert = false;
+        }
+    }
+}
+
 function bindInlineDrawerPersistence(root = document) {
     for (const drawer of getInlineDrawers(root)) {
         if (!(drawer instanceof HTMLElement) || !shouldPersistInlineDrawer(drawer)) {
@@ -9876,21 +9911,12 @@ function applyDefaultDrawerStates() {
 }
 
 function syncMobileExtensionDrawerState() {
-    ensureMobileExtensionSummaries();
-
     if (!isMobileViewport()) {
-        for (const root of getMobileExtensionDirectRoots()) {
-            root.hidden = false;
-            root.removeAttribute('aria-hidden');
-            delete root.dataset.sbMobileExtensionExpanded;
-
-            if ('inert' in root) {
-                root.inert = false;
-            }
-        }
-
+        resetMobileExtensionSummaries();
         return;
     }
+
+    ensureMobileExtensionSummaries();
 
     for (const drawer of getInlineDrawers(document.getElementById('rm_extensions_block') ?? document)) {
         if (isExtensionSettingsDrawer(drawer)) {


### PR DESCRIPTION
## What?
This PR keeps generated mobile extension summary rows out of the extension settings deduper, prevents mobile-only summary rows from leaking into desktop layouts, and keeps collapsed extension roots paired with readable touch-safe summary buttons.

## Why?
The mobile extension settings summary behavior needed to remain stable after the previous forms change, especially when dedupe logic and desktop layouts interact with injected extension settings.

## How?
The summary rows are excluded from the extension settings dedupe path, mobile-only rows are scoped away from desktop layouts, and collapsed roots remain paired with their generated summary controls.

## Testing?
- `npm run lint -- --quiet`
- `git diff --check -- public/scripts/sillybunny-tabs.js public/css/sillybunny-tabs.css public/scripts/extensions.js`
- Browser probe at 393x852: 8 collapsed summaries, all paired to hidden inert roots, 0 effective touch-target failures
- Browser probe with Quick Image Gen expanded: shell panel scroller owns scroll, 0 effective touch-target failures

## Screenshots (optional)
Screenshots were not included. Browser probes at 393x852 verified collapsed summaries and an expanded Quick Image Gen settings flow.

## Anything Else?
This was a follow-up to PR #32 after that PR was merged externally before this stability commit landed.