### PR TITLE
fix: stabilize mobile chat scroll

### DIFF
--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1531,6 +1531,7 @@ body.sb-shell-resizing * {
     overflow-x: auto;
     overflow-y: hidden;
     flex-shrink: 0;
+    overscroll-behavior: contain;
     -webkit-overflow-scrolling: touch;
 }
 
@@ -4177,7 +4178,7 @@ body.sb-shell-resizing * {
     .sb-shell-nav {
         justify-content: flex-start;
         scroll-padding-inline: 24px;
-        touch-action: pan-x;
+        touch-action: none;
     }
 
     .sb-shell-panel-scroller,
@@ -4432,7 +4433,7 @@ body.sb-shell-resizing * {
         align-items: stretch;
         overflow-x: auto;
         overflow-y: hidden;
-        overscroll-behavior-x: contain;
+        overscroll-behavior: contain;
         -webkit-overflow-scrolling: touch;
         scrollbar-width: none;
         scroll-snap-type: x proximity;

--- a/public/script.js
+++ b/public/script.js
@@ -557,8 +557,11 @@ const MOBILE_CHAT_VIEWPORT_SCROLL_SUPPRESS_MS = 500;
 const MOBILE_CHAT_BOTTOM_PIN_MS = 1500;
 const CHAT_SCROLL_BOTTOM_THRESHOLD_PX = 8;
 const SHOW_MORE_DUPLICATE_EVENT_GUARD_MS = 750;
+const SHOW_MORE_TOUCH_MOVE_CANCEL_PX = 12;
 let isLoadingMoreMessages = false;
 let lastShowMoreTouchEventAt = 0;
+let showMoreTouchStart = null;
+let showMoreTouchMoved = false;
 let pendingMobileMessageUpdateFrame = 0;
 let pendingMobileMessageUpdateTimer = 0;
 /** @type {Map<number, { message: object, rerenderMessage: boolean }>} */
@@ -1810,6 +1813,55 @@ function waitForNextFrame() {
     return new Promise(resolve => requestAnimationFrame(() => resolve()));
 }
 
+function captureVisibleChatMessageAnchor() {
+    const chatNode = chatElement[0];
+
+    if (!(chatNode instanceof HTMLElement)) {
+        return null;
+    }
+
+    const chatRect = chatNode.getBoundingClientRect();
+    const messages = Array.from(chatNode.querySelectorAll('.mes[mesid]'));
+    const anchorElement = messages.find(message => {
+        const messageRect = message.getBoundingClientRect();
+        return messageRect.bottom > chatRect.top && messageRect.top < chatRect.bottom;
+    });
+
+    if (!(anchorElement instanceof HTMLElement)) {
+        return null;
+    }
+
+    return {
+        messageId: anchorElement.getAttribute('mesid'),
+        offsetTop: anchorElement.getBoundingClientRect().top - chatRect.top,
+    };
+}
+
+function restoreVisibleChatMessageAnchor(anchor) {
+    const chatNode = chatElement[0];
+
+    if (!(chatNode instanceof HTMLElement) || !anchor?.messageId) {
+        return;
+    }
+
+    const anchorElement = chatNode.querySelector(`.mes[mesid="${anchor.messageId}"]`);
+
+    if (!(anchorElement instanceof HTMLElement)) {
+        return;
+    }
+
+    const chatRect = chatNode.getBoundingClientRect();
+    const nextOffsetTop = anchorElement.getBoundingClientRect().top - chatRect.top;
+    chatNode.scrollTop += nextOffsetTop - anchor.offsetTop;
+}
+
+async function settleVisibleChatMessageAnchor(anchor, frames = 8) {
+    for (let i = 0; i < frames; i++) {
+        await waitForNextFrame();
+        restoreVisibleChatMessageAnchor(anchor);
+    }
+}
+
 function flushPendingMobileMessageUpdates() {
     pendingMobileMessageUpdateFrame = 0;
     pendingMobileMessageUpdateTimer = 0;
@@ -1872,14 +1924,14 @@ export async function showMoreMessages(messagesToLoad = null) {
         const insertionReference = showMoreButtonElement instanceof HTMLElement
             ? showMoreButtonElement.nextSibling
             : chatElement[0]?.firstChild ?? null;
-        const shouldPreserveScroll = isElementInViewport(showMoreButtonElement);
+        const anchor = captureVisibleChatMessageAnchor();
+        const shouldPreserveScroll = Boolean(anchor);
 
         if (showMoreButtonElement instanceof HTMLElement) {
             showMoreButtonElement.setAttribute('aria-busy', 'true');
         }
 
         for (let offset = 0; offset < messages.length; offset += batchSize) {
-            const prevHeight = chatElement.prop('scrollHeight');
             const fragment = document.createDocumentFragment();
             const batch = messages.slice(offset, offset + batchSize);
 
@@ -1894,12 +1946,14 @@ export async function showMoreMessages(messagesToLoad = null) {
             insertShowMoreFragment(insertionReference, fragment);
 
             if (shouldPreserveScroll) {
-                const newHeight = chatElement.prop('scrollHeight');
-                chatElement.scrollTop(chatElement.scrollTop() + newHeight - prevHeight);
+                restoreVisibleChatMessageAnchor(anchor);
             }
 
             if (shouldYieldBetweenBatches && offset + batchSize < messages.length) {
                 await waitForNextFrame();
+                if (shouldPreserveScroll) {
+                    restoreVisibleChatMessageAnchor(anchor);
+                }
             }
         }
 
@@ -1912,6 +1966,11 @@ export async function showMoreMessages(messagesToLoad = null) {
         }
 
         applyStylePins();
+
+        if (shouldPreserveScroll) {
+            await settleVisibleChatMessageAnchor(anchor);
+        }
+
         await eventSource.emit(event_types.MORE_MESSAGES_LOADED);
     } finally {
         if (showMoreButtonElement instanceof HTMLElement) {
@@ -15078,13 +15137,42 @@ jQuery(async function () {
         $('#avatar-and-name-block').slideToggle();
     });
 
+    $(document).on('touchstart', '#show_more_messages', function (event) {
+        const touch = event.originalEvent?.changedTouches?.[0];
+        showMoreTouchMoved = false;
+        showMoreTouchStart = touch ? { x: touch.clientX, y: touch.clientY } : null;
+    });
+
+    $(document).on('touchmove', '#show_more_messages', function (event) {
+        if (!showMoreTouchStart) {
+            return;
+        }
+
+        const touch = event.originalEvent?.changedTouches?.[0];
+
+        if (!touch) {
+            return;
+        }
+
+        const deltaX = Math.abs(touch.clientX - showMoreTouchStart.x);
+        const deltaY = Math.abs(touch.clientY - showMoreTouchStart.y);
+        showMoreTouchMoved = showMoreTouchMoved || deltaX > SHOW_MORE_TOUCH_MOVE_CANCEL_PX || deltaY > SHOW_MORE_TOUCH_MOVE_CANCEL_PX;
+    });
+
     $(document).on('mouseup touchend', '#show_more_messages', async function (event) {
         if (event.type === 'touchend') {
             lastShowMoreTouchEventAt = Date.now();
+            showMoreTouchStart = null;
+
+            if (showMoreTouchMoved) {
+                showMoreTouchMoved = false;
+                return;
+            }
         } else if (event.type === 'mouseup' && Date.now() - lastShowMoreTouchEventAt < SHOW_MORE_DUPLICATE_EVENT_GUARD_MS) {
             return;
         }
 
+        showMoreTouchMoved = false;
         event.stopPropagation();
         event.preventDefault();
         await showMoreMessages();

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -948,9 +948,11 @@ export function initRossMods() {
                 const threshold = 1;
                 const newHeight = chatBlock.offsetHeight;
                 const deltaHeight = newHeight - lastHeight;
-                const isScrollAtBottom = Math.abs(chatBlock.scrollHeight - chatBlock.scrollTop - newHeight) <= threshold;
+                const wasScrollAtBottom = Math.abs(chatBlock.scrollHeight - chatBlock.scrollTop - lastHeight) <= threshold;
 
-                if (!isScrollAtBottom && Math.abs(deltaHeight) > threshold) {
+                if (wasScrollAtBottom) {
+                    chatBlock.scrollTop = chatBlock.scrollHeight;
+                } else if (!isMobile() && Math.abs(deltaHeight) > threshold) {
                     chatBlock.scrollTop -= deltaHeight;
                 }
                 lastHeight = newHeight;

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -72,6 +72,7 @@ const SB_INLINE_DRAWER_CUSTOM_PERSISTENCE_SELECTOR = '.sb-openai-settings-drawer
 const SB_STORAGE_PREFIX = 'sb-';
 const SB_STORAGE_WRITE_DEBOUNCE_MS = 120;
 const SB_MOBILE_NAV_OPEN_GRACE_MS = 450;
+const SB_SHELL_NAV_TOUCH_DRAG_THRESHOLD_PX = 6;
 
 let sbInlineDrawerPersistenceObserver = null;
 let sbInlineDrawerPersistenceQueued = false;
@@ -1181,6 +1182,26 @@ function isMobileViewport() {
 
 function prefersReducedMotion() {
     return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+function scrollShellTabButtonIntoView(nav, button, { smooth = false } = {}) {
+    if (!(nav instanceof HTMLElement) || !(button instanceof HTMLElement)) {
+        return;
+    }
+
+    const navRect = nav.getBoundingClientRect();
+    const buttonRect = button.getBoundingClientRect();
+    const leftOverflow = buttonRect.left - navRect.left;
+    const rightOverflow = buttonRect.right - navRect.right;
+
+    if (leftOverflow >= 0 && rightOverflow <= 0) {
+        return;
+    }
+
+    nav.scrollBy({
+        left: leftOverflow < 0 ? leftOverflow : rightOverflow,
+        behavior: smooth && !prefersReducedMotion() ? 'smooth' : 'auto',
+    });
 }
 
 function isTouchOnlyDesktopViewport() {
@@ -8710,11 +8731,7 @@ function setActiveTab(shellKey, tabId, { focusButton = false } = {}) {
     const activeTab = shellState.tabs.get(tabId);
     shellState.headerTitle.textContent = activeTab.label;
     shellState.headerSubtitle.textContent = activeTab.description;
-    activeTab.button?.scrollIntoView({
-        block: 'nearest',
-        inline: 'nearest',
-        behavior: focusButton && !prefersReducedMotion() ? 'smooth' : 'auto',
-    });
+    scrollShellTabButtonIntoView(shellState.nav, activeTab.button, { smooth: focusButton });
     shellState.updateNavScrollIndicators?.();
 
     if (focusButton) {
@@ -8847,6 +8864,79 @@ function buildShell(shellKey) {
         });
     };
 
+    let navTouchDrag = null;
+    let suppressNavClickUntil = 0;
+
+    const clearNavTouchDrag = () => {
+        navTouchDrag = null;
+    };
+
+    const finishNavTouchDrag = event => {
+        if (navTouchDrag?.dragging) {
+            suppressNavClickUntil = Date.now() + 350;
+            event.stopPropagation();
+        }
+
+        clearNavTouchDrag();
+    };
+
+    const beginNavTouchDrag = event => {
+        const touch = event.touches?.[0];
+
+        if (!isMobileViewport() || !touch) {
+            clearNavTouchDrag();
+            return;
+        }
+
+        navTouchDrag = {
+            x: touch.clientX,
+            y: touch.clientY,
+            scrollLeft: nav.scrollLeft,
+            dragging: false,
+        };
+    };
+
+    const updateNavTouchDrag = event => {
+        if (!navTouchDrag) {
+            return;
+        }
+
+        const touch = event.touches?.[0];
+
+        if (!touch) {
+            clearNavTouchDrag();
+            return;
+        }
+
+        const deltaX = touch.clientX - navTouchDrag.x;
+        const deltaY = touch.clientY - navTouchDrag.y;
+
+        navTouchDrag.dragging = navTouchDrag.dragging
+            || Math.abs(deltaX) > SB_SHELL_NAV_TOUCH_DRAG_THRESHOLD_PX
+            || Math.abs(deltaY) > SB_SHELL_NAV_TOUCH_DRAG_THRESHOLD_PX;
+
+        if (!navTouchDrag.dragging) {
+            return;
+        }
+
+        if (event.cancelable) {
+            event.preventDefault();
+        }
+
+        event.stopPropagation();
+        nav.scrollLeft = navTouchDrag.scrollLeft - deltaX;
+        updateNavScrollIndicators();
+    };
+
+    const suppressClickAfterNavDrag = event => {
+        if (Date.now() >= suppressNavClickUntil) {
+            return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+    };
+
     const updateNavScrollIndicators = () => {
         const canScrollLeft = nav.scrollLeft > 0;
         const canScrollRight = Math.ceil(nav.scrollLeft + nav.clientWidth) < nav.scrollWidth;
@@ -8857,6 +8947,11 @@ function buildShell(shellKey) {
     };
 
     nav.addEventListener('scroll', updateNavScrollIndicators, { passive: true });
+    nav.addEventListener('click', suppressClickAfterNavDrag, true);
+    nav.addEventListener('touchstart', beginNavTouchDrag, { passive: true });
+    nav.addEventListener('touchmove', updateNavTouchDrag, { passive: false });
+    nav.addEventListener('touchend', finishNavTouchDrag, { passive: true });
+    nav.addEventListener('touchcancel', clearNavTouchDrag, { passive: true });
     window.addEventListener('resize', updateNavScrollIndicators, { passive: true });
     navScrollLeft.addEventListener('click', () => scrollNavByPage(-1));
     navScrollRight.addEventListener('click', () => scrollNavByPage(1));


### PR DESCRIPTION
## What?
Stabilizes mobile chat scrolling when the user drags across SillyBunny shell tabs or loads older messages.

## Why?
Mobile users could be reading around later messages and get snapped upward to an earlier message after slow scrolling, tab-strip interaction, or older-message insertion. The tab strip was a likely trigger because browser-level tab `scrollIntoView()` and touch chaining could move ancestor scroll containers.

## How?
- Replaces active-tab `scrollIntoView()` with horizontal-only nav scrolling.
- Adds mobile tab-drag handling that consumes touch movement inside the tab strip and suppresses accidental tab clicks after a drag.
- Contains tab-strip overscroll in CSS and disables default touch panning for the mobile shell nav.
- Preserves the visible chat message anchor when loading older messages, including a short settle period for async height changes.
- Avoids mobile chat resize compensation unless the chat was already at bottom.

## Testing?
- `npm ci --ignore-scripts`
- `npm run lint`
- `git diff --check origin/staging..HEAD`
- Chrome DevTools mobile smoke on `390x844x2`: tab drag kept `#chat.scrollTop` delta at `0`; tab click kept delta at `0`; synthetic older-message insertion kept the anchor message top delta at `0`.

## Screenshots (optional)
No screenshot. This is a behavioral scroll fix; verified with a mobile viewport and DOM scroll-position probes instead.

## Anything Else?
This PR is based on `origin/staging` and contains only the mobile chat scroll stabilization commit.