### PR TITLE
chore: add runtime worktree workflow

### DIFF
--- a/CONTRIBUTING_RUNTIME_WORKTREE.md
+++ b/CONTRIBUTING_RUNTIME_WORKTREE.md
@@ -1,0 +1,87 @@
+# Runtime Worktree Contribution Workflow
+
+Use this workflow when you are contributing from pull-request branches and want the SillyBunny server to keep running from a stable, tracked branch.
+
+The normal launchers and built-in updater expect the running checkout to be clean and to have upstream tracking. Feature branches and stacked PR branches are often not in that state, so the runtime worktree helper keeps the server checkout separate from the worktree where you edit code.
+
+## Start A Stable Runtime
+
+Windows PowerShell:
+
+```powershell
+.\scripts\Start-RuntimeWorktree.ps1
+```
+
+macOS, Linux, or WSL:
+
+```bash
+./scripts/start-runtime-worktree.sh
+```
+
+By default the helper:
+
+- creates or updates a runtime worktree under a sibling `SillyBunny Contribution` folder;
+- runs the local branch `runtime/sillybunny-server`;
+- tracks and fast-forwards from `origin/staging`;
+- installs production dependencies in the runtime worktree;
+- starts `server.js` from the runtime worktree;
+- forwards the current checkout's `data/` directory;
+- forwards the current checkout's `config.yaml` when that file exists.
+
+## Use A Different Runtime Ref
+
+Use another stable ref when a PR stack needs to run on an integration branch that is not `origin/staging`.
+
+Windows PowerShell:
+
+```powershell
+.\scripts\Start-RuntimeWorktree.ps1 -RuntimeRef origin/my-stable-branch
+```
+
+macOS, Linux, or WSL:
+
+```bash
+SILLYBUNNY_RUNTIME_REF=origin/my-stable-branch ./scripts/start-runtime-worktree.sh
+```
+
+You can also pass the POSIX option form:
+
+```bash
+./scripts/start-runtime-worktree.sh --runtime-ref origin/my-stable-branch
+```
+
+## Forward Server Arguments
+
+Windows PowerShell:
+
+```powershell
+.\scripts\Start-RuntimeWorktree.ps1 -ServerArgs @('--port', '4445')
+```
+
+macOS, Linux, or WSL:
+
+```bash
+./scripts/start-runtime-worktree.sh -- --port 4445
+```
+
+## Keep Contribution Files Together
+
+Keep additional PR worktrees, runtime logs, and temporary contribution artifacts under the same sibling `SillyBunny Contribution` folder. This keeps the main checkout clean and makes it clear which folders are contribution tooling rather than the primary app checkout.
+
+For example:
+
+```text
+SillyBunny/
+SillyBunny Contribution/
+  SillyBunny-runtime/
+  SillyBunny-runtime-logs/
+  SillyBunny-feature-worktree/
+```
+
+## Safety Rules
+
+The helper refuses to update a runtime worktree with local changes. Commit, stash, or remove those changes first.
+
+Runtime updates use fast-forward merges only. If the runtime branch diverges from the selected runtime ref, resolve that branch manually before using the helper again.
+
+The helper does not move or delete your main checkout. It only creates or updates the requested runtime worktree.

--- a/scripts/Start-RuntimeWorktree.ps1
+++ b/scripts/Start-RuntimeWorktree.ps1
@@ -1,0 +1,252 @@
+[CmdletBinding()]
+param(
+    [string]$RuntimePath,
+    [string]$RuntimeRef = $(if ($env:SILLYBUNNY_RUNTIME_REF) { $env:SILLYBUNNY_RUNTIME_REF } else { 'origin/staging' }),
+    [string]$RuntimeBranch = $(if ($env:SILLYBUNNY_RUNTIME_BRANCH) { $env:SILLYBUNNY_RUNTIME_BRANCH } else { 'runtime/sillybunny-server' }),
+    [switch]$SkipFetch,
+    [switch]$SkipInstall,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$ServerArgs
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Git {
+    param(
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]]$Arguments
+    )
+
+    $output = & git @Arguments 2>&1
+    $exitCode = $LASTEXITCODE
+
+    return [pscustomobject]@{
+        Output = @($output)
+        ExitCode = $exitCode
+    }
+}
+
+function Invoke-CheckedGit {
+    param(
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]]$Arguments
+    )
+
+    $result = Invoke-Git @Arguments
+    if ($result.ExitCode -ne 0) {
+        throw "git $($Arguments -join ' ') failed.`n$($result.Output -join "`n")"
+    }
+
+    return $result
+}
+
+function Get-FirstGitOutputLine {
+    param(
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$Result
+    )
+
+    return (($Result.Output | Select-Object -First 1) -as [string]).Trim()
+}
+
+function Resolve-RepositoryRoot {
+    $rootResult = Invoke-CheckedGit rev-parse --show-toplevel
+    return (Resolve-Path -LiteralPath (Get-FirstGitOutputLine $rootResult)).Path
+}
+
+function Resolve-DefaultRuntimePath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$SourceRoot
+    )
+
+    $sourceItem = Get-Item -LiteralPath $SourceRoot
+    $parentItem = $sourceItem.Parent
+    $contributionRoot = if ($parentItem.Name -eq 'SillyBunny Contribution') {
+        $parentItem.FullName
+    } else {
+        Join-Path $parentItem.FullName 'SillyBunny Contribution'
+    }
+    $leaf = $sourceItem.Name
+
+    if ($leaf -like '*-runtime-workflow') {
+        $leaf = $leaf -replace '-runtime-workflow$', '-runtime'
+    } elseif ($leaf -like '*-runtime') {
+        $leaf = "$leaf-server"
+    } else {
+        $leaf = "$leaf-runtime"
+    }
+
+    return (Join-Path $contributionRoot $leaf)
+}
+
+function Resolve-GitRef {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Ref
+    )
+
+    $refResult = Invoke-Git rev-parse --verify "$Ref^{commit}"
+    if ($refResult.ExitCode -ne 0) {
+        throw "Could not resolve runtime ref '$Ref'. Fetch it first or pass -RuntimeRef with an existing branch/ref."
+    }
+
+    return Get-FirstGitOutputLine $refResult
+}
+
+function Get-RemoteNameFromRef {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Ref
+    )
+
+    if ($Ref -match '^[^/\s]+/.+') {
+        $candidate = $Ref.Split('/')[0]
+        $remoteResult = Invoke-Git remote get-url $candidate
+        if ($remoteResult.ExitCode -eq 0) {
+            return $candidate
+        }
+    }
+
+    return $null
+}
+
+function Test-CleanWorktree {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    Push-Location $Path
+    try {
+        $statusResult = Invoke-CheckedGit status --porcelain --untracked-files=normal
+        return (($statusResult.Output -join "`n").Trim().Length -eq 0)
+    } finally {
+        Pop-Location
+    }
+}
+
+function Initialize-OrUpdateRuntimeWorktree {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RuntimeWorktreePath,
+        [Parameter(Mandatory = $true)]
+        [string]$TargetCommit
+    )
+
+    $existingPath = if (Test-Path -LiteralPath $RuntimeWorktreePath) {
+        (Resolve-Path -LiteralPath $RuntimeWorktreePath).Path
+    } else {
+        $null
+    }
+
+    if (-not $existingPath) {
+        $runtimeParent = Split-Path -Parent $RuntimeWorktreePath
+        if (-not (Test-Path -LiteralPath $runtimeParent)) {
+            New-Item -ItemType Directory -Path $runtimeParent | Out-Null
+        }
+
+        Write-Host "Creating runtime worktree at $RuntimeWorktreePath from $RuntimeRef..."
+        $branchExists = (Invoke-Git show-ref --verify --quiet "refs/heads/$RuntimeBranch").ExitCode -eq 0
+        if ($branchExists) {
+            Invoke-CheckedGit worktree add $RuntimeWorktreePath $RuntimeBranch | Out-Null
+            Push-Location $RuntimeWorktreePath
+            try {
+                Invoke-CheckedGit merge --ff-only $TargetCommit | Out-Null
+            } finally {
+                Pop-Location
+            }
+        } else {
+            Invoke-CheckedGit worktree add -b $RuntimeBranch $RuntimeWorktreePath $TargetCommit | Out-Null
+        }
+    } else {
+        Write-Host "Updating runtime worktree at $existingPath..."
+        Push-Location $existingPath
+        try {
+            $branchResult = Invoke-CheckedGit symbolic-ref --quiet --short HEAD
+            $currentBranch = Get-FirstGitOutputLine $branchResult
+            if ($currentBranch -ne $RuntimeBranch) {
+                throw "Runtime worktree is on branch '$currentBranch', expected '$RuntimeBranch'."
+            }
+
+            if (-not (Test-CleanWorktree -Path $existingPath)) {
+                throw "Runtime worktree has local changes. Commit, stash, or remove them before updating $existingPath."
+            }
+
+            Invoke-CheckedGit merge --ff-only $TargetCommit | Out-Null
+        } finally {
+            Pop-Location
+        }
+    }
+
+    Push-Location $RuntimeWorktreePath
+    try {
+        $remoteName = Get-RemoteNameFromRef -Ref $RuntimeRef
+        if ($remoteName) {
+            Invoke-CheckedGit branch --set-upstream-to=$RuntimeRef $RuntimeBranch | Out-Null
+        }
+    } finally {
+        Pop-Location
+    }
+}
+
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    throw 'Git is required to manage the runtime worktree.'
+}
+
+if (-not (Get-Command bun -ErrorAction SilentlyContinue)) {
+    throw 'Bun is required to start the SillyBunny runtime worktree.'
+}
+
+$sourceRoot = Resolve-RepositoryRoot
+if ([string]::IsNullOrWhiteSpace($RuntimePath)) {
+    $RuntimePath = Resolve-DefaultRuntimePath -SourceRoot $sourceRoot
+}
+
+if (-not [System.IO.Path]::IsPathRooted($RuntimePath)) {
+    $RuntimePath = Join-Path $sourceRoot $RuntimePath
+}
+
+$RuntimePath = [System.IO.Path]::GetFullPath($RuntimePath)
+$dataRoot = Join-Path $sourceRoot 'data'
+$configPath = Join-Path $sourceRoot 'config.yaml'
+
+if (-not $SkipFetch) {
+    $runtimeRemote = Get-RemoteNameFromRef -Ref $RuntimeRef
+    if ($runtimeRemote) {
+        Write-Host "Fetching $runtimeRemote for runtime ref $RuntimeRef..."
+        Invoke-CheckedGit fetch --quiet $runtimeRemote | Out-Null
+    }
+}
+
+$targetCommit = Resolve-GitRef -Ref $RuntimeRef
+Initialize-OrUpdateRuntimeWorktree -RuntimeWorktreePath $RuntimePath -TargetCommit $targetCommit
+
+Push-Location $RuntimePath
+try {
+    if (-not $SkipInstall) {
+        Write-Host 'Installing runtime dependencies...'
+        bun install --frozen-lockfile --production --no-progress --no-summary
+        if ($LASTEXITCODE -ne 0) {
+            throw 'bun install failed in the runtime worktree.'
+        }
+    }
+
+    $forwardedArgs = @('--dataRoot', $dataRoot)
+    if (Test-Path -LiteralPath $configPath) {
+        $forwardedArgs += @('--configPath', $configPath)
+    }
+    $forwardedArgs += $ServerArgs
+
+    Write-Host "Starting SillyBunny from $RuntimePath"
+    Write-Host "Using contributor data root $dataRoot"
+    if (Test-Path -LiteralPath $configPath) {
+        Write-Host "Using contributor config $configPath"
+    }
+
+    bun server.js @forwardedArgs
+    exit $LASTEXITCODE
+} finally {
+    Pop-Location
+}

--- a/scripts/start-runtime-worktree.sh
+++ b/scripts/start-runtime-worktree.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+runtime_path="${SILLYBUNNY_RUNTIME_PATH:-}"
+runtime_ref="${SILLYBUNNY_RUNTIME_REF:-origin/staging}"
+runtime_branch="${SILLYBUNNY_RUNTIME_BRANCH:-runtime/sillybunny-server}"
+skip_fetch=0
+skip_install=0
+server_args=()
+
+usage() {
+    cat <<'USAGE'
+Usage: scripts/start-runtime-worktree.sh [options] [-- server args...]
+
+Options:
+  --runtime-path PATH      Runtime worktree path (default: SillyBunny Contribution/*-runtime)
+  --runtime-ref REF        Stable ref to run (default: origin/staging)
+  --runtime-branch NAME    Local runtime branch (default: runtime/sillybunny-server)
+  --skip-fetch             Do not fetch the runtime ref remote before updating
+  --skip-install           Do not run bun install in the runtime worktree
+  -h, --help               Show this help
+
+Environment overrides:
+  SILLYBUNNY_RUNTIME_PATH
+  SILLYBUNNY_RUNTIME_REF
+  SILLYBUNNY_RUNTIME_BRANCH
+USAGE
+}
+
+while (($#)); do
+    case "$1" in
+        --runtime-path)
+            runtime_path="${2:?Missing value for --runtime-path}"
+            shift 2
+            ;;
+        --runtime-ref)
+            runtime_ref="${2:?Missing value for --runtime-ref}"
+            shift 2
+            ;;
+        --runtime-branch)
+            runtime_branch="${2:?Missing value for --runtime-branch}"
+            shift 2
+            ;;
+        --skip-fetch)
+            skip_fetch=1
+            shift
+            ;;
+        --skip-install)
+            skip_install=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            server_args+=("$@")
+            break
+            ;;
+        *)
+            server_args+=("$1")
+            shift
+            ;;
+    esac
+done
+
+die() {
+    echo "start-runtime-worktree: $*" >&2
+    exit 1
+}
+
+have_command() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+resolve_remote_name() {
+    local ref="$1"
+    local candidate
+
+    case "$ref" in
+        */*)
+            candidate="${ref%%/*}"
+            if git remote get-url "$candidate" >/dev/null 2>&1; then
+                printf '%s\n' "$candidate"
+                return 0
+            fi
+            ;;
+    esac
+
+    return 1
+}
+
+default_runtime_path() {
+    local source_root="$1"
+    local parent parent_leaf contribution_root leaf
+
+    parent="$(dirname "$source_root")"
+    parent_leaf="$(basename "$parent")"
+    if [[ "$parent_leaf" == "SillyBunny Contribution" ]]; then
+        contribution_root="$parent"
+    else
+        contribution_root="$parent/SillyBunny Contribution"
+    fi
+
+    leaf="$(basename "$source_root")"
+
+    case "$leaf" in
+        *-runtime-workflow)
+            leaf="${leaf%-runtime-workflow}-runtime"
+            ;;
+        *-runtime)
+            leaf="${leaf}-server"
+            ;;
+        *)
+            leaf="${leaf}-runtime"
+            ;;
+    esac
+
+    printf '%s/%s\n' "$contribution_root" "$leaf"
+}
+
+absolute_path() {
+    local path="$1"
+    local parent leaf
+
+    case "$path" in
+        /*|[A-Za-z]:/*) ;;
+        *) path="$source_root/$path" ;;
+    esac
+
+    parent="$(dirname "$path")"
+    leaf="$(basename "$path")"
+    mkdir -p "$parent"
+    printf '%s/%s\n' "$(cd "$parent" && pwd)" "$leaf"
+}
+
+require_clean_runtime_worktree() {
+    local path="$1"
+    local status
+
+    status="$(git -C "$path" status --porcelain --untracked-files=normal)"
+    [[ -z "$status" ]] || die "Runtime worktree has local changes. Commit, stash, or remove them before updating $path."
+}
+
+have_command git || die "Git is required to manage the runtime worktree."
+have_command bun || die "Bun is required to start the SillyBunny runtime worktree."
+
+source_root="$(git rev-parse --show-toplevel)"
+source_root="$(cd "$source_root" && pwd)"
+
+if [[ -z "$runtime_path" ]]; then
+    runtime_path="$(default_runtime_path "$source_root")"
+fi
+
+runtime_path="$(absolute_path "$runtime_path")"
+
+if (( ! skip_fetch )); then
+    if runtime_remote="$(resolve_remote_name "$runtime_ref")"; then
+        echo "Fetching $runtime_remote for runtime ref $runtime_ref..."
+        git fetch --quiet "$runtime_remote"
+    fi
+fi
+
+target_commit="$(git rev-parse --verify "${runtime_ref}^{commit}")" \
+    || die "Could not resolve runtime ref '$runtime_ref'. Fetch it first or pass --runtime-ref with an existing branch/ref."
+
+if [[ ! -e "$runtime_path" ]]; then
+    echo "Creating runtime worktree at $runtime_path from $runtime_ref..."
+    if git show-ref --verify --quiet "refs/heads/$runtime_branch"; then
+        git worktree add "$runtime_path" "$runtime_branch"
+        git -C "$runtime_path" merge --ff-only "$target_commit"
+    else
+        git worktree add -b "$runtime_branch" "$runtime_path" "$target_commit"
+    fi
+else
+    echo "Updating runtime worktree at $runtime_path..."
+    current_branch="$(git -C "$runtime_path" symbolic-ref --quiet --short HEAD)" \
+        || die "Runtime worktree at $runtime_path is detached or invalid."
+    [[ "$current_branch" == "$runtime_branch" ]] \
+        || die "Runtime worktree is on branch '$current_branch', expected '$runtime_branch'."
+
+    require_clean_runtime_worktree "$runtime_path"
+    git -C "$runtime_path" merge --ff-only "$target_commit"
+fi
+
+if runtime_remote="$(resolve_remote_name "$runtime_ref")"; then
+    git -C "$runtime_path" branch --set-upstream-to="$runtime_ref" "$runtime_branch" >/dev/null
+fi
+
+cd "$runtime_path"
+
+if (( ! skip_install )); then
+    echo "Installing runtime dependencies..."
+    bun install --frozen-lockfile --production --no-progress --no-summary
+fi
+
+data_root="$source_root/data"
+config_path="$source_root/config.yaml"
+forwarded_args=(--dataRoot "$data_root")
+if [[ -f "$config_path" ]]; then
+    forwarded_args+=(--configPath "$config_path")
+fi
+forwarded_args+=("${server_args[@]}")
+
+echo "Starting SillyBunny from $runtime_path"
+echo "Using contributor data root $data_root"
+if [[ -f "$config_path" ]]; then
+    echo "Using contributor config $config_path"
+fi
+
+exec bun server.js "${forwarded_args[@]}"


### PR DESCRIPTION
## What?
This PR adds Windows and POSIX helpers for running SillyBunny from a stable runtime worktree, defaults contribution artifacts into a sibling `SillyBunny Contribution` folder, and adds a standalone contribution workflow guide without modifying existing documentation files.

## Why?
Contributors needed a repeatable way to keep one SillyBunny copy runnable while doing contribution work in separate worktrees.

## How?
The new helper scripts create or reuse a runtime worktree at the requested path and reference, with defaults aimed at `D:\AIStuff\SillyBunny Contribution`. The workflow guide documents the runtime/contribution split as a standalone document so existing repo docs are left untouched.

## Testing?
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\Start-RuntimeWorktree.ps1 -RuntimePath 'D:\AIStuff\SillyBunny Contribution\SillyBunny-runtime' -RuntimeRef origin/codex/mobile-shell-foundation -SkipFetch -SkipInstall -ServerArgs @('--help')`
- `bash -lc './scripts/start-runtime-worktree.sh --runtime-path "D:/AIStuff/SillyBunny Contribution/SillyBunny-runtime" --runtime-ref origin/codex/mobile-shell-foundation --skip-fetch --skip-install -- --help'`
- `bash -n ./scripts/start-runtime-worktree.sh`
- `git diff origin/codex/mobile-shell-foundation --check`
- `npm run lint -- --quiet`

## Screenshots (optional)
Screenshots were not applicable for this script/workflow change.

## Anything Else?
Existing repository documentation files were intentionally not modified.