### PR TITLE
fix: restore mobile composer auto-grow

### DIFF
--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -1672,8 +1672,9 @@
         width: 100% !important;
         min-width: 0 !important;
         min-height: var(--sb-mobile-composer-input-height) !important;
-        height: var(--sb-mobile-composer-input-height) !important;
+        field-sizing: content !important;
         max-height: 42dvh !important;
+        overflow-y: auto !important;
         padding: 8px 10px !important;
         font-size: 16px !important;
         line-height: 1.25 !important;
@@ -1683,7 +1684,6 @@
 
     :root[data-sb-compact-mode='true'] #send_textarea {
         min-height: var(--sb-mobile-composer-input-height) !important;
-        height: var(--sb-mobile-composer-input-height) !important;
         padding: 7px 9px !important;
         line-height: 1.22 !important;
     }

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -1049,6 +1049,9 @@ select.text_pole:where(:not([multiple]):not([size]):not(.select2-hidden-accessib
 #send_textarea {
     min-height: 68px;
     height: auto;
+    field-sizing: content;
+    max-height: min(50vh, 28rem);
+    overflow-y: auto;
     padding: var(--input-padding-y, 14px) var(--input-padding-x, 16px);
     line-height: 1.56;
     border-radius: var(--sb-radius-md);


### PR DESCRIPTION
## What?
Restores auto-growing behavior for the chat composer textarea on the SillyBunny mobile shell.

## Why?
The mobile composer was pinned to the compact one-line height, so multi-line input became harder to review before sending.

## How?
Removes the mobile fixed-height override, keeps the existing minimum height, enables content-based field sizing, and caps growth with a viewport-aware max height plus internal scrolling.

## Testing?
- `npm ci --ignore-scripts`
- `npm run lint -- --quiet`
- `npm run check:frontend-budgets` against an LF-only committed-tree archive: blocking stylesheets 14 / 672.7 KiB, startup scripts 21 / 1547.8 KiB
- `git diff --check origin/staging..HEAD`
- Manual Playwright probe before split: textarea grew from 46px to 119px for five lines at the mobile shell.
- Manual Chrome DevTools probe before split: 1920x1200 mobile touch landscape showed no horizontal overflow and textarea growth around 123px.

## Screenshots (optional)
Not included. Manual browser probes verified the layout behavior instead of capturing a static screenshot.

## Anything Else?
This PR is one focused slice from the pinned SillyBunny actionables work and is independent of the preset-confirmation and README troubleshooting PRs.