### PR TITLE
fix: polish shell menu focus and mobile controls

### DIFF
--- a/public/css/extensions-panel.css
+++ b/public/css/extensions-panel.css
@@ -66,15 +66,15 @@ label[for="extensions_notify_updates"] input[type="checkbox"] {
 }
 
 .extensions_info .disabled {
-    color: lightgray;
+    color: var(--sb-muted-fg, color-mix(in srgb, var(--SmartThemeBodyColor) 58%, transparent));
 }
 
 .extensions_info .toggle_enable {
-    color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 88%, white 12%);
+    color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 88%, var(--SmartThemeBodyColor) 12%);
 }
 
 .extensions_info .toggle_disable {
-    color: rgb(238, 144, 144);
+    color: var(--sb-danger, color-mix(in srgb, #fb7185 88%, var(--SmartThemeBodyColor) 12%));
 }
 
 .extensions_info .extension_enabled {
@@ -82,11 +82,11 @@ label[for="extensions_notify_updates"] input[type="checkbox"] {
 }
 
 .extensions_info .extension_disabled {
-    color: lightgray;
+    color: var(--sb-muted-fg, color-mix(in srgb, var(--SmartThemeBodyColor) 58%, transparent));
 }
 
 .extensions_info .extension_missing {
-    color: gray;
+    color: var(--sb-muted-fg, color-mix(in srgb, var(--SmartThemeBodyColor) 48%, transparent));
 }
 
 .extensions_info .extension_modules {

--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -48,7 +48,7 @@
 
     #right-nav-panel #CharListButtonAndHotSwaps {
         display: grid;
-        grid-template-columns: 36px minmax(0, 1fr) 36px 36px;
+        grid-template-columns: var(--sb-mobile-touch-target, 44px) minmax(0, 1fr) var(--sb-mobile-touch-target, 44px) var(--sb-mobile-touch-target, 44px);
         align-items: center;
         gap: 6px;
         width: 100%;
@@ -62,8 +62,8 @@
         align-items: center;
         justify-content: center;
         gap: 0;
-        width: 36px;
-        min-width: 36px;
+        width: var(--sb-mobile-touch-target, 44px);
+        min-width: var(--sb-mobile-touch-target, 44px);
     }
 
     #right-nav-panel #HotSwapWrapper {
@@ -542,10 +542,10 @@
         position: absolute;
         top: 5px;
         right: 5px;
-        width: 30px;
-        height: 30px;
-        background-color: rgba(0, 0, 0, 0.4);
-        color: white;
+        width: var(--sb-mobile-touch-target, 44px);
+        height: var(--sb-mobile-touch-target, 44px);
+        background-color: color-mix(in srgb, var(--SmartThemeShadowColor) 58%, transparent);
+        color: var(--SmartThemeBodyColor);
         border-radius: 6px;
         z-index: 3;
         cursor: pointer;

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1697,7 +1697,7 @@ body.sb-shell-resizing * {
     position: absolute;
     top: 18px;
     right: 18px;
-    display: none;
+    display: inline-flex;
     width: 40px;
     height: 40px;
     border: 1px solid color-mix(in srgb, var(--sb-shell-border) 88%, transparent);
@@ -1730,6 +1730,12 @@ body.sb-shell-resizing * {
 .sb-shell-close:focus-visible {
     outline: none;
     box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--sb-focus-ring) 78%, transparent);
+}
+
+.sb-shell-title:focus-visible {
+    outline: none;
+    border-radius: var(--sb-radius-sm);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--sb-focus-ring) 72%, transparent);
 }
 
 .sb-character-close,

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -74,6 +74,14 @@ const SB_STORAGE_PREFIX = 'sb-';
 const SB_STORAGE_WRITE_DEBOUNCE_MS = 120;
 const SB_MOBILE_NAV_OPEN_GRACE_MS = 450;
 const SB_SHELL_NAV_TOUCH_DRAG_THRESHOLD_PX = 6;
+const SB_SHELL_FOCUSABLE_SELECTOR = [
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled]):not([type="hidden"])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+].join(',');
 
 let sbInlineDrawerPersistenceObserver = null;
 let sbInlineDrawerPersistenceQueued = false;
@@ -1196,6 +1204,86 @@ function isMobileViewport() {
 
 function prefersReducedMotion() {
     return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+function getShellProxyButton(shellKey) {
+    const shellConfig = getShellConfig(shellKey);
+    const proxyButton = shellConfig?.proxyButtonId ? document.getElementById(shellConfig.proxyButtonId) : null;
+    return proxyButton instanceof HTMLElement ? proxyButton : null;
+}
+
+function getShellActivePanel(shellState) {
+    return shellState?.tabs.get(shellState.activeTabId)?.panel ?? null;
+}
+
+function getShellFocusTarget(shellState) {
+    if (shellState?.headerTitle instanceof HTMLElement) {
+        return shellState.headerTitle;
+    }
+
+    const panel = getShellActivePanel(shellState);
+    const focusable = Array.from(panel?.querySelectorAll(SB_SHELL_FOCUSABLE_SELECTOR) ?? [])
+        .find(element => element instanceof HTMLElement
+            && isActuallyVisible(element)
+            && !element.closest('[hidden], [aria-hidden="true"], [inert]'));
+
+    if (focusable instanceof HTMLElement) {
+        return focusable;
+    }
+
+    return shellState?.nav instanceof HTMLElement ? shellState.nav : null;
+}
+
+function focusShellPanel(shellKey, { force = false } = {}) {
+    const shellState = getShellState(shellKey);
+    const shellRoot = shellState?.root;
+
+    if (!(shellRoot instanceof HTMLElement) || !shellRoot.classList.contains('openDrawer')) {
+        return;
+    }
+
+    const activeElement = document.activeElement;
+    if (!force && activeElement instanceof HTMLElement && shellRoot.contains(activeElement)) {
+        return;
+    }
+
+    const target = getShellFocusTarget(shellState);
+    if (target instanceof HTMLElement) {
+        target.focus({ preventScroll: true });
+    }
+}
+
+function rememberShellFocusOrigin(shellKey) {
+    const shellState = getShellState(shellKey);
+    const shellRoot = shellState?.root;
+    const activeElement = document.activeElement;
+
+    if (!shellState || !(activeElement instanceof HTMLElement)) {
+        return;
+    }
+
+    if (shellRoot instanceof HTMLElement && shellRoot.contains(activeElement)) {
+        return;
+    }
+
+    shellState.restoreFocusTarget = activeElement;
+}
+
+function restoreShellFocus(shellKey) {
+    const shellState = getShellState(shellKey);
+    const restoreTarget = shellState?.restoreFocusTarget;
+    const proxyButton = getShellProxyButton(shellKey);
+    const target = restoreTarget instanceof HTMLElement && document.contains(restoreTarget)
+        ? restoreTarget
+        : proxyButton;
+
+    if (shellState) {
+        delete shellState.restoreFocusTarget;
+    }
+
+    if (target instanceof HTMLElement && !target.hasAttribute('disabled')) {
+        target.focus({ preventScroll: true });
+    }
 }
 
 function scrollShellTabButtonIntoView(nav, button, { smooth = false } = {}) {
@@ -5334,6 +5422,7 @@ function toggleShellPanel(shellKey, tabId = null) {
         return;
     }
 
+    rememberShellFocusOrigin(shellKey);
     closeAllDropdowns({ except: shellKey });
     window.requestAnimationFrame(() => openShell(shellKey, tabId));
 }
@@ -5745,6 +5834,27 @@ function createShellPanel(tabConfig) {
     panel.appendChild(scroller);
 
     return { panel, scroller };
+}
+
+function closeFocusedShell() {
+    const activeElement = document.activeElement;
+
+    if (!(activeElement instanceof HTMLElement)) {
+        return false;
+    }
+
+    const shellRoot = activeElement.closest('.sb-shell-root.openDrawer');
+    if (!(shellRoot instanceof HTMLElement)) {
+        return false;
+    }
+
+    const shellKey = shellRoot.dataset.sbShellKey;
+    if (!shellKey || !getShellState(shellKey)) {
+        return false;
+    }
+
+    closeShell(shellKey);
+    return true;
 }
 
 function moveChildrenIntoContainer(sourceElement, targetElement) {
@@ -9185,6 +9295,8 @@ function setActiveTab(shellKey, tabId, { focusButton = false } = {}) {
 
     if (focusButton) {
         activeTab.button?.focus();
+    } else if (isShellOpen(shellKey)) {
+        window.requestAnimationFrame(() => focusShellPanel(shellKey, { force: true }));
     }
 
     if (previousTab && previousTab.id !== activeTab.id) {
@@ -9208,6 +9320,7 @@ function openShell(shellKey, tabId = null) {
     }
 
     closeMobileNav();
+    rememberShellFocusOrigin(shellKey);
 
     if (tabId) {
         setActiveTab(shellKey, tabId);
@@ -9216,11 +9329,13 @@ function openShell(shellKey, tabId = null) {
     shellState.lastOpenedAt = performance.now();
 
     if (isDrawerActuallyOpen(shellRoot)) {
+        window.requestAnimationFrame(() => focusShellPanel(shellKey));
         return;
     }
 
     if (shellRoot.classList.contains('openDrawer')) {
         forceDrawerState(shellRoot, true, shellConfig.hostIconSelector);
+        window.requestAnimationFrame(() => focusShellPanel(shellKey));
         return;
     }
 
@@ -9230,6 +9345,7 @@ function openShell(shellKey, tabId = null) {
             if (!isDrawerActuallyOpen(shellRoot)) {
                 forceDrawerState(shellRoot, true, shellConfig.hostIconSelector);
             }
+            focusShellPanel(shellKey);
         });
     }
 }
@@ -9250,12 +9366,18 @@ function closeShell(shellKey) {
         return;
     }
 
-    if (document.activeElement instanceof HTMLElement && shellRoot.contains(document.activeElement)) {
+    const shouldRestoreFocus = document.activeElement instanceof HTMLElement && shellRoot.contains(document.activeElement);
+    if (shouldRestoreFocus) {
         document.activeElement.blur();
     }
 
     // Managed shells do not need the legacy drawer toggle close animation.
     forceDrawerState(shellRoot, false, shellConfig.hostIconSelector);
+    if (shouldRestoreFocus) {
+        window.requestAnimationFrame(() => restoreShellFocus(shellKey));
+    } else {
+        delete shellState?.restoreFocusTarget;
+    }
 }
 
 function buildShell(shellKey) {
@@ -9418,7 +9540,7 @@ function buildShell(shellKey) {
         },
     });
     const eyebrow = createElement('div', { className: 'sb-shell-kicker', text: shellConfig.title });
-    const title = createElement('h2', { className: 'sb-shell-title', text: shellConfig.baseTab.label });
+    const title = createElement('h2', { className: 'sb-shell-title', text: shellConfig.baseTab.label, attrs: { tabindex: '-1' } });
     const subtitle = createElement('p', { className: 'sb-shell-subtitle', text: shellConfig.baseTab.description });
     const shellDescription = createElement('p', { className: 'sb-shell-description', text: shellConfig.subtitle });
     const panelBody = createElement('div', { className: 'sb-shell-body' });
@@ -9431,6 +9553,16 @@ function buildShell(shellKey) {
 
     closeButton.innerHTML = '<i class="fa-solid fa-xmark" aria-hidden="true"></i>';
     closeButton.addEventListener('click', () => closeShell(shellKey));
+    shellRoot.addEventListener('keydown', event => {
+        if (event.key !== 'Escape') {
+            return;
+        }
+
+        if (closeFocusedShell()) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+    });
     bindShellResizeHandle(resizeHandle, shellKey);
 
     header.append(closeButton, eyebrow, title, subtitle, shellDescription);
@@ -9469,6 +9601,7 @@ function buildShell(shellKey) {
             activeTab?.onActivate?.();
             dispatchShellTabActivated(shellKey, activeTab);
             updateNavScrollIndicators();
+            window.requestAnimationFrame(() => focusShellPanel(shellKey));
             queueMobileModalStateSync();
             return;
         }


### PR DESCRIPTION
## What?
Polishes SillyBunny shell menu usability and mobile control visibility. The change adds managed-shell focus behavior, restores visible desktop shell close controls, raises mobile character drawer controls to 44px touch targets, and maps extension status colors to theme tokens.

## Why?
The UI polish pass found that shell menus were visually available but not consistently keyboard-friendly: opening or switching panels did not reliably move focus into the active shell, Escape did not close the focused shell, and desktop users lacked an obvious close button. Mobile character drawer controls also used undersized tap areas, and extension status colors drifted from theme-aware styling.

## How?
Shell focus is handled through small helper functions in `public/scripts/sillybunny-tabs.js` that remember the opener, focus the shell heading or active panel, restore focus on close, and handle Escape only when focus is inside an open shell. CSS changes keep the desktop close button visible, add a focus-visible style for shell titles, promote character drawer controls to the existing mobile touch target token, and replace hardcoded extension status colors with theme-token fallbacks.

## Testing?
- `node --check public/scripts/sillybunny-tabs.js`
- `npm ci --ignore-scripts`
- `npm run lint -- --quiet`
- `git diff --cached --check`

No screenshots are attached. This is a focused accessibility and touch-target polish patch; prior local browser probes covered desktop shell focus restoration and mobile drawer sizing before the branch was cut.

## Anything Else?
Backward compatibility is preserved: existing SillyTavern IDs, shell class names, drawer behavior, storage keys, and mobile layout hooks remain in place. The branch is based on `origin/staging` at `ac2a26b88` and keeps the upstream mobile bottom-chat persistence and centered secondary row behavior.