### PR TITLE
fix: preserve chat completion tab scroll

### DIFF
--- a/public/scripts/extensions/third-party/ChatCompletionTabs/components/tab-manager.js
+++ b/public/scripts/extensions/third-party/ChatCompletionTabs/components/tab-manager.js
@@ -359,21 +359,6 @@ export class TabManager {
             content.toggleAttribute('hidden', !isActive);
         });
 
-        // Scroll to top - check multiple possible scroll containers
-        const scrollContainers = [
-            '#left-nav-panel .scrollableInner',
-            '#user-settings-block',
-            '#user-settings-block-content',
-            '.drawer-content',
-        ];
-
-        scrollContainers.forEach(selector => {
-            const container = document.querySelector(selector);
-            if (container) {
-                container.scrollTop = 0;
-            }
-        });
-
         this.activeTab = tabId;
         this.saveTabPreference(tabId);
 


### PR DESCRIPTION
## What?
Removes the forced scroll reset from Chat Completion Tabs tab switching.

The tab manager now updates tab button and panel state without setting `scrollTop = 0` on unrelated scroll containers.

## Why?
The previous tab-switch behavior reset several broad containers every time a tab was selected. That could interrupt normal scroll feedback and make the active panel feel like it was fighting the user's attempt to scroll back up.

Preserving the browser's natural scroll state is the safer default for this tab UI.

## How?
The change deletes the scroll-reset block from `switchTab()` and leaves the existing tab-state behavior intact:

- `active` classes still update for tab buttons and content panels.
- `aria-selected`, `tabindex`, and `hidden` still update normally.
- Keyboard tab navigation still focuses the selected tab button.
- Active-tab persistence still writes to `localStorage`.

No CSS changes were needed. Existing sticky tab styling, reduced-motion handling, and button sizing remain unchanged.

## Testing?
Automated and static checks run locally:

- `node --check` on all Chat Completion Tabs JavaScript files.
- ESLint on all Chat Completion Tabs JavaScript files using the project configuration.
- JSON parsing for the extension manifest and i18n files.
- `git diff --check`.
- Local-path scan over the extension content.

PR checks passing:

- Merge conflict check.
- Default-user state guard.
- ESLint.
- Frontend budgets.
- Unit tests.
- Merge-blocking label check.

4SR review status:

- Ran the required review workflow in chat.
- No blocking findings from the static review pass.

Not yet verified in browser:

- Scroll position preservation after switching between Parameters and Prompts.
- No scroll jumping when scrolling back up in the active panel.
- Keyboard tab navigation without page scroll jumps.
- Reduced-motion behavior.
- Mobile viewport touch target sanity check.

## Screenshots (optional)
Not included. This is behavior-only scroll handling and browser verification is still pending.

## Anything Else?
Follow-up to the Chat Completion Tabs integration. This does not change extension metadata, tab selectors, accessibility attributes, or core Chat Completion request behavior.
