### PR TITLE
fix: let chat completion tab switcher scroll

### DIFF
--- a/public/scripts/extensions/third-party/ChatCompletionTabs/style.css
+++ b/public/scripts/extensions/third-party/ChatCompletionTabs/style.css
@@ -31,8 +31,6 @@
 /* Base Tab Buttons */
 .openai-tab-buttons {
     display: flex;
-    position: sticky;
-    top: 0;
     gap: 4px;
     margin-top: 8px;
     padding: 4px;
@@ -41,7 +39,6 @@
     overflow: visible;
     background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 92%, var(--SmartThemeBodyColor) 8%);
     box-shadow: 0 8px 18px color-mix(in srgb, var(--SmartThemeShadowColor, var(--SmartThemeBodyColor)) 10%, transparent);
-    z-index: 1000;
     flex-wrap: nowrap;
 }
 
@@ -106,10 +103,6 @@
 }
 
 @media (max-width: 600px) {
-    .openai-tab-buttons {
-        top: 4px;
-    }
-
     .openai-tab-button {
         min-height: 44px;
         padding-inline: 8px;


### PR DESCRIPTION
## What?
Lets the Chat Completion Tabs switcher scroll naturally with the preset panel instead of staying pinned while the user scrolls down.

This removes sticky positioning from the tab button row and deletes its sticky-only offset/z-index rules.

## Why?
User feedback after the scroll-preservation fix was that the switcher should not continue floating while scrolling through long preset content. Some normal scrolling is acceptable; the desired behavior is for the switcher to remain where it appears when the user switches views, then scroll away with the rest of the content.

## How?
The CSS for `.openai-tab-buttons` now stays in normal document flow:

- Removed `position: sticky`.
- Removed the sticky `top` offsets, including the mobile override.
- Removed the high `z-index` that was only needed for sticky layering.
- Left spacing, border, background, shadow, button sizing, focus styling, and mobile 44px touch targets intact.

## Testing?
Automated and static checks run locally:

- `node --check` on all Chat Completion Tabs JavaScript files.
- ESLint on all Chat Completion Tabs JavaScript files using the project configuration.
- JSON parsing for the extension manifest and i18n files.
- `git diff --check`.
- Scan confirmed no sticky/z-index switcher rules remain in the extension stylesheet.
- Local-path scan over extension files and public PR text.

Browser verification on the PR branch:

- Desktop short-viewport pass: after switching tabs, the switcher stayed in normal document flow; scrolling the preset panel moved the row with the content instead of pinning it.
- Desktop full-height pass: the row was visible after switching tabs, with `position: static`, `top: auto`, and `z-index: auto`.
- Mobile-width pass: the row stayed `static`, moved with panel scroll, and both tab buttons remained 44px high.

GitHub PR checks are passing:

- Semantic PR.
- Merge conflicts.
- Default-user state guard.
- ESLint.
- Frontend budgets.
- Unit tests.
- Label and merge-blocking workflows.

## Screenshots (optional)
Not included. This is a small behavior/style adjustment, and the browser pass used computed layout and scroll measurements instead.

## Anything Else?
Follow-up to the Chat Completion Tabs scroll polish. This does not change tab selectors, moved content behavior, accessibility attributes, or Chat Completion request behavior.

4SR review completed in chat; no GitHub review comments were posted.