### PR TITLE
docs: add update troubleshooting steps

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -141,6 +141,28 @@ bash start.sh
 
 ---
 
+## Troubleshooting
+
+### Blank Screen Or Stale UI After Update
+
+1. Hard refresh the tab: `Ctrl+Shift+R` on Windows/Linux or `Cmd+Shift+R` on macOS.
+2. If the old UI still appears, clear site data for the SillyBunny address in your browser settings or DevTools.
+3. Temporarily disable browser extensions such as ad blockers, script blockers, and privacy filters, then reload.
+
+Clearing cookies/site data signs you out and resets browser-local UI state for that address, so try a hard refresh first.
+
+### Connection Or Fetch Errors
+
+- Confirm the SillyBunny server window is still running.
+- Open `http://127.0.0.1:4444` directly in the same browser.
+- Check whether a firewall, VPN, proxy, or browser extension is blocking localhost traffic.
+
+### Bun Install Fails During Update
+
+The launcher retries dependency installs without `--frozen-lockfile` when a stale Bun lockfile blocks startup. If startup still fails after that retry, close the server window, delete `bun.lock`, and run the launcher again.
+
+---
+
 ## Project Goals (AKA, why we made this fork)
 
 Our primary goals for SillyBunny are as follows:

--- a/README.md
+++ b/README.md
@@ -139,6 +139,28 @@ bash start.sh
 
 ---
 
+## Troubleshooting
+
+### Blank Screen Or Stale UI After Update
+
+1. Hard refresh the tab: `Ctrl+Shift+R` on Windows/Linux or `Cmd+Shift+R` on macOS.
+2. If the old UI still appears, clear site data for the SillyBunny address in your browser settings or DevTools.
+3. Temporarily disable browser extensions such as ad blockers, script blockers, and privacy filters, then reload.
+
+Clearing cookies/site data signs you out and resets browser-local UI state for that address, so try a hard refresh first.
+
+### Connection Or Fetch Errors
+
+- Confirm the SillyBunny server window is still running.
+- Open `http://127.0.0.1:4444` directly in the same browser.
+- Check whether a firewall, VPN, proxy, or browser extension is blocking localhost traffic.
+
+### Bun Install Fails During Update
+
+The launcher retries dependency installs without `--frozen-lockfile` when a stale Bun lockfile blocks startup. If startup still fails after that retry, close the server window, delete `bun.lock`, and run the launcher again.
+
+---
+
 ## Project Goals (AKA, why we made this fork)
 
 Our primary goals for SillyBunny are as follows:


### PR DESCRIPTION
## What?
Adds README troubleshooting steps for stale UI after updates, localhost connection/fetch errors, and Bun install failures during startup/update.

## Why?
These are common recovery paths users need after updating or launching the fork, and they should be visible in the main project docs.

## How?
Adds a concise troubleshooting section to the root README and updates the GitHub README mirror with the repository sync script.

## Testing?
- `bash scripts/sync-readme-mirror.sh --check`
- `git diff --check origin/staging..HEAD`

## Screenshots (optional)
Not applicable for documentation-only changes.

## Anything Else?
The `.github/readme.md` file was generated from `README.md` with the existing mirror script.