### PR TITLE
fix(extensions): treat Bunny Preset Tools as bundled

### DIFF
--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -566,6 +566,10 @@ function getExtensionType(externalId) {
     return id ? extensionTypes[id] : '';
 }
 
+function isExternalExtension(externalId) {
+    return ['local', 'global'].includes(getExtensionType(externalId));
+}
+
 /**
  * Performs a fetch of the Extras API.
  * @param {string|URL} endpoint Extras API endpoint
@@ -1429,7 +1433,7 @@ function getExtensionData(extension) {
     const manifest = extension[1];
     const isActive = activeExtensions.has(name);
     const isDisabled = extension_settings.disabledExtensions.includes(name);
-    const isExternal = name.startsWith('third-party');
+    const isExternal = isExternalExtension(name);
 
     const checkboxClass = isDisabled ? 'checkbox_disabled' : '';
 
@@ -2273,7 +2277,7 @@ function processVersionCheckQueue() {
  */
 async function checkForUpdatesManual(sortFn, abortSignal) {
     const promises = [];
-    for (const id of Object.keys(manifests).filter(x => x.startsWith('third-party')).sort((a, b) => sortFn(manifests[a], manifests[b]))) {
+    for (const id of Object.keys(manifests).filter(isExternalExtension).sort((a, b) => sortFn(manifests[a], manifests[b]))) {
         const externalId = id.replace('third-party', '');
         const promise = enqueueVersionCheck(async () => {
             try {
@@ -2357,7 +2361,7 @@ async function checkForExtensionUpdates(force) {
             continue;
         }
 
-        if (manifest.auto_update && id.startsWith('third-party')) {
+        if (manifest.auto_update && isExternalExtension(id)) {
             const promise = enqueueVersionCheck(async () => {
                 try {
                     const data = await getExtensionVersion(id.replace('third-party', ''));
@@ -2385,7 +2389,7 @@ async function checkForExtensionUpdates(force) {
  * @returns {Promise<void>}
  */
 async function autoUpdateExtensions(forceAll) {
-    if (!Object.values(manifests).some(x => x.auto_update)) {
+    if (!Object.entries(manifests).some(([id, manifest]) => isExternalExtension(id) && (forceAll || manifest.auto_update))) {
         return;
     }
 
@@ -2404,7 +2408,7 @@ async function autoUpdateExtensions(forceAll) {
             console.debug(`Skipping global extension: ${manifest.display_name} (${id}) for non-admin user`);
             continue;
         }
-        if ((forceAll || manifest.auto_update) && id.startsWith('third-party')) {
+        if ((forceAll || manifest.auto_update) && isExternalExtension(id)) {
             console.debug(`Auto-updating 3rd-party extension: ${manifest.display_name} (${id})`);
             promises.push(updateExtension(id.replace('third-party', ''), true, autoUpdateTimeout));
         }

--- a/public/scripts/extensions/third-party/BunnyPresetTools/content.js
+++ b/public/scripts/extensions/third-party/BunnyPresetTools/content.js
@@ -30,6 +30,7 @@ let backgroundLayerElement = null;
 let backgroundMutationObserver = null;
 let backgroundCardObserversAttached = false;
 let backgroundSyncTimer = null;
+let backgroundLifecycleHandlersAttached = false;
 let legacySettingsMigrationChecked = false;
 
 function migrateLegacySettings() {
@@ -666,6 +667,8 @@ function attachBackgroundEnhancer() {
         });
     }
 
+    attachBackgroundLifecycleHandlers();
+
     const backgroundDrawer = document.getElementById('Backgrounds');
     if (backgroundDrawer) {
         injectAnimatedBackgroundPanel(backgroundDrawer);
@@ -929,6 +932,10 @@ function buildYouTubeEmbedUrl(videoId) {
     return `https://www.youtube.com/embed/${videoId}?${params.toString()}`;
 }
 
+function isIOSWebKit() {
+    return /iPad|iPhone|iPod/.test(navigator.platform) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+}
+
 function clearAnimatedBackgroundLayer() {
     if (!backgroundLayerElement) {
         return;
@@ -938,6 +945,62 @@ function clearAnimatedBackgroundLayer() {
     backgroundLayerElement.removeAttribute('data-active-key');
     document.body.classList.remove('bpt-animated-bg-active');
     renderAnimatedSourceList();
+}
+
+function suspendAnimatedBackgroundMedia() {
+    if (!isIOSWebKit() || !backgroundLayerElement) {
+        return;
+    }
+
+    const video = backgroundLayerElement.querySelector('video');
+    if (video) {
+        video.pause();
+    }
+
+    const iframe = backgroundLayerElement.querySelector('iframe');
+    if (iframe instanceof HTMLIFrameElement && !iframe.dataset.bptSuspendedSrc) {
+        iframe.dataset.bptSuspendedSrc = iframe.getAttribute('src') || '';
+        iframe.removeAttribute('src');
+    }
+}
+
+function resumeAnimatedBackgroundMedia() {
+    if (!isIOSWebKit() || !backgroundLayerElement) {
+        return;
+    }
+
+    const iframe = backgroundLayerElement.querySelector('iframe[data-bpt-suspended-src]');
+    if (iframe instanceof HTMLIFrameElement) {
+        iframe.src = iframe.dataset.bptSuspendedSrc || '';
+        delete iframe.dataset.bptSuspendedSrc;
+    }
+
+    const video = backgroundLayerElement.querySelector('video');
+    if (video && ensureSettings().animatedBackgroundAutoplay) {
+        const playPromise = video.play();
+        if (playPromise?.catch) {
+            playPromise.catch(() => {});
+        }
+    }
+
+    scheduleBackgroundSync();
+}
+
+function attachBackgroundLifecycleHandlers() {
+    if (backgroundLifecycleHandlersAttached) {
+        return;
+    }
+
+    document.addEventListener('visibilitychange', () => {
+        if (document.hidden) {
+            suspendAnimatedBackgroundMedia();
+        } else {
+            resumeAnimatedBackgroundMedia();
+        }
+    });
+    window.addEventListener('pagehide', suspendAnimatedBackgroundMedia, { passive: true });
+    window.addEventListener('pageshow', resumeAnimatedBackgroundMedia, { passive: true });
+    backgroundLifecycleHandlersAttached = true;
 }
 
 function syncAnimatedBackgroundLayer() {
@@ -986,7 +1049,7 @@ function syncAnimatedBackgroundLayer() {
         video.controls = settings.animatedBackgroundShowControls;
         video.autoplay = settings.animatedBackgroundAutoplay;
         video.playsInline = true;
-        video.preload = 'auto';
+        video.preload = isIOSWebKit() ? 'metadata' : 'auto';
         video.volume = settings.animatedBackgroundMuted ? 0 : settings.animatedBackgroundVolume / 100;
         video.style.objectFit = getObjectFitValue();
         backgroundLayerElement.appendChild(video);

--- a/src/endpoints/extensions.js
+++ b/src/endpoints/extensions.js
@@ -11,6 +11,9 @@ import { getConfigValue, isValidUrl } from '../util.js';
 import { createGitClient } from '../git/client.js';
 
 const gitBackend = getConfigValue('git.backend', 'auto');
+const BUNDLED_THIRD_PARTY_EXTENSIONS = new Set([
+    'BunnyPresetTools',
+]);
 
 /**
  * @type {Partial<import('simple-git').SimpleGitOptions>}
@@ -158,6 +161,19 @@ async function ensureExtensionRepo(extensionPath, isGlobal = false) {
     } finally {
         fs.rmSync(snapshotPath, { recursive: true, force: true });
     }
+}
+
+function isBundledThirdPartyExtension(extensionName) {
+    return BUNDLED_THIRD_PARTY_EXTENSIONS.has(sanitize(extensionName));
+}
+
+function rejectBundledThirdPartyExtension(extensionName, response, action) {
+    if (!isBundledThirdPartyExtension(extensionName)) {
+        return false;
+    }
+
+    response.status(400).send(`Bad Request: ${extensionName} is bundled with SillyBunny and cannot be ${action} through the extension updater.`);
+    return true;
 }
 
 /**
@@ -315,6 +331,9 @@ router.post('/update', async (request, response) => {
         if (!extensionNameSanitized) {
             return response.status(400).send('Bad Request: A valid extensionName is required in the request body.');
         }
+        if (rejectBundledThirdPartyExtension(extensionNameSanitized, response, 'updated')) {
+            return;
+        }
 
         if (global && !request.user.profile.admin) {
             console.error(`User ${request.user.profile.handle} does not have permission to update global extensions.`);
@@ -392,6 +411,9 @@ router.post('/branches', async (request, response) => {
         if (!extensionNameSanitized) {
             return response.status(400).send('Bad Request: A valid extensionName is required in the request body.');
         }
+        if (rejectBundledThirdPartyExtension(extensionNameSanitized, response, 'managed')) {
+            return;
+        }
 
         if (global && !request.user.profile.admin) {
             console.error(`User ${request.user.profile.handle} does not have permission to list branches of global extensions.`);
@@ -442,6 +464,9 @@ router.post('/switch', async (request, response) => {
         const extensionNameSanitized = sanitize(extensionName);
         if (!extensionNameSanitized || !branch) {
             return response.status(400).send('Bad Request: A valid extensionName and branch are required in the request body.');
+        }
+        if (rejectBundledThirdPartyExtension(extensionNameSanitized, response, 'switched')) {
+            return;
         }
 
         if (global && !request.user.profile.admin) {
@@ -508,6 +533,9 @@ router.post('/move', async (request, response) => {
         if (!extensionNameSanitized || !source || !destination) {
             return response.status(400).send('Bad Request: A valid extensionName, source, and destination are required in the request body.');
         }
+        if (rejectBundledThirdPartyExtension(extensionNameSanitized, response, 'moved')) {
+            return;
+        }
 
         if (!request.user.profile.admin) {
             console.error(`User ${request.user.profile.handle} does not have permission to move extensions.`);
@@ -566,6 +594,9 @@ router.post('/version', async (request, response) => {
         if (!extensionNameSanitized) {
             return response.status(400).send('Bad Request: A valid extensionName is required in the request body.');
         }
+        if (isBundledThirdPartyExtension(extensionNameSanitized)) {
+            return response.send({ currentBranchName: '', currentCommitHash: '', isUpToDate: true, remoteUrl: '' });
+        }
 
         const basePath = global ? PUBLIC_DIRECTORIES.globalExtensions : request.user.directories.extensions;
         const extensionPath = path.join(basePath, extensionNameSanitized);
@@ -623,6 +654,9 @@ router.post('/delete', async (request, response) => {
         if (!extensionNameSanitized) {
             return response.status(400).send('Bad Request: A valid extensionName is required in the request body.');
         }
+        if (rejectBundledThirdPartyExtension(extensionNameSanitized, response, 'deleted')) {
+            return;
+        }
 
         if (global && !request.user.profile.admin) {
             console.error(`User ${request.user.profile.handle} does not have permission to delete global extensions.`);
@@ -670,6 +704,7 @@ router.get('/discover', function (request, response) {
     const userExtensions = fs
         .readdirSync(path.join(request.user.directories.extensions))
         .filter(f => fs.statSync(path.join(request.user.directories.extensions, f)).isDirectory())
+        .filter(f => !isBundledThirdPartyExtension(f))
         .map(f => ({ type: 'local', name: `third-party/${f}` }));
 
     // Get all folders in global extensions folder
@@ -677,7 +712,7 @@ router.get('/discover', function (request, response) {
     const globalExtensions = fs
         .readdirSync(PUBLIC_DIRECTORIES.globalExtensions)
         .filter(f => fs.statSync(path.join(PUBLIC_DIRECTORIES.globalExtensions, f)).isDirectory())
-        .map(f => ({ type: 'global', name: `third-party/${f}` }))
+        .map(f => ({ type: isBundledThirdPartyExtension(f) ? 'system' : 'global', name: `third-party/${f}` }))
         .filter(f => !userExtensions.some(e => e.name === f.name));
 
     // Combine all extensions


### PR DESCRIPTION
## What?
Treat bundled Bunny Preset Tools as a SillyBunny system extension instead of an updateable third-party install.

Also add an iOS WebKit lifecycle mitigation for Bunny Preset Tools animated backgrounds by pausing local video, unloading YouTube iframes while the page is hidden, and using metadata-only preload for local video on iOS.

## Why?
Bunny Preset Tools ships with SillyBunny for the dropdown preset UI, but discovery classified its `third-party/BunnyPresetTools` folder as a global extension. That exposed update/delete/move/branch controls and could bootstrap it from the main SillyBunny repository homepage, creating a dirty nested checkout that looked like an external Nemo-era extension.

The iOS change reduces background media pressure during Safari/WebKit page lifecycle transitions, which is a plausible cause of fast tab refresh/crash behavior when animated backgrounds are active.

## How?
Server discovery now marks known bundled third-party folders as `system`, ignores stale same-name user extension folders, and blocks updater-style mutation endpoints for Bunny Preset Tools. The version endpoint reports bundled tools as already up to date for compatibility.

The client extension UI now uses discovered extension type to decide whether an entry is external, so system third-party entries render with built-in controls and are skipped by manual, notification, and auto-update checks.

Bunny Preset Tools adds iOS WebKit lifecycle handlers that suspend/resume background media on `visibilitychange`, `pagehide`, and `pageshow` without changing the visible interface.

## Testing?
- `node --check public/scripts/extensions.js`
- `node --check src/endpoints/extensions.js`
- `node --check public/scripts/extensions/third-party/BunnyPresetTools/content.js`
- `npm run lint`
- `git diff --check`

Manual iOS device verification was not available in this environment.

## Screenshots (optional)
Not applicable. This changes extension classification/update behavior and mobile media lifecycle handling, not visible layout.

## Anything Else?
The runtime checkout at `D:/AIStuff/SillyBunny` was left on `staging`; changes were made in the contribution worktree.