### PR TITLE
fix: support runtime worktrees on main

### DIFF
--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -5571,7 +5571,7 @@ function renderServerAdminStatus(data) {
         className: 'text_pole',
         attrs: { style: 'width: 100%; max-width: 200px;' },
     });
-    const currentBranch = repository?.branch || version?.gitBranch || 'Unknown';
+    const currentBranch = repository?.displayBranch || repository?.branch || version?.gitBranch || 'Unknown';
     const currentOption = createElement('option', { attrs: { value: currentBranch, selected: 'selected' } });
     currentOption.textContent = currentBranch;
     branchSelect.appendChild(currentOption);
@@ -6122,7 +6122,7 @@ async function handleServerAdminBranchSwitch(selectElement) {
     }
 
     const targetBranch = selectElement.value;
-    const currentBranch = state.lastStatusData?.repository?.branch || '';
+    const currentBranch = state.lastStatusData?.repository?.displayBranch || state.lastStatusData?.repository?.branch || '';
 
     if (targetBranch === currentBranch) {
         return;

--- a/src/endpoints/server-admin.js
+++ b/src/endpoints/server-admin.js
@@ -7,9 +7,17 @@ import express from 'express';
 import yaml from 'yaml';
 import { sync as writeFileAtomicSync } from 'write-file-atomic';
 import { sync as commandExistsSync } from 'command-exists';
-import { CheckRepoActions, default as simpleGit } from 'simple-git';
+import simpleGit from 'simple-git';
 
 import { APP_NAME, formatRuntimeLabel, isBunRuntime, isNativeTermuxEnvironment } from '../runtime.js';
+import {
+    getBranchDisplayNames,
+    getRemoteBranchesFromSummary,
+    getStatusDisplayBranch,
+    isRuntimeBranch,
+    isGitRepository,
+    resolveRemoteBranchName,
+} from '../server-admin-git.js';
 import { getServerLogSnapshot } from '../server-log-buffer.js';
 import { serverDirectory } from '../server-directory.js';
 import { requireAdminMiddleware } from '../users.js';
@@ -398,6 +406,7 @@ async function getRepositoryStatus() {
         trackingBranch: '',
         currentCommit: '',
         remoteCommit: '',
+        displayBranch: '',
         ahead: 0,
         behind: 0,
         hasLocalChanges: false,
@@ -415,7 +424,7 @@ async function getRepositoryStatus() {
     status.supported = true;
 
     const git = simpleGit({ baseDir: serverDirectory, ...GIT_OPTIONS });
-    const isRepo = await git.checkIsRepo(CheckRepoActions.IS_REPO_ROOT).catch(() => false);
+    const isRepo = await isGitRepository(git);
 
     if (!isRepo) {
         status.message = 'This install is not running from a Git repository.';
@@ -437,6 +446,7 @@ async function getRepositoryStatus() {
 
     const trackingBranch = toTrimmedString(await git.revparse(['--abbrev-ref', '@{u}']).catch(() => ''));
     status.trackingBranch = trackingBranch;
+    status.displayBranch = getStatusDisplayBranch(status.branch, trackingBranch);
 
     if (!trackingBranch) {
         status.message = 'This branch is not tracking an upstream remote.';
@@ -817,7 +827,7 @@ router.post('/branches', requireAdminMiddleware, async (_request, response) => {
         }
 
         const git = simpleGit({ baseDir: serverDirectory, ...GIT_OPTIONS });
-        const isRepo = await git.checkIsRepo(CheckRepoActions.IS_REPO_ROOT).catch(() => false);
+        const isRepo = await isGitRepository(git);
 
         if (!isRepo) {
             return response.status(400).json({ error: 'This install is not running from a Git repository.' });
@@ -825,16 +835,17 @@ router.post('/branches', requireAdminMiddleware, async (_request, response) => {
 
         // Get current branch
         const currentBranch = toTrimmedString(await git.revparse(['--abbrev-ref', 'HEAD']).catch(() => ''));
+        const trackingBranch = toTrimmedString(await git.revparse(['--abbrev-ref', '@{u}']).catch(() => ''));
+        const displayBranch = getStatusDisplayBranch(currentBranch, trackingBranch);
 
         // Get all remote branches
+        await git.fetch(['--all', '--prune']);
         const branchSummary = await git.branch(['-r']);
-        const branches = Object.keys(branchSummary.branches)
-            .filter(branch => !branch.includes('HEAD'))
-            .map(branch => branch.replace(/^origin\//, ''))
-            .filter((branch, index, self) => self.indexOf(branch) === index); // Remove duplicates
+        const branches = getBranchDisplayNames(getRemoteBranchesFromSummary(branchSummary));
 
         response.json({
             currentBranch,
+            displayBranch,
             branches,
         });
     } catch (error) {
@@ -857,7 +868,7 @@ router.post('/switch-branch', requireAdminMiddleware, async (request, response) 
         }
 
         const git = simpleGit({ baseDir: serverDirectory, ...GIT_OPTIONS });
-        const isRepo = await git.checkIsRepo(CheckRepoActions.IS_REPO_ROOT).catch(() => false);
+        const isRepo = await isGitRepository(git);
 
         if (!isRepo) {
             return response.status(400).json({ error: 'This install is not running from a Git repository.' });
@@ -880,8 +891,18 @@ router.post('/switch-branch', requireAdminMiddleware, async (request, response) 
             await git.stash(['push', '-u', '-m', `Auto-stash before switching to ${branch}`]);
         }
 
-        // Switch branch
-        await git.checkout(branch);
+        await git.fetch(['--all', '--prune']);
+        const branchSummary = await git.branch(['-r']);
+        const remoteBranches = getRemoteBranchesFromSummary(branchSummary);
+        const remoteBranch = resolveRemoteBranchName(remoteBranches, branch);
+        const currentBranch = toTrimmedString(await git.revparse(['--abbrev-ref', 'HEAD']).catch(() => ''));
+
+        if (remoteBranch && isRuntimeBranch(currentBranch)) {
+            await git.raw(['checkout', '-B', currentBranch, remoteBranch]);
+            await git.raw(['branch', `--set-upstream-to=${remoteBranch}`, currentBranch]);
+        } else {
+            await git.checkout(branch);
+        }
 
         // Try to pop stash if we stashed
         let stashRestored = false;

--- a/src/server-admin-git.js
+++ b/src/server-admin-git.js
@@ -1,0 +1,70 @@
+const ORIGIN_REMOTE_PREFIX = 'origin/';
+const RUNTIME_BRANCH_PREFIX = 'runtime/';
+
+function uniqueSorted(values) {
+    return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+}
+
+export async function isGitRepository(git) {
+    return Boolean(await git.checkIsRepo().catch(() => false));
+}
+
+export function getRemoteBranchDisplayName(remoteBranch) {
+    const branch = String(remoteBranch ?? '').trim();
+
+    if (branch.startsWith(ORIGIN_REMOTE_PREFIX)) {
+        return branch.slice(ORIGIN_REMOTE_PREFIX.length);
+    }
+
+    return branch;
+}
+
+export function isRuntimeBranch(branch) {
+    return String(branch ?? '').trim().startsWith(RUNTIME_BRANCH_PREFIX);
+}
+
+export function getStatusDisplayBranch(branch, trackingBranch) {
+    const currentBranch = String(branch ?? '').trim();
+    const upstreamBranch = String(trackingBranch ?? '').trim();
+
+    if (currentBranch.startsWith(RUNTIME_BRANCH_PREFIX) && upstreamBranch) {
+        return getRemoteBranchDisplayName(upstreamBranch);
+    }
+
+    return currentBranch;
+}
+
+export function getRemoteBranchesFromSummary(branchSummary) {
+    const branches = branchSummary?.branches ?? {};
+
+    return uniqueSorted(Object.keys(branches)
+        .map(branch => String(branch ?? '').trim())
+        .filter(branch => branch && !branch.endsWith('/HEAD') && !branch.includes('/HEAD -> ')));
+}
+
+export function getBranchDisplayNames(remoteBranches) {
+    return uniqueSorted(remoteBranches
+        .map(getRemoteBranchDisplayName)
+        .filter(Boolean));
+}
+
+export function resolveRemoteBranchName(remoteBranches, branch) {
+    const requestedBranch = String(branch ?? '').trim();
+
+    if (!requestedBranch) {
+        return '';
+    }
+
+    if (remoteBranches.includes(requestedBranch)) {
+        return requestedBranch;
+    }
+
+    const originBranch = `${ORIGIN_REMOTE_PREFIX}${requestedBranch}`;
+    if (remoteBranches.includes(originBranch)) {
+        return originBranch;
+    }
+
+    const matchingBranches = remoteBranches.filter(remoteBranch => getRemoteBranchDisplayName(remoteBranch) === requestedBranch);
+
+    return matchingBranches.length === 1 ? matchingBranches[0] : '';
+}

--- a/tests/server-admin-git.test.js
+++ b/tests/server-admin-git.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, jest, test } from '@jest/globals';
+
+import {
+    getBranchDisplayNames,
+    getRemoteBranchesFromSummary,
+    getStatusDisplayBranch,
+    isGitRepository,
+    isRuntimeBranch,
+    resolveRemoteBranchName,
+} from '../src/server-admin-git.js';
+
+describe('server admin git helpers', () => {
+    test('accepts linked worktrees as Git repositories', async () => {
+        const git = {
+            checkIsRepo: jest.fn(async () => true),
+        };
+
+        await expect(isGitRepository(git)).resolves.toBe(true);
+        expect(git.checkIsRepo).toHaveBeenCalledWith();
+    });
+
+    test('uses the tracked remote as the display branch for runtime worktrees', () => {
+        expect(getStatusDisplayBranch('runtime/sillybunny-server', 'origin/staging')).toBe('staging');
+        expect(getStatusDisplayBranch('feature/admin-git', 'origin/feature/admin-git')).toBe('feature/admin-git');
+    });
+
+    test('lists display names from remote branch summaries', () => {
+        const remoteBranches = getRemoteBranchesFromSummary({
+            branches: {
+                'origin/HEAD': {},
+                'origin/main': {},
+                'origin/staging': {},
+                'fork/main': {},
+            },
+        });
+
+        expect(remoteBranches).toEqual(['fork/main', 'origin/main', 'origin/staging']);
+        expect(getBranchDisplayNames(remoteBranches)).toEqual(['fork/main', 'main', 'staging']);
+    });
+
+    test('resolves stable branch names to origin before other remotes', () => {
+        const remoteBranches = ['fork/main', 'origin/main', 'origin/staging'];
+
+        expect(resolveRemoteBranchName(remoteBranches, 'main')).toBe('origin/main');
+        expect(resolveRemoteBranchName(remoteBranches, 'staging')).toBe('origin/staging');
+        expect(resolveRemoteBranchName(remoteBranches, 'fork/main')).toBe('fork/main');
+    });
+
+    test('recognizes runtime branches', () => {
+        expect(isRuntimeBranch('runtime/sillybunny-server')).toBe(true);
+        expect(isRuntimeBranch('main')).toBe(false);
+    });
+});


### PR DESCRIPTION
## What?
This PR ports the runtime worktree Git admin fix from staging PR #36 to `main`. It accepts linked Git worktrees in the server admin status, update, and branch endpoints, shows the tracked stable branch name for runtime branches, resolves Main/Staging selections to `origin/main` and `origin/staging`, and retargets the existing runtime branch instead of switching the runnable worktree away from it.

## Why?
The runnable runtime worktree must be able to pull both Main and Staging from inside the application. Without this fix on `main`, switching the app to Main can restart into code that still reports a linked worktree as not being a Git repository.

## How?
The server admin Git behavior is moved into focused helpers for repository detection, remote branch display names, runtime branch recognition, and remote branch resolution. The admin endpoint now uses `checkIsRepo()` so linked worktrees are accepted, fetches/prunes remotes before listing or switching branches, and uses `checkout -B <runtime-branch> <remote-ref>` for runtime branches so the stable runtime branch remains the checked-out branch while tracking the selected stable remote.

## Testing?
- `npm ci --ignore-scripts`
- `npm ci --ignore-scripts --prefix tests`
- `npm run test:unit --prefix tests -- tests/server-admin-git.test.js`
- `npm run lint -- --quiet`
- `git diff --cached --check`

## Screenshots (optional)
Screenshots were not included. This is a server admin Git behavior fix with focused unit coverage and lint/diff validation.

## Anything Else?
This is the main-targeted counterpart to staging PR #36, but it intentionally omits the staging-only mobile shell CSS budget extraction. npm install reported existing dependency audit findings; no package files were changed by this PR.
