### PR TITLE
fix: polish UI shell and mobile prompt editor

### DIFF
--- a/public/css/animations.css
+++ b/public/css/animations.css
@@ -143,3 +143,24 @@
         transform: translateX(var(--slide-mes-x-end, 0px));
     }
 }
+
+@keyframes sb-list-item-in {
+    from {
+        opacity: 0;
+        transform: translateY(4px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .flash,
+    [class*="flash"],
+    .pulse,
+    [class*="pulse"] {
+        animation: none !important;
+    }
+}

--- a/public/css/backgrounds.css
+++ b/public/css/backgrounds.css
@@ -6,7 +6,7 @@
     position: absolute;
     width: 100%;
     height: 100%;
-    transition: background-image var(--animation-duration-3x) ease-in-out;
+    transition: background-image var(--sb-transition-slow);
     z-index: -1;
 }
 
@@ -284,7 +284,7 @@
     visibility: hidden;
     transform: scale(0.9);
     transform-origin: center;
-    transition: opacity var(--animation-duration) ease-out, visibility var(--animation-duration) ease-out, transform var(--animation-duration) ease-out;
+    transition: opacity var(--sb-transition), visibility var(--sb-transition), transform var(--sb-transition);
 }
 
 .bg_example:hover .jg-menu,
@@ -304,7 +304,7 @@
     padding: 5px;
     font-size: 1.1em;
     border-radius: 5px;
-    transition: background-color var(--animation-duration) ease;
+    transition: background-color var(--sb-transition);
 }
 
 .bg_example .jg-button:hover {
@@ -323,13 +323,13 @@
     border: 1px solid var(--SmartThemeBorderColor);
     border-radius: 50%;
     cursor: pointer;
-    z-index: 10;
+    z-index: var(--sb-z-raised);
     font-size: 18px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     opacity: 0;
-    transition: opacity var(--animation-duration) ease;
+    transition: opacity var(--sb-transition);
     pointer-events: none;
 }
 
@@ -386,7 +386,7 @@
     -webkit-line-clamp: 2;
     line-clamp: 2;
     opacity: 0;
-    transition: opacity var(--animation-duration) ease-in-out;
+    transition: opacity var(--sb-transition);
     pointer-events: none;
     border-radius: 0 0 8px 8px;
 }
@@ -500,7 +500,7 @@
     align-items: center;
     justify-content: center;
     background-color: var(--SmartThemeBlurTintColor);
-    transition: filter var(--animation-duration) ease;
+    transition: filter var(--sb-transition);
 }
 
 .bg_folder_tile:hover {
@@ -568,7 +568,7 @@
     visibility: hidden;
     transform: scale(0.9);
     transform-origin: center;
-    transition: opacity var(--animation-duration) ease-out, visibility var(--animation-duration) ease-out, transform var(--animation-duration) ease-out;
+    transition: opacity var(--sb-transition), visibility var(--sb-transition), transform var(--sb-transition);
 }
 
 .bg_folder_tile:hover .bg_folder_tile_menu,
@@ -588,7 +588,7 @@
     padding: 5px;
     font-size: 1.1em;
     border-radius: 5px;
-    transition: background-color var(--animation-duration) ease;
+    transition: background-color var(--sb-transition);
 }
 
 .bg_folder_tile .jg-button:hover {

--- a/public/css/character-group-overlay.css
+++ b/public/css/character-group-overlay.css
@@ -1,5 +1,5 @@
 #rm_print_characters_block.group_overlay_mode_select .character_select {
-    transition: background-color var(--animation-duration-3x) ease;
+    transition: background-color var(--sb-transition-slow);
     background-color: rgba(170, 170, 170, 0.15);
 }
 
@@ -34,7 +34,7 @@
 #character_context_menu {
     position: absolute;
     padding: 3px;
-    z-index: 9998;
+    z-index: var(--sb-z-context-menu);
     background-color: var(--black90a);
     border: 1px solid var(--black90a);
     border-radius: 10px;
@@ -92,7 +92,7 @@
     width: 100%;
     height: 100vh;
     height: 100dvh;
-    z-index: 9998;
+    z-index: var(--sb-z-context-menu);
     top: 0;
 }
 

--- a/public/css/chat-backups.css
+++ b/public/css/chat-backups.css
@@ -2,7 +2,7 @@
     display: flex;
     flex-direction: column;
     gap: 5px;
-    transition: height var(--animation-duration) ease;
+    transition: height var(--sb-transition);
     max-height: min(25dvh, 250px);
     overflow-y: auto;
     border-radius: 10px;

--- a/public/css/loader.css
+++ b/public/css/loader.css
@@ -4,7 +4,7 @@
     padding: 0;
     top: 0;
     left: 0;
-    z-index: 999999;
+    z-index: var(--sb-z-loader);
     width: 100vw;
     height: 100vh;
     width: 100dvw;
@@ -18,7 +18,7 @@
 
 #load-spinner {
     --spinner-size: 2em;
-    transition: all var(--animation-duration-2x) ease-out;
+    transition: all var(--sb-transition-slow);
     opacity: 1;
     top: calc(50% - var(--spinner-size) / 2);
     left: calc(50% - var(--spinner-size) / 2);
@@ -46,7 +46,7 @@
     cursor: pointer;
     font-size: 1.2em;
     opacity: 0.8;
-    transition: opacity 0.15s ease, color 0.15s ease;
+    transition: opacity var(--sb-transition-fast), color var(--sb-transition-fast);
 }
 
 .action-loader-stop:hover {
@@ -63,7 +63,7 @@
     gap: 4rem;
     width: 100%;
     height: 100%;
-    transition: all var(--animation-duration-2x) ease-out;
+    transition: all var(--sb-transition-slow);
 }
 
 #loader.splash-screen #load-spinner {

--- a/public/css/login.css
+++ b/public/css/login.css
@@ -24,7 +24,7 @@ body.login .userSelect {
     width: 30%;
     cursor: pointer;
     margin: 5px 0;
-    transition: background-color var(--animation-duration) ease-in-out;
+    transition: background-color var(--sb-transition);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/public/css/logprobs.css
+++ b/public/css/logprobs.css
@@ -11,7 +11,7 @@
     display: none;
     flex-direction: column;
     box-shadow: 0 0 10px var(--black70a);
-    z-index: 3000;
+    z-index: var(--sb-z-modal);
     left: 0;
     top: 0;
     margin: 0;

--- a/public/css/macros.css
+++ b/public/css/macros.css
@@ -471,9 +471,9 @@
     align-items: baseline;
     gap: 0.5em;
     padding: 0.5em 0.75em;
-    background: linear-gradient(90deg, rgba(248, 148, 6, 0.2), transparent);
-    border-left: 3px solid #F89406;
-    border-radius: 0 4px 4px 0;
+    background: color-mix(in srgb, #F89406 8%, transparent);
+    border: 1px solid color-mix(in srgb, #F89406 40%, var(--SmartThemeBorderColor));
+    border-radius: 4px;
     margin-bottom: 0.5em;
     font-size: 0.9em;
     color: #F89406;
@@ -489,9 +489,9 @@
     align-items: baseline;
     gap: 0.5em;
     padding: 0.5em 0.75em;
-    background: linear-gradient(90deg, rgba(91, 192, 222, 0.2), transparent);
-    border-left: 3px solid #5BC0DE;
-    border-radius: 0 4px 4px 0;
+    background: color-mix(in srgb, #5BC0DE 8%, transparent);
+    border: 1px solid color-mix(in srgb, #5BC0DE 40%, var(--SmartThemeBorderColor));
+    border-radius: 4px;
     margin-bottom: 0.5em;
     font-size: 0.9em;
     color: #5BC0DE;
@@ -554,9 +554,9 @@
     align-items: baseline;
     gap: 0.5em;
     padding: 0.5em 0.75em;
-    background: linear-gradient(90deg, var(--ac-color-selectedBackground, var(--SmartThemeQuoteColor)), transparent);
-    border-left: 3px solid var(--ac-color-matchedText, var(--SmartThemeBorderColor));
-    border-radius: 0 4px 4px 0;
+    background: color-mix(in srgb, var(--ac-color-matchedText, var(--SmartThemeBorderColor)) 8%, transparent);
+    border: 1px solid color-mix(in srgb, var(--ac-color-matchedText, var(--SmartThemeBorderColor)) 50%, var(--SmartThemeBorderColor));
+    border-radius: 4px;
     margin-bottom: 0.5em;
     font-size: 0.9em;
 }

--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -773,7 +773,7 @@
         position: absolute;
         padding: 0;
         filter: drop-shadow(2px 2px 2px #51515199);
-        z-index: 30;
+        z-index: var(--sb-z-raised);
         overflow: hidden;
         right: 0;
         width: fit-content;
@@ -1193,7 +1193,7 @@
         left: 0;
         right: 0;
         filter: drop-shadow(2px 2px 2px #51515199);
-        z-index: 1 !important;
+        z-index: var(--sb-z-raised) !important;
     }
 
     body.waifuMode img.expression {
@@ -1266,7 +1266,7 @@
         position: absolute;
         padding: 0;
         filter: drop-shadow(2px 2px 2px #51515199);
-        z-index: 30;
+        z-index: var(--sb-z-raised);
         overflow: hidden;
         display: none;
         right: 0;
@@ -1384,14 +1384,14 @@
     /* Fix closing artifact - ensure smooth transition */
     .sb-shell-root.fillLeft:not(.openDrawer),
     .sb-shell-root.fillRight:not(.openDrawer) {
-        transition: opacity 180ms ease, visibility 0s 180ms;
+        transition: opacity var(--sb-transition-fast), visibility 0s 180ms;
         opacity: 0;
         visibility: hidden;
     }
 
     .sb-shell-root.fillLeft.openDrawer,
     .sb-shell-root.fillRight.openDrawer {
-        transition: opacity 180ms ease;
+        transition: opacity var(--sb-transition-fast);
         opacity: 1;
         visibility: visible;
     }
@@ -1435,7 +1435,7 @@
         max-width: 100dvw !important;
         height: calc(100dvh - var(--topBarBlockSize)) !important;
         max-height: calc(100dvh - var(--topBarBlockSize)) !important;
-        z-index: 9000 !important;
+        z-index: var(--sb-z-loader) !important;
         overflow-y: auto !important;
         border-radius: 0 !important;
         backdrop-filter: blur(20px);
@@ -1443,7 +1443,7 @@
     }
 
     #character_popup {
-        z-index: 9100 !important;
+        z-index: var(--sb-z-loader) !important;
     }
 
     /*
@@ -1497,7 +1497,7 @@
     }
 
     .select2-dropdown {
-        z-index: 9999 !important;
+        z-index: var(--sb-z-critical) !important;
     }
 
     .select2-container--open .select2-dropdown {

--- a/public/css/popup.css
+++ b/public/css/popup.css
@@ -32,16 +32,16 @@ dialog {
     -webkit-font-smoothing: subpixel-antialiased;
 
     /* Variables setup */
-    --popup-animation-speed: 200ms;
+    --popup-animation-speed: var(--sb-transition);
 }
 
 /** Popup styles applied to the main popup */
 .popup--animation-fast {
-    --popup-animation-speed: var(--animation-duration);
+    --popup-animation-speed: var(--sb-transition-fast);
 }
 
 .popup--animation-slow {
-    --popup-animation-speed: var(--animation-duration-slow);
+    --popup-animation-speed: var(--sb-transition-slow);
 }
 
 .popup--animation-none {
@@ -94,11 +94,11 @@ dialog {
 
 /* Opening animation */
 .popup[opening] {
-    animation: pop-in var(--popup-animation-speed) ease-in-out;
+    animation: pop-in var(--popup-animation-speed) var(--sb-ease-out);
 }
 
 .popup[opening]::backdrop {
-    animation: fade-in var(--popup-animation-speed) ease-in-out;
+    animation: fade-in var(--popup-animation-speed) var(--sb-ease-out);
 }
 
 /* Fix toast container snapping into the backdrop while the animation is running */
@@ -124,11 +124,11 @@ body.no-blur .popup[open]::backdrop {
 
 /* Closing animation */
 .popup[closing] {
-    animation: pop-out var(--popup-animation-speed) ease-in-out;
+    animation: pop-out var(--popup-animation-speed) var(--sb-ease-out);
 }
 
 .popup[closing]::backdrop {
-    animation: fade-out var(--popup-animation-speed) ease-in-out;
+    animation: fade-out var(--popup-animation-speed) var(--sb-ease-out);
 }
 
 /* Edge inset to match Toastr default spacing */
@@ -226,10 +226,19 @@ body.no-blur .popup[open]::backdrop {
     font-size: 20px;
     padding: 2px 3px 3px 2px;
     opacity: 0.7;
-    transition: opacity 200ms ease;
+    transition: opacity var(--sb-transition);
     backface-visibility: hidden;
 }
 
 .popup .popup-button-close:hover {
     opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .popup[opening],
+    .popup[opening]::backdrop,
+    .popup[closing],
+    .popup[closing]::backdrop {
+        animation-duration: 0.01ms !important;
+    }
 }

--- a/public/css/promptmanager.css
+++ b/public/css/promptmanager.css
@@ -108,9 +108,9 @@
     border: 1px solid var(--SmartThemeBorderColor);
     border-radius: 14px;
     transition:
-        border-color var(--animation-duration-2x) ease,
-        background-color var(--animation-duration-2x) ease,
-        transform var(--animation-duration-2x) ease;
+        border-color var(--sb-transition-slow),
+        background-color var(--sb-transition-slow),
+        transform var(--sb-transition-slow);
 }
 
 #completion_prompt_manager #completion_prompt_manager_list li.completion_prompt_manager_prompt .prompt_manager_prompt_controls {
@@ -137,20 +137,30 @@
     pointer-events: none;
 }
 
-#completion_prompt_manager #completion_prompt_manager_list li.completion_prompt_manager_prompt span span span {
+#completion_prompt_manager #completion_prompt_manager_list li.completion_prompt_manager_prompt .prompt_manager_prompt_controls > :is(
+    .prompt-manager-send-to-agents-action,
+    .prompt-manager-detach-action,
+    .prompt-manager-edit-action,
+    .prompt-manager-toggle-action
+) {
     align-items: center;
     flex-direction: row;
     justify-content: center;
     margin-left: 0;
     cursor: pointer;
-    transition: background-color var(--animation-duration-2x) ease-in-out, color var(--animation-duration-2x) ease-in-out, opacity var(--animation-duration-2x) ease-in-out;
+    transition: background-color var(--sb-transition-slow), color var(--sb-transition-slow), opacity var(--sb-transition-slow);
     height: 28px;
     width: 28px;
     filter: drop-shadow(0px 0px 2px black);
     opacity: 0.58;
 }
 
-#completion_prompt_manager #completion_prompt_manager_list li.completion_prompt_manager_prompt span span:hover {
+#completion_prompt_manager #completion_prompt_manager_list li.completion_prompt_manager_prompt .prompt_manager_prompt_controls > :is(
+    .prompt-manager-send-to-agents-action,
+    .prompt-manager-detach-action,
+    .prompt-manager-edit-action,
+    .prompt-manager-toggle-action
+):hover {
     opacity: 1;
     background: color-mix(in srgb, var(--SmartThemeBodyColor) 8%, transparent);
 }
@@ -390,7 +400,7 @@
     margin-left: 0.25em;
     font-weight: 600;
     color: var(--SmartThemeBodyColor);
-    transition: var(--animation-duration-2x) ease-in-out;
+    transition: color var(--sb-transition-slow);
     filter: drop-shadow(0px 0px 2px black);
 }
 
@@ -487,7 +497,7 @@
     padding: 1em;
     border: 1px solid var(--SmartThemeBorderColor);
     flex-direction: column;
-    z-index: 9000 !important;
+    z-index: var(--sb-z-loader) !important;
     border-radius: 0;
     backdrop-filter: blur(20px);
     background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 94%, black 6%);

--- a/public/css/rm-groups.css
+++ b/public/css/rm-groups.css
@@ -171,7 +171,7 @@
 #rm_group_members .group_member:not(.disabled) .right_menu_button[data-action="disable"] {
     opacity: 0.4;
     filter: brightness(0.5);
-    transition: all var(--animation-duration-2x) ease-in-out;
+    transition: all var(--sb-transition-slow);
 }
 
 /* #rm_group_members .right_menu_button[data-action="speak"]:hover, */

--- a/public/css/select2-overrides.css
+++ b/public/css/select2-overrides.css
@@ -12,7 +12,7 @@
     text-shadow: 0px 0px calc(var(--shadowWidth) * 1px) var(--SmartThemeShadowColor);
     backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)*2));
     color: var(--SmartThemeBodyColor);
-    z-index: 40000;
+    z-index: var(--sb-z-critical);
     user-select: none;
     pointer-events: auto;
 }
@@ -136,7 +136,7 @@
     background-color: unset;
     color: var(--SmartThemeBodyColor);
     opacity: 0.5;
-    transition: opacity var(--animation-duration-2x) ease-in-out;
+    transition: opacity var(--sb-transition-slow);
     position: relative;
 }
 

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -199,7 +199,7 @@
     top: 0 !important;
     left: 0;
     right: 0;
-    z-index: 4100;
+    z-index: var(--sb-z-shell);
     pointer-events: none;
     display: flex;
     align-items: flex-start;
@@ -258,7 +258,7 @@ body.sb-topbar-compact #sb-chatbar-layer {
     position: relative;
     width: 100%;
     transform: translate(var(--sb-topbar-offset-x, 0px), var(--sb-topbar-offset-y, 0px));
-    transition: transform 180ms ease;
+    transition: transform var(--sb-transition-fast);
     contain: layout style;
 }
 
@@ -363,15 +363,15 @@ body.sb-topbar-compact #sb-chatbar-layer {
     justify-content: center;
     width: 100%;
     min-height: var(--sb-topbar-search-row-height);
-    z-index: 12;
+    z-index: var(--sb-z-raised);
     opacity: 0;
     visibility: hidden;
     pointer-events: none;
     transform: translateY(calc(var(--sb-topbar-stack-gap) * -0.5)) scale(0.985);
     transform-origin: top center;
     transition:
-        opacity 150ms ease,
-        transform 180ms ease,
+        opacity var(--sb-transition-fast),
+        transform var(--sb-transition-fast),
         visibility 0s linear 180ms;
 }
 
@@ -381,8 +381,8 @@ body.sb-topbar-compact #sb-chatbar-layer {
     pointer-events: auto;
     transform: translateY(0) scale(1);
     transition:
-        opacity 150ms ease,
-        transform 180ms ease,
+        opacity var(--sb-transition-fast),
+        transform var(--sb-transition-fast),
         visibility 0s linear 0s;
 }
 
@@ -460,7 +460,7 @@ body.sb-topbar-compact #sb-chatbar-layer {
     top: calc(100% + var(--sb-topbar-search-panel-gap));
     left: 0;
     right: 0;
-    z-index: 6;
+    z-index: var(--sb-z-raised);
 }
 
 .sb-universal-search:not(.is-open) .sb-universal-search-panel {
@@ -547,7 +547,7 @@ body.sb-topbar-compact #sb-chatbar-layer {
     min-height: 0 !important;
     line-height: 1;
     box-sizing: border-box;
-    transition: transform 160ms ease, border-color 160ms ease, background-color 160ms ease, opacity 160ms ease;
+    transition: transform var(--sb-transition-fast), border-color var(--sb-transition-fast), background-color var(--sb-transition-fast), opacity var(--sb-transition-fast);
 }
 
 .sb-chatbar-button::before,
@@ -699,8 +699,8 @@ body.sb-topbar-compact #sb-chatbar-layer {
     opacity: 0;
     visibility: hidden;
     pointer-events: none;
-    z-index: 6;
-    transition: opacity 180ms ease, transform 180ms ease, visibility 180ms ease;
+    z-index: var(--sb-z-raised);
+    transition: opacity var(--sb-transition-fast), transform var(--sb-transition-fast), visibility var(--sb-transition-fast);
 }
 
 #sb-connection-strip::before {
@@ -749,7 +749,7 @@ body.sb-topbar-compact #sb-chatbar-layer {
     font: inherit;
     white-space: nowrap;
     cursor: pointer;
-    transition: transform 160ms ease, border-color 160ms ease, opacity 160ms ease;
+    transition: transform var(--sb-transition-fast), border-color var(--sb-transition-fast), opacity var(--sb-transition-fast);
 }
 
 .sb-connection-strip-connect::before {
@@ -828,7 +828,7 @@ body:not(.movingUI) .drawer-content.maximized {
     width: min(360px, calc(100vw - 32px));
     height: min(70vh, calc(100dvh - var(--sb-topbar-layout-offset) - 24px));
     max-height: calc(100dvh - var(--sb-topbar-layout-offset) - 24px);
-    z-index: 3805;
+    z-index: var(--sb-z-shell-sidebar);
     flex-direction: column;
 }
 
@@ -873,7 +873,7 @@ body:not(.movingUI) .drawer-content.maximized {
     gap: 6px;
     padding: 12px;
     cursor: pointer;
-    transition: transform 160ms ease, border-color 160ms ease, background-color 160ms ease;
+    transition: transform var(--sb-transition-fast), border-color var(--sb-transition-fast), background-color var(--sb-transition-fast);
 }
 
 .sb-chat-file:hover {
@@ -1067,20 +1067,20 @@ body:not(.movingUI) .drawer-content.maximized {
     color: var(--SmartThemeBodyColor);
     background: transparent;
     cursor: pointer;
-    transition: transform 180ms ease, background-color 180ms ease, border-color 180ms ease, opacity 180ms ease;
+    transition: transform var(--sb-transition-fast), background-color var(--sb-transition-fast), border-color var(--sb-transition-fast), opacity var(--sb-transition-fast);
     opacity: 0.82;
 }
 
 .sb-proxy-button i {
     font-size: var(--sb-proxy-icon-size);
-    transition: transform 180ms ease, color 180ms ease;
+    transition: transform var(--sb-transition-fast), color var(--sb-transition-fast);
 }
 
 .sb-proxy-button span {
     font-size: var(--sb-proxy-label-size);
     font-weight: var(--sb-weight-control);
     white-space: nowrap;
-    transition: transform 180ms ease, opacity 180ms ease;
+    transition: transform var(--sb-transition-fast), opacity var(--sb-transition-fast);
 }
 
 .sb-proxy-button::after {
@@ -1094,7 +1094,7 @@ body:not(.movingUI) .drawer-content.maximized {
     background: linear-gradient(90deg, color-mix(in srgb, var(--color-primary, var(--sb-accent)) 86%, transparent), color-mix(in srgb, var(--color-accent, var(--sb-accent-soft)) 86%, transparent));
     transform: scaleX(0);
     transform-origin: center;
-    transition: transform 180ms ease;
+    transition: transform var(--sb-transition-fast);
 }
 
 .sb-proxy-button:hover {
@@ -1184,7 +1184,7 @@ body:not(.movingUI) .drawer-content.maximized {
     left: 0;
     right: 0;
     pointer-events: none;
-    z-index: 4005;
+    z-index: var(--sb-z-shell-panel);
 }
 
 #top-settings-holder .drawer-content,
@@ -1196,7 +1196,7 @@ body:not(.movingUI) .drawer-content.maximized {
 
 #left-nav-panel select {
     position: relative;
-    z-index: 1;
+    z-index: var(--sb-z-raised);
     touch-action: auto;
 }
 
@@ -1270,7 +1270,7 @@ body:not(.movingUI) .drawer-content.maximized {
     width: 0 !important;
     height: 0 !important;
     overflow: hidden !important;
-    transition: opacity 180ms ease, visibility 0s 180ms, width 0s 180ms, height 0s 180ms, overflow 0s 180ms;
+    transition: opacity var(--sb-transition-fast), visibility 0s 180ms, width 0s 180ms, height 0s 180ms, overflow 0s 180ms;
 }
 
 .sb-shell-root.fillLeft.openDrawer,
@@ -1278,7 +1278,7 @@ body:not(.movingUI) .drawer-content.maximized {
 #right-nav-panel.openDrawer {
     opacity: 1;
     visibility: visible;
-    transition: opacity 180ms ease;
+    transition: opacity var(--sb-transition-fast);
 }
 
 #left-nav-panel.openDrawer,
@@ -1303,7 +1303,7 @@ body:not(.movingUI) .drawer-content.maximized {
 
 .sb-shell-root.fillLeft.openDrawer,
 .sb-shell-root.fillRight.openDrawer {
-    animation: sbShellReveal 240ms ease;
+    animation: sbShellReveal 240ms var(--sb-ease-out);
     transform-origin: center;
 }
 
@@ -1316,7 +1316,7 @@ body:not(.movingUI) .drawer-content.maximized {
     right: 0 !important;
     margin-left: auto !important;
     margin-right: auto !important;
-    animation: sbShellReveal 240ms ease;
+    animation: sbShellReveal 240ms var(--sb-ease-out);
     transform-origin: center;
 }
 
@@ -1338,21 +1338,21 @@ body.movingUI #right-nav-panel.openDrawer > .sb-shell-resize-handle {
 }
 
 .sb-shell-root.openDrawer .sb-shell-nav-wrapper {
-    animation: sbShellContentReveal 280ms ease both;
+    animation: sbShellContentReveal 280ms var(--sb-ease-out) both;
 }
 
 .sb-shell-root.openDrawer .sb-shell-main {
-    animation: sbShellContentReveal 320ms ease both;
+    animation: sbShellContentReveal 320ms var(--sb-ease-out) both;
 }
 
 #right-nav-panel.openDrawer > #CharListButtonAndHotSwaps,
 #right-nav-panel.openDrawer > #rm_PinAndTabs {
-    animation: sbShellContentReveal 280ms ease both;
+    animation: sbShellContentReveal 280ms var(--sb-ease-out) both;
 }
 
 #right-nav-panel.openDrawer > .scrollableInner,
 #right-nav-panel.openDrawer > .scrollableInnerFull {
-    animation: sbShellContentReveal 320ms ease both;
+    animation: sbShellContentReveal 320ms var(--sb-ease-out) both;
 }
 
 .sb-shell-frame {
@@ -1370,7 +1370,7 @@ body.movingUI #right-nav-panel.openDrawer > .sb-shell-resize-handle {
     position: absolute;
     right: 10px;
     bottom: 10px;
-    z-index: 3;
+    z-index: var(--sb-z-raised);
     display: none;
     width: 28px;
     height: 28px;
@@ -1431,7 +1431,7 @@ body.sb-shell-resizing * {
 .sb-shell-nav-scroll {
     position: absolute;
     top: 50%;
-    z-index: 3;
+    z-index: var(--sb-z-raised);
     width: 34px;
     height: 34px;
     display: none;
@@ -1445,7 +1445,7 @@ body.sb-shell-resizing * {
     opacity: 0;
     pointer-events: none;
     transform: translateY(-50%);
-    transition: opacity 180ms ease, transform 180ms ease, background-color 180ms ease;
+    transition: opacity var(--sb-transition-fast), transform var(--sb-transition-fast), background-color var(--sb-transition-fast);
     touch-action: manipulation;
 }
 
@@ -1495,7 +1495,7 @@ body.sb-shell-resizing * {
     pointer-events: none;
     z-index: 2;
     opacity: 0;
-    transition: opacity 200ms ease;
+    transition: opacity var(--sb-transition);
 }
 
 .sb-shell-nav-wrapper::before {
@@ -1589,7 +1589,7 @@ body.sb-shell-resizing * {
     flex-shrink: 1;
     min-width: 0;
     overflow: hidden;
-    transition: transform 180ms ease, background-color 180ms ease, border-color 180ms ease;
+    transition: transform var(--sb-transition-fast), background-color var(--sb-transition-fast), border-color var(--sb-transition-fast);
 }
 
 .sb-shell-tab:hover {
@@ -1708,7 +1708,7 @@ body.sb-shell-resizing * {
     justify-content: center;
     cursor: pointer;
     overflow: hidden;
-    transition: transform var(--sb-transition-fast, 180ms ease), background-color var(--sb-transition-fast, 180ms ease), border-color var(--sb-transition-fast, 180ms ease);
+    transition: transform var(--sb-transition-fast), background-color var(--sb-transition-fast), border-color var(--sb-transition-fast);
 }
 
 .sb-shell-close::before {
@@ -2057,7 +2057,7 @@ body.sb-shell-resizing * {
     font: inherit;
     text-align: left;
     cursor: pointer;
-    transition: transform 160ms ease, border-color 160ms ease, background-color 160ms ease;
+    transition: transform var(--sb-transition-fast), border-color var(--sb-transition-fast), background-color var(--sb-transition-fast);
 }
 
 .sb-search-result:hover,
@@ -2304,19 +2304,19 @@ body.sb-shell-resizing * {
 
 .sb-server-pill[data-tone='good'],
 .sb-server-inline-state[data-state='saved'] {
-    color: color-mix(in srgb, var(--color-success, #22c55e) 88%, white);
-    background: color-mix(in srgb, var(--color-success, #22c55e) 18%, transparent);
+    color: color-mix(in srgb, var(--color-success, var(--sb-color-success)) 88%, white);
+    background: color-mix(in srgb, var(--color-success, var(--sb-color-success)) 18%, transparent);
 }
 
 .sb-server-pill[data-tone='warn'] {
-    color: color-mix(in srgb, var(--color-warning, #f59e0b) 92%, white);
-    background: color-mix(in srgb, var(--color-warning, #f59e0b) 20%, transparent);
+    color: color-mix(in srgb, var(--color-warning, var(--sb-color-warning)) 92%, white);
+    background: color-mix(in srgb, var(--color-warning, var(--sb-color-warning)) 20%, transparent);
 }
 
 .sb-server-pill[data-tone='danger'],
 .sb-server-inline-state[data-state='dirty'] {
-    color: color-mix(in srgb, var(--warning, #ef4444) 92%, white);
-    background: color-mix(in srgb, var(--warning, #ef4444) 16%, transparent);
+    color: color-mix(in srgb, var(--color-danger, var(--sb-color-danger)) 92%, white);
+    background: color-mix(in srgb, var(--color-danger, var(--sb-color-danger)) 16%, transparent);
 }
 
 .sb-server-note {
@@ -2331,15 +2331,15 @@ body.sb-shell-resizing * {
 }
 
 .sb-server-note[data-tone='good'] {
-    border-color: color-mix(in srgb, var(--color-success, #22c55e) 32%, transparent);
+    border-color: color-mix(in srgb, var(--color-success, var(--sb-color-success)) 32%, transparent);
 }
 
 .sb-server-note[data-tone='warn'] {
-    border-color: color-mix(in srgb, var(--color-warning, #f59e0b) 32%, transparent);
+    border-color: color-mix(in srgb, var(--color-warning, var(--sb-color-warning)) 32%, transparent);
 }
 
 .sb-server-note[data-tone='danger'] {
-    border-color: color-mix(in srgb, var(--warning, #ef4444) 32%, transparent);
+    border-color: color-mix(in srgb, var(--color-danger, var(--sb-color-danger)) 32%, transparent);
 }
 
 .sb-server-actions {
@@ -2949,7 +2949,7 @@ body.sb-shell-resizing * {
     color: var(--SmartThemeBodyColor);
     font: inherit;
     cursor: pointer;
-    transition: transform 160ms ease, border-color 160ms ease, background-color 160ms ease;
+    transition: transform var(--sb-transition-fast), border-color var(--sb-transition-fast), background-color var(--sb-transition-fast);
 }
 
 :root[data-sb-compact-mode='true'] .sb-theme-option {
@@ -3090,7 +3090,7 @@ body.sb-shell-resizing * {
     color: var(--SmartThemeBodyColor);
     cursor: pointer;
     box-sizing: border-box;
-    transition: transform 160ms ease, border-color 160ms ease, background-color 160ms ease;
+    transition: transform var(--sb-transition-fast), border-color var(--sb-transition-fast), background-color var(--sb-transition-fast);
 }
 
 .sb-compact-mode-option::before {
@@ -3331,7 +3331,7 @@ body.sb-shell-resizing * {
     box-sizing: border-box;
     border-radius: calc(8px * var(--sb-bottom-bar-scale));
     font-size: calc(var(--mainFontSize) * 0.9 * var(--sb-bottom-bar-scale));
-    transition: opacity 180ms ease, background-color 180ms ease;
+    transition: opacity var(--sb-transition-fast), background-color var(--sb-transition-fast);
 }
 
 .sb-bottom-chat-btn:hover {
@@ -3535,7 +3535,7 @@ body.sb-shell-resizing * {
     --sb-chat-delete-vv-height: 100dvh;
     position: fixed;
     inset: 0;
-    z-index: 12000;
+    z-index: var(--sb-z-loader);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -3724,7 +3724,7 @@ body.sb-shell-resizing * {
     background-color: color-mix(in srgb, var(--SmartThemeBodyColor) 4%, var(--sb-composer-surface-base, var(--SmartThemeBlurTintColor)));
     cursor: pointer;
     flex-shrink: 0;
-    transition: border-color 180ms ease, transform 180ms ease;
+    transition: border-color var(--sb-transition-fast), transform var(--sb-transition-fast);
 }
 
 #sb-persona-bubble:hover {
@@ -3766,10 +3766,10 @@ body.sb-shell-resizing * {
     border: 1px solid var(--SmartThemeBorderColor);
     border-radius: 12px;
     padding: 6px;
-    z-index: 3010;
+    z-index: var(--sb-z-modal-content);
     backdrop-filter: blur(20px);
     box-shadow: 0 8px 24px color-mix(in srgb, var(--SmartThemeShadowColor) 30%, transparent);
-    animation: sbShellContentReveal 200ms ease;
+    animation: sbShellContentReveal 200ms var(--sb-ease-out);
 }
 
 .sb-persona-option {
@@ -3784,7 +3784,7 @@ body.sb-shell-resizing * {
     border-radius: 8px;
     cursor: pointer;
     text-align: left;
-    transition: background-color 150ms ease;
+    transition: background-color var(--sb-transition-fast);
     font-size: calc(var(--mainFontSize) * 0.85);
     color: var(--SmartThemeBodyColor);
     min-height: 44px;
@@ -3843,7 +3843,7 @@ body.sb-shell-resizing * {
 }
 
 .char-button-group-primary .menu_button[data-label]::after {
-    font-family: 'Public Sans', sans-serif;
+    font-family: var(--mainFontFamily);
 }
 
 .char-button-group-primary .menu_button[data-label] {
@@ -3896,7 +3896,7 @@ body.sb-shell-resizing * {
     background: transparent;
     color: var(--SmartThemeBodyColor);
     cursor: pointer;
-    transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
+    transition: transform var(--sb-transition-fast), border-color var(--sb-transition-fast), box-shadow var(--sb-transition-fast), background-color var(--sb-transition-fast);
 }
 
 :root[data-sb-compact-mode='true'] .sb-topbar-label-option {
@@ -3992,7 +3992,7 @@ body.sb-shell-resizing * {
 }
 
 .sb-search-hit {
-    animation: sb-search-hit 2.2s ease;
+    animation: sb-search-hit 2.2s var(--sb-ease-out);
 }
 
 @keyframes sbShellReveal {
@@ -4601,7 +4601,7 @@ body.sb-shell-resizing * {
         min-width: 0 !important;
         margin-top: 0 !important;
         border-radius: 22px 22px 0 0 !important;
-        animation: sbMobileShellSheetIn 220ms cubic-bezier(0.2, 0.8, 0.2, 1) both !important;
+        animation: sbMobileShellSheetIn 220ms var(--sb-ease-out) both !important;
         transform-origin: center bottom;
     }
 
@@ -4623,7 +4623,7 @@ body.sb-shell-resizing * {
         position: absolute;
         top: 6px;
         left: 50%;
-        z-index: 5;
+        z-index: var(--sb-z-raised);
         width: 42px;
         height: 4px;
         border-radius: 999px;
@@ -4882,7 +4882,7 @@ body.sb-shell-resizing * {
         visibility: hidden;
         opacity: 0;
         pointer-events: none;
-        transition: opacity 180ms ease;
+        transition: opacity var(--sb-transition-fast);
     }
 
     #sb-mobile-nav::before {
@@ -4900,7 +4900,7 @@ body.sb-shell-resizing * {
         display: block;
         visibility: visible;
         pointer-events: auto;
-        z-index: 3600;
+        z-index: var(--sb-z-modal);
         backdrop-filter: none;
         -webkit-backdrop-filter: none;
     }
@@ -4926,7 +4926,7 @@ body.sb-shell-resizing * {
         visibility: hidden;
         opacity: 0;
         pointer-events: none;
-        transition: opacity 180ms ease;
+        transition: opacity var(--sb-transition-fast);
         background: transparent;
     }
 
@@ -4935,7 +4935,7 @@ body.sb-shell-resizing * {
         opacity: 1;
         visibility: visible;
         pointer-events: auto;
-        z-index: 3602;
+        z-index: var(--sb-z-modal-content);
         backdrop-filter: blur(22px);
         -webkit-backdrop-filter: blur(22px);
     }
@@ -5026,7 +5026,7 @@ body.sb-shell-resizing * {
         line-height: 1.15;
         text-align: left;
         cursor: pointer;
-        transition: transform 160ms ease, border-color 160ms ease, background-color 160ms ease;
+        transition: transform var(--sb-transition-fast), border-color var(--sb-transition-fast), background-color var(--sb-transition-fast);
     }
 
     .sb-nav-item i {
@@ -5151,7 +5151,7 @@ body.sb-shell-resizing * {
         max-height: 0 !important;
         overflow: visible !important;
         pointer-events: auto !important;
-        z-index: 4005 !important;
+        z-index: var(--sb-z-popout) !important;
     }
 
     #top-settings-holder > .drawer,
@@ -5215,7 +5215,7 @@ body.sb-shell-resizing * {
         opacity: 1 !important;
         visibility: visible !important;
         pointer-events: auto !important;
-        z-index: 3500 !important;
+        z-index: var(--sb-z-modal) !important;
         top: var(--sb-topbar-layout-offset) !important;
         height: calc(100dvh - var(--sb-topbar-layout-offset) - 16px) !important;
         max-height: calc(100dvh - var(--sb-topbar-layout-offset) - 16px) !important;

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -11,6 +11,28 @@
     --sb-transition-fast: 180ms cubic-bezier(0.22, 1, 0.36, 1);
     --sb-transition: 240ms cubic-bezier(0.22, 1, 0.36, 1);
     --sb-transition-slow: 360ms cubic-bezier(0.22, 1, 0.36, 1);
+    --sb-ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+    --sb-z-base: 0;
+    --sb-z-raised: 10;
+    --sb-z-dropdown: 100;
+    --sb-z-sticky: 500;
+    --sb-z-shell: 1000;
+    --sb-z-shell-panel: 1100;
+    --sb-z-shell-sidebar: 1200;
+    --sb-z-overlay: 2000;
+    --sb-z-modal: 3000;
+    --sb-z-modal-content: 3100;
+    --sb-z-popout: 4000;
+    --sb-z-toast: 5000;
+    --sb-z-streaming: 6000;
+    --sb-z-context-menu: 8000;
+    --sb-z-loader: 9000;
+    --sb-z-critical: 10000;
+    --sb-color-warning: #facc15;
+    --sb-color-danger: #fb7185;
+    --sb-color-error: #ff6b6b;
+    --sb-color-success: #22c55e;
+    --sb-color-info: #5BC0DE;
     --sb-icon-control-size: 2rem;
     --sb-icon-control-radius: 10px;
     --sb-inline-drawer-icon-size: 2rem;
@@ -22,11 +44,11 @@
     --sb-select-arrow-inset: 14px;
     --sb-row-gap: 10px;
     --sb-section-gap: 14px;
-    --sb-settings-card-padding: 12px 14px;
+    --sb-settings-card-padding: var(--spacing-md) 14px;
     --sb-message-icon-size: 1.75rem;
     --sb-message-meta-line-height: 1.18;
-    --sb-chat-composer-gap: 8px;
-    --sb-chat-composer-edge-gap: 8px;
+    --sb-chat-composer-gap: var(--spacing-sm);
+    --sb-chat-composer-edge-gap: var(--spacing-sm);
     --sb-safe-area-bottom: env(safe-area-inset-bottom, 0px);
     --sb-mobile-safe-area-bottom: max(34px, env(safe-area-inset-bottom, 0px));
     --sb-mobile-touch-target: 44px;
@@ -80,17 +102,17 @@
     --sb-positive-bg: color-mix(in srgb, var(--SmartThemeQuoteColor) 22%, transparent);
     --sb-muted-fg: color-mix(in srgb, var(--SmartThemeBodyColor) 74%, transparent);
     --sb-muted-bg: color-mix(in srgb, var(--SmartThemeBodyColor) 7%, transparent);
-    --sb-state-favorite: color-mix(in srgb, var(--color-warning, var(--warning, #facc15)) 82%, var(--SmartThemeBodyColor) 18%);
+    --sb-state-favorite: color-mix(in srgb, var(--color-warning, var(--sb-color-warning)) 82%, var(--SmartThemeBodyColor) 18%);
     --sb-state-favorite-bg: color-mix(in srgb, var(--sb-state-favorite) 14%, var(--sb-button-bg));
     --sb-state-favorite-border: color-mix(in srgb, var(--sb-state-favorite) 40%, var(--sb-shell-border));
-    --sb-state-attention: color-mix(in srgb, var(--color-danger, var(--danger, #fb7185)) 86%, var(--SmartThemeBodyColor) 14%);
+    --sb-state-attention: color-mix(in srgb, var(--color-danger, var(--sb-color-danger)) 86%, var(--SmartThemeBodyColor) 14%);
     --sb-state-attention-bg: color-mix(in srgb, var(--sb-state-attention) 18%, transparent);
     --sb-state-attention-border: color-mix(in srgb, var(--sb-state-attention) 44%, transparent);
     --sb-on-accent: rgb(0, 0, 0);
     --sb-on-solid-accent: var(--sb-on-accent);
-    --sb-warning-fg: color-mix(in srgb, var(--warning, #ff6b6b) 72%, var(--SmartThemeBodyColor) 28%);
-    --sb-warning-bg: color-mix(in srgb, var(--warning, #ff6b6b) 12%, var(--SmartThemeBlurTintColor) 88%);
-    --sb-warning-border: color-mix(in srgb, var(--warning, #ff6b6b) 42%, var(--SmartThemeBorderColor) 58%);
+    --sb-warning-fg: color-mix(in srgb, var(--color-danger, var(--sb-color-error)) 72%, var(--SmartThemeBodyColor) 28%);
+    --sb-warning-bg: color-mix(in srgb, var(--color-danger, var(--sb-color-error)) 12%, var(--SmartThemeBlurTintColor) 88%);
+    --sb-warning-border: color-mix(in srgb, var(--color-danger, var(--sb-color-error)) 42%, var(--SmartThemeBorderColor) 58%);
     --sb-input-bg: color-mix(in srgb, var(--SmartThemeBlurTintColor) 90%, transparent);
     --sb-input-border: color-mix(in srgb, var(--SmartThemeBorderColor) 92%, transparent);
     --sb-focus-ring: color-mix(in srgb, var(--SmartThemeQuoteColor) 70%, transparent);
@@ -246,7 +268,7 @@ body::before {
         radial-gradient(circle at top left, var(--sb-ambient-a), transparent 28%),
         radial-gradient(circle at top right, var(--sb-ambient-b), transparent 32%);
     opacity: 1;
-    z-index: 0;
+    z-index: var(--sb-z-base);
     will-change: auto;
     contain: layout style paint;
 }
@@ -264,7 +286,7 @@ body::before {
 .popup,
 #sb-mobile-nav {
     position: relative;
-    z-index: 1;
+    z-index: var(--sb-z-raised);
 }
 
 #chat {
@@ -569,7 +591,8 @@ h3:not(.popup h3):not(#chat h3) {
 .menu_button:not(.disabled):not([disabled]):active,
 .menu_button_icon:not(.disabled):not([disabled]):active,
 .right_menu_button:active {
-    transform: none;
+    transform: scale(0.97);
+    transition: transform 100ms var(--sb-ease-out);
 }
 
 .menu_button:is(.fa, .fa-solid, .fa-regular, .fa-brands):empty,
@@ -664,6 +687,11 @@ h3:not(.popup h3):not(#chat h3) {
 .drawer-icon.openIcon {
     background: var(--sb-button-hover);
     border-color: color-mix(in srgb, var(--sb-shell-border) 90%, transparent);
+}
+
+.inline-drawer-toggle .inline-drawer-icon,
+.inline-drawer-toggle :is(i, .fa, .fa-solid, .fa-regular, .fa-brands).inline-drawer-icon {
+    transition: color var(--sb-transition-fast), opacity var(--sb-transition-fast);
 }
 
 .text_pole,
@@ -4654,6 +4682,19 @@ input[type='range']::-moz-range-thumb {
     border-radius: var(--sb-radius-md) !important;
     backdrop-filter: blur(14px);
     -webkit-backdrop-filter: blur(14px);
+    animation: sb-toast-in 240ms var(--sb-ease-out) both;
+}
+
+@keyframes sb-toast-in {
+    from {
+        opacity: 0;
+        transform: translateY(-8px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
 :focus-visible {

--- a/public/css/streaming-display.css
+++ b/public/css/streaming-display.css
@@ -14,13 +14,13 @@
     border: 1px solid var(--SmartThemeBorderColor);
     border-radius: 10px;
     padding: 14px;
-    z-index: 9000;
+    z-index: var(--sb-z-streaming);
     display: flex;
     flex-direction: column;
     gap: 10px;
     opacity: 0;
     transform: translateY(20px);
-    transition: opacity var(--animation-duration, 125ms) ease, transform var(--animation-duration, 125ms) ease;
+    transition: opacity var(--sb-transition-fast), transform var(--sb-transition-fast);
     overflow: hidden;
     box-shadow: 0 4px 24px rgba(0, 0, 0, 0.25);
     backdrop-filter: blur(12px);
@@ -107,7 +107,7 @@
     align-items: center;
     justify-content: center;
     opacity: 0.6;
-    transition: opacity 0.15s ease, background-color 0.15s ease;
+    transition: opacity var(--sb-transition-fast), background-color var(--sb-transition-fast);
 }
 
 .streaming-display-btn:hover {
@@ -134,7 +134,7 @@
     flex-direction: column;
     gap: 10px;
     overflow: hidden;
-    transition: max-height var(--animation-duration, 125ms) ease, opacity var(--animation-duration, 125ms) ease;
+    transition: max-height var(--sb-transition-fast), opacity var(--sb-transition-fast);
 }
 
 /* Minimized state - hide content sections */
@@ -161,10 +161,10 @@
 
 /* Reasoning (thinking) section */
 .streaming-display-reasoning {
-    background: color-mix(in srgb, var(--SmartThemeBodyColor) 5%, transparent);
+    background: color-mix(in srgb, var(--SmartThemeBodyColor) 4%, transparent);
     border-radius: 6px;
     padding: 8px 10px;
-    border-left: 3px solid color-mix(in srgb, var(--SmartThemeBodyColor) 25%, transparent);
+    border: 1px solid color-mix(in srgb, var(--SmartThemeBodyColor) 18%, transparent);
 }
 
 .streaming-display-reasoning-label {
@@ -233,4 +233,11 @@
 .streaming-display-text-content q:before,
 .streaming-display-text-content q:after {
     content: '';
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .streaming-display-led {
+        animation: none !important;
+        opacity: 0.7;
+    }
 }

--- a/public/css/toggle-dependent.css
+++ b/public/css/toggle-dependent.css
@@ -430,7 +430,7 @@ body.waifuMode .zoomed_avatar {
     position: absolute;
     padding: 0;
     filter: drop-shadow(2px 2px 2px #51515199);
-    z-index: 29;
+    z-index: var(--sb-z-raised);
     overflow: hidden;
     display: none;
     left: 0;

--- a/public/css/welcome.css
+++ b/public/css/welcome.css
@@ -932,7 +932,7 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
     cursor: pointer;
     border: 1px solid color-mix(in srgb, var(--sb-shell-border, var(--SmartThemeBorderColor)) 80%, transparent);
     background: transparent;
-    transition: transform 180ms ease, background-color 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+    transition: transform var(--sb-transition-fast), background-color var(--sb-transition-fast), border-color var(--sb-transition-fast), box-shadow var(--sb-transition-fast);
 }
 
 .welcomeRecent .recentChatList .recentChat::before {
@@ -944,7 +944,7 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
     pointer-events: none;
     background: var(--sb-welcome-surface-bg);
     opacity: var(--sb-page-control-opacity, 1);
-    transition: background 180ms ease;
+    transition: background var(--sb-transition-fast);
 }
 
 .welcomeRecent .recentChatList .recentChat:hover {
@@ -1358,7 +1358,7 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
 
 .welcomeDeckPanel.is-active {
     display: flex;
-    animation: welcomeDeckFadeIn 180ms ease;
+    animation: welcomeDeckFadeIn 180ms var(--sb-ease-out);
 }
 
 .welcomeAssistantButton {
@@ -2364,5 +2364,19 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
 
     .welcomePanelModeChip {
         min-width: 42px;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .welcomeHeroMascot,
+    .welcomeHeroFrame,
+    .welcomeHeroSpark,
+    [class*="welcomeOrbit"] {
+        animation: none !important;
+    }
+
+    .welcomeDeckPanel.is-active {
+        animation: none !important;
+        opacity: 1;
     }
 }

--- a/public/css/world-info.css
+++ b/public/css/world-info.css
@@ -17,7 +17,7 @@
     right: 0;
     display: flex;
     flex-direction: column;
-    z-index: 3010;
+    z-index: var(--sb-z-modal-content);
     overflow-y: hidden;
     gap: 10px;
 }
@@ -403,7 +403,7 @@
 }
 
 .world_entry .killSwitch.is-disabled i {
-    color: color-mix(in srgb, #d16b6b 78%, var(--SmartThemeBodyColor));
+    color: color-mix(in srgb, var(--sb-color-danger, #d16b6b) 78%, var(--SmartThemeBodyColor));
 }
 
 .world_entry .killSwitch:not(.is-disabled) i {
@@ -512,8 +512,8 @@
 }
 
 .world_entry.wi-entry-state-constant .WIEntryTitleAndStatus select[name="entryStateSelector"] {
-    border-color: color-mix(in srgb, #5aa9ff 58%, transparent);
-    background: color-mix(in srgb, #5aa9ff 12%, transparent);
+    border-color: color-mix(in srgb, var(--sb-color-info, #5aa9ff) 58%, transparent);
+    background: color-mix(in srgb, var(--sb-color-info, #5aa9ff) 12%, transparent);
 }
 
 .world_entry.wi-entry-state-normal .WIEntryTitleAndStatus select[name="entryStateSelector"] {
@@ -521,8 +521,8 @@
 }
 
 .world_entry.wi-entry-state-vectorized .WIEntryTitleAndStatus select[name="entryStateSelector"] {
-    border-color: color-mix(in srgb, #8ecf7a 58%, transparent);
-    background: color-mix(in srgb, #8ecf7a 12%, transparent);
+    border-color: color-mix(in srgb, var(--sb-color-success, #8ecf7a) 58%, transparent);
+    background: color-mix(in srgb, var(--sb-color-success, #8ecf7a) 12%, transparent);
 }
 
 .WIEnteryHeaderControls {
@@ -993,7 +993,7 @@ select.keyselect+span.select2-container .select2-selection--multiple {
         position: fixed;
         top: calc(var(--sb-topbar-layout-offset, var(--topBarBlockSize)) + 18px);
         left: 50%;
-        z-index: 4010;
+        z-index: var(--sb-z-popout);
         box-sizing: border-box;
         width: min(920px, calc(100dvw - 48px));
         max-width: calc(100dvw - 24px);

--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -2005,7 +2005,7 @@ class PromptManager {
                     <span title="Remove" class="prompt-manager-detach-action caution fa-solid fa-chain-broken fa-xs"></span>
                 `;
             } else {
-                detachSpanHtml = '<span class="fa-solid"></span>';
+                detachSpanHtml = '<span class="prompt-manager-control-placeholder" aria-hidden="true"></span>';
             }
 
             let editSpanHtml = '';
@@ -2020,7 +2020,7 @@ class PromptManager {
                     <span title="edit" class="prompt-manager-edit-action fa-solid fa-pencil fa-xs"></span>
                 `;
             } else {
-                editSpanHtml = '<span class="fa-solid"></span>';
+                editSpanHtml = '<span class="prompt-manager-control-placeholder" aria-hidden="true"></span>';
             }
 
             let toggleSpanHtml = '';
@@ -2029,7 +2029,7 @@ class PromptManager {
                     <span class="prompt-manager-toggle-action ${listEntry.enabled ? 'fa-solid fa-toggle-on' : 'fa-solid fa-toggle-off'}"></span>
                 `;
             } else {
-                toggleSpanHtml = '<span class="fa-solid"></span>';
+                toggleSpanHtml = '<span class="prompt-manager-control-placeholder" aria-hidden="true"></span>';
             }
 
             const encodedName = escapeHtml(prompt.name);
@@ -2310,12 +2310,12 @@ class PromptManager {
         if (!this.isDesktopSplitLayout() && window.matchMedia('(max-width: 768px)').matches) {
             setTimeout(() => {
                 if (popup) {
-                    popup.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                    // Also scroll the parent container to top
+                    popup.scrollTop = 0;
                     const shellScroller = popup.closest('.sb-shell-scroller');
                     if (shellScroller) {
                         shellScroller.scrollTop = 0;
                     }
+                    window.dispatchEvent(new CustomEvent('sb-mobile-viewport-reset'));
                 }
             }, 250); // Wait for slideDown animation
         }
@@ -2341,7 +2341,7 @@ class PromptManager {
         }
 
         $('#' + this.configuration.prefix + 'prompt_manager_popup').first()
-            .slideUp(200, 'swing')
+            .slideUp(200, 'swing', () => window.dispatchEvent(new CustomEvent('sb-mobile-viewport-reset')))
             .removeClass('openDrawer');
         this.syncEditorPaneState();
         this.syncListSelection();

--- a/public/scripts/browser-fixes.js
+++ b/public/scripts/browser-fixes.js
@@ -109,12 +109,46 @@ function applyBrowserFixes() {
         const viewport = window.visualViewport;
         const isIOSWebKit = /iPad|iPhone|iPod/.test(navigator.platform) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
         let viewportFixScheduled = false;
+        let viewportResetScheduled = false;
         let lastViewportHeight = Math.round(viewport?.height || window.innerHeight || 0);
         let lastSendInteractionAt = 0;
         let lastSendFocusedAt = 0;
 
         const updateViewportBaseline = () => {
             lastViewportHeight = Math.round(viewport?.height || window.innerHeight || 0);
+        };
+
+        const resetTransientViewportPosition = () => {
+            document.documentElement.style.position = '';
+            document.documentElement.style.top = '';
+            document.documentElement.style.left = '';
+            document.documentElement.style.right = '';
+            document.documentElement.style.bottom = '';
+            document.body.style.position = '';
+            document.body.style.top = '';
+            document.body.style.left = '';
+            document.body.style.right = '';
+            document.body.style.bottom = '';
+            document.body.style.transform = '';
+        };
+
+        const scheduleViewportReset = () => {
+            if (viewportResetScheduled) {
+                return;
+            }
+
+            viewportResetScheduled = true;
+
+            requestAnimationFrame(() => {
+                resetTransientViewportPosition();
+                updateViewportBaseline();
+
+                window.setTimeout(() => {
+                    resetTransientViewportPosition();
+                    updateViewportBaseline();
+                    viewportResetScheduled = false;
+                }, 80);
+            });
         };
 
         const applyPositionFix = ({ force = false } = {}) => {
@@ -140,7 +174,7 @@ function applyBrowserFixes() {
             console.debug('[Mobile] Device viewport change detected.');
             document.documentElement.style.position = 'fixed';
             requestAnimationFrame(() => {
-                document.documentElement.style.position = '';
+                resetTransientViewportPosition();
                 viewportFixScheduled = false;
             });
         };
@@ -189,7 +223,18 @@ function applyBrowserFixes() {
                 updateViewportBaseline();
             }
         });
-        document.addEventListener('focusout', () => requestAnimationFrame(updateViewportBaseline), true);
+        document.addEventListener('focusout', scheduleViewportReset, true);
+        document.addEventListener('click', (event) => {
+            if (event.target instanceof HTMLElement && event.target.closest('#completion_prompt_manager_popup :is(.menu_button, .popup-button-close, [id$="_close_button"], [id$="_form_close"], [id$="_form_save"])')) {
+                scheduleViewportReset();
+            }
+        }, true);
+        document.addEventListener('transitionend', (event) => {
+            if (event.target instanceof HTMLElement && event.target.id === 'completion_prompt_manager_popup') {
+                scheduleViewportReset();
+            }
+        }, true);
+        window.addEventListener('sb-mobile-viewport-reset', scheduleViewportReset);
     }
 
     addSafariPatch();


### PR DESCRIPTION
## What?
Polishes the SillyBunny shell/UI CSS pass and fixes two prompt-manager regressions:

- Standardizes SillyBunny CSS motion, z-index, state color, popup, toast, and reduced-motion primitives.
- Stops prompt-manager placeholder controls from rendering/styling as live Font Awesome action icons.
- Resets transient mobile viewport positioning after prompt-editor focus/close flows so the UI does not stay shifted after keyboard interaction.

## Why?
The UI polish pass had drifted easing/z-index/state patterns across several surfaces, and the prompt manager had two user-facing bugs: blank controls could light up like real icons, and opening the prompt editor then invoking the mobile keyboard could leave the app visually shifted.

## How?
The CSS changes route repeated magic values through existing/new `--sb-*` tokens, remove thick side-stripe accents, add targeted reduced-motion guards, and keep vendor/minified CSS untouched.

The prompt-manager hotfix changes unavailable actions from empty `.fa-solid` spans into inert placeholder spans, then scopes hover styling to named real action classes.

The mobile hotfix replaces `scrollIntoView()` on the fixed prompt popup with local scroll reset and dispatches a SillyBunny mobile viewport reset event. `browser-fixes.js` now clears transient root/body inline positioning on focusout, prompt popup close/save clicks, popup transitions, and that reset event.

## Testing?
- `npm run lint`
- `npx eslint public/scripts/browser-fixes.js public/scripts/PromptManager.js`
- `git diff --check -- public/css public/scripts/browser-fixes.js public/scripts/PromptManager.js`
- CSS scans for banned side-stripes, stale ease transitions, and hard-coded drift exceptions.
- Chrome DevTools MCP against shared Chrome at `127.0.0.1:9222`.
- Playwright CDP verification against the same shared Chrome instance:
  - checked widths `375`, `768`, `1024`, `1440` for horizontal overflow
  - verified prompt manager had inert placeholders and no stale empty Font Awesome action slots
  - verified mobile prompt popup focus/close cleared root/body `position`, `top`, and `transform`

## Screenshots (optional)
No screenshots attached. Browser verification was done through Chrome DevTools MCP snapshots plus Playwright CDP DOM/state probes on the shared Chrome instance.

## Anything Else?
Target base is `staging`. This PR is intentionally not merged.

The existing runtime checkout had unrelated dirty `output/playwright/**` deletions and `output/audit/`; they are not included in this PR.
