### PR TITLE
fix: add Claude disable top k option

### DIFF
--- a/default/content/presets/openai/Pura's Director Preset (SillyBunny).json
+++ b/default/content/presets/openai/Pura's Director Preset (SillyBunny).json
@@ -5,6 +5,7 @@
     "top_p": 0.99,
     "claude_disable_temperature": false,
     "claude_disable_top_p": false,
+    "claude_disable_top_k": false,
     "top_k": 0,
     "top_a": 0,
     "min_p": 0.05,

--- a/public/index.html
+++ b/public/index.html
@@ -752,6 +752,15 @@
                                         </div>
                                     </div>
                                 </div>
+                                <div class="range-block" data-source="claude">
+                                    <label for="claude_disable_top_k" class="checkbox_label widthFreeExpand" title="Omit top_k from Claude requests." data-i18n="[title]Omit top_k from Claude requests.">
+                                        <input id="claude_disable_top_k" type="checkbox" />
+                                        <span data-i18n="Disable top_k">Disable top_k</span>
+                                    </label>
+                                    <div class="toggle-description justifyLeft">
+                                        <span data-i18n="When enabled, Claude requests leave top_k unset instead of sending a numeric value.">When enabled, Claude requests leave top_k unset instead of sending a numeric value.</span>
+                                    </div>
+                                </div>
                                 <div class="range-block" data-source="openai,claude,aimlapi,openrouter,ai21,makersuite,vertexai,mistralai,custom,cohere,perplexity,groq,siliconflow,minimax,electronhub,chutes,nanogpt,deepseek,xai,pollinations,moonshot,fireworks,cometapi,azure_openai,zai,workers_ai">
                                     <div class="range-block-title" data-i18n="Top P">
                                         <span data-i18n="Top P">Top P</span>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -369,6 +369,7 @@ export const settingsToUpdate = {
     top_p: ['#top_p_openai', 'top_p_openai', false, false],
     claude_disable_temperature: ['#claude_disable_temperature', 'claude_disable_temperature', true, false],
     claude_disable_top_p: ['#claude_disable_top_p', 'claude_disable_top_p', true, false],
+    claude_disable_top_k: ['#claude_disable_top_k', 'claude_disable_top_k', true, false],
     top_k: ['#top_k_openai', 'top_k_openai', false, false],
     top_a: ['#top_a_openai', 'top_a_openai', false, false],
     min_p: ['#min_p_openai', 'min_p_openai', false, false],
@@ -503,6 +504,7 @@ const default_settings = {
     claude_model: 'claude-sonnet-4-5',
     claude_disable_temperature: false,
     claude_disable_top_p: false,
+    claude_disable_top_k: false,
     google_model: 'gemini-2.5-pro',
     vertexai_model: 'gemini-2.5-pro',
     ai21_model: 'jamba-large',
@@ -2826,6 +2828,7 @@ function groupOpenAISettingsIntoDrawers() {
                 '#range_block_openai > .range-block:has(#freq_pen_openai)',
                 '#range_block_openai > .range-block:has(#pres_pen_openai)',
                 '#range_block_openai > .range-block:has(#top_k_openai)',
+                '#range_block_openai > .range-block:has(#claude_disable_top_k)',
                 '#range_block_openai > .range-block:has(#top_p_openai)',
                 '#range_block_openai > .range-block:has(#claude_disable_top_p)',
                 '#range_block_openai > .range-block:has(#repetition_penalty_openai)',
@@ -4577,6 +4580,7 @@ export async function createGenerationParameters(settings, model, type, messages
     if (settings.chat_completion_source === chat_completion_sources.CLAUDE) {
         generate_data.claude_disable_temperature = Boolean(settings.claude_disable_temperature);
         generate_data.claude_disable_top_p = Boolean(settings.claude_disable_top_p);
+        generate_data.claude_disable_top_k = Boolean(settings.claude_disable_top_k);
     }
 
     if (settings.chat_completion_source === chat_completion_sources.XAI) {
@@ -5874,6 +5878,8 @@ export class ChatCompletion {
  * @param {ChatCompletionSettings} settings Settings to migrate
  */
 function migrateChatCompletionSettings(settings) {
+    settings.claude_disable_top_k ??= false;
+
     const migrateMap = [
         { oldKey: 'group_nudge_prompt', oldValue: legacy_group_nudge_prompt, newKey: 'group_nudge_prompt', newValue: default_group_nudge_prompt },
         { oldKey: 'names_in_completion', oldValue: true, newKey: 'names_behavior', newValue: character_names_behavior.COMPLETION },
@@ -8591,6 +8597,11 @@ export function initOpenAI() {
 
     $('#claude_disable_top_p').on('input', function () {
         oai_settings.claude_disable_top_p = !!$(this).prop('checked');
+        saveSettingsDebounced();
+    });
+
+    $('#claude_disable_top_k').on('input', function () {
+        oai_settings.claude_disable_top_k = !!$(this).prop('checked');
         saveSettingsDebounced();
     });
 

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -5908,12 +5908,13 @@ const SB_SAMPLING_BACKENDS = Object.freeze([
             '#openai_logit_bias_preset',
             '#temp_openai',
             '#claude_disable_temperature',
-            '#top_p_openai',
-            '#claude_disable_top_p',
             '#repetition_penalty_openai',
             '#freq_pen_openai',
             '#pres_pen_openai',
             '#top_k_openai',
+            '#claude_disable_top_k',
+            '#top_p_openai',
+            '#claude_disable_top_p',
             '#min_p_openai',
             '#top_a_openai',
         ],
@@ -6112,7 +6113,7 @@ function neutralizeChatCompletionSamplers() {
         }
     }
 
-    ['#claude_disable_temperature', '#claude_disable_top_p'].forEach(selector => {
+    ['#claude_disable_temperature', '#claude_disable_top_p', '#claude_disable_top_k'].forEach(selector => {
         const input = document.querySelector(selector);
         if (input instanceof HTMLInputElement) {
             input.checked = false;

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -382,6 +382,10 @@ async function sendClaudeRequest(request, response) {
             delete requestBody.top_p;
         }
 
+        if (request.body.claude_disable_top_k) {
+            delete requestBody.top_k;
+        }
+
         const reasoningEffort = request.body.reasoning_effort;
         const budgetTokens = calculateClaudeBudgetTokens(requestBody.max_tokens, reasoningEffort, requestBody.stream, isAdaptiveModel);
 

--- a/tests/claude-sampling.test.js
+++ b/tests/claude-sampling.test.js
@@ -1,0 +1,87 @@
+import { beforeAll, afterAll, describe, expect, test } from '@jest/globals';
+import express from 'express';
+import { fileURLToPath } from 'node:url';
+
+import { CHAT_COMPLETION_SOURCES } from '../src/constants.js';
+import { setConfigFilePath } from '../src/util.js';
+import { MockServer } from './util/mock-server.js';
+
+setConfigFilePath(fileURLToPath(new URL('../default/config.yaml', import.meta.url)));
+
+describe('Claude sampling controls', () => {
+    /** @type {import('express').Router} */
+    let chatCompletionsRouter;
+    /** @type {MockServer} */
+    let upstream;
+    /** @type {import('http').Server} */
+    let appServer;
+
+    beforeAll(async () => {
+        ({ router: chatCompletionsRouter } = await import('../src/endpoints/backends/chat-completions.js'));
+
+        upstream = new MockServer({ port: 3002, host: '127.0.0.1' });
+        await upstream.start();
+
+        const app = express();
+        app.use(express.json());
+        app.use((req, _res, next) => {
+            req.user = {
+                directories: {
+                    root: '/tmp/sillybunny-test-user',
+                },
+            };
+            next();
+        });
+        app.use('/api/backends/chat-completions', chatCompletionsRouter);
+
+        await new Promise((resolve) => {
+            appServer = app.listen(3011, '127.0.0.1', resolve);
+        });
+    });
+
+    afterAll(async () => {
+        await upstream.stop();
+
+        if (appServer) {
+            await new Promise((resolve, reject) => {
+                appServer.close((err) => err ? reject(err) : resolve());
+            });
+        }
+    });
+
+    test('omits top_k from Claude reverse proxy requests when disabled', async () => {
+        const response = await fetch('http://127.0.0.1:3011/api/backends/chat-completions/generate', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                chat_completion_source: CHAT_COMPLETION_SOURCES.CLAUDE,
+                reverse_proxy: 'http://127.0.0.1:3002/v1',
+                proxy_password: 'test-key',
+                model: 'claude-3-5-sonnet-latest',
+                stream: false,
+                temperature: 1,
+                max_tokens: 32,
+                top_p: 1,
+                top_k: 40,
+                claude_disable_top_k: true,
+                messages: [
+                    { role: 'user', content: 'Hello from Claude.' },
+                ],
+            }),
+        });
+
+        expect(response.status).toBe(200);
+        expect(upstream.requests).toHaveLength(1);
+        expect(upstream.requests[0]).toMatchObject({
+            method: 'POST',
+            url: '/v1/messages',
+        });
+        expect(upstream.requests[0].body).toEqual(expect.not.objectContaining({
+            top_k: expect.anything(),
+        }));
+        expect(upstream.requests[0].body).toMatchObject({
+            temperature: 1,
+            top_p: 1,
+        });
+    });
+});

--- a/tests/util/mock-server.js
+++ b/tests/util/mock-server.js
@@ -8,6 +8,8 @@ export class MockServer {
     port;
     /** @type {import('http').Server} */
     server;
+    /** @type {object[]} */
+    requests = [];
 
     /**
      * Creates an instance of MockServer.
@@ -150,10 +152,26 @@ export class MockServer {
                 try {
                     const body = await readAllChunks(req);
                     const jsonBody = tryParse(body.toString());
+                    this.requests.push({
+                        method: req.method,
+                        url: req.url,
+                        body: jsonBody,
+                        headers: req.headers,
+                    });
                     if (req.method === 'POST' && req.url === '/v1/chat/completions') {
                         const mockResponse = this.handleChatCompletions(jsonBody);
                         res.writeHead(200, { 'Content-Type': 'application/json' });
                         res.end(JSON.stringify(mockResponse));
+                    } else if (req.method === 'POST' && req.url === '/v1/messages') {
+                        res.writeHead(200, { 'Content-Type': 'application/json' });
+                        res.end(JSON.stringify({
+                            content: [
+                                {
+                                    type: 'text',
+                                    text: String(jsonBody?.messages?.at?.(-1)?.content ?? 'No prompt messages.'),
+                                },
+                            ],
+                        }));
                     } else if (req.method === 'GET' && req.url === '/v1/models') {
                         const mockResponse = this.handleModels();
                         res.writeHead(200, { 'Content-Type': 'application/json' });


### PR DESCRIPTION
## What?
Adds a Claude-only `Disable top_k` sampling option alongside the existing `Disable temperature` and `Disable top_p` controls.

## Why?
Some Claude API reverse proxies reject `top_k` even when the value is effectively unset or zero, which can produce Top_K errors for users who are not intentionally using that sampler.

## How?
- Adds the `Disable top_k` checkbox to the Claude sampling UI and SillyBunny Sampling panel ordering.
- Persists and exports/imports `claude_disable_top_k` through chat completion settings and bundled defaults.
- Omits `top_k` from Claude request bodies when the new setting is enabled.
- Extends the mock server and adds a regression test covering Claude reverse proxy payload omission.

## Testing?
- `npm ci --ignore-scripts`
- `npm ci --ignore-scripts --prefix tests`
- `npm run test:unit --prefix tests -- claude-sampling.test.js openai-responses.test.js`
- `npx eslint public/scripts/openai.js public/scripts/sillybunny-tabs.js src/endpoints/backends/chat-completions.js tests/claude-sampling.test.js tests/util/mock-server.js`
- `git diff --check`
- Playwright browser check confirmed the Sampling panel shows `Disable top_k` beside the Top K control. Chrome DevTools MCP verification was blocked locally by: `The browser is already running for C:\Users\TheLonelyDevil\.cache\chrome-devtools-mcp\chrome-profile. Use --isolated to run multiple browser instances.`

## Screenshots (optional)
Not included. The UI change is a single checkbox in the existing Claude sampling controls; the browser check above confirmed placement.

## Anything Else?
This is intentionally scoped to Claude request payload compatibility and keeps the default behavior unchanged unless users opt into omitting `top_k`.