### PR TITLE
fix: honor profile secret ids for custom chat completions

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -1824,7 +1824,7 @@ router.post('/status', async function (request, statusResponse) {
             headers = {};
         } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.CUSTOM) {
             apiUrl = request.body.custom_url;
-            apiKey = readSecret(request.user.directories, SECRET_KEYS.CUSTOM);
+            apiKey = readSecret(request.user.directories, SECRET_KEYS.CUSTOM, request.body.secret_id);
             headers = {};
             mergeObjectWithYaml(headers, request.body.custom_include_headers);
         } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.COHERE) {
@@ -2762,7 +2762,7 @@ router.post('/generate', async function (request, response) {
             }
         } else if (request.body.chat_completion_source === CHAT_COMPLETION_SOURCES.CUSTOM) {
             apiUrl = request.body.custom_url;
-            apiKey = readSecret(request.user.directories, SECRET_KEYS.CUSTOM);
+            apiKey = readSecret(request.user.directories, SECRET_KEYS.CUSTOM, request.body.secret_id);
             headers = {};
             bodyParams = {
                 logprobs: request.body.logprobs,

--- a/src/endpoints/secrets.js
+++ b/src/endpoints/secrets.js
@@ -471,10 +471,11 @@ export function deleteSecret(directories, key) {
  * Reads a secret from the secrets file
  * @param {import('../users.js').UserDirectoryList} directories User directories
  * @param {string} key Secret key
+ * @param {string?} id ID of the secret to read (optional)
  * @returns {string} Secret value
  */
-export function readSecret(directories, key) {
-    return new SecretManager(directories).readSecret(key, null);
+export function readSecret(directories, key, id = null) {
+    return new SecretManager(directories).readSecret(key, id);
 }
 
 /**

--- a/tests/secrets.test.js
+++ b/tests/secrets.test.js
@@ -1,0 +1,50 @@
+import { afterEach, describe, test, expect, jest } from '@jest/globals';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tempDirs = [];
+
+async function importSecrets() {
+    jest.resetModules();
+
+    let idCounter = 0;
+    await jest.unstable_mockModule('../src/util.js', () => ({
+        color: {
+            green: value => value,
+            red: value => value,
+        },
+        getConfigValue: jest.fn(() => false),
+        uuidv4: jest.fn(() => `secret-id-${++idCounter}`),
+    }));
+
+    return await import('../src/endpoints/secrets.js');
+}
+
+function createUserDirectories() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-secrets-'));
+    const backups = path.join(root, 'backups');
+    fs.mkdirSync(backups, { recursive: true });
+    tempDirs.push(root);
+    return { root, backups };
+}
+
+afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+describe('secret helpers', () => {
+    test('reads a non-active secret by id through the compatibility helper', async () => {
+        const { SECRET_KEYS, SecretManager, readSecret } = await importSecrets();
+        const directories = createUserDirectories();
+        const manager = new SecretManager(directories);
+        const firstId = manager.writeSecret(SECRET_KEYS.CUSTOM, 'first-key', 'first');
+        const secondId = manager.writeSecret(SECRET_KEYS.CUSTOM, 'second-key', 'second');
+
+        expect(readSecret(directories, SECRET_KEYS.CUSTOM)).toBe('second-key');
+        expect(readSecret(directories, SECRET_KEYS.CUSTOM, firstId)).toBe('first-key');
+        expect(readSecret(directories, SECRET_KEYS.CUSTOM, secondId)).toBe('second-key');
+    });
+});


### PR DESCRIPTION
## What?
Fixes Custom OpenAI-compatible chat completion requests so saved connection profile secret IDs are honored instead of falling back to the currently active Custom API key.

## Why?
In-chat agents and other profile-driven requests can send the correct profile `secret_id`, but the backend Custom chat completion path ignored it. This made profile requests authenticate with whichever Custom key was active in the main settings UI, causing unauthorized errors when profile URLs expected a different saved key.

## How?
- Forwards the optional `id` argument through the `readSecret` compatibility helper.
- Passes `request.body.secret_id` into Custom chat completion status and generate secret lookups.
- Adds a regression test proving the compatibility helper can read a non-active secret by ID while preserving active-secret fallback behavior.

## Testing?
- `npm run test:unit --prefix tests -- tests/secrets.test.js`
- `npm run test:unit --prefix tests -- tests/secrets.test.js tests/openai-responses.test.js`
- `npm exec -- eslint src/endpoints/secrets.js src/endpoints/backends/chat-completions.js tests/secrets.test.js`
- `npm run lint`

## Screenshots (optional)
Not applicable; this is backend request authentication behavior.

## Anything Else?
Root and nested test dependencies were installed with `npm ci --ignore-scripts` in the contribution worktree for local verification. npm reported pre-existing audit warnings during install; this PR does not change dependencies.
