### PR TITLE
docs: add server hygiene lesson

### DIFF
--- a/lessons.md
+++ b/lessons.md
@@ -241,5 +241,6 @@ Takeaway: the current direction is toward agent-friendly worktrees, mobile shell
 - Treat bundled defaults as versioned product behavior.
 - Treat upstream syncs as migrations with compatibility acceptance criteria.
 - Treat cache and performance work as lifecycle-specific work.
+- Treat temporary debug servers as owned resources: record the PID and port when starting them, then verify both process exit and port release before ending the task.
 - Keep docs clean by separating raw agent analysis from curated user-facing text.
 - Prefer short, scoped patches, but make each patch carry its verification proof.


### PR DESCRIPTION
## What?
Adds an explicit `lessons.md` operating principle for temporary debug server hygiene.

## Why?
The persistent `AGENTS.md` instruction already says to record and shut down temporary dev/debug servers, but the same mistake also belongs in the history-derived lessons so future agents see it before planning or editing.

## How?
Adds one concise operating-principles bullet that treats temporary debug servers as owned resources and requires PID/port tracking plus process and port-release verification.

## Testing?
- `git diff --check`
- Confirmed the new `lessons.md` line is present.
- Confirmed the prior temporary server PID `34704` is stopped and port `4451` is clear.

## Screenshots (optional)
Not applicable. This is an agent-instruction correction.

## Anything Else?
This is a follow-up to PR #42 to capture the server hygiene rule in `lessons.md` itself.