### PR TITLE
fix: harden update launchers for bun lock refresh

### DIFF
--- a/UpdateAndStart.bat
+++ b/UpdateAndStart.bat
@@ -42,17 +42,42 @@ set NODE_ENV=production
 set NODE_NO_WARNINGS=1
 set SILLYBUNNY_LAUNCHER=1
 set "_dependency_profile=bun-production"
+set "_bun_install_args=--frozen-lockfile --production --no-progress --no-summary"
+set "_bun_fallback_args=--production --no-progress --no-summary"
 if exist node_modules\eslint\package.json set "_dependency_profile=bun-development"
+if "!_dependency_profile!"=="bun-development" (
+    set "_bun_install_args=--frozen-lockfile --no-progress --no-summary"
+    set "_bun_fallback_args=--no-progress --no-summary"
+)
 bun scripts\dependency-state.js check !_dependency_profile! > nul 2>&1
 if !errorlevel! neq 0 (
     if "!_dependency_profile!"=="bun-development" (
         echo Installing Bun packages including development tooling...
-        call bun install --frozen-lockfile --no-progress --no-summary
     ) else (
         echo Installing Bun packages...
-        call bun install --frozen-lockfile --production --no-progress --no-summary
+    )
+    set "_restore_bun_lock=0"
+    if exist .git if exist bun.lock (
+        git ls-files --error-unmatch bun.lock > nul 2>&1
+        if !errorlevel! equ 0 (
+            git diff --quiet -- bun.lock > nul 2>&1
+            if !errorlevel! equ 0 set "_restore_bun_lock=1"
+        )
+    )
+    call bun install !_bun_install_args!
+    if !errorlevel! neq 0 (
+        echo Bun lockfile check failed; retrying without --frozen-lockfile so bun.lock can refresh.
+        call bun install !_bun_fallback_args!
     )
     if !errorlevel! neq 0 goto end
+    if "!_restore_bun_lock!"=="1" (
+        git diff --quiet -- bun.lock > nul 2>&1
+        if !errorlevel! neq 0 (
+            echo Restoring tracked bun.lock after Bun lockfile refresh...
+            git restore -- bun.lock
+            if !errorlevel! neq 0 goto end
+        )
+    )
     bun scripts\dependency-state.js mark !_dependency_profile!
     if !errorlevel! neq 0 goto end
 ) else (

--- a/UpdateForkAndStart.bat
+++ b/UpdateForkAndStart.bat
@@ -119,17 +119,42 @@ set NODE_ENV=production
 set NODE_NO_WARNINGS=1
 set SILLYBUNNY_LAUNCHER=1
 set "_dependency_profile=bun-production"
+set "_bun_install_args=--frozen-lockfile --production --no-progress --no-summary"
+set "_bun_fallback_args=--production --no-progress --no-summary"
 if exist node_modules\eslint\package.json set "_dependency_profile=bun-development"
+if "!_dependency_profile!"=="bun-development" (
+    set "_bun_install_args=--frozen-lockfile --no-progress --no-summary"
+    set "_bun_fallback_args=--no-progress --no-summary"
+)
 bun scripts\dependency-state.js check !_dependency_profile! > nul 2>&1
 if !errorlevel! neq 0 (
     if "!_dependency_profile!"=="bun-development" (
         echo Installing Bun packages including development tooling...
-        call bun install --frozen-lockfile --no-progress --no-summary
     ) else (
         echo Installing Bun packages...
-        call bun install --frozen-lockfile --production --no-progress --no-summary
+    )
+    set "_restore_bun_lock=0"
+    if exist .git if exist bun.lock (
+        git ls-files --error-unmatch bun.lock > nul 2>&1
+        if !errorlevel! equ 0 (
+            git diff --quiet -- bun.lock > nul 2>&1
+            if !errorlevel! equ 0 set "_restore_bun_lock=1"
+        )
+    )
+    call bun install !_bun_install_args!
+    if !errorlevel! neq 0 (
+        echo Bun lockfile check failed; retrying without --frozen-lockfile so bun.lock can refresh.
+        call bun install !_bun_fallback_args!
     )
     if !errorlevel! neq 0 goto end
+    if "!_restore_bun_lock!"=="1" (
+        git diff --quiet -- bun.lock > nul 2>&1
+        if !errorlevel! neq 0 (
+            echo Restoring tracked bun.lock after Bun lockfile refresh...
+            git restore -- bun.lock
+            if !errorlevel! neq 0 goto end
+        )
+    )
     bun scripts\dependency-state.js mark !_dependency_profile!
     if !errorlevel! neq 0 goto end
 ) else (

--- a/bun.lock
+++ b/bun.lock
@@ -135,7 +135,8 @@
         "eslint": "^8.57.1",
         "eslint-plugin-jest": "^27.9.0",
         "eslint-plugin-jsdoc": "^48.10.0",
-        "eslint-plugin-playwright": "^2.3.0",
+        "eslint-plugin-playwright": "^2.10.2",
+        "terser": "^5.46.2",
         "typescript": "^5.9.3",
       },
     },
@@ -637,7 +638,7 @@
 
     "command-exists": ["command-exists@1.2.9", "", {}, "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="],
 
-    "commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
+    "commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "comment-parser": ["comment-parser@1.4.1", "", {}, "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg=="],
 
@@ -1379,7 +1380,7 @@
 
     "tar-stream": ["tar-stream@3.1.7", "", { "dependencies": { "b4a": "^1.6.4", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ=="],
 
-    "terser": ["terser@5.46.0", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.15.0", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": "bin/terser" }, "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg=="],
+    "terser": ["terser@5.47.1", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.15.0", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": { "terser": "bin/terser" } }, "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw=="],
 
     "terser-webpack-plugin": ["terser-webpack-plugin@5.3.17", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "jest-worker": "^27.4.5", "schema-utils": "^4.3.0", "terser": "^5.31.1" }, "peerDependencies": { "webpack": "^5.1.0" } }, "sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw=="],
 
@@ -1689,11 +1690,13 @@
 
     "send/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "showdown/commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
+
     "simple-git/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
     "socks-proxy-agent/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
-    "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
+    "terser-webpack-plugin/terser": ["terser@5.46.0", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.15.0", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": "bin/terser" }, "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg=="],
 
     "tsutils/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 


### PR DESCRIPTION
## What?
Fixes the Windows update launchers so Bun dependency refreshes no longer stop on a stale frozen lockfile. The PR also refreshes `bun.lock` to match the current dependency graph.

## Why?
After local development leaves dev tooling in `node_modules`, `UpdateAndStart.bat` and `UpdateForkAndStart.bat` select the development dependency profile and run `bun install --frozen-lockfile`. The current `bun.lock` was stale, so the update flow failed with `lockfile had changes, but lockfile is frozen` and paused before launch.

## How?
The two update launchers now mirror the already-hardened `Start.bat` flow: choose frozen install arguments by dependency profile, retry once without `--frozen-lockfile` if Bun reports a lock refresh is needed, and restore tracked `bun.lock` after a runtime-only refresh when the file was clean beforehand. `bun.lock` is also updated so normal frozen installs pass without requiring fallback.

## Testing?
- `bun install --frozen-lockfile --no-progress --no-summary`
- `bun install --frozen-lockfile --production --no-progress --no-summary`
- `git diff --check`

No screenshots needed; this fixes a launcher/dependency install failure.

## Anything Else?
Backward compatibility is preserved: existing launcher entry points, dependency profile detection, update flow, and server restart behavior remain unchanged. The fallback only runs after the frozen install fails.