### PR TITLE
feat: add pre-generation agent interceptors

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -177,7 +177,7 @@ SillyBunny has support for In-Chat Agents. These are custom prompt fields that c
 
 **Pipeline:**
 
-1. **Pre-generation agents** injects prompt text before the main reply is generated.
+1. **Pre-generation agents** inject prompt text before the main reply is generated, or run as interceptors that rewrite the assembled outgoing context before it reaches the main model.
 2. **Main Model** writes the main RP reply.
 3. **Post-generation agents** optionally rewrites the contents of the main response, or appends extra content after the reply.
 4. **Post-process utilities** can extract structured data, run regex cleanup/formatting, or preserve machine-readable blocks while showing cleaner UI.
@@ -204,6 +204,7 @@ SillyBunny has support for In-Chat Agents. These are custom prompt fields that c
 **Agent Behaviors and Settings**
 * Agentic prompts feature inline run-order editing, click-to-edit functionality, and fullscreen prompt editors.
 * Agents use the main connection profile by default with an 8192 max token limit. Separate connection profile support is available when explicitly selected.
+* Pre-generation interceptors can replace the outgoing context, wrap or append helper output, or add tagged patches. Multiple interceptors run in agent order.
 * Bundled trackers, including CYOA Choices, are configured for pre-generation. The main model emits clickable options directly in the response.
 * All bundled tracker and menu agents default to the User injection role to maintain compatibility with models that deprioritize System injections.
 * Built-in groups are available for the full preset, trackers only, and randomizers only.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ SillyBunny has support for In-Chat Agents. These are custom prompt fields that c
 
 **Pipeline:**
 
-1. **Pre-generation agents** injects prompt text before the main reply is generated.
+1. **Pre-generation agents** inject prompt text before the main reply is generated, or run as interceptors that rewrite the assembled outgoing context before it reaches the main model.
 2. **Main Model** writes the main RP reply.
 3. **Post-generation agents** optionally rewrites the contents of the main response, or appends extra content after the reply.
 4. **Post-process utilities** can extract structured data, run regex cleanup/formatting, or preserve machine-readable blocks while showing cleaner UI.
@@ -202,6 +202,7 @@ SillyBunny has support for In-Chat Agents. These are custom prompt fields that c
 **Agent Behaviors and Settings**
 * Agentic prompts feature inline run-order editing, click-to-edit functionality, and fullscreen prompt editors.
 * Agents use the main connection profile by default with an 8192 max token limit. Separate connection profile support is available when explicitly selected.
+* Pre-generation interceptors can replace the outgoing context, wrap or append helper output, or add tagged patches. Multiple interceptors run in agent order.
 * Bundled trackers, including CYOA Choices, are configured for pre-generation. The main model emits clickable options directly in the response.
 * All bundled tracker and menu agents default to the User injection role to maintain compatibility with models that deprioritize System injections.
 * Built-in groups are available for the full preset, trackers only, and randomizers only.

--- a/public/script.js
+++ b/public/script.js
@@ -441,6 +441,7 @@ const MESSAGE_SCREENSHOT_INPUT_IDS = Object.freeze({
     end: 'message_screenshot_end_id',
 });
 const IN_CHAT_AGENT_TRANSFORM_HISTORY_KEY = 'inChatAgentTransformHistory';
+const IN_CHAT_AGENT_PRE_GENERATION_INTERCEPT_HISTORY_KEY = 'inChatAgentPreGenerationInterceptHistory';
 /** @type {ChatMessage[]} */
 export let chat = [];
 
@@ -3417,13 +3418,20 @@ function updateMessageMetaBadges(messageElement, message) {
 
 function hasPromptTransformHistoryForActiveSwipe(message) {
     const storedHistory = getActiveSwipeExtraValue(message, IN_CHAT_AGENT_TRANSFORM_HISTORY_KEY);
-    return Array.isArray(storedHistory) && storedHistory.some(entry => {
+    const hasPostGenerationHistory = Array.isArray(storedHistory) && storedHistory.some(entry => {
         if (!entry || typeof entry !== 'object') {
             return false;
         }
 
         return normalizeContentText(entry.afterText) === normalizeContentText(message?.mes);
     });
+
+    if (hasPostGenerationHistory) {
+        return true;
+    }
+
+    const preGenerationHistory = getActiveSwipeExtraValue(message, IN_CHAT_AGENT_PRE_GENERATION_INTERCEPT_HISTORY_KEY);
+    return Array.isArray(preGenerationHistory) && preGenerationHistory.some(entry => entry && typeof entry === 'object');
 }
 
 function getActiveSwipeExtraValue(message, key) {
@@ -4497,6 +4505,7 @@ class StreamingProcessor {
             }
             if (this.type === 'swipe') {
                 delete chat[messageId].extra[IN_CHAT_AGENT_TRANSFORM_HISTORY_KEY];
+                delete chat[messageId].extra[IN_CHAT_AGENT_PRE_GENERATION_INTERCEPT_HISTORY_KEY];
             }
             chat[messageId].extra.time_to_first_token = this.timeToFirstToken;
 
@@ -4588,6 +4597,7 @@ class StreamingProcessor {
             delete swipeInfoExtra.reasoning_duration;
             delete swipeInfoExtra.reasoning_tokens;
             delete swipeInfoExtra[IN_CHAT_AGENT_TRANSFORM_HISTORY_KEY];
+            delete swipeInfoExtra[IN_CHAT_AGENT_PRE_GENERATION_INTERCEPT_HISTORY_KEY];
             const swipeInfo = {
                 send_date: message.send_date,
                 gen_started: message.gen_started,
@@ -7717,6 +7727,7 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
             lastMessage.extra.reasoning_duration = null;
             lastMessage.extra.reasoning_signature = reasoningSignature;
             delete lastMessage.extra[IN_CHAT_AGENT_TRANSFORM_HISTORY_KEY];
+            delete lastMessage.extra[IN_CHAT_AGENT_PRE_GENERATION_INTERCEPT_HISTORY_KEY];
             await processImageAttachment(lastMessage, { imageUrls });
             await updateMessageTokenAccounting(lastMessage, { reasoning, reasoningTokens });
             const chat_id = (chat.length - 1);
@@ -7842,6 +7853,7 @@ export async function saveReply({ type, getMessage, fromStreaming = false, title
         delete swipeInfoExtra.reasoning_duration;
         delete swipeInfoExtra.reasoning_tokens;
         delete swipeInfoExtra[IN_CHAT_AGENT_TRANSFORM_HISTORY_KEY];
+        delete swipeInfoExtra[IN_CHAT_AGENT_PRE_GENERATION_INTERCEPT_HISTORY_KEY];
         const swipeInfo = {
             send_date: item.send_date,
             gen_started: item.gen_started,
@@ -12598,6 +12610,7 @@ export async function swipe(event, direction, { source, repeated, message = chat
             delete message.extra.title;
             delete message.extra.append_title;
             delete message.extra[IN_CHAT_AGENT_TRANSFORM_HISTORY_KEY];
+            delete message.extra[IN_CHAT_AGENT_PRE_GENERATION_INTERCEPT_HISTORY_KEY];
         }
         delete message.gen_started;
         delete message.gen_finished;

--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -3006,7 +3006,14 @@ async function onChatCompletionPromptReady(eventData) {
         return;
     }
 
-    eventData.chat = await runPreGenerationInterceptorsOnChat(eventData.chat, currentMainGenerationType);
+    const originalChat = eventData.chat;
+    const nextChat = await runPreGenerationInterceptorsOnChat(originalChat, currentMainGenerationType);
+    if (nextChat === originalChat) {
+        return;
+    }
+
+    originalChat.splice(0, originalChat.length, ...nextChat);
+    eventData.chat = originalChat;
 }
 
 async function onImpersonateReady(text = '') {

--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -51,6 +51,7 @@ const MESSAGE_EXTRA_KEY = 'inChatAgents';
 const POST_PROCESSING_RUNS_EXTRA_KEY = 'inChatAgentPostRuns';
 export const PROMPT_RUNS_EXTRA_KEY = 'inChatAgentPromptRuns';
 export const PROMPT_TRANSFORM_HISTORY_KEY = 'inChatAgentTransformHistory';
+export const PRE_GENERATION_INTERCEPT_HISTORY_KEY = 'inChatAgentPreGenerationInterceptHistory';
 const MAX_TRANSFORM_HISTORY = 10;
 const pendingRefreshTimeouts = new Map();
 const pendingRegexSnapshotSaves = new WeakSet();
@@ -90,6 +91,7 @@ let activeManualAgentRun = null;
 let parallelManualRunCount = 0;
 let agentGenerationCancelRevision = 0;
 const promptTransformIdleResolvers = new Set();
+let pendingPreGenerationInterceptRuns = [];
 let generationStartChatLength = 0;
 let generationStartLastAssistantIndex = -1;
 let generationStartLastAssistantMessage = null;
@@ -1625,13 +1627,8 @@ function shouldRefreshTransformHistoryUi(messageIndex, message) {
         return false;
     }
 
-    const history = getPromptTransformHistoryForText(getAgentExtraValue(message, PROMPT_TRANSFORM_HISTORY_KEY), message.mes);
-    if (history.length === 0) {
-        return false;
-    }
-
     const messageElement = document.querySelector(`.mes[mesid="${numericMessageIndex}"]`);
-    return Boolean(messageElement && !messageElement.querySelector('.agent-transform-badge'));
+    return Boolean(messageElement && hasAgentDocumentHistory(message) && !messageElement.querySelector('.agent-transform-badge'));
 }
 
 function getPromptTransformHistoryForText(history, currentText) {
@@ -1661,6 +1658,23 @@ function getPromptTransformHistoryForText(history, currentText) {
 export function getPromptTransformHistoryForMessage(message) {
     const storedHistory = getAgentExtraValue(message, PROMPT_TRANSFORM_HISTORY_KEY);
     return getPromptTransformHistoryForText(storedHistory, message?.mes);
+}
+
+function getPreGenerationInterceptHistoryFromValue(history) {
+    return Array.isArray(history)
+        ? history.filter(entry => entry && typeof entry === 'object')
+        : [];
+}
+
+export function getPreGenerationInterceptHistoryForMessage(message) {
+    return getPreGenerationInterceptHistoryFromValue(
+        getAgentExtraValue(message, PRE_GENERATION_INTERCEPT_HISTORY_KEY),
+    );
+}
+
+function hasAgentDocumentHistory(message) {
+    return getPromptTransformHistoryForMessage(message).length > 0 ||
+        getPreGenerationInterceptHistoryForMessage(message).length > 0;
 }
 
 function unwrapAssistantResponseWrapper(value) {
@@ -1859,6 +1873,52 @@ function sanitizePromptTransformRunForStorage(result) {
     const storedResult = { ...result };
     delete storedResult.outputText;
     return storedResult;
+}
+
+function sanitizePreGenerationInterceptRunForStorage(result) {
+    if (!result || typeof result !== 'object') {
+        return result;
+    }
+
+    return {
+        agentId: result.agentId,
+        agentName: result.agentName,
+        applyMode: result.applyMode,
+        contextFormat: result.contextFormat,
+        status: result.status,
+        changed: Boolean(result.changed),
+        beforeText: normalizeContentText(result.beforeText),
+        afterText: normalizeContentText(result.afterText),
+        outputText: normalizeContentText(result.outputText),
+        profileId: result.profileId ?? '',
+        runner: result.runner ?? '',
+        role: result.role ?? '',
+        timestamp: result.timestamp,
+        error: result.error,
+    };
+}
+
+function takePendingPreGenerationInterceptRuns() {
+    const runs = pendingPreGenerationInterceptRuns;
+    pendingPreGenerationInterceptRuns = [];
+    return runs;
+}
+
+function storePreGenerationInterceptHistory(message, runs) {
+    if (!message || !Array.isArray(runs) || runs.length === 0) {
+        return false;
+    }
+
+    const storedRuns = runs
+        .map(result => sanitizePreGenerationInterceptRunForStorage(result))
+        .filter(result => result && typeof result === 'object' && result.status !== 'skipped-empty-prompt');
+
+    if (storedRuns.length === 0) {
+        return false;
+    }
+
+    setAgentExtraValue(message, PRE_GENERATION_INTERCEPT_HISTORY_KEY, storedRuns.slice(-MAX_TRANSFORM_HISTORY));
+    return true;
 }
 
 function consolidateAppendPromptTransformOutputs(baseText, agents, results) {
@@ -2364,6 +2424,7 @@ function onGenerationStarted(generationType, _options, dryRun) {
     clearPostGenerationRecoveryCheck();
     clearMissedGenerationEndRecoveryCheck();
     clearAllPromptTransformRunningToasts();
+    takePendingPreGenerationInterceptRuns();
     pendingGenerationSnapshot = buildActivationSnapshot(currentMainGenerationType);
     generationStartChatLength = chat.length;
     const latestAssistantMessageIndex = getLatestAssistantMessageIndex();
@@ -2415,6 +2476,7 @@ function onGenerationStopped() {
     clearMissedGenerationEndRecoveryCheck();
     clearDeferredPostProcessing();
     clearAllPromptTransformRunningToasts();
+    takePendingPreGenerationInterceptRuns();
     abortActivePathfinderRetrieval('Pathfinder retrieval cancelled because generation stopped.');
 }
 
@@ -2536,6 +2598,10 @@ async function processReceivedMessage(messageIndex, generationType, activationSn
 
     let chatStateChanged = false;
     let messageDisplayChanged = false;
+    if (storePreGenerationInterceptHistory(message, takePendingPreGenerationInterceptRuns())) {
+        chatStateChanged = true;
+        messageDisplayChanged = true;
+    }
 
     const promptRuns = [];
     let currentPromptTransformText = unwrapAssistantResponseWrapper(message.mes);
@@ -2841,14 +2907,34 @@ async function runPromptTransformAgentsForText(promptTransformAgents, initialTex
     };
 }
 
-async function runContextInterceptAgentOutput(agent, currentContextText, generationType, contextFormat) {
+async function runContextInterceptAgent(agent, currentContextText, generationType, contextFormat) {
+    const beforeText = normalizeContentText(currentContextText);
+    const applyMode = ['wrap', 'patch'].includes(String(agent?.preProcess?.applyMode))
+        ? String(agent.preProcess.applyMode)
+        : 'replace';
+    const baseResult = {
+        agentId: agent.id,
+        agentName: agent.name,
+        applyMode,
+        contextFormat,
+        changed: false,
+        beforeText,
+        afterText: beforeText,
+        outputText: '',
+        profileId: '',
+        runner: 'none',
+        timestamp: new Date().toISOString(),
+    };
     const expandedPrompt = substituteParams(agent.prompt, {
         original: currentContextText,
         dynamicMacros: buildPromptDynamicMacros(currentContextText, null, agent, generationType),
     }).trim();
 
     if (!expandedPrompt || !currentContextText.trim()) {
-        return null;
+        return {
+            ...baseResult,
+            status: 'skipped-empty-prompt',
+        };
     }
 
     const promptMessages = buildContextInterceptMessages(expandedPrompt, currentContextText, generationType, contextFormat);
@@ -2861,10 +2947,22 @@ async function runContextInterceptAgentOutput(agent, currentContextText, generat
 
     if (!outputText) {
         console.warn(`[InChatAgents] pre-generation intercept agent "${agent.name}" returned an empty response.`);
-        return null;
+        return {
+            ...baseResult,
+            status: 'empty-response',
+            profileId: response.profileId,
+            runner: response.runner,
+        };
     }
 
-    return outputText;
+    return {
+        ...baseResult,
+        status: 'changed',
+        changed: true,
+        outputText,
+        profileId: response.profileId,
+        runner: response.runner,
+    };
 }
 
 function getGenerationContextSnapshot(generationType = null) {
@@ -2879,34 +2977,55 @@ function getGenerationContextSnapshot(generationType = null) {
 
 async function runPreGenerationInterceptorsOnText(initialContextText, generationType, contextFormat) {
     if (internalPromptTransformDepth > 0 || !areAgentsGloballyEnabled()) {
-        return initialContextText;
+        return { text: initialContextText, runs: [] };
     }
 
     let currentContextText = String(initialContextText ?? '');
     if (!currentContextText.trim()) {
-        return currentContextText;
+        return { text: currentContextText, runs: [] };
     }
 
     const activationSnapshot = getGenerationContextSnapshot(generationType);
     const interceptAgents = getPreGenerationInterceptAgents(getSnapshotAgents(activationSnapshot));
     if (interceptAgents.length === 0) {
-        return currentContextText;
+        return { text: currentContextText, runs: [] };
     }
 
+    const runs = [];
     for (const agent of interceptAgents) {
         try {
-            const outputText = await runContextInterceptAgentOutput(agent, currentContextText, activationSnapshot.generationType, contextFormat);
-            if (outputText === null) {
+            const result = await runContextInterceptAgent(agent, currentContextText, activationSnapshot.generationType, contextFormat);
+            if (result.status !== 'changed') {
+                runs.push(result);
                 continue;
             }
 
-            currentContextText = applyContextInterceptText(currentContextText, outputText, agent.preProcess);
+            currentContextText = applyContextInterceptText(currentContextText, result.outputText, agent.preProcess);
+            result.afterText = currentContextText;
+            result.changed = result.afterText !== result.beforeText;
+            result.status = result.changed ? 'changed' : 'unchanged';
+            runs.push(result);
         } catch (error) {
             console.warn(`[InChatAgents] Pre-generation intercept agent "${agent.name}" failed. Leaving context unchanged for this agent.`, error);
+            runs.push({
+                agentId: agent.id,
+                agentName: agent.name,
+                applyMode: ['wrap', 'patch'].includes(String(agent?.preProcess?.applyMode)) ? String(agent.preProcess.applyMode) : 'replace',
+                contextFormat,
+                changed: false,
+                status: 'error',
+                error: error instanceof Error ? error.message : String(error),
+                beforeText: currentContextText,
+                afterText: currentContextText,
+                outputText: '',
+                profileId: '',
+                runner: 'error',
+                timestamp: new Date().toISOString(),
+            });
         }
     }
 
-    return currentContextText;
+    return { text: currentContextText, runs };
 }
 
 function getContextInterceptChatRole(agent) {
@@ -2935,50 +3054,81 @@ function insertContextInterceptChatMessage(chatMessages, content, agent) {
 
 async function runPreGenerationInterceptorsOnChat(initialChatMessages, generationType) {
     if (internalPromptTransformDepth > 0 || !areAgentsGloballyEnabled()) {
-        return initialChatMessages;
+        return { chat: initialChatMessages, runs: [] };
     }
 
     let currentChatMessages = Array.isArray(initialChatMessages) ? [...initialChatMessages] : [];
     if (currentChatMessages.length === 0) {
-        return currentChatMessages;
+        return { chat: currentChatMessages, runs: [] };
     }
 
     const activationSnapshot = getGenerationContextSnapshot(generationType);
     const interceptAgents = getPreGenerationInterceptAgents(getSnapshotAgents(activationSnapshot));
     if (interceptAgents.length === 0) {
-        return currentChatMessages;
+        return { chat: currentChatMessages, runs: [] };
     }
 
+    const runs = [];
     for (const agent of interceptAgents) {
         const contextText = serializeChatContext(currentChatMessages);
 
         try {
-            const outputText = await runContextInterceptAgentOutput(agent, contextText, activationSnapshot.generationType, 'chat');
-            if (outputText === null) {
+            const result = await runContextInterceptAgent(agent, contextText, activationSnapshot.generationType, 'chat');
+            if (result.status !== 'changed') {
+                runs.push(result);
                 continue;
             }
 
             if (agent.preProcess?.applyMode === 'wrap') {
                 insertContextInterceptChatMessage(
                     currentChatMessages,
-                    `${String(agent.preProcess?.wrapPrefix ?? '')}${outputText}${String(agent.preProcess?.wrapSuffix ?? '')}`,
+                    `${String(agent.preProcess?.wrapPrefix ?? '')}${result.outputText}${String(agent.preProcess?.wrapSuffix ?? '')}`,
                     agent,
                 );
+                result.afterText = serializeChatContext(currentChatMessages);
+                result.changed = result.afterText !== result.beforeText;
+                result.status = result.changed ? 'changed' : 'unchanged';
+                result.role = getContextInterceptChatRole(agent);
+                runs.push(result);
                 continue;
             }
 
             if (agent.preProcess?.applyMode === 'patch') {
-                insertContextInterceptChatMessage(currentChatMessages, buildPatchTaggedText(outputText, agent.preProcess), agent);
+                insertContextInterceptChatMessage(currentChatMessages, buildPatchTaggedText(result.outputText, agent.preProcess), agent);
+                result.afterText = serializeChatContext(currentChatMessages);
+                result.changed = result.afterText !== result.beforeText;
+                result.status = result.changed ? 'changed' : 'unchanged';
+                result.role = getContextInterceptChatRole(agent);
+                runs.push(result);
                 continue;
             }
 
-            currentChatMessages = parseChatContext(outputText);
+            currentChatMessages = parseChatContext(result.outputText);
+            result.afterText = serializeChatContext(currentChatMessages);
+            result.changed = result.afterText !== result.beforeText;
+            result.status = result.changed ? 'changed' : 'unchanged';
+            runs.push(result);
         } catch (error) {
             console.warn(`[InChatAgents] Pre-generation intercept agent "${agent.name}" failed. Leaving chat context unchanged for this agent.`, error);
+            runs.push({
+                agentId: agent.id,
+                agentName: agent.name,
+                applyMode: ['wrap', 'patch'].includes(String(agent?.preProcess?.applyMode)) ? String(agent.preProcess.applyMode) : 'replace',
+                contextFormat: 'chat',
+                changed: false,
+                status: 'error',
+                error: error instanceof Error ? error.message : String(error),
+                beforeText: contextText,
+                afterText: contextText,
+                outputText: '',
+                profileId: '',
+                runner: 'error',
+                timestamp: new Date().toISOString(),
+            });
         }
     }
 
-    return currentChatMessages;
+    return { chat: currentChatMessages, runs };
 }
 
 async function onGenerateAfterCombinePrompts(eventData) {
@@ -2990,11 +3140,13 @@ async function onGenerateAfterCombinePrompts(eventData) {
         return;
     }
 
-    eventData.prompt = await runPreGenerationInterceptorsOnText(
+    const result = await runPreGenerationInterceptorsOnText(
         eventData.prompt,
         currentMainGenerationType,
         'text',
     );
+    eventData.prompt = result.text;
+    pendingPreGenerationInterceptRuns.push(...result.runs);
 }
 
 async function onChatCompletionPromptReady(eventData) {
@@ -3007,7 +3159,9 @@ async function onChatCompletionPromptReady(eventData) {
     }
 
     const originalChat = eventData.chat;
-    const nextChat = await runPreGenerationInterceptorsOnChat(originalChat, currentMainGenerationType);
+    const result = await runPreGenerationInterceptorsOnChat(originalChat, currentMainGenerationType);
+    const nextChat = result.chat;
+    pendingPreGenerationInterceptRuns.push(...result.runs);
     if (nextChat === originalChat) {
         return;
     }

--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -26,6 +26,7 @@ import {
     getGlobalSettings,
     getPromptTransformMode,
     isToolAgent,
+    normalizePreProcessMaxTokens,
     normalizePromptTransformMaxTokens,
     resolveConnectionProfile,
 } from './agent-store.js';
@@ -61,6 +62,7 @@ const PREPEND_PROMPT_TRANSFORM_TEMPLATE_IDS = new Set([
 ]);
 const PREPEND_PROMPT_TRANSFORM_TAG_RE = /\[(?:SCENE|TIME)\|/;
 const ASSISTANT_RESPONSE_WRAPPER_RE = /^\s*<assistant_response>\s*([\s\S]*?)\s*<\/assistant_response>\s*$/i;
+const CONTEXT_INTERCEPT_OUTPUT_RE = /^\s*<context>\s*([\s\S]*?)\s*<\/context>\s*$/i;
 const BODY_GENERATING_FLAG_GRACE_MS = 1500;
 const DEFERRED_POST_PROCESSING_RETRY_MS = 50;
 const LATEST_ASSISTANT_POST_PROCESSING_FALLBACK_WINDOW_MS = 30000;
@@ -1398,6 +1400,15 @@ function getPromptTransformAgentsForImpersonate(activeAgents) {
     return getPromptTransformAgents(activeAgents).filter(agent => Boolean(agent?.conditions?.runOnImpersonate));
 }
 
+function getPreGenerationInterceptAgents(activeAgents) {
+    return activeAgents.filter(agent =>
+        !isToolAgent(agent) &&
+        (agent.phase === 'pre' || agent.phase === 'both') &&
+        agent.preProcess?.mode === 'intercept' &&
+        String(agent.prompt ?? '').trim(),
+    ).sort((a, b) => Number(a?.injection?.order ?? 100) - Number(b?.injection?.order ?? 100));
+}
+
 function describePromptTransformMode(mode) {
     return mode === 'append' ? 'prompt append' : 'prompt rewrite';
 }
@@ -1671,6 +1682,81 @@ function unwrapAssistantResponseWrapper(value) {
     return text;
 }
 
+function unwrapContextInterceptOutput(value = '') {
+    let text = unwrapAssistantResponseWrapper(value);
+    let previousText = null;
+    let passCount = 0;
+
+    while (text !== previousText && passCount < 8) {
+        previousText = text;
+        const match = text.match(CONTEXT_INTERCEPT_OUTPUT_RE);
+        if (!match) {
+            break;
+        }
+
+        text = match[1];
+        passCount += 1;
+    }
+
+    return text;
+}
+
+function formatContextMessageContent(content) {
+    if (typeof content === 'string') {
+        return content;
+    }
+
+    if (content === null || content === undefined) {
+        return '';
+    }
+
+    return JSON.stringify(content, null, 2);
+}
+
+function serializeChatContext(chatMessages) {
+    return JSON.stringify((Array.isArray(chatMessages) ? chatMessages : []).map(message => ({
+        ...message,
+        content: formatContextMessageContent(message?.content),
+    })), null, 2);
+}
+
+function parseChatContext(value) {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) {
+        throw new Error('Intercepted chat context must be a JSON array of chat messages.');
+    }
+
+    return parsed;
+}
+
+function buildPatchTaggedText(text, preProcess = {}) {
+    const startTag = String(preProcess.patchStartTag ?? '').trim() || '<context_patch>';
+    const endTag = String(preProcess.patchEndTag ?? '').trim() || '</context_patch>';
+    return `${startTag}\n${text}\n${endTag}`;
+}
+
+function applyContextInterceptText(originalText, interceptText, preProcess = {}) {
+    const outputText = unwrapContextInterceptOutput(interceptText);
+    const applyMode = preProcess.applyMode === 'wrap' || preProcess.applyMode === 'patch'
+        ? preProcess.applyMode
+        : 'replace';
+
+    if (applyMode === 'wrap') {
+        const wrappedText = `${String(preProcess.wrapPrefix ?? '')}${outputText}${String(preProcess.wrapSuffix ?? '')}`;
+        if (preProcess.wrapPosition === 'before') {
+            return joinPromptTransformText(wrappedText, originalText);
+        }
+
+        return joinPromptTransformText(originalText, wrappedText);
+    }
+
+    if (applyMode === 'patch') {
+        return joinPromptTransformText(originalText, buildPatchTaggedText(outputText, preProcess));
+    }
+
+    return outputText;
+}
+
 function buildPromptTransformMessages(agentPrompt, messageText, assistantName, generationType, mode) {
     const isImpersonate = isImpersonateGenerationType(generationType);
     const targetLabel = isImpersonate ? 'generated impersonation text' : 'assistant response';
@@ -1690,6 +1776,21 @@ function buildPromptTransformMessages(agentPrompt, messageText, assistantName, g
         {
             role: 'user',
             content: `Assistant name: ${assistantName || 'Assistant'}\nGeneration type: ${generationType}\n\n${responseLabel}:\n<assistant_response>\n${currentAssistantResponse}\n</assistant_response>`,
+        },
+    ];
+}
+
+function buildContextInterceptMessages(agentPrompt, contextText, generationType, contextFormat) {
+    const formatLabel = contextFormat === 'chat' ? 'JSON array of chat-completion messages' : 'plain text completion prompt';
+
+    return [
+        {
+            role: 'system',
+            content: `${agentPrompt}\n\nYou are modifying the complete outgoing context before the main model sees it. Return only the revised context content requested by the instructions above. Do not add commentary, labels, or code fences unless they are part of the context itself. If no changes are needed, return the original context content verbatim.`,
+        },
+        {
+            role: 'user',
+            content: `Generation type: ${generationType}\nContext format: ${formatLabel}\n\nOutgoing context:\n<context>\n${contextText}\n</context>`,
         },
     ];
 }
@@ -2213,7 +2314,10 @@ function clearInChatAgentExtensionPrompts() {
 }
 
 function injectPreGenerationAgentPrompts(activeAgents, generationType) {
-    const promptAgents = activeAgents.filter(agent => agent.phase === 'pre' || agent.phase === 'both');
+    const promptAgents = activeAgents.filter(agent =>
+        (agent.phase === 'pre' || agent.phase === 'both') &&
+        agent.preProcess?.mode !== 'intercept',
+    );
 
     for (const agent of promptAgents) {
         if (isToolAgent(agent)) {
@@ -2737,6 +2841,174 @@ async function runPromptTransformAgentsForText(promptTransformAgents, initialTex
     };
 }
 
+async function runContextInterceptAgentOutput(agent, currentContextText, generationType, contextFormat) {
+    const expandedPrompt = substituteParams(agent.prompt, {
+        original: currentContextText,
+        dynamicMacros: buildPromptDynamicMacros(currentContextText, null, agent, generationType),
+    }).trim();
+
+    if (!expandedPrompt || !currentContextText.trim()) {
+        return null;
+    }
+
+    const promptMessages = buildContextInterceptMessages(expandedPrompt, currentContextText, generationType, contextFormat);
+    const response = await requestPromptTransform(
+        agent,
+        promptMessages,
+        normalizePreProcessMaxTokens(agent.preProcess?.maxTokens),
+    );
+    const outputText = unwrapContextInterceptOutput(response.output).trim();
+
+    if (!outputText) {
+        console.warn(`[InChatAgents] pre-generation intercept agent "${agent.name}" returned an empty response.`);
+        return null;
+    }
+
+    return outputText;
+}
+
+function getGenerationContextSnapshot(generationType = null) {
+    const normalizedGenerationType = normalizeGenerationType(generationType ?? currentMainGenerationType);
+
+    if (pendingGenerationSnapshot?.generationType === normalizedGenerationType) {
+        return cloneActivationSnapshot(pendingGenerationSnapshot, normalizedGenerationType);
+    }
+
+    return buildActivationSnapshot(normalizedGenerationType);
+}
+
+async function runPreGenerationInterceptorsOnText(initialContextText, generationType, contextFormat) {
+    if (internalPromptTransformDepth > 0 || !areAgentsGloballyEnabled()) {
+        return initialContextText;
+    }
+
+    let currentContextText = String(initialContextText ?? '');
+    if (!currentContextText.trim()) {
+        return currentContextText;
+    }
+
+    const activationSnapshot = getGenerationContextSnapshot(generationType);
+    const interceptAgents = getPreGenerationInterceptAgents(getSnapshotAgents(activationSnapshot));
+    if (interceptAgents.length === 0) {
+        return currentContextText;
+    }
+
+    for (const agent of interceptAgents) {
+        try {
+            const outputText = await runContextInterceptAgentOutput(agent, currentContextText, activationSnapshot.generationType, contextFormat);
+            if (outputText === null) {
+                continue;
+            }
+
+            currentContextText = applyContextInterceptText(currentContextText, outputText, agent.preProcess);
+        } catch (error) {
+            console.warn(`[InChatAgents] Pre-generation intercept agent "${agent.name}" failed. Leaving context unchanged for this agent.`, error);
+        }
+    }
+
+    return currentContextText;
+}
+
+function getContextInterceptChatRole(agent) {
+    switch (Number(agent?.injection?.role)) {
+        case extension_prompt_roles.USER:
+            return 'user';
+        case extension_prompt_roles.ASSISTANT:
+            return 'assistant';
+        default:
+            return 'system';
+    }
+}
+
+function insertContextInterceptChatMessage(chatMessages, content, agent) {
+    const message = {
+        role: getContextInterceptChatRole(agent),
+        content,
+    };
+
+    if (agent?.preProcess?.wrapPosition === 'before') {
+        chatMessages.unshift(message);
+    } else {
+        chatMessages.push(message);
+    }
+}
+
+async function runPreGenerationInterceptorsOnChat(initialChatMessages, generationType) {
+    if (internalPromptTransformDepth > 0 || !areAgentsGloballyEnabled()) {
+        return initialChatMessages;
+    }
+
+    let currentChatMessages = Array.isArray(initialChatMessages) ? [...initialChatMessages] : [];
+    if (currentChatMessages.length === 0) {
+        return currentChatMessages;
+    }
+
+    const activationSnapshot = getGenerationContextSnapshot(generationType);
+    const interceptAgents = getPreGenerationInterceptAgents(getSnapshotAgents(activationSnapshot));
+    if (interceptAgents.length === 0) {
+        return currentChatMessages;
+    }
+
+    for (const agent of interceptAgents) {
+        const contextText = serializeChatContext(currentChatMessages);
+
+        try {
+            const outputText = await runContextInterceptAgentOutput(agent, contextText, activationSnapshot.generationType, 'chat');
+            if (outputText === null) {
+                continue;
+            }
+
+            if (agent.preProcess?.applyMode === 'wrap') {
+                insertContextInterceptChatMessage(
+                    currentChatMessages,
+                    `${String(agent.preProcess?.wrapPrefix ?? '')}${outputText}${String(agent.preProcess?.wrapSuffix ?? '')}`,
+                    agent,
+                );
+                continue;
+            }
+
+            if (agent.preProcess?.applyMode === 'patch') {
+                insertContextInterceptChatMessage(currentChatMessages, buildPatchTaggedText(outputText, agent.preProcess), agent);
+                continue;
+            }
+
+            currentChatMessages = parseChatContext(outputText);
+        } catch (error) {
+            console.warn(`[InChatAgents] Pre-generation intercept agent "${agent.name}" failed. Leaving chat context unchanged for this agent.`, error);
+        }
+    }
+
+    return currentChatMessages;
+}
+
+async function onGenerateAfterCombinePrompts(eventData) {
+    if (eventData?.dryRun || internalPromptTransformDepth > 0 || !isGenerationInProgress) {
+        return;
+    }
+
+    if (!eventData || typeof eventData.prompt !== 'string') {
+        return;
+    }
+
+    eventData.prompt = await runPreGenerationInterceptorsOnText(
+        eventData.prompt,
+        currentMainGenerationType,
+        'text',
+    );
+}
+
+async function onChatCompletionPromptReady(eventData) {
+    if (eventData?.dryRun || internalPromptTransformDepth > 0 || !isGenerationInProgress) {
+        return;
+    }
+
+    if (!eventData || !Array.isArray(eventData.chat)) {
+        return;
+    }
+
+    eventData.chat = await runPreGenerationInterceptorsOnChat(eventData.chat, currentMainGenerationType);
+}
+
 async function onImpersonateReady(text = '') {
     if (internalPromptTransformDepth > 0 || !areAgentsGloballyEnabled()) {
         return;
@@ -2991,6 +3263,14 @@ export function initAgentRunner() {
 
     if (event_types.CHAT_COMPLETION_SETTINGS_READY) {
         eventSource.on(event_types.CHAT_COMPLETION_SETTINGS_READY, onChatCompletionSettingsReady);
+    }
+
+    if (event_types.GENERATE_AFTER_COMBINE_PROMPTS) {
+        eventSource.on(event_types.GENERATE_AFTER_COMBINE_PROMPTS, onGenerateAfterCombinePrompts);
+    }
+
+    if (event_types.CHAT_COMPLETION_PROMPT_READY) {
+        eventSource.on(event_types.CHAT_COMPLETION_PROMPT_READY, onChatCompletionPromptReady);
     }
 
     if (event_types.WORLDINFO_ENTRIES_LOADED) {

--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -1740,6 +1740,27 @@ function parseChatContext(value) {
         throw new Error('Intercepted chat context must be a JSON array of chat messages.');
     }
 
+    const allowedRoles = new Set(['system', 'user', 'assistant', 'tool']);
+    for (const [index, message] of parsed.entries()) {
+        if (!message || typeof message !== 'object' || Array.isArray(message)) {
+            throw new Error(`Intercepted chat message at index ${index} must be an object.`);
+        }
+
+        if (!allowedRoles.has(message.role)) {
+            throw new Error(`Intercepted chat message at index ${index} has an unsupported role.`);
+        }
+
+        const hasContent = typeof message.content === 'string' || Array.isArray(message.content);
+        const hasToolCalls = Array.isArray(message.tool_calls);
+        if (!hasContent && !hasToolCalls) {
+            throw new Error(`Intercepted chat message at index ${index} must include content or tool_calls.`);
+        }
+
+        if (message.role === 'tool' && typeof message.tool_call_id !== 'string') {
+            throw new Error(`Intercepted chat message at index ${index} must include tool_call_id for tool role.`);
+        }
+    }
+
     return parsed;
 }
 

--- a/public/scripts/extensions/in-chat-agents/agent-store.js
+++ b/public/scripts/extensions/in-chat-agents/agent-store.js
@@ -17,6 +17,18 @@ import {
  */
 
 /**
+ * @typedef {object} AgentPreProcess
+ * @property {'inject'|'intercept'} mode - Inject is the existing setExtensionPrompt flow; intercept rewrites the assembled outgoing context.
+ * @property {'replace'|'wrap'|'patch'} applyMode
+ * @property {'before'|'after'} wrapPosition
+ * @property {string} wrapPrefix
+ * @property {string} wrapSuffix
+ * @property {string} patchStartTag
+ * @property {string} patchEndTag
+ * @property {number} maxTokens
+ */
+
+/**
  * @typedef {object} AgentPostProcess
  * @property {boolean} enabled
  * @property {'regex'|'append'|'extract'} type
@@ -70,6 +82,7 @@ import {
  * @property {string} prompt
  * @property {'pre'|'post'|'both'} phase
  * @property {AgentInjection} injection
+ * @property {AgentPreProcess} preProcess
  * @property {AgentPostProcess} postProcess
  * @property {AgentRegexScript[]} regexScripts
  * @property {string} connectionProfile
@@ -588,6 +601,14 @@ export function normalizePromptTransformMaxTokens(value) {
     return Math.max(16, Math.min(16000, Number(value)));
 }
 
+export function normalizePreProcessMaxTokens(value) {
+    if (!Number.isFinite(Number(value))) {
+        return DEFAULT_AGENT_MAX_TOKENS;
+    }
+
+    return Math.max(16, Math.min(16000, Number(value)));
+}
+
 const TRACKER_CATEGORY_TEMPLATE_IDS = new Set([
     'tpl-cyoa-choices',
     'tpl-direction-menu',
@@ -706,6 +727,16 @@ export function createDefaultAgent() {
             order: 100,
             scan: false,
         },
+        preProcess: {
+            mode: 'inject',
+            applyMode: 'replace',
+            wrapPosition: 'after',
+            wrapPrefix: '',
+            wrapSuffix: '',
+            patchStartTag: '<context_patch>',
+            patchEndTag: '</context_patch>',
+            maxTokens: DEFAULT_AGENT_MAX_TOKENS,
+        },
         postProcess: {
             enabled: false,
             type: 'regex',
@@ -761,6 +792,7 @@ export function normalizeToolDef(raw = {}) {
  */
 export function normalizeAgent(rawAgent = {}) {
     const defaults = createDefaultAgent();
+    const rawPreProcess = rawAgent.preProcess && typeof rawAgent.preProcess === 'object' ? rawAgent.preProcess : {};
     const rawPostProcess = rawAgent.postProcess && typeof rawAgent.postProcess === 'object' ? rawAgent.postProcess : {};
     const conditions = rawAgent.conditions && typeof rawAgent.conditions === 'object' ? rawAgent.conditions : {};
 
@@ -785,6 +817,28 @@ export function normalizeAgent(rawAgent = {}) {
         injection: {
             ...defaults.injection,
             ...(rawAgent.injection ?? {}),
+        },
+        preProcess: {
+            ...defaults.preProcess,
+            ...rawPreProcess,
+            mode: ['inject', 'intercept'].includes(String(rawPreProcess.mode))
+                ? String(rawPreProcess.mode)
+                : defaults.preProcess.mode,
+            applyMode: ['replace', 'wrap', 'patch'].includes(String(rawPreProcess.applyMode))
+                ? String(rawPreProcess.applyMode)
+                : defaults.preProcess.applyMode,
+            wrapPosition: ['before', 'after'].includes(String(rawPreProcess.wrapPosition))
+                ? String(rawPreProcess.wrapPosition)
+                : defaults.preProcess.wrapPosition,
+            wrapPrefix: typeof rawPreProcess.wrapPrefix === 'string' ? rawPreProcess.wrapPrefix : defaults.preProcess.wrapPrefix,
+            wrapSuffix: typeof rawPreProcess.wrapSuffix === 'string' ? rawPreProcess.wrapSuffix : defaults.preProcess.wrapSuffix,
+            patchStartTag: typeof rawPreProcess.patchStartTag === 'string' && rawPreProcess.patchStartTag.trim()
+                ? rawPreProcess.patchStartTag
+                : defaults.preProcess.patchStartTag,
+            patchEndTag: typeof rawPreProcess.patchEndTag === 'string' && rawPreProcess.patchEndTag.trim()
+                ? rawPreProcess.patchEndTag
+                : defaults.preProcess.patchEndTag,
+            maxTokens: normalizePreProcessMaxTokens(rawPreProcess.maxTokens),
         },
         postProcess: {
             ...defaults.postProcess,

--- a/public/scripts/extensions/in-chat-agents/editor.html
+++ b/public/scripts/extensions/in-chat-agents/editor.html
@@ -48,7 +48,7 @@
             </div>
         </div>
         <div class="ica--editor-row">
-            <label>Connection Profile <small>(overrides the extension default connection profile for this agent's AI refinement and prompt-based post-generation rewrites)</small>
+            <label>Connection Profile <small>(overrides the extension default connection profile for this agent's AI refinement, pre-generation intercepts, and prompt-based post-generation rewrites)</small>
                 <select id="ica--editor-connectionProfile" class="text_pole">
                     <option value="">Use extension default</option>
                 </select>
@@ -91,7 +91,61 @@
     </div>
 
     <div class="ica--editor-section" id="ica--injection-section">
-        <strong>Injection Settings</strong>
+        <strong>Pre-Generation Settings</strong>
+        <div class="ica--editor-row">
+            <label>Mode
+                <select id="ica--editor-pre-mode" class="text_pole">
+                    <option value="inject">Inject prompt into context</option>
+                    <option value="intercept">Run agent to modify outgoing context</option>
+                </select>
+            </label>
+        </div>
+        <div id="ica--pre-intercept-options" style="display:none">
+            <div class="ica--editor-row flex-container flexGap5">
+                <label class="flex1">Apply Mode
+                    <select id="ica--editor-pre-applyMode" class="text_pole">
+                        <option value="replace">Replace context</option>
+                        <option value="wrap">Wrap / append</option>
+                        <option value="patch">Patch via tags</option>
+                    </select>
+                </label>
+                <label class="flex1">Max Tokens
+                    <input type="number" id="ica--editor-pre-maxTokens" class="text_pole" min="16" max="16000" value="8192" />
+                </label>
+            </div>
+            <div class="ica--editor-row" id="ica--pre-wrap-position-row">
+                <label>Insert Position
+                    <select id="ica--editor-pre-wrapPosition" class="text_pole">
+                        <option value="after">After original context</option>
+                        <option value="before">Before original context</option>
+                    </select>
+                </label>
+            </div>
+            <div id="ica--pre-wrap-options" style="display:none">
+                <div class="ica--editor-row">
+                    <label>Wrap Prefix <small>(optional)</small>
+                        <textarea id="ica--editor-pre-wrapPrefix" class="text_pole textarea_compact" rows="2" placeholder="Text before the agent output"></textarea>
+                    </label>
+                </div>
+                <div class="ica--editor-row">
+                    <label>Wrap Suffix <small>(optional)</small>
+                        <textarea id="ica--editor-pre-wrapSuffix" class="text_pole textarea_compact" rows="2" placeholder="Text after the agent output"></textarea>
+                    </label>
+                </div>
+            </div>
+            <div id="ica--pre-patch-options" style="display:none">
+                <div class="ica--editor-row flex-container flexGap5">
+                    <label class="flex1">Patch Start Tag
+                        <input type="text" id="ica--editor-pre-patchStartTag" class="text_pole" value="&lt;context_patch&gt;" />
+                    </label>
+                    <label class="flex1">Patch End Tag
+                        <input type="text" id="ica--editor-pre-patchEndTag" class="text_pole" value="&lt;/context_patch&gt;" />
+                    </label>
+                </div>
+            </div>
+            <div class="ica--regex-note">Intercept mode runs this agent before the main model receives the assembled context. Agents run by Order. Replace mode expects a full replacement context; for chat completion that must be a JSON array of chat messages. Wrap and patch add a new message on chat-completion APIs using the Role below.</div>
+        </div>
+        <div class="ica--regex-note" id="ica--pre-injection-note">Inject mode uses the existing extension prompt path. Position, Depth, Role, and World Info scanning control where the prompt is inserted.</div>
         <div class="ica--editor-row flex-container flexGap5">
             <label class="flex1">Position
                 <select id="ica--editor-position" class="text_pole">

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -45,6 +45,7 @@ import {
     initAgentRunner,
     isAgentGenerationActive,
     onAgentGenerationStateChanged,
+    getPreGenerationInterceptHistoryForMessage,
     getPromptTransformHistoryForMessage,
     runAgentOnMessage,
     syncToolAgentRegistrations,
@@ -2556,19 +2557,52 @@ function buildPromptTransformDiffMarkup(beforeText, afterText) {
     }).join('');
 }
 
+function getPreGenerationInterceptModeLabel(entry) {
+    const mode = String(entry?.applyMode ?? 'replace');
+    if (mode === 'wrap') {
+        return 'wrap';
+    }
+    if (mode === 'patch') {
+        return 'patch';
+    }
+    return 'replace';
+}
+
+function buildPreGenerationInterceptEntryMarkup(entry, i) {
+    const timestamp = entry.timestamp ? new Date(entry.timestamp).toLocaleString() : '';
+    const status = String(entry.status ?? 'changed');
+    const statusText = status === 'error'
+        ? `Error: ${escapeHtml(entry.error || 'unknown error')}`
+        : `${entry.changed ? 'Changed' : 'No visible change'} the ${entry.contextFormat === 'chat' ? 'chat message array' : 'text prompt'}`;
+    const modeLabel = getPreGenerationInterceptModeLabel(entry);
+    const output = String(entry.outputText ?? '').trim();
+
+    return `
+        <div class="ica-transform-history-entry ica-preintercept-history-entry" data-index="${i}">
+            <h5>${escapeHtml(entry.agentName || 'Agent')} <small>(pre-gen ${escapeHtml(modeLabel)})</small></h5>
+            <small>${escapeHtml(timestamp)}${timestamp ? ' · ' : ''}${escapeHtml(statusText)}</small>
+            ${output ? `<div class="ica-transform-output-title">Agent output</div><div class="ica-transform-diff">${escapeHtml(output)}</div>` : ''}
+            <div class="ica-transform-output-title">Context diff</div>
+            <div class="ica-transform-diff">${buildPromptTransformDiffMarkup(entry.beforeText ?? '', entry.afterText ?? '')}</div>
+        </div>
+    `;
+}
+
 async function openPromptTransformHistoryPopup(messageIndex) {
     if (!Number.isInteger(Number(messageIndex)) || !chat[messageIndex]) {
         return;
     }
 
     const message = chat[Number(messageIndex)];
+    const preGenerationHistory = getPreGenerationInterceptHistoryForMessage(message);
     const history = getPromptTransformHistoryForMessage(message);
-    if (!Array.isArray(history) || history.length === 0) {
-        toastr.info('No transform history available.');
+    if ((!Array.isArray(preGenerationHistory) || preGenerationHistory.length === 0) && (!Array.isArray(history) || history.length === 0)) {
+        toastr.info('No agent document history available.');
         return;
     }
 
-    const entries = history.map((entry, i) => {
+    const preGenerationEntries = preGenerationHistory.map(buildPreGenerationInterceptEntryMarkup).join('');
+    const postGenerationEntries = history.map((entry, i) => {
         const timestamp = entry.timestamp ? new Date(entry.timestamp).toLocaleString() : '';
         return `
             <div class="ica-transform-history-entry" data-index="${i}">
@@ -2583,7 +2617,10 @@ async function openPromptTransformHistoryPopup(messageIndex) {
         `;
     }).join('');
 
-    const html = $(`<div class="ica-transform-history">${entries}</div>`);
+    const html = $(`<div class="ica-transform-history">
+        ${preGenerationEntries ? `<section class="ica-transform-history-section"><h4>Pre-Generation Intercepts</h4>${preGenerationEntries}</section>` : ''}
+        ${postGenerationEntries ? `<section class="ica-transform-history-section"><h4>Post-Generation Changes</h4>${postGenerationEntries}</section>` : ''}
+    </div>`);
 
     html.find('.ica-undo-btn').on('click', function () {
         const idx = Number($(this).data('mesid'));

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -122,6 +122,16 @@ const AGENT_PHASE_LABELS = {
     post: 'post',
     both: 'pre + post',
 };
+const DEFAULT_PRE_PROCESS = {
+    mode: 'inject',
+    applyMode: 'replace',
+    wrapPosition: 'after',
+    wrapPrefix: '',
+    wrapSuffix: '',
+    patchStartTag: '<context_patch>',
+    patchEndTag: '</context_patch>',
+    maxTokens: DEFAULT_AGENT_MAX_TOKENS,
+};
 
 function getTemplateAssetUrl(filename) {
     return `/scripts/extensions/${MODULE_NAME}/templates/${filename}?v=${encodeURIComponent(CLIENT_VERSION || 'dev')}`;
@@ -349,6 +359,20 @@ function hasPromptTransform(agent) {
     );
 }
 
+function getAgentPreProcess(agent) {
+    return {
+        ...DEFAULT_PRE_PROCESS,
+        ...(agent?.preProcess ?? {}),
+    };
+}
+
+function isPreGenerationInterceptAgent(agent) {
+    return Boolean(
+        ['pre', 'both'].includes(String(agent?.phase ?? '')) &&
+        getAgentPreProcess(agent).mode === 'intercept',
+    );
+}
+
 function canPreviewPreGenerationPrompt(agent) {
     return Boolean(
         !isPathfinderAgent(agent) &&
@@ -371,9 +395,12 @@ async function previewPreGenerationPrompt(agent, promptOverride = null) {
     const previewText = substituteParams(prompt, {
         dynamicMacros: buildPromptDynamicMacros('', null, agent, 'normal'),
     });
+    const previewNote = isPreGenerationInterceptAgent(agent)
+        ? 'Preview shows the agent instruction after macro substitution. At runtime, intercept mode also receives the assembled outgoing context and can rewrite it before the main model sees it.'
+        : 'Preview uses the current chat context with no generated assistant message yet. Random macros are evaluated now and may differ when the agent runs.';
     const previewHtml = $(
         `<div class="ica--prompt-preview">
-            <div class="ica--regex-note">Preview uses the current chat context with no generated assistant message yet. Random macros are evaluated now and may differ when the agent runs.</div>
+            <div class="ica--regex-note">${escapeHtml(previewNote)}</div>
             <pre>${escapeHtml(previewText || '(empty after macro substitution)')}</pre>
         </div>`,
     );
@@ -1288,8 +1315,9 @@ function renderAgentList() {
             const regexCount = getAgentRegexScripts(agent).length;
             const promptTransformEnabled = hasPromptTransform(agent);
             const promptTransformLabel = getPromptTransformLabel(agent);
+            const preInterceptEnabled = isPreGenerationInterceptAgent(agent);
             const previewPromptButton = canPreviewPreGenerationPrompt(agent)
-                ? '<button type="button" class="ica--card-btn ica--btn-preview-prompt" title="Preview this pre-generation prompt after macro substitution"><i class="fa-solid fa-eye"></i> Preview Prompt</button>'
+                ? `<button type="button" class="ica--card-btn ica--btn-preview-prompt" title="Preview this pre-generation prompt after macro substitution"><i class="fa-solid fa-eye"></i> ${preInterceptEnabled ? 'Preview Instruction' : 'Preview Prompt'}</button>`
                 : '';
             const connectionProfileLabel = agent.connectionProfile
                 ? profileNames.get(agent.connectionProfile) || `Missing profile (${agent.connectionProfile})`
@@ -1316,7 +1344,8 @@ function renderAgentList() {
                     <div class="ica--card-desc">${escapeHtml(desc)}</div>
                     <div class="ica--card-meta">
                         ${agent.conditions.triggerProbability < 100 ? `<span class="ica--card-pill"><i class="fa-solid fa-dice fa-xs"></i> ${agent.conditions.triggerProbability}%</span>` : ''}
-                        ${agent.injection.position === 1 ? `<span class="ica--card-pill">depth ${agent.injection.depth}</span>` : ''}
+                        ${preInterceptEnabled ? '<span class="ica--card-pill"><i class="fa-solid fa-shuffle fa-xs"></i> pre intercept</span>' : ''}
+                        ${!preInterceptEnabled && agent.injection.position === 1 ? `<span class="ica--card-pill">depth ${agent.injection.depth}</span>` : ''}
                         ${promptTransformEnabled ? `<span class="ica--card-pill"><i class="fa-solid fa-robot fa-xs"></i> ${promptTransformLabel}</span>` : ''}
                         ${regexCount > 0 ? `<span class="ica--card-pill"><i class="fa-solid fa-wand-magic-sparkles fa-xs"></i> ${regexCount} regex</span>` : ''}
                         ${connectionProfileLabel ? `<span class="ica--card-pill"><i class="fa-solid fa-plug fa-xs"></i> ${escapeHtml(connectionProfileLabel)}</span>` : ''}
@@ -1576,6 +1605,15 @@ async function openEditor(agentId = null) {
     editorEl.find('#ica--editor-role').val(agent.injection.role);
     editorEl.find('#ica--editor-order').val(agent.injection.order);
     editorEl.find('#ica--editor-scan').prop('checked', agent.injection.scan);
+    const preProcess = getAgentPreProcess(agent);
+    editorEl.find('#ica--editor-pre-mode').val(preProcess.mode);
+    editorEl.find('#ica--editor-pre-applyMode').val(preProcess.applyMode);
+    editorEl.find('#ica--editor-pre-wrapPosition').val(preProcess.wrapPosition);
+    editorEl.find('#ica--editor-pre-wrapPrefix').val(preProcess.wrapPrefix);
+    editorEl.find('#ica--editor-pre-wrapSuffix').val(preProcess.wrapSuffix);
+    editorEl.find('#ica--editor-pre-patchStartTag').val(preProcess.patchStartTag);
+    editorEl.find('#ica--editor-pre-patchEndTag').val(preProcess.patchEndTag);
+    editorEl.find('#ica--editor-pre-maxTokens').val(preProcess.maxTokens ?? DEFAULT_AGENT_MAX_TOKENS);
 
     // Post-process
     const postProcessType = agent.postProcess.type === 'append' ? 'append' : 'extract';
@@ -1611,8 +1649,24 @@ async function openEditor(agentId = null) {
         const phase = editorEl.find('#ica--editor-phase').val();
         editorEl.find('#ica--injection-section').toggle(phase === 'pre' || phase === 'both');
         editorEl.find('#ica--postprocess-section').toggle(phase === 'post' || phase === 'both');
+        updatePreProcessVisibility();
     }
     editorEl.find('#ica--editor-phase').on('change', updatePhaseVisibility);
+
+    function updatePreProcessVisibility() {
+        const phase = editorEl.find('#ica--editor-phase').val();
+        const preGenerationVisible = phase === 'pre' || phase === 'both';
+        const preMode = editorEl.find('#ica--editor-pre-mode').val()?.toString() || 'inject';
+        const applyMode = editorEl.find('#ica--editor-pre-applyMode').val()?.toString() || 'replace';
+        const interceptVisible = preGenerationVisible && preMode === 'intercept';
+
+        editorEl.find('#ica--pre-intercept-options').toggle(interceptVisible);
+        editorEl.find('#ica--pre-injection-note').toggle(preGenerationVisible && preMode !== 'intercept');
+        editorEl.find('#ica--pre-wrap-position-row').toggle(interceptVisible && (applyMode === 'wrap' || applyMode === 'patch'));
+        editorEl.find('#ica--pre-wrap-options').toggle(interceptVisible && applyMode === 'wrap');
+        editorEl.find('#ica--pre-patch-options').toggle(interceptVisible && applyMode === 'patch');
+    }
+    editorEl.find('#ica--editor-pre-mode, #ica--editor-pre-applyMode').on('change', updatePreProcessVisibility);
     updatePhaseVisibility();
 
     // Show/hide post-process options
@@ -1822,6 +1876,10 @@ async function openEditor(agentId = null) {
             ...agent,
             name: editorEl.find('#ica--editor-name').val()?.toString().trim() || agent.name,
             phase: editorEl.find('#ica--editor-phase').val()?.toString() || agent.phase,
+            preProcess: {
+                ...getAgentPreProcess(agent),
+                mode: editorEl.find('#ica--editor-pre-mode').val()?.toString() || 'inject',
+            },
         };
         await previewPreGenerationPrompt(previewAgent, editorEl.find('#ica--editor-prompt').val()?.toString() || '');
     });
@@ -1851,6 +1909,24 @@ async function openEditor(agentId = null) {
     agent.injection.role = Number(editorEl.find('#ica--editor-role').val());
     agent.injection.order = Number(editorEl.find('#ica--editor-order').val());
     agent.injection.scan = editorEl.find('#ica--editor-scan').prop('checked');
+    agent.preProcess = {
+        ...getAgentPreProcess(agent),
+        mode: editorEl.find('#ica--editor-pre-mode').val()?.toString() === 'intercept' ? 'intercept' : 'inject',
+        applyMode: ['replace', 'wrap', 'patch'].includes(editorEl.find('#ica--editor-pre-applyMode').val()?.toString())
+            ? editorEl.find('#ica--editor-pre-applyMode').val().toString()
+            : 'replace',
+        wrapPosition: editorEl.find('#ica--editor-pre-wrapPosition').val()?.toString() === 'before' ? 'before' : 'after',
+        wrapPrefix: editorEl.find('#ica--editor-pre-wrapPrefix').val()?.toString() ?? '',
+        wrapSuffix: editorEl.find('#ica--editor-pre-wrapSuffix').val()?.toString() ?? '',
+        patchStartTag: editorEl.find('#ica--editor-pre-patchStartTag').val()?.toString() || DEFAULT_PRE_PROCESS.patchStartTag,
+        patchEndTag: editorEl.find('#ica--editor-pre-patchEndTag').val()?.toString() || DEFAULT_PRE_PROCESS.patchEndTag,
+        maxTokens: Number(editorEl.find('#ica--editor-pre-maxTokens').val()) || DEFAULT_AGENT_MAX_TOKENS,
+    };
+
+    if (['pre', 'both'].includes(agent.phase) && agent.preProcess.mode === 'intercept' && !agent.prompt.trim()) {
+        toastr.warning('Pre-generation intercept mode needs an agent prompt.');
+        return;
+    }
 
     if (editorEl.find('#ica--editor-pp-promptEnabled').prop('checked') && !agent.prompt.trim()) {
         toastr.warning('Prompt-based post-generation passes need an agent prompt.');

--- a/public/scripts/extensions/in-chat-agents/templates/index.json
+++ b/public/scripts/extensions/in-chat-agents/templates/index.json
@@ -758,6 +758,67 @@
     }
   },
   {
+    "id": "tpl-npc-motivator",
+    "name": "NPC Motivator",
+    "description": "Helps NPCs feel less static and gives them more agency to pursue their own goals",
+    "icon": "",
+    "category": "content",
+    "tags": [
+      "npc",
+      "motivation",
+      "agency"
+    ],
+    "version": 1,
+    "author": "Sheep",
+    "prompt": "The roleplay is now concluded. Now you are a meticulous AI agent whose task is to crystallize each character's motivations and plan out their actions. Aside from {{user}}, analyse every character in the roleplay's current scene. Write out each character's next actions according to their personality, current situation, and background. Search the provided documents for any extra and relevant information to comprehend the characters better.\nThis is the output and formatting required of you. Please follow:\n[Character's full name]:\n- Long Term Goal — [one-liner on the character's main and long term goal]\n  - Motivation — [brief motivation/reasoning for their long term goal]\n- Current Goal — [brief the character's current objective/problem]\n  - Motivation — [motivations/reasonings for their current objective]\n- Assumptions — [collection of relevant assumptions of the character in the current scene.]\n- Next Action — [given the character's goals, motivations, assumptions, and personality, write how they will tackle the current goal. Also write what their most likely set of actions will be and why.]\n\nNOTE: There may be no characters in the scene right now. In such a case output \"Observation: No other characters in this scene.\" Do not use **bold**, *italics*, or # headers. Follow the output strictly and in its exact bullet point formatting.",
+    "phase": "pre",
+    "preProcess": {
+      "mode": "intercept",
+      "applyMode": "patch",
+      "wrapPosition": "after",
+      "wrapPrefix": "",
+      "wrapSuffix": "",
+      "patchStartTag": "<npc_motivation_plan>",
+      "patchEndTag": "</npc_motivation_plan>",
+      "maxTokens": 4096
+    },
+    "injection": {
+      "position": 1,
+      "depth": 0,
+      "role": 0,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "extract",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": "",
+      "promptTransformEnabled": false,
+      "promptTransformShowNotifications": true,
+      "promptTransformMode": "rewrite",
+      "promptTransformMaxTokens": 8192
+    },
+    "regexScripts": [],
+    "enabled": false,
+    "phaseLocked": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal",
+        "continue",
+        "impersonate"
+      ]
+    },
+    "tools": [],
+    "settings": {}
+  },
+  {
     "id": "tpl-parallel-tracker",
     "name": "Parallel Off-Screen",
     "description": "Track what absent characters and the wider world are doing off-screen",

--- a/public/scripts/extensions/in-chat-agents/templates/npc-motivator.json
+++ b/public/scripts/extensions/in-chat-agents/templates/npc-motivator.json
@@ -1,0 +1,61 @@
+{
+    "id": "tpl-npc-motivator",
+    "name": "NPC Motivator",
+    "description": "Helps NPCs feel less static and gives them more agency to pursue their own goals",
+    "icon": "",
+    "category": "content",
+    "tags": [
+        "npc",
+        "motivation",
+        "agency"
+    ],
+    "version": 1,
+    "author": "Sheep",
+    "prompt": "The roleplay is now concluded. Now you are a meticulous AI agent whose task is to crystallize each character's motivations and plan out their actions. Aside from {{user}}, analyse every character in the roleplay's current scene. Write out each character's next actions according to their personality, current situation, and background. Search the provided documents for any extra and relevant information to comprehend the characters better.\nThis is the output and formatting required of you. Please follow:\n[Character's full name]:\n- Long Term Goal — [one-liner on the character's main and long term goal]\n  - Motivation — [brief motivation/reasoning for their long term goal]\n- Current Goal — [brief the character's current objective/problem]\n  - Motivation — [motivations/reasonings for their current objective]\n- Assumptions — [collection of relevant assumptions of the character in the current scene.]\n- Next Action — [given the character's goals, motivations, assumptions, and personality, write how they will tackle the current goal. Also write what their most likely set of actions will be and why.]\n\nNOTE: There may be no characters in the scene right now. In such a case output \"Observation: No other characters in this scene.\" Do not use **bold**, *italics*, or # headers. Follow the output strictly and in its exact bullet point formatting.",
+    "phase": "pre",
+    "preProcess": {
+        "mode": "intercept",
+        "applyMode": "patch",
+        "wrapPosition": "after",
+        "wrapPrefix": "",
+        "wrapSuffix": "",
+        "patchStartTag": "<npc_motivation_plan>",
+        "patchEndTag": "</npc_motivation_plan>",
+        "maxTokens": 4096
+    },
+    "injection": {
+        "position": 1,
+        "depth": 0,
+        "role": 0,
+        "order": 100,
+        "scan": false
+    },
+    "postProcess": {
+        "enabled": false,
+        "type": "extract",
+        "regexFind": "",
+        "regexReplace": "",
+        "regexFlags": "g",
+        "appendText": "",
+        "extractPattern": "",
+        "extractVariable": "",
+        "promptTransformEnabled": false,
+        "promptTransformShowNotifications": true,
+        "promptTransformMode": "rewrite",
+        "promptTransformMaxTokens": 8192
+    },
+    "regexScripts": [],
+    "enabled": false,
+    "phaseLocked": false,
+    "conditions": {
+        "triggerKeywords": [],
+        "triggerProbability": 100,
+        "generationTypes": [
+            "normal",
+            "continue",
+            "impersonate"
+        ]
+    },
+    "tools": [],
+    "settings": {}
+}

--- a/public/scripts/openai-prompt-budget.js
+++ b/public/scripts/openai-prompt-budget.js
@@ -1,0 +1,26 @@
+/**
+ * Recounts a finalized chat-completion payload against the prompt budget.
+ *
+ * @param {object[]} chat Final chat-completion messages.
+ * @param {object} userSettings Chat-completion settings.
+ * @param {(chat: object[]) => Promise<number>|number} countTokens Token counter for the payload.
+ * @returns {Promise<{promptTokens: number, promptTokenBudget: number, exceeded: boolean}>}
+ */
+export async function checkPostInterceptChatBudget(chat, userSettings = {}, countTokens) {
+    if (!Array.isArray(chat)) {
+        throw new TypeError('Post-intercept chat payload must be an array.');
+    }
+
+    if (typeof countTokens !== 'function') {
+        throw new TypeError('Post-intercept chat budget check requires a token counter.');
+    }
+
+    const promptTokenBudget = Number(userSettings?.openai_max_context) - Number(userSettings?.openai_max_tokens);
+    const promptTokens = await countTokens(chat);
+
+    return {
+        promptTokens,
+        promptTokenBudget,
+        exceeded: Number.isFinite(promptTokenBudget) && Number.isFinite(promptTokens) && promptTokens > promptTokenBudget,
+    };
+}

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -82,6 +82,7 @@ import { accountStorage } from './util/AccountStorage.js';
 import { COMETAPI_IGNORE_PATTERNS, IGNORE_SYMBOL, MEDIA_DISPLAY, MEDIA_TYPE } from './constants.js';
 import { syncOpenRouterProvidersForModel, updateOpenRouterProvidersWarning } from './textgen-models.js';
 import { hasTextOrArrayPayload, stripOocBlocksFromContext } from './ooc-blocks.js';
+import { checkPostInterceptChatBudget } from './openai-prompt-budget.js';
 
 export {
     openai_messages_count,
@@ -1709,10 +1710,27 @@ export async function prepareOpenAIMessages({
         if (false === dryRun) promptManager.render(false);
     }
 
-    const chat = chatCompletion.getChat();
+    let chat = chatCompletion.getChat();
 
     const eventData = { chat, dryRun };
     await eventSource.emit(event_types.CHAT_COMPLETION_PROMPT_READY, eventData);
+    if (!Array.isArray(eventData.chat)) {
+        chatCompletion.log('Pre-generation intercepts produced an invalid chat payload.');
+        throw new Error('Pre-generation intercepts produced an invalid chat payload.');
+    }
+
+    chat = eventData.chat;
+
+    if (!dryRun) {
+        const { promptTokens, promptTokenBudget, exceeded } = await checkPostInterceptChatBudget(chat, userSettings, countTokensOpenAIAsync);
+        if (exceeded) {
+            toastr.error(t`Pre-generation intercepts exceed the context size.`);
+            chatCompletion.log(`Pre-generation intercepts exceed the context size. Tokens: ${promptTokens}. Budget: ${promptTokenBudget}.`);
+            promptManager.error = t`Pre-generation intercepts made the prompt too large. Reduce intercept output, raise your token limit, or disable the intercept agent.`;
+            promptManager.render(false);
+            throw new TokenBudgetExceededError('pre-generation intercepts');
+        }
+    }
 
     openai_messages_count = chat.filter(x => !x?.tool_calls && ['user', 'assistant', 'tool'].includes(x?.role)).length || 0;
 

--- a/public/style.css
+++ b/public/style.css
@@ -7393,6 +7393,18 @@ body:not(.movingUI) .drawer-content.maximized {
     gap: 12px;
 }
 
+.ica-transform-history-section {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.ica-transform-history-section h4 {
+    margin: 0;
+    font-size: calc(var(--mainFontSize) * 0.95);
+    letter-spacing: 0.02em;
+}
+
 .ica-transform-history-entry {
     padding: 12px;
     border: 1px solid color-mix(in srgb, var(--SmartThemeBorderColor, #444) 55%, transparent);
@@ -7408,6 +7420,15 @@ body:not(.movingUI) .drawer-content.maximized {
     display: block;
     margin-bottom: 8px;
     opacity: 0.72;
+}
+
+.ica-transform-output-title {
+    margin: 10px 0 5px;
+    font-size: calc(var(--mainFontSize) * 0.72);
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    opacity: 0.68;
 }
 
 .ica-transform-diff {

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -619,15 +619,14 @@ describe('in-chat agent post-processing runner', () => {
         initAgentRunner();
 
         await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
-        const eventData = {
-            chat: [{ role: 'user', content: 'original user prompt' }],
-            dryRun: false,
-        };
+        const originalChat = [{ role: 'user', content: 'original user prompt' }];
+        const eventData = { chat: originalChat, dryRun: false };
         await eventSource.emit(eventTypes.CHAT_COMPLETION_PROMPT_READY, eventData);
 
         expect(generateQuietPrompt).toHaveBeenCalledTimes(1);
         expect(generateQuietPrompt.mock.calls[0][0].quietPrompt).toContain('JSON array of chat-completion messages');
         expect(generateQuietPrompt.mock.calls[0][0].quietPrompt).toContain('original user prompt');
+        expect(eventData.chat).toBe(originalChat);
         expect(eventData.chat).toEqual([
             { role: 'system', content: 'rewritten system prompt' },
             { role: 'user', content: 'rewritten user prompt' },

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -572,6 +572,30 @@ describe('in-chat agent post-processing runner', () => {
         expect(generateQuietPrompt.mock.calls[0][0].quietPrompt).toContain('Outgoing context:');
         expect(generateQuietPrompt.mock.calls[0][0].quietPrompt).toContain('Original outgoing prompt');
         expect(eventData.prompt).toBe('quiet result');
+
+        chat.push({
+            name: 'Assistant',
+            mes: 'Final assistant reply',
+            is_user: false,
+            is_system: false,
+            extra: {},
+        });
+        await eventSource.emit(eventTypes.MESSAGE_RECEIVED, 0, 'normal');
+        await eventSource.emit(eventTypes.GENERATION_ENDED, chat.length);
+        await waitFor(() => Array.isArray(chat[0].extra.inChatAgentPreGenerationInterceptHistory));
+
+        expect(chat[0].extra.inChatAgentPreGenerationInterceptHistory).toEqual([expect.objectContaining({
+            agentId: 'agent-pre-intercept',
+            agentName: 'Pre Intercept',
+            applyMode: 'replace',
+            contextFormat: 'text',
+            beforeText: 'Original outgoing prompt',
+            outputText: 'quiet result',
+            afterText: 'quiet result',
+            changed: true,
+            status: 'changed',
+        })]);
+        expect(chat[0].swipe_info[0].extra.inChatAgentPreGenerationInterceptHistory).toEqual(chat[0].extra.inChatAgentPreGenerationInterceptHistory);
     });
 
     test('chains multiple pre-generation intercept agents by order', async () => {
@@ -657,6 +681,27 @@ describe('in-chat agent post-processing runner', () => {
             { role: 'user', content: '<patch>\npatch note\n</patch>' },
             originalMessage,
         ]);
+
+        chat.push({
+            name: 'Assistant',
+            mes: 'Chat reply',
+            is_user: false,
+            is_system: false,
+            extra: {},
+        });
+        await eventSource.emit(eventTypes.MESSAGE_RECEIVED, 0, 'normal');
+        await eventSource.emit(eventTypes.GENERATION_ENDED, chat.length);
+        await waitFor(() => Array.isArray(chat[0].extra.inChatAgentPreGenerationInterceptHistory));
+
+        expect(chat[0].extra.inChatAgentPreGenerationInterceptHistory).toEqual([expect.objectContaining({
+            applyMode: 'patch',
+            contextFormat: 'chat',
+            outputText: 'patch note',
+            role: 'user',
+            status: 'changed',
+        })]);
+        expect(chat[0].extra.inChatAgentPreGenerationInterceptHistory[0].beforeText).toContain('original user prompt');
+        expect(JSON.parse(chat[0].extra.inChatAgentPreGenerationInterceptHistory[0].afterText)[0].content).toBe('<patch>\npatch note\n</patch>');
     });
 
     test('skips pre-generation intercepts during dry runs and outside active generation', async () => {
@@ -675,6 +720,45 @@ describe('in-chat agent post-processing runner', () => {
         expect(generateQuietPrompt).not.toHaveBeenCalled();
         expect(inactiveEventData.prompt).toBe('inactive prompt');
         expect(dryRunEventData.prompt).toBe('dry run prompt');
+    });
+
+    test('exposes pre-generation intercept history for message document UI', async () => {
+        const { getPreGenerationInterceptHistoryForMessage } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        const message = {
+            name: 'Assistant',
+            mes: 'Visible swipe',
+            is_user: false,
+            is_system: false,
+            swipe_id: 1,
+            swipes: ['Other swipe', 'Visible swipe'],
+            swipe_info: [
+                { extra: {} },
+                {
+                    extra: {
+                        inChatAgentPreGenerationInterceptHistory: [{
+                            agentId: 'agent-pre-intercept',
+                            agentName: 'Pre Intercept',
+                            applyMode: 'patch',
+                            contextFormat: 'chat',
+                            status: 'changed',
+                            outputText: 'visible plan',
+                        }],
+                    },
+                },
+            ],
+            extra: {
+                inChatAgentPreGenerationInterceptHistory: [{
+                    agentId: 'stale',
+                    agentName: 'Stale',
+                    outputText: 'hidden plan',
+                }],
+            },
+        };
+
+        expect(getPreGenerationInterceptHistoryForMessage(message)).toEqual([expect.objectContaining({
+            agentId: 'agent-pre-intercept',
+            outputText: 'visible plan',
+        })]);
     });
 
     test('queues manual agent runs while another manual agent is active in sequential mode', async () => {

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -657,6 +657,60 @@ describe('in-chat agent post-processing runner', () => {
         ]);
     });
 
+    test('leaves chat completion prompts unchanged when intercept output has invalid messages', async () => {
+        const invalidReplacementChats = [
+            ['a non-object entry', ['bad message']],
+            ['an unsupported role', [{ role: 'developer', content: 'bad role' }]],
+            ['missing content', [{ role: 'user' }]],
+            ['a tool message without an id', [{ role: 'tool', content: 'tool output' }]],
+        ];
+        enabledAgents = [createPreInterceptAgent()];
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        try {
+            const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+            initAgentRunner();
+
+            for (const [caseName, replacementChat] of invalidReplacementChats) {
+                generateQuietPrompt.mockResolvedValueOnce(JSON.stringify(replacementChat));
+
+                await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+                const originalMessage = { role: 'user', content: `original user prompt for ${caseName}` };
+                const originalChat = [originalMessage];
+                const eventData = { chat: originalChat, dryRun: false };
+                await eventSource.emit(eventTypes.CHAT_COMPLETION_PROMPT_READY, eventData);
+
+                expect(eventData.chat).toBe(originalChat);
+                expect(eventData.chat).toEqual([originalMessage]);
+                expect(warnSpy).toHaveBeenCalledWith(
+                    expect.stringContaining('Leaving chat context unchanged'),
+                    expect.any(Error),
+                );
+
+                const messageIndex = chat.length;
+                chat.push({
+                    name: 'Assistant',
+                    mes: `Chat reply for ${caseName}`,
+                    is_user: false,
+                    is_system: false,
+                    extra: {},
+                });
+                await eventSource.emit(eventTypes.MESSAGE_RECEIVED, messageIndex, 'normal');
+                await eventSource.emit(eventTypes.GENERATION_ENDED, chat.length);
+                await waitFor(() => Array.isArray(chat[messageIndex].extra.inChatAgentPreGenerationInterceptHistory));
+
+                expect(chat[messageIndex].extra.inChatAgentPreGenerationInterceptHistory).toEqual([expect.objectContaining({
+                    status: 'error',
+                    changed: false,
+                    beforeText: JSON.stringify(originalChat, null, 2),
+                    afterText: JSON.stringify(originalChat, null, 2),
+                })]);
+            }
+        } finally {
+            warnSpy.mockRestore();
+        }
+    });
+
     test('adds patch messages for chat completion intercept agents in patch mode', async () => {
         enabledAgents = [createPreInterceptAgent({
             injection: { role: 1 },

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -59,6 +59,8 @@ describe('in-chat agent post-processing runner', () => {
             CHARACTER_MESSAGE_RENDERED: 'character_message_rendered',
             IMPERSONATE_READY: 'impersonate_ready',
             MESSAGE_SWIPED: 'message_swiped',
+            GENERATE_AFTER_COMBINE_PROMPTS: 'generate_after_combine_prompts',
+            CHAT_COMPLETION_PROMPT_READY: 'chat_completion_prompt_ready',
             CHAT_COMPLETION_SETTINGS_READY: 'chat_completion_settings_ready',
             WORLDINFO_ENTRIES_LOADED: 'worldinfo_entries_loaded',
             CHAT_CHANGED: 'chat_changed',
@@ -138,7 +140,7 @@ describe('in-chat agent post-processing runner', () => {
                     extra: {},
                 }));
             }),
-            extension_prompt_roles: { SYSTEM: 0 },
+            extension_prompt_roles: { SYSTEM: 0, USER: 1, ASSISTANT: 2 },
             extension_prompt_types: { IN_PROMPT: 0, IN_CHAT: 1 },
             extension_prompts: extensionPrompts,
             setExtensionPrompt: jest.fn((key, value) => {
@@ -195,6 +197,7 @@ describe('in-chat agent post-processing runner', () => {
             getGlobalSettings: jest.fn(() => globalSettings),
             getPromptTransformMode: jest.fn(agent => agent?.postProcess?.promptTransformMode === 'append' ? 'append' : 'rewrite'),
             isToolAgent: jest.fn(() => false),
+            normalizePreProcessMaxTokens: jest.fn(value => Number.isFinite(Number(value)) ? Math.max(16, Math.min(16000, Number(value))) : 8192),
             normalizePromptTransformMaxTokens: jest.fn(value => Number.isFinite(Number(value)) ? Math.max(16, Math.min(16000, Number(value))) : 8192),
             resolveConnectionProfile: jest.fn(value => value ?? ''),
         }));
@@ -276,6 +279,45 @@ describe('in-chat agent post-processing runner', () => {
                 generationTypes: ['normal'],
             },
         }];
+    }
+
+    function createPreInterceptAgent(overrides = {}) {
+        return {
+            id: overrides.id ?? 'agent-pre-intercept',
+            name: overrides.name ?? 'Pre Intercept',
+            phase: overrides.phase ?? 'pre',
+            prompt: overrides.prompt ?? 'Rewrite the outgoing context.',
+            injection: {
+                position: 0,
+                depth: 4,
+                scan: false,
+                role: 0,
+                order: 100,
+                ...(overrides.injection ?? {}),
+            },
+            preProcess: {
+                mode: 'intercept',
+                applyMode: 'replace',
+                wrapPosition: 'after',
+                wrapPrefix: '',
+                wrapSuffix: '',
+                patchStartTag: '<context_patch>',
+                patchEndTag: '</context_patch>',
+                maxTokens: 8192,
+                ...(overrides.preProcess ?? {}),
+            },
+            postProcess: {
+                enabled: false,
+                promptTransformEnabled: false,
+                ...(overrides.postProcess ?? {}),
+            },
+            conditions: {
+                triggerKeywords: [],
+                triggerProbability: 100,
+                generationTypes: ['normal'],
+                ...(overrides.conditions ?? {}),
+            },
+        };
     }
 
     function useManualTransformAgents() {
@@ -503,6 +545,137 @@ describe('in-chat agent post-processing runner', () => {
 
         expect(extensionPrompts.pathfinder_pipeline_retrieval).toEqual({ value: 'retrieved lore' });
         expect(extensionPrompts['inchat_agent_agent-pre-prompt']).toEqual({ value: 'Use the current scene style.' });
+    });
+
+    test('runs pre-generation intercept agents on text prompts without injecting their prompt', async () => {
+        enabledAgents = [createPreInterceptAgent({
+            preProcess: { applyMode: 'replace', maxTokens: 123 },
+        })];
+
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        await eventSource.emit(eventTypes.GENERATION_AFTER_COMMANDS, 'normal', {}, false);
+
+        const eventData = { prompt: 'Original outgoing prompt', dryRun: false };
+        await eventSource.emit(eventTypes.GENERATE_AFTER_COMBINE_PROMPTS, eventData);
+
+        expect(extensionPrompts['inchat_agent_agent-pre-intercept']).toBeUndefined();
+        expect(generateQuietPrompt).toHaveBeenCalledTimes(1);
+        expect(generateQuietPrompt.mock.calls[0][0]).toEqual(expect.objectContaining({
+            quietName: 'In-Chat Agent',
+            responseLength: 123,
+            skipWIAN: true,
+            removeReasoning: true,
+        }));
+        expect(generateQuietPrompt.mock.calls[0][0].quietPrompt).toContain('Outgoing context:');
+        expect(generateQuietPrompt.mock.calls[0][0].quietPrompt).toContain('Original outgoing prompt');
+        expect(eventData.prompt).toBe('quiet result');
+    });
+
+    test('chains multiple pre-generation intercept agents by order', async () => {
+        enabledAgents = [
+            createPreInterceptAgent({
+                id: 'agent-second',
+                name: 'Second',
+                prompt: 'Second pass.',
+                injection: { order: 20 },
+            }),
+            createPreInterceptAgent({
+                id: 'agent-first',
+                name: 'First',
+                prompt: 'First pass.',
+                injection: { order: 10 },
+            }),
+        ];
+        generateQuietPrompt
+            .mockResolvedValueOnce('first output')
+            .mockResolvedValueOnce('second output');
+
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        const eventData = { prompt: 'Original prompt', dryRun: false };
+        await eventSource.emit(eventTypes.GENERATE_AFTER_COMBINE_PROMPTS, eventData);
+
+        expect(generateQuietPrompt).toHaveBeenCalledTimes(2);
+        expect(generateQuietPrompt.mock.calls[0][0].quietPrompt).toContain('First pass.');
+        expect(generateQuietPrompt.mock.calls[0][0].quietPrompt).toContain('Original prompt');
+        expect(generateQuietPrompt.mock.calls[1][0].quietPrompt).toContain('Second pass.');
+        expect(generateQuietPrompt.mock.calls[1][0].quietPrompt).toContain('first output');
+        expect(eventData.prompt).toBe('second output');
+    });
+
+    test('replaces chat completion prompts when intercept output is a message array', async () => {
+        enabledAgents = [createPreInterceptAgent()];
+        generateQuietPrompt.mockResolvedValue(JSON.stringify([
+            { role: 'system', content: 'rewritten system prompt' },
+            { role: 'user', content: 'rewritten user prompt' },
+        ]));
+
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        const eventData = {
+            chat: [{ role: 'user', content: 'original user prompt' }],
+            dryRun: false,
+        };
+        await eventSource.emit(eventTypes.CHAT_COMPLETION_PROMPT_READY, eventData);
+
+        expect(generateQuietPrompt).toHaveBeenCalledTimes(1);
+        expect(generateQuietPrompt.mock.calls[0][0].quietPrompt).toContain('JSON array of chat-completion messages');
+        expect(generateQuietPrompt.mock.calls[0][0].quietPrompt).toContain('original user prompt');
+        expect(eventData.chat).toEqual([
+            { role: 'system', content: 'rewritten system prompt' },
+            { role: 'user', content: 'rewritten user prompt' },
+        ]);
+    });
+
+    test('adds patch messages for chat completion intercept agents in patch mode', async () => {
+        enabledAgents = [createPreInterceptAgent({
+            injection: { role: 1 },
+            preProcess: {
+                applyMode: 'patch',
+                wrapPosition: 'before',
+                patchStartTag: '<patch>',
+                patchEndTag: '</patch>',
+            },
+        })];
+        generateQuietPrompt.mockResolvedValue('patch note');
+
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        const originalMessage = { role: 'user', content: 'original user prompt' };
+        const eventData = { chat: [originalMessage], dryRun: false };
+        await eventSource.emit(eventTypes.CHAT_COMPLETION_PROMPT_READY, eventData);
+
+        expect(eventData.chat).toEqual([
+            { role: 'user', content: '<patch>\npatch note\n</patch>' },
+            originalMessage,
+        ]);
+    });
+
+    test('skips pre-generation intercepts during dry runs and outside active generation', async () => {
+        enabledAgents = [createPreInterceptAgent()];
+
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+
+        const inactiveEventData = { prompt: 'inactive prompt', dryRun: false };
+        await eventSource.emit(eventTypes.GENERATE_AFTER_COMBINE_PROMPTS, inactiveEventData);
+
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        const dryRunEventData = { prompt: 'dry run prompt', dryRun: true };
+        await eventSource.emit(eventTypes.GENERATE_AFTER_COMBINE_PROMPTS, dryRunEventData);
+
+        expect(generateQuietPrompt).not.toHaveBeenCalled();
+        expect(inactiveEventData.prompt).toBe('inactive prompt');
+        expect(dryRunEventData.prompt).toBe('dry run prompt');
     });
 
     test('queues manual agent runs while another manual agent is active in sequential mode', async () => {

--- a/tests/in-chat-agents-store.test.js
+++ b/tests/in-chat-agents-store.test.js
@@ -138,6 +138,53 @@ describe('in-chat agent scoped enabled state', () => {
         });
     });
 
+    test('normalizes pre-generation intercept settings with safe defaults', async () => {
+        const store = await importStore();
+        store.loadAgents([{
+            id: 'agent-intercept',
+            name: 'Intercept Agent',
+            preProcess: {
+                mode: 'intercept',
+                applyMode: 'patch',
+                wrapPosition: 'before',
+                wrapPrefix: 'prefix',
+                wrapSuffix: 'suffix',
+                patchStartTag: '',
+                patchEndTag: '<done>',
+                maxTokens: 999999,
+            },
+        }]);
+
+        expect(store.getAgentById('agent-intercept').preProcess).toEqual(expect.objectContaining({
+            mode: 'intercept',
+            applyMode: 'patch',
+            wrapPosition: 'before',
+            wrapPrefix: 'prefix',
+            wrapSuffix: 'suffix',
+            patchStartTag: '<context_patch>',
+            patchEndTag: '<done>',
+            maxTokens: 16000,
+        }));
+
+        store.loadAgents([{
+            id: 'agent-invalid-intercept',
+            name: 'Invalid Intercept Agent',
+            preProcess: {
+                mode: 'unknown',
+                applyMode: 'unknown',
+                wrapPosition: 'middle',
+                maxTokens: 'not-a-number',
+            },
+        }]);
+
+        expect(store.getAgentById('agent-invalid-intercept').preProcess).toEqual(expect.objectContaining({
+            mode: 'inject',
+            applyMode: 'replace',
+            wrapPosition: 'after',
+            maxTokens: store.DEFAULT_AGENT_MAX_TOKENS,
+        }));
+    });
+
     test('preserves disabled Pathfinder summary tool toggles while normalizing agents', async () => {
         const store = await importStore();
         store.loadAgents([

--- a/tests/in-chat-agents-templates.test.js
+++ b/tests/in-chat-agents-templates.test.js
@@ -8,10 +8,11 @@ function readTemplate(filename) {
 }
 
 describe('in-chat agent bundled templates', () => {
-    test('keeps tracker source files synced with the template browser catalog', () => {
+    test('keeps source files synced with the template browser catalog', () => {
         const catalog = readTemplate('index.json');
         const sourceFilenames = [
             'achievements-tracker.json',
+            'npc-motivator.json',
             'scene-tracker.json',
         ];
 
@@ -20,5 +21,25 @@ describe('in-chat agent bundled templates', () => {
             const catalogTemplate = catalog.find(template => template.id === source.id);
             expect(catalogTemplate).toEqual(source);
         }
+    });
+
+    test('bundles NPC Motivator as a pre-generation intercept patch agent', () => {
+        const template = readTemplate('npc-motivator.json');
+
+        expect(template).toEqual(expect.objectContaining({
+            id: 'tpl-npc-motivator',
+            name: 'NPC Motivator',
+            author: 'Sheep',
+            phase: 'pre',
+            enabled: false,
+        }));
+        expect(template.preProcess).toEqual(expect.objectContaining({
+            mode: 'intercept',
+            applyMode: 'patch',
+            patchStartTag: '<npc_motivation_plan>',
+            patchEndTag: '</npc_motivation_plan>',
+            maxTokens: 4096,
+        }));
+        expect(template.conditions.generationTypes).toEqual(['normal', 'continue', 'impersonate']);
     });
 });

--- a/tests/openai-prompt-budget.test.js
+++ b/tests/openai-prompt-budget.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import { checkPostInterceptChatBudget } from '../public/scripts/openai-prompt-budget.js';
+
+describe('OpenAI post-intercept prompt budget', () => {
+    test('recounts chat payloads after pre-generation intercepts', async () => {
+        const chat = [{ role: 'user', content: 'intercept-expanded prompt' }];
+        const countTokens = jest.fn(async () => 120);
+
+        const result = await checkPostInterceptChatBudget(chat, {
+            openai_max_context: 150,
+            openai_max_tokens: 40,
+        }, countTokens);
+
+        expect(countTokens).toHaveBeenCalledWith(chat);
+        expect(result).toEqual({
+            promptTokens: 120,
+            promptTokenBudget: 110,
+            exceeded: true,
+        });
+    });
+
+    test('does not flag payloads that stay within the post-intercept budget', async () => {
+        const result = await checkPostInterceptChatBudget([{ role: 'user', content: 'prompt' }], {
+            openai_max_context: 150,
+            openai_max_tokens: 40,
+        }, async () => 110);
+
+        expect(result.exceeded).toBe(false);
+    });
+
+    test('rejects non-array post-intercept payloads', async () => {
+        await expect(checkPostInterceptChatBudget(null, {
+            openai_max_context: 150,
+            openai_max_tokens: 40,
+        }, async () => 0)).rejects.toThrow('Post-intercept chat payload must be an array.');
+    });
+});


### PR DESCRIPTION
## Summary
- Add pre-generation intercept mode so in-chat agents can modify assembled text or chat-completion context before the main model receives it.
- Add editor settings, schema normalization, docs, and tests for replace, wrap, and patch application modes.
- Bundle Sheep's NPC Motivator as a disabled-by-default pre-generation intercept patch agent.

## Tests
- npm run test:unit --prefix tests -- tests/in-chat-agents-runner.test.js tests/in-chat-agents-store.test.js
- npm run test:unit --prefix tests -- tests/in-chat-agents-templates.test.js tests/in-chat-agents-store.test.js tests/in-chat-agents-runner.test.js
- npm run test:unit --prefix tests -- tests/in-chat-agents-templates.test.js