### PR TITLE
feat: add chat completion tabs extension

### DIFF
--- a/public/scripts/extensions/third-party/ChatCompletionTabs/components/openai-tab-manager.js
+++ b/public/scripts/extensions/third-party/ChatCompletionTabs/components/openai-tab-manager.js
@@ -1,0 +1,68 @@
+/**
+ * OpenAI Settings Tab Manager (Refactored)
+ * When using the Chat Completion API, add separate tabs for Parameters and Prompt.
+ */
+
+// Import required functions
+import { main_api } from '../../../../../script.js';
+import { oai_settings } from '../../../../openai.js';
+import { TabManager } from './tab-manager.js';
+
+export class OpenAITabManager {
+    constructor() {
+        this.tabManager = new TabManager({
+            containerSelector: '#left-nav-panel #openai_api-presets',
+            insertAfterSelector: '#left-nav-panel #openai_api-presets > div',
+            tabPrefix: 'openai-tab',
+            activeTabStorageKey: 'ChatCompletionTabs.openai.activeTab',
+            defaultTab: 'parameters',
+            className: 'openai-tab',
+            tabs: {
+                parameters: {
+                    label: 'Parameters',
+                    icon: 'fa-solid fa-vial',
+                    contentSelectors: [
+                        '#left-nav-panel #range_block_openai',
+                        '#left-nav-panel #openai_settings',
+                        '#left-nav-panel #logit_bias_openai',
+                        '#left-nav-panel [data-source*="openai"]:not(.openai-tab-content):not(.openai-tab-buttons)',
+                    ],
+                },
+                prompts: {
+                    label: 'Prompts',
+                    icon: 'fa-solid fa-file-edit',
+                    contentSelectors: [
+                        '#left-nav-panel #sb-openai-prompt-manager',
+                        '#left-nav-panel .range-block:has(> #completion_prompt_manager)',
+                    ],
+                },
+            },
+            checkCondition: () => {
+                return typeof main_api !== 'undefined' &&
+                       main_api === 'openai' &&
+                       typeof oai_settings !== 'undefined' &&
+                       document.querySelector('#left-nav-panel') !== null;
+            },
+        });
+
+        this.enabled = true;
+    }
+
+    setEnabled(enabled) {
+        this.enabled = enabled;
+        this.tabManager.setEnabled(enabled);
+    }
+
+    refreshTabs() {
+        this.tabManager.refreshTabs();
+    }
+
+    // Backward compatibility methods
+    get activeTab() {
+        return this.tabManager.activeTab;
+    }
+
+    get isTabsCreated() {
+        return this.tabManager.isTabsCreated;
+    }
+}

--- a/public/scripts/extensions/third-party/ChatCompletionTabs/components/openai-tab-manager.js
+++ b/public/scripts/extensions/third-party/ChatCompletionTabs/components/openai-tab-manager.js
@@ -22,10 +22,9 @@ export class OpenAITabManager {
                     label: 'Parameters',
                     icon: 'fa-solid fa-vial',
                     contentSelectors: [
-                        '#left-nav-panel #range_block_openai',
-                        '#left-nav-panel #openai_settings',
-                        '#left-nav-panel #logit_bias_openai',
-                        '#left-nav-panel [data-source*="openai"]:not(.openai-tab-content):not(.openai-tab-buttons)',
+                        '#left-nav-panel #sb-openai-budget',
+                        '#left-nav-panel #sb-openai-output',
+                        '#left-nav-panel #sb-openai-advanced',
                     ],
                 },
                 prompts: {
@@ -41,7 +40,8 @@ export class OpenAITabManager {
                 return typeof main_api !== 'undefined' &&
                        main_api === 'openai' &&
                        typeof oai_settings !== 'undefined' &&
-                       document.querySelector('#left-nav-panel') !== null;
+                       document.querySelector('#left-nav-panel') !== null &&
+                       document.querySelector('#left-nav-panel #sb-openai-budget') !== null;
             },
         });
 

--- a/public/scripts/extensions/third-party/ChatCompletionTabs/components/tab-manager.js
+++ b/public/scripts/extensions/third-party/ChatCompletionTabs/components/tab-manager.js
@@ -49,6 +49,7 @@ export class TabManager {
             // Double-check removal after a short delay
             setTimeout(() => {
                 if (!this.enabled) {
+                    this.restoreMovedElements(document.querySelector(this.config.containerSelector));
                     this.forceRemoveAllTabElements();
                 }
             }, 100);
@@ -65,10 +66,6 @@ export class TabManager {
         // Remove tab buttons container
         const tabButtons = document.querySelectorAll(`.${this.config.className}-buttons`);
         tabButtons.forEach(el => el.remove());
-
-        // Remove all tab content containers
-        const tabContents = document.querySelectorAll(`.${this.config.className}-content`);
-        tabContents.forEach(el => el.remove());
 
         this.tabButtonsContainer = null;
         this.isTabsCreated = false;

--- a/public/scripts/extensions/third-party/ChatCompletionTabs/components/tab-manager.js
+++ b/public/scripts/extensions/third-party/ChatCompletionTabs/components/tab-manager.js
@@ -1,0 +1,434 @@
+/**
+ * Generic Tab Manager for dynamic tab creation and management
+ */
+
+export class TabManager {
+    constructor(config) {
+        this.config = {
+            containerSelector: config.containerSelector,
+            insertAfterSelector: config.insertAfterSelector,
+            insertBeforeSelector: config.insertBeforeSelector, // New option
+            useContainerForContent: config.useContainerForContent || false, // New option
+            tabPrefix: config.tabPrefix || 'tab',
+            activeTabStorageKey: config.activeTabStorageKey,
+            defaultTab: config.defaultTab || Object.keys(config.tabs)[0],
+            tabs: config.tabs, // { id: { label, icon, contentSelector } }
+            checkCondition: config.checkCondition || (() => true),
+            onTabSwitch: config.onTabSwitch,
+            className: config.className || 'generic-tab',
+        };
+
+        this.activeTab = this.config.defaultTab;
+        this.tabButtonsContainer = null;
+        this.movedElements = new Map();
+        this.isTabsCreated = false;
+        this.enabled = true;
+
+        this.init();
+    }
+
+    init() {
+        setTimeout(() => this.checkConditionAndInitialize(), 300);
+        this.intervalId = setInterval(() => this.checkConditionAndInitialize(), 2000);
+    }
+
+    setEnabled(enabled) {
+        this.enabled = enabled;
+        if (!enabled) {
+            // Clear interval to prevent re-creation
+            if (this.intervalId) {
+                clearInterval(this.intervalId);
+                this.intervalId = null;
+            }
+
+            // Force remove tabs immediately when disabled
+            if (this.isTabsCreated) {
+                this.removeTabs();
+            }
+
+            // Double-check removal after a short delay
+            setTimeout(() => {
+                if (!this.enabled) {
+                    this.forceRemoveAllTabElements();
+                }
+            }, 100);
+        } else if (enabled && !this.intervalId) {
+            // Re-enable interval checking when enabled
+            this.intervalId = setInterval(() => this.checkConditionAndInitialize(), 2000);
+            // Check immediately
+            this.checkConditionAndInitialize();
+        }
+    }
+
+    // Force remove all tab-related elements by class name
+    forceRemoveAllTabElements() {
+        // Remove tab buttons container
+        const tabButtons = document.querySelectorAll(`.${this.config.className}-buttons`);
+        tabButtons.forEach(el => el.remove());
+
+        // Remove all tab content containers
+        const tabContents = document.querySelectorAll(`.${this.config.className}-content`);
+        tabContents.forEach(el => el.remove());
+
+        this.tabButtonsContainer = null;
+        this.isTabsCreated = false;
+    }
+
+    checkConditionAndInitialize() {
+        if (!this.enabled) {
+            // If disabled, ensure tabs are removed
+            if (this.isTabsCreated) {
+                this.removeTabs();
+            }
+            return;
+        }
+
+        const shouldShowTabs = this.config.checkCondition();
+
+        if (shouldShowTabs && !this.isTabsCreated) {
+            this.createTabs();
+        } else if (!shouldShowTabs && this.isTabsCreated) {
+            this.removeTabs();
+        }
+    }
+
+    createTabs() {
+        // Prevent duplicate creation
+        if (document.querySelector(`.${this.config.className}-buttons`)) {
+            this.isTabsCreated = true;
+            return;
+        }
+
+        // Determine where to insert tabs
+        let insertElement;
+        let insertMethod = 'afterend';
+
+        if (this.config.insertBeforeSelector) {
+            insertElement = document.querySelector(this.config.insertBeforeSelector);
+            insertMethod = 'beforebegin';
+        } else if (this.config.insertAfterSelector) {
+            insertElement = document.querySelector(this.config.insertAfterSelector);
+            insertMethod = 'afterend';
+        }
+
+        if (!insertElement) {
+            return;
+        }
+
+        // Generate tab buttons HTML
+        const tabButtonsHTML = Object.entries(this.config.tabs)
+            .map(([id, tab], index) => `
+                <button id="${this.config.tabPrefix}-btn-${id}" class="${this.config.className}-button ${index === 0 ? 'active' : ''}" role="tab" aria-selected="${index === 0 ? 'true' : 'false'}" aria-controls="${this.config.tabPrefix}-content-${id}" tabindex="${index === 0 ? '0' : '-1'}" type="button">
+                    <i class="${tab.icon}"></i>
+                    <span data-i18n="${tab.label}">${tab.label}</span>
+                </button>
+            `).join('');
+
+        insertElement.insertAdjacentHTML(insertMethod, `
+            <div class="${this.config.className}-buttons" role="tablist">
+                ${tabButtonsHTML}
+            </div>
+        `);
+
+        this.tabButtonsContainer = document.querySelector(`.${this.config.className}-buttons`);
+        this.organizeContent();
+        this.bindEvents();
+        this.setInitialState();
+        this.isTabsCreated = true;
+    }
+
+    organizeContent() {
+        const tabButtons = this.tabButtonsContainer;
+        if (!tabButtons) {
+            return;
+        }
+
+        if (this.config.useContainerForContent) {
+            // For user settings: create tab containers inside the existing container
+            const existingContainer = document.querySelector(this.config.containerSelector);
+            if (!existingContainer) {
+                return;
+            }
+
+            // First, collect all elements that need to be moved BEFORE clearing the container
+            const elementsToMove = {};
+            Object.entries(this.config.tabs).forEach(([id, tab]) => {
+                elementsToMove[id] = [];
+
+                tab.contentSelectors.forEach(selector => {
+                    const elements = document.querySelectorAll(selector);
+                    elements.forEach(element => {
+                        // Find the wrapper (range-block or direct element)
+                        const wrapper = element.closest('.range-block') ||
+                                       element.closest('[name]') ||
+                                       element;
+
+                        if (wrapper && wrapper.parentNode) {
+                            elementsToMove[id].push(wrapper);
+                        }
+                    });
+                });
+            });
+
+            // Now create tab containers inside the existing container
+            const tabContainersHTML = Object.keys(this.config.tabs)
+                .map((id, index) => `
+                    <div id="${this.config.tabPrefix}-content-${id}" class="${this.config.className}-content ${index === 0 ? 'active' : ''}" role="tabpanel" aria-labelledby="${this.config.tabPrefix}-btn-${id}" ${index === 0 ? '' : 'hidden'}></div>
+                `).join('');
+
+            existingContainer.innerHTML = tabContainersHTML;
+
+            // Move collected content to respective tabs
+            Object.entries(elementsToMove).forEach(([id, elements]) => {
+                const tabContainer = document.querySelector(`#${this.config.tabPrefix}-content-${id}`);
+                if (tabContainer) {
+                    elements.forEach(element => {
+                        if (element && element.parentNode) {
+                            tabContainer.appendChild(element);
+                        }
+                    });
+                }
+            });
+        } else {
+            // Original behavior: create tab containers after tab buttons
+            const tabContainersHTML = Object.keys(this.config.tabs)
+                .map((id, index) => `
+                    <div id="${this.config.tabPrefix}-content-${id}" class="${this.config.className}-content ${index === 0 ? 'active' : ''}" role="tabpanel" aria-labelledby="${this.config.tabPrefix}-btn-${id}" ${index === 0 ? '' : 'hidden'}></div>
+                `).join('');
+
+            tabButtons.insertAdjacentHTML('afterend', tabContainersHTML);
+
+            // Move content to respective tabs
+            Object.entries(this.config.tabs).forEach(([id, tab]) => {
+                const tabContainer = document.querySelector(`#${this.config.tabPrefix}-content-${id}`);
+
+                tab.contentSelectors.forEach(selector => {
+                    const elements = document.querySelectorAll(selector);
+                    elements.forEach(element => {
+                        // Find the wrapper (range-block or direct element)
+                        const wrapper = element.closest('.range-block') ||
+                                       element.closest('[name]') ||
+                                       element;
+
+                        if (wrapper && !tabContainer.contains(wrapper) && wrapper.parentNode) {
+                            this.trackOriginalPosition(wrapper);
+                            tabContainer.appendChild(wrapper);
+                        }
+                    });
+                });
+            });
+        }
+    }
+
+    removeTabs() {
+        // Remove tab buttons
+        if (this.tabButtonsContainer) {
+            this.tabButtonsContainer.remove();
+            this.tabButtonsContainer = null;
+        }
+
+        const originalContainer = document.querySelector(this.config.containerSelector);
+
+        if (this.config.useContainerForContent && originalContainer) {
+            // For user settings: collect all content from tab containers and restore original structure
+            const allContent = [];
+
+            // Collect content from all tab containers
+            Object.keys(this.config.tabs).forEach(id => {
+                const tabContent = document.querySelector(`#${this.config.tabPrefix}-content-${id}`);
+                if (tabContent) {
+                    while (tabContent.firstChild) {
+                        allContent.push(tabContent.firstChild);
+                        tabContent.removeChild(tabContent.firstChild);
+                    }
+                }
+            });
+
+            // Remove all tab containers
+            Object.keys(this.config.tabs).forEach(id => {
+                const tabContent = document.querySelector(`#${this.config.tabPrefix}-content-${id}`);
+                if (tabContent) {
+                    tabContent.remove();
+                }
+            });
+
+            // Clear the container and restore all content directly
+            originalContainer.innerHTML = '';
+            allContent.forEach(element => {
+                originalContainer.appendChild(element);
+            });
+        } else {
+            this.restoreMovedElements(originalContainer);
+        }
+
+        // Force remove any remaining tab elements
+        this.forceRemoveAllTabElements();
+
+        this.isTabsCreated = false;
+    }
+
+    bindEvents() {
+        document.querySelectorAll(`.${this.config.className}-button`).forEach(button => {
+            button.addEventListener('click', (e) => {
+                e.preventDefault();
+                const tabId = e.target.closest(`.${this.config.className}-button`).id
+                    .replace(`${this.config.tabPrefix}-btn-`, '');
+                this.switchTab(tabId);
+            });
+
+            button.addEventListener('keydown', (e) => this.handleTabKeydown(e));
+        });
+    }
+
+    trackOriginalPosition(element) {
+        if (this.movedElements.has(element)) {
+            return;
+        }
+
+        this.movedElements.set(element, {
+            parent: element.parentNode,
+            nextSibling: element.nextSibling,
+        });
+    }
+
+    restoreMovedElements(fallbackContainer) {
+        for (const [element, position] of Array.from(this.movedElements.entries()).reverse()) {
+            const parent = position.parent?.isConnected ? position.parent : fallbackContainer;
+
+            if (!element || !parent) {
+                continue;
+            }
+
+            if (position.nextSibling?.parentNode === parent) {
+                parent.insertBefore(element, position.nextSibling);
+            } else {
+                parent.appendChild(element);
+            }
+        }
+
+        Object.keys(this.config.tabs).forEach(id => {
+            document.querySelector(`#${this.config.tabPrefix}-content-${id}`)?.remove();
+        });
+
+        this.movedElements.clear();
+    }
+
+    handleTabKeydown(event) {
+        const buttons = Array.from(document.querySelectorAll(`.${this.config.className}-button`));
+        const currentIndex = buttons.indexOf(event.currentTarget);
+
+        if (currentIndex === -1) {
+            return;
+        }
+
+        const keyActions = {
+            ArrowLeft: () => (currentIndex - 1 + buttons.length) % buttons.length,
+            ArrowUp: () => (currentIndex - 1 + buttons.length) % buttons.length,
+            ArrowRight: () => (currentIndex + 1) % buttons.length,
+            ArrowDown: () => (currentIndex + 1) % buttons.length,
+            Home: () => 0,
+            End: () => buttons.length - 1,
+        };
+
+        const getNextIndex = keyActions[event.key];
+        if (!getNextIndex) {
+            return;
+        }
+
+        event.preventDefault();
+        const nextButton = buttons[getNextIndex()];
+        const tabId = nextButton.id.replace(`${this.config.tabPrefix}-btn-`, '');
+        this.switchTab(tabId);
+        nextButton.focus();
+    }
+
+    switchTab(tabId) {
+        if (!Object.keys(this.config.tabs).includes(tabId)) {
+            return;
+        }
+
+        // Update buttons
+        document.querySelectorAll(`.${this.config.className}-button`).forEach(button => {
+            const isActive = button.id === `${this.config.tabPrefix}-btn-${tabId}`;
+            button.classList.toggle('active', isActive);
+            button.setAttribute('aria-selected', String(isActive));
+            button.setAttribute('tabindex', isActive ? '0' : '-1');
+        });
+
+        // Update content
+        document.querySelectorAll(`.${this.config.className}-content`).forEach(content => {
+            const isActive = content.id === `${this.config.tabPrefix}-content-${tabId}`;
+            content.classList.toggle('active', isActive);
+            content.toggleAttribute('hidden', !isActive);
+        });
+
+        // Scroll to top - check multiple possible scroll containers
+        const scrollContainers = [
+            '#left-nav-panel .scrollableInner',
+            '#user-settings-block',
+            '#user-settings-block-content',
+            '.drawer-content',
+        ];
+
+        scrollContainers.forEach(selector => {
+            const container = document.querySelector(selector);
+            if (container) {
+                container.scrollTop = 0;
+            }
+        });
+
+        this.activeTab = tabId;
+        this.saveTabPreference(tabId);
+
+        // Call custom callback if provided
+        if (this.config.onTabSwitch) {
+            this.config.onTabSwitch(tabId);
+        }
+    }
+
+    setInitialState() {
+        const savedTab = this.loadTabPreference();
+        const initialTab = Object.keys(this.config.tabs).includes(savedTab) ? savedTab : this.config.defaultTab;
+        this.switchTab(initialTab);
+    }
+
+    saveTabPreference(tabId) {
+        if (!this.config.activeTabStorageKey) {
+            return;
+        }
+        try {
+            localStorage.setItem(this.config.activeTabStorageKey, tabId);
+        } catch (error) {
+            // Silent fail
+        }
+    }
+
+    loadTabPreference() {
+        if (!this.config.activeTabStorageKey) {
+            return null;
+        }
+
+        try {
+            return localStorage.getItem(this.config.activeTabStorageKey);
+        } catch (error) {
+            return null;
+        }
+    }
+
+    refreshTabs() {
+        if (this.enabled) {
+            this.checkConditionAndInitialize();
+        }
+    }
+
+    // Clean up method to stop all timers
+    destroy() {
+        if (this.intervalId) {
+            clearInterval(this.intervalId);
+            this.intervalId = null;
+        }
+        if (this.isTabsCreated) {
+            this.removeTabs();
+        }
+    }
+}

--- a/public/scripts/extensions/third-party/ChatCompletionTabs/i18n/zh-cn.json
+++ b/public/scripts/extensions/third-party/ChatCompletionTabs/i18n/zh-cn.json
@@ -1,0 +1,5 @@
+{
+    "Enable Chat Completion Tabs": "启用聊天补全标签页",
+    "Parameters": "参数",
+    "Prompts": "提示词"
+}

--- a/public/scripts/extensions/third-party/ChatCompletionTabs/i18n/zh-tw.json
+++ b/public/scripts/extensions/third-party/ChatCompletionTabs/i18n/zh-tw.json
@@ -1,0 +1,5 @@
+{
+    "Enable Chat Completion Tabs": "啟用聊天補全分頁",
+    "Parameters": "參數",
+    "Prompts": "提示詞"
+}

--- a/public/scripts/extensions/third-party/ChatCompletionTabs/index.js
+++ b/public/scripts/extensions/third-party/ChatCompletionTabs/index.js
@@ -1,0 +1,178 @@
+/**
+ * Chat Completion Tabs extension for SillyTavern
+ */
+
+// Global settings and constants
+const EXTENSION_NAME = 'Chat Completion Tabs';
+const settingsKey = 'ChatCompletionTabs';
+const VERSION = '1.0.0';
+
+// Import required functions
+import { t } from '../../../i18n.js';
+
+// Import components
+import { OpenAITabManager } from './components/openai-tab-manager.js';
+
+/**
+ * Default settings configuration
+ */
+const defaultSettings = {
+    enabled: true,
+};
+
+// Global tab manager instances
+let openAITabManager = null;
+
+/**
+ * Main extension initialization function
+ */
+(function initExtension() {
+    // Get SillyTavern context
+    const context = SillyTavern.getContext();
+
+    // Initialize settings
+    if (!context.extensionSettings[settingsKey]) {
+        context.extensionSettings[settingsKey] = { ...defaultSettings };
+    }
+
+    // Ensure all default setting keys exist
+    for (const key of Object.keys(defaultSettings)) {
+        if (context.extensionSettings[settingsKey][key] === undefined) {
+            context.extensionSettings[settingsKey][key] = defaultSettings[key];
+        }
+    }
+
+    // Save settings
+    context.saveSettingsDebounced();
+
+    // Initialize extension UI when DOM is fully loaded
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initExtensionUI);
+    } else {
+        initExtensionUI();
+    }
+})();
+
+/**
+ * Initialize UI elements and events for the extension
+ */
+function initExtensionUI() {
+    // Render extension settings
+    renderExtensionSettings();
+
+    // Initialize tab managers
+    initializeOpenAITabs();
+}
+
+/**
+ * Initialize OpenAI tab management
+ */
+function initializeOpenAITabs() {
+    const context = SillyTavern.getContext();
+    const settings = context.extensionSettings[settingsKey];
+
+    if (!openAITabManager) {
+        openAITabManager = new OpenAITabManager();
+    }
+
+    // Set enabled state based on settings
+    openAITabManager.setEnabled(settings.enabled);
+}
+
+/**
+ * Render extension settings panel
+ */
+function renderExtensionSettings() {
+    const context = SillyTavern.getContext();
+    const settingsContainer = document.getElementById(`${settingsKey}-container`) ?? document.getElementById('extensions_settings2');
+    if (!settingsContainer) {
+        return;
+    }
+
+    // Find existing settings drawer to avoid duplication
+    let existingDrawer = settingsContainer.querySelector(`#${settingsKey}-drawer`);
+    if (existingDrawer) {
+        return; // Don't recreate if exists
+    }
+
+    // Create settings drawer
+    const inlineDrawer = document.createElement('div');
+    inlineDrawer.id = `${settingsKey}-drawer`;
+    inlineDrawer.classList.add('inline-drawer');
+    settingsContainer.append(inlineDrawer);
+
+    // Create drawer title
+    const inlineDrawerToggle = document.createElement('div');
+    inlineDrawerToggle.classList.add('inline-drawer-toggle', 'inline-drawer-header');
+
+    const extensionNameElement = document.createElement('b');
+    extensionNameElement.textContent = EXTENSION_NAME;
+
+    const inlineDrawerIcon = document.createElement('div');
+    inlineDrawerIcon.classList.add('inline-drawer-icon', 'fa-solid', 'fa-circle-chevron-down', 'down');
+
+    inlineDrawerToggle.append(extensionNameElement, inlineDrawerIcon);
+
+    // Create settings content area
+    const inlineDrawerContent = document.createElement('div');
+    inlineDrawerContent.classList.add('inline-drawer-content');
+
+    // Add to drawer
+    inlineDrawer.append(inlineDrawerToggle, inlineDrawerContent);
+
+    // Get settings
+    const settings = context.extensionSettings[settingsKey];
+
+    // Create enable switch
+    const enabledCheckboxLabel = document.createElement('label');
+    enabledCheckboxLabel.classList.add('checkbox_label');
+    enabledCheckboxLabel.htmlFor = `${settingsKey}-enabled`;
+
+    const enabledCheckbox = document.createElement('input');
+    enabledCheckbox.id = `${settingsKey}-enabled`;
+    enabledCheckbox.type = 'checkbox';
+    enabledCheckbox.checked = settings.enabled;
+
+    enabledCheckbox.addEventListener('change', () => {
+        settings.enabled = enabledCheckbox.checked;
+
+        // Update tab manager based on enabled state
+        if (openAITabManager) {
+            openAITabManager.setEnabled(settings.enabled);
+        }
+
+        context.saveSettingsDebounced();
+    });
+
+    const enabledCheckboxText = document.createElement('span');
+    enabledCheckboxText.textContent = t`Enable Chat Completion Tabs`;
+
+    enabledCheckboxLabel.append(enabledCheckbox, enabledCheckboxText);
+    inlineDrawerContent.append(enabledCheckboxLabel);
+
+    // Initialize drawer toggle functionality
+    inlineDrawerToggle.addEventListener('click', function () {
+        this.classList.toggle('open');
+        inlineDrawerIcon.classList.toggle('down');
+        inlineDrawerIcon.classList.toggle('up');
+        inlineDrawerContent.classList.toggle('open');
+    });
+}
+// Additional initialization calls with delays to ensure proper loading
+setTimeout(() => {
+    if (openAITabManager) {
+        openAITabManager.refreshTabs();
+    }
+}, 1000);
+
+setTimeout(() => {
+    if (openAITabManager) {
+        openAITabManager.refreshTabs();
+    }
+}, 3000);
+
+// Export for debugging purposes
+window.ChatCompletionTabs = {
+    openAITabManager,
+    VERSION,
+};

--- a/public/scripts/extensions/third-party/ChatCompletionTabs/manifest.json
+++ b/public/scripts/extensions/third-party/ChatCompletionTabs/manifest.json
@@ -1,0 +1,16 @@
+{
+    "display_name": "Chat Completion Tabs",
+    "author": "Rivelle",
+    "version": "1.0.0",
+    "description": "Adds Parameters/Prompts tabs to the Chat Completion presets panel.",
+    "requires": [],
+    "optional": [],
+    "js": "index.js",
+    "css": "style.css",
+    "homePage": "https://github.com/RivelleDays/SillyTavern-ChatCompletionTabs",
+    "loading_order": 10,
+    "i18n": {
+        "zh-tw": "i18n/zh-tw.json",
+        "zh-cn": "i18n/zh-cn.json"
+    }
+}

--- a/public/scripts/extensions/third-party/ChatCompletionTabs/style.css
+++ b/public/scripts/extensions/third-party/ChatCompletionTabs/style.css
@@ -1,0 +1,146 @@
+/* -- Generic Tab System -- */
+
+/* Base Tab Content */
+.openai-tab-content {
+    display: none;
+    animation: fadeIn var(--animation-duration-slow, 0.2s) ease-in-out;
+}
+
+.openai-tab-content[hidden] {
+    display: none !important;
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.openai-tab-content.active {
+    display: block;
+    margin-top: 0.8em;
+    margin-bottom: 0.8em;
+    width: 100%;
+}
+
+/* Base Tab Buttons */
+.openai-tab-buttons {
+    display: flex;
+    position: sticky;
+    top: 0;
+    gap: 4px;
+    margin-top: 8px;
+    padding: 4px;
+    border: 1px solid color-mix(in srgb, var(--SmartThemeBodyColor) 14%, var(--SmartThemeBorderColor, transparent));
+    border-radius: 12px;
+    overflow: visible;
+    background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 92%, var(--SmartThemeBodyColor) 8%);
+    box-shadow: 0 8px 18px color-mix(in srgb, var(--SmartThemeShadowColor, var(--SmartThemeBodyColor)) 10%, transparent);
+    z-index: 1000;
+    flex-wrap: nowrap;
+}
+
+.openai-tab-button {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    min-height: 38px;
+    margin: 0;
+    padding: 8px 10px;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 9px;
+    color: var(--SmartThemeBodyColor);
+    font-size: calc(var(--mainFontSize, 1rem) * 0.85);
+    font-weight: 700;
+    line-height: 1.2;
+    cursor: pointer;
+    position: relative;
+    opacity: 0.72;
+    transition:
+        background-color var(--animation-duration-fast, 0.15s) ease-out,
+        border-color var(--animation-duration-fast, 0.15s) ease-out,
+        color var(--animation-duration-fast, 0.15s) ease-out,
+        opacity var(--animation-duration-fast, 0.15s) ease-out,
+        box-shadow var(--animation-duration-fast, 0.15s) ease-out;
+    white-space: nowrap;
+    min-width: 0;
+}
+
+.openai-tab-button:hover {
+    opacity: 1;
+    background: color-mix(in srgb, var(--SmartThemeBodyColor) 7%, transparent);
+    border-color: color-mix(in srgb, var(--SmartThemeBodyColor) 16%, transparent);
+}
+
+.openai-tab-button:focus-visible {
+    outline: none;
+    border-color: color-mix(in srgb, var(--color-primary, var(--SmartThemeQuoteColor)) 46%, var(--SmartThemeBorderColor, transparent));
+    box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--sb-focus-ring, var(--color-primary, var(--SmartThemeQuoteColor))) 58%, transparent);
+}
+
+.openai-tab-button.active {
+    background: color-mix(in srgb, var(--color-primary, var(--SmartThemeQuoteColor)) 14%, var(--SmartThemeBlurTintColor));
+    border-color: color-mix(in srgb, var(--color-primary, var(--SmartThemeQuoteColor)) 38%, var(--SmartThemeBorderColor, transparent));
+    color: var(--SmartThemeBodyColor);
+    opacity: 1;
+    box-shadow: inset 0 -2px 0 color-mix(in srgb, var(--color-primary, var(--SmartThemeQuoteColor)) 54%, transparent);
+}
+
+.openai-tab-button i {
+    font-size: 0.9em;
+    color: color-mix(in srgb, var(--color-primary, var(--SmartThemeQuoteColor)) 64%, var(--SmartThemeBodyColor));
+    pointer-events: none;
+}
+
+.openai-tab-button span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+@media (max-width: 600px) {
+    .openai-tab-buttons {
+        top: 4px;
+    }
+
+    .openai-tab-button {
+        min-height: 44px;
+        padding-inline: 8px;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .openai-tab-content {
+        animation: none;
+    }
+
+    .openai-tab-button {
+        transition: none;
+    }
+}
+
+/* -- OpenAI Specific Styles -- */
+
+body:has(.openai-tab-buttons) {
+    #completion_prompt_manager .completion_prompt_manager_header {
+        margin-top: unset;
+    }
+    #completion_prompt_manager .completion_prompt_manager_header div {
+        margin-top: unset;
+    }
+}
+#movingUIreset {
+    width: fit-content;
+}
+
+#ChatCompletionTabs-drawer label[for="ChatCompletionTabs-enabled"] {
+    margin-top: 0.75em;
+    margin-bottom: 0.75em;
+}


### PR DESCRIPTION
## What?
Adds the Chat Completion Tabs third-party extension under `public/scripts/extensions/third-party/ChatCompletionTabs`.

The extension adds a two-tab layout to the Chat Completion preset editor:

- `Parameters` for non-sampling Chat Completion preset drawers such as token budget, output behavior, and advanced/reasoning options.
- `Prompts` for the prompt manager drawer.

It also adds extension settings, Chinese i18n files, and theme-aware tab styling.

## Why?
The Chat Completion preset editor has many controls in one long panel. Splitting the OpenAI preset controls into logical tabs reduces visual clutter while keeping the existing controls available.

## How?
The extension is added as a focused third-party extension with no SillyBunny core file changes.

Implementation highlights:

- Adds a reusable `TabManager` that moves existing DOM sections into tab panels and restores them when disabled.
- Adds an OpenAI-specific wrapper that targets the Chat Completion preset panel only when the main API is OpenAI.
- Uses SillyBunny-compatible selectors for the local prompt manager drawer.
- Excludes controls already owned by the Navigate sampling panel, including sampler sliders, seed, and logit bias.
- Persists the active OpenAI tab in `localStorage`.
- Adds accessible tab semantics, keyboard navigation, focus styling, 44px mobile targets, and reduced-motion handling.
- Preserves moved content during disable cleanup so controls are restored before tab UI is removed.
- Keeps extension metadata public-safe and avoids local machine paths.

Compatibility notes:

- The extension is toggleable from the Extensions settings panel.
- It does not modify core Chat Completion settings behavior.
- It is expected to self-initialize after SillyBunny's grouped OpenAI drawers exist.

## Testing?
Automated and static checks run locally:

- `node --check` on all new JavaScript files.
- ESLint on the new extension JavaScript files using the project configuration.
- JSON parsing for the manifest and i18n files.
- `git diff --check` against the base branch.
- Local-path scan over the new extension content.
- Selector sanity scan confirmed the targeted Chat Completion preset, OpenAI grouped drawers, and prompt manager elements exist in the app.
- Confirmed the extension no longer references sampler-owned controls from the Navigate sampling panel.

PR checks passing before the latest review fix:

- Merge conflict check.
- Default-user state guard.
- ESLint.
- Frontend budgets.
- Unit tests.
- Merge-blocking label check.

4SR review status:

- Ran the required review workflow in chat.
- Found and fixed one disable-cleanup issue before marking the initial review complete.
- Addressed reviewer feedback by removing sampler-owned controls from the extension scope.

Not yet verified in browser:

- Extension panel rendering.
- Runtime tab switching.
- Enable/disable restoration.
- Console-error check.
- Mobile viewport visual pass.

## Screenshots (optional)
Not included. Browser verification is still pending, so screenshots would be premature.

## Anything Else?
This PR is intentionally limited to adding the extension and adapting it to SillyBunny's Chat Completion preset structure. It does not change core preset serialization, generation behavior, or API request construction.
