### PR TITLE
feat: add topbar repository logo

### DIFF
--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -299,6 +299,46 @@ body.sb-topbar-compact #sb-chatbar-layer {
     flex-wrap: wrap;
 }
 
+.sb-topbar-logo-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--sb-proxy-button-height);
+    min-width: var(--sb-proxy-button-height);
+    height: var(--sb-proxy-button-height);
+    min-height: var(--sb-proxy-button-height);
+    flex: 0 0 var(--sb-proxy-button-height);
+    border: 1px solid transparent;
+    border-radius: 999px;
+    color: var(--SmartThemeBodyColor);
+    opacity: 0.9;
+    text-decoration: none;
+    transition: transform 180ms ease, background-color 180ms ease, border-color 180ms ease, opacity 180ms ease;
+}
+
+.sb-topbar-logo-link:hover {
+    opacity: 1;
+    transform: translateY(-1px);
+    background: color-mix(in srgb, var(--sb-button-hover) 74%, transparent);
+}
+
+.sb-topbar-logo-link:focus-visible {
+    outline: none;
+    opacity: 1;
+    border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 42%, var(--sb-shell-border) 58%);
+    box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--sb-focus-ring) 64%, transparent);
+}
+
+.sb-topbar-logo {
+    width: calc(var(--sb-proxy-button-height) * 0.72);
+    height: calc(var(--sb-proxy-button-height) * 0.72);
+    object-fit: contain;
+    image-rendering: pixelated;
+    border: 0;
+    border-radius: 8px;
+    box-shadow: none;
+}
+
 @media screen and (min-width: 769px) {
     #sb-topbar-primary .sb-topbar-group-right {
         align-items: center;
@@ -4340,7 +4380,8 @@ body.sb-shell-resizing * {
     }
 
     #sb-topbar-primary .sb-proxy-button,
-    #sb-topbar-primary .sb-chatbar-button {
+    #sb-topbar-primary .sb-chatbar-button,
+    #sb-topbar-primary .sb-topbar-logo-link {
         width: var(--sb-mobile-toggle-size) !important;
         min-width: var(--sb-mobile-toggle-size) !important;
         max-width: var(--sb-mobile-toggle-size) !important;
@@ -4353,6 +4394,11 @@ body.sb-shell-resizing * {
         box-sizing: border-box !important;
         line-height: 1 !important;
         aspect-ratio: 1 / 1;
+    }
+
+    #sb-topbar-primary .sb-topbar-logo {
+        width: calc(var(--sb-mobile-toggle-size) * 0.62);
+        height: calc(var(--sb-mobile-toggle-size) * 0.62);
     }
 
     #sb-topbar-primary .sb-proxy-button span,
@@ -5700,6 +5746,7 @@ body.sb-shell-resizing * {
 
 @media (prefers-reduced-motion: reduce) {
     .sb-proxy-button,
+    .sb-topbar-logo-link,
     .sb-shell-tab,
     .sb-search-result,
     .sb-theme-option,

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
     </style>
     <link rel="preload" as="style" href="style.css">
     <link rel="modulepreload" href="script.js">
-    <link rel="modulepreload" href="scripts/sillybunny-tabs.js?v=20260507a">
+    <link rel="modulepreload" href="scripts/sillybunny-tabs.js?v=20260509a">
     <link rel="preload" as="font" type="font/woff2" href="webfonts/Figtree/Figtree-Regular.woff2?v=20260422b" crossorigin>
     <link rel="manifest" crossorigin="use-credentials" href="manifest.json">
     <link href="webfonts/Figtree/stylesheet.css?v=20260422b" rel="stylesheet">
@@ -46,7 +46,7 @@
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css">
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260505a" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260507a">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260508a">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260509a">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260506a" media="(max-width: 1000px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
@@ -8703,7 +8703,7 @@
     <script type="module" src="scripts/i18n.js"></script>
     <script type="module" src="scripts/performance-loader.js"></script>
     <script type="module" src="script.js"></script>
-    <script type="module" src="scripts/sillybunny-tabs.js?v=20260507a"></script>
+    <script type="module" src="scripts/sillybunny-tabs.js?v=20260509a"></script>
     <script>
         window.addEventListener('load', (event) => {
             const documentHeight = () => {

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -23,6 +23,7 @@ const SB_STORAGE_KEYS = Object.freeze({
     compactMode: 'sb-compact-mode',
     frontendIcon: 'sb-frontend-icon',
 });
+const SB_GITHUB_REPO_URL = 'https://github.com/platberlitz/SillyBunny';
 
 const SB_SHORTCUT_TARGETS = Object.freeze([
     { value: 'left:presets', label: 'Presets', icon: 'fa-sliders' },
@@ -5701,6 +5702,28 @@ function buildTopBar() {
     const centerGroup = createElement('div', { className: 'sb-topbar-brand' });
     const rightGroup = createElement('div', { className: 'sb-topbar-group sb-topbar-group-right' });
 
+    const repoLink = createElement('a', {
+        id: 'sb-github-logo-link',
+        className: 'sb-topbar-logo-link',
+        attrs: {
+            href: SB_GITHUB_REPO_URL,
+            target: '_blank',
+            rel: 'noopener noreferrer',
+            title: 'Open the SillyBunny GitHub repository',
+            'aria-label': 'Open the SillyBunny GitHub repository',
+        },
+    });
+    const repoLogo = createElement('img', {
+        className: 'sb-topbar-logo',
+        attrs: {
+            src: getFrontendIconSrc(sbState.frontendIcon),
+            alt: 'SillyBunny',
+            'data-sb-frontend-icon': 'true',
+        },
+    });
+    repoLink.appendChild(repoLogo);
+    stopProxyPointerPropagation(repoLink);
+
     const mobileButton = createElement('button', {
         id: 'sb-hamburger',
         className: 'sb-proxy-button sb-mobile-toggle',
@@ -5786,7 +5809,7 @@ function buildTopBar() {
         <div id="sb-topbar-title" class="sb-brand-title">${SB_IDLE_BRAND_LABEL}</div>
     `;
 
-    leftGroup.append(mobileButton, leftButton, rightButton, leftShortcut);
+    leftGroup.append(repoLink, mobileButton, leftButton, rightButton, leftShortcut);
     rightGroup.append(rightShortcut, homeButton, charactersButton);
     topBarInner.append(leftGroup, centerGroup, rightGroup);
     primaryRow.appendChild(topBarInner);


### PR DESCRIPTION
## What?
Adds a SillyBunny logo link to the far-left side of the chat top bar. The logo opens the SillyBunny GitHub repository in a new tab and uses the same frontend icon source as the app startup/favicon branding.

## Why?
This gives users a visible, always-available path back to the project repository without adding another text-heavy navigation item or disrupting the existing chat controls.

## How?
The top-bar builder now creates an accessible external repository link before the Workspace controls. The image is marked with `data-sb-frontend-icon`, so it follows the existing SillyBunny frontend icon preference. The CSS gives it the same compact button sizing, focus behavior, mobile sizing, and reduced-motion handling as the rest of the shell controls. The shell asset query strings were bumped so updated JS/CSS are not stuck behind cached assets.

## Testing?
- `npm run lint -- --quiet`
- `git diff --check`
- 4SR local review: no blocking or non-trivial findings found after adding the reduced-motion selector coverage.

Browser UI verification was not run because this session exposes Playwright tools but no Chrome DevTools MCP tool, and the local verification policy requires Playwright and Chrome DevTools MCP together on the shared Chrome instance.

## Screenshots (optional)
Not included because browser UI verification was blocked by the missing Chrome DevTools MCP tool in this session.

## Anything Else?
No dependency, API, or persisted-data changes. Main residual risk is visual crowding on very narrow mobile top bars until a browser pass can confirm the final layout.