### PR TITLE
feat: add character bot sources browser

### DIFF
--- a/public/scripts/extensions/character-bot-sources/index.js
+++ b/public/scripts/extensions/character-bot-sources/index.js
@@ -1,0 +1,427 @@
+import { getRequestHeaders } from '../../../script.js';
+import { POPUP_TYPE, Popup } from '../../popup.js';
+import { escapeHtml, importFromExternalUrl } from '../../utils.js';
+
+const MODULE_NAME = 'character-bot-sources';
+const BUTTON_ID = 'character_bot_sources_button';
+const API_BASE = '/api/character-bot-sources';
+
+let sources = [];
+let activeSourceId = 'chub';
+let currentPage = 1;
+
+/**
+ * @returns {Promise<void>}
+ */
+export async function init() {
+    if (document.getElementById(BUTTON_ID)) {
+        return;
+    }
+
+    const container = document.getElementById('rm_buttons_container');
+    if (!container) {
+        return;
+    }
+
+    const button = document.createElement('div');
+    button.id = BUTTON_ID;
+    button.className = 'menu_button menu_button_icon';
+    button.title = 'Browse online character sources';
+    button.setAttribute('aria-label', 'Browse online character sources');
+    button.innerHTML = '<i class="fa-solid fa-globe"></i><span>Browse Online</span>';
+    button.addEventListener('click', openBrowserPopup);
+    container.append(button);
+}
+
+/**
+ * @returns {Promise<void>}
+ */
+async function openBrowserPopup() {
+    const root = createBrowserElement();
+    await loadSources(root);
+
+    await new Popup(root, POPUP_TYPE.TEXT, '', {
+        okButton: 'Close',
+        wide: true,
+        large: true,
+        allowVerticalScrolling: true,
+        allowHorizontalScrolling: false,
+        onOpen: () => {
+            bindBrowserEvents(root);
+            renderSourcePicker(root);
+            updateSourceHelp(root);
+            renderEmpty(root, 'Pick a source, enter search text or paste a URL, then import.');
+        },
+    }).show();
+}
+
+/**
+ * @returns {HTMLElement}
+ */
+function createBrowserElement() {
+    const root = document.createElement('div');
+    root.className = 'cbs-browser';
+    root.innerHTML = `
+        <div class="cbs-header">
+            <div>
+                <div class="cbs-eyebrow">Character Sources</div>
+                <h2>Browse Online</h2>
+                <p>Search verified sources or paste a card URL. Imports use SillyBunny's existing safe import pipeline.</p>
+            </div>
+        </div>
+        <div class="cbs-source-row" data-cbs-sources></div>
+        <form class="cbs-search" data-cbs-search-form>
+            <label class="cbs-field cbs-query-field">
+                <span data-cbs-query-label>Search or URL</span>
+                <input class="text_pole" name="query" autocomplete="off" placeholder="Search Chub or paste a character URL">
+            </label>
+            <label class="cbs-field cbs-tags-field" data-cbs-tags-wrap>
+                <span>Tags</span>
+                <input class="text_pole" name="tags" autocomplete="off" placeholder="optional, comma separated">
+            </label>
+            <label class="cbs-nsfw" data-cbs-nsfw-wrap>
+                <input type="checkbox" name="nsfw">
+                <span>Include NSFW</span>
+            </label>
+            <button class="menu_button menu_button_primary" type="submit" data-cbs-submit>
+                <i class="fa-solid fa-magnifying-glass"></i>
+                <span>Search</span>
+            </button>
+        </form>
+        <div class="cbs-helper" data-cbs-helper></div>
+        <div class="cbs-status" data-cbs-status aria-live="polite"></div>
+        <div class="cbs-results" data-cbs-results></div>
+        <div class="cbs-pager" data-cbs-pager hidden>
+            <button class="menu_button" type="button" data-cbs-prev>
+                <i class="fa-solid fa-chevron-left"></i>
+                <span>Prev</span>
+            </button>
+            <span data-cbs-page></span>
+            <button class="menu_button" type="button" data-cbs-next>
+                <span>Next</span>
+                <i class="fa-solid fa-chevron-right"></i>
+            </button>
+        </div>
+    `;
+    return root;
+}
+
+/**
+ * @param {HTMLElement} root
+ */
+async function loadSources(root) {
+    if (sources.length) {
+        return;
+    }
+
+    setStatus(root, 'Loading sources...');
+    try {
+        const response = await fetch(`${API_BASE}/list`, { headers: getRequestHeaders() });
+        if (!response.ok) {
+            throw new Error(response.statusText || `HTTP ${response.status}`);
+        }
+
+        const data = await response.json();
+        sources = Array.isArray(data.sources) ? data.sources : [];
+        if (sources.length && !sources.some(source => source.id === activeSourceId)) {
+            activeSourceId = sources[0].id;
+        }
+        setStatus(root, '');
+    } catch (error) {
+        console.error(`[${MODULE_NAME}] Source list failed`, error);
+        setStatus(root, 'Could not load source list. Try again after checking the server logs.', true);
+    }
+}
+
+/**
+ * @param {HTMLElement} root
+ */
+function bindBrowserEvents(root) {
+    root.querySelector('[data-cbs-search-form]')?.addEventListener('submit', event => {
+        event.preventDefault();
+        void runSearch(root, 1);
+    });
+
+    root.querySelector('[data-cbs-prev]')?.addEventListener('click', () => {
+        if (currentPage > 1) {
+            void runSearch(root, currentPage - 1);
+        }
+    });
+
+    root.querySelector('[data-cbs-next]')?.addEventListener('click', () => {
+        void runSearch(root, currentPage + 1);
+    });
+}
+
+/**
+ * @param {HTMLElement} root
+ */
+function renderSourcePicker(root) {
+    const row = root.querySelector('[data-cbs-sources]');
+    if (!row) {
+        return;
+    }
+
+    row.innerHTML = sources.map(source => `
+        <button class="cbs-source ${source.id === activeSourceId ? 'is-active' : ''}" type="button" data-source-id="${escapeHtml(source.id)}">
+            <span>${escapeHtml(source.label)}</span>
+            <small>${source.searchable ? 'Search' : 'URL'}</small>
+        </button>
+    `).join('');
+
+    for (const button of row.querySelectorAll('[data-source-id]')) {
+        button.addEventListener('click', () => {
+            activeSourceId = button.getAttribute('data-source-id') || activeSourceId;
+            currentPage = 1;
+            renderSourcePicker(root);
+            updateSourceHelp(root);
+            renderEmpty(root, getActiveSource()?.searchable ? 'Search this source to list cards.' : 'Paste a supported card URL to import.');
+        });
+    }
+}
+
+/**
+ * @param {HTMLElement} root
+ */
+function updateSourceHelp(root) {
+    const source = getActiveSource();
+    const searchable = Boolean(source?.searchable);
+    const helper = root.querySelector('[data-cbs-helper]');
+    const queryLabel = root.querySelector('[data-cbs-query-label]');
+    const queryInput = root.querySelector('input[name="query"]');
+    const tagsWrap = root.querySelector('[data-cbs-tags-wrap]');
+    const nsfwWrap = root.querySelector('[data-cbs-nsfw-wrap]');
+    const submitLabel = root.querySelector('[data-cbs-submit] span');
+
+    if (helper) {
+        helper.innerHTML = `
+            <strong>${escapeHtml(source?.label || 'Source')}</strong>
+            <span>${escapeHtml(source?.helper || '')}</span>
+            <code>${escapeHtml(source?.urlHint || '')}</code>
+        `;
+    }
+    if (queryLabel) {
+        queryLabel.textContent = searchable ? 'Search' : 'Card URL';
+    }
+    if (queryInput) {
+        queryInput.placeholder = searchable ? 'name, creator, prompt idea' : source?.urlHint || 'https://...';
+    }
+    if (tagsWrap) {
+        tagsWrap.hidden = !searchable;
+    }
+    if (nsfwWrap) {
+        nsfwWrap.hidden = !searchable;
+    }
+    if (submitLabel) {
+        submitLabel.textContent = searchable ? 'Search' : 'Check URL';
+    }
+}
+
+/**
+ * @param {HTMLElement} root
+ * @param {number} page
+ */
+async function runSearch(root, page) {
+    const form = root.querySelector('[data-cbs-search-form]');
+    if (!(form instanceof HTMLFormElement)) {
+        return;
+    }
+
+    const formData = new FormData(form);
+    const query = String(formData.get('query') || '').trim();
+    const tags = String(formData.get('tags') || '')
+        .split(',')
+        .map(tag => tag.trim())
+        .filter(Boolean);
+
+    if (!query) {
+        renderEmpty(root, getActiveSource()?.searchable ? 'Enter a search term first.' : 'Paste a card URL first.');
+        return;
+    }
+
+    currentPage = page;
+    setBusy(root, true);
+    setStatus(root, 'Searching...');
+    renderEmpty(root, '');
+
+    try {
+        const response = await fetch(`${API_BASE}/search`, {
+            method: 'POST',
+            headers: getRequestHeaders(),
+            body: JSON.stringify({
+                source: activeSourceId,
+                query,
+                tags,
+                page,
+                nsfw: Boolean(formData.get('nsfw')),
+            }),
+        });
+
+        if (!response.ok) {
+            throw new Error(response.statusText || `HTTP ${response.status}`);
+        }
+
+        renderResults(root, await response.json());
+    } catch (error) {
+        console.error(`[${MODULE_NAME}] Search failed`, error);
+        setStatus(root, 'Search failed. The source may be unavailable right now.', true);
+        renderEmpty(root, 'No results to show.');
+    } finally {
+        setBusy(root, false);
+    }
+}
+
+/**
+ * @param {HTMLElement} root
+ * @param {object} payload
+ */
+function renderResults(root, payload) {
+    const results = Array.isArray(payload?.results) ? payload.results : [];
+    const total = Number(payload?.total) || results.length;
+    const source = getActiveSource();
+    setStatus(root, results.length ? `${total} result${total === 1 ? '' : 's'} from ${source?.label || 'source'}.` : 'No matching cards found.');
+
+    if (!results.length) {
+        renderEmpty(root, source?.searchable ? 'Try a broader search or fewer tags.' : 'Check that the pasted URL is public and supported.');
+        renderPager(root, false);
+        return;
+    }
+
+    const container = root.querySelector('[data-cbs-results]');
+    if (!container) {
+        return;
+    }
+
+    container.innerHTML = results.map((result, index) => renderResultCard(result, index)).join('');
+
+    for (const button of container.querySelectorAll('[data-cbs-import]')) {
+        button.addEventListener('click', async () => {
+            const index = Number(button.getAttribute('data-cbs-import'));
+            const result = results[index];
+            if (!result?.importUrl) {
+                toastr.warning('This result has no import URL.');
+                return;
+            }
+
+            button.classList.add('disabled');
+            button.setAttribute('aria-busy', 'true');
+            try {
+                await importFromExternalUrl(result.importUrl);
+            } catch (error) {
+                console.error(`[${MODULE_NAME}] Import failed`, error);
+                toastr.error('Import failed. Check the URL and server logs.');
+            } finally {
+                button.classList.remove('disabled');
+                button.removeAttribute('aria-busy');
+            }
+        });
+    }
+
+    renderPager(root, Boolean(payload?.hasMore));
+}
+
+/**
+ * @param {object} result
+ * @param {number} index
+ * @returns {string}
+ */
+function renderResultCard(result, index) {
+    const tags = Array.isArray(result.tags) ? result.tags.slice(0, 6) : [];
+    const metrics = [];
+    if (Number.isFinite(result.stars)) {
+        metrics.push(`<span><i class="fa-solid fa-star"></i> ${result.stars}</span>`);
+    }
+    if (Number.isFinite(result.downloads)) {
+        metrics.push(`<span><i class="fa-solid fa-comments"></i> ${result.downloads}</span>`);
+    }
+    if (result.nsfw) {
+        metrics.push('<span class="cbs-nsfw-chip">NSFW</span>');
+    }
+
+    return `
+        <article class="cbs-card">
+            <div class="cbs-thumb" aria-hidden="true">
+                ${result.thumbnailUrl ? `<img src="${escapeHtml(result.thumbnailUrl)}" alt="">` : '<i class="fa-solid fa-user-astronaut"></i>'}
+            </div>
+            <div class="cbs-card-main">
+                <div class="cbs-card-title-row">
+                    <h3>${escapeHtml(result.name || 'Unknown')}</h3>
+                    ${result.pageUrl ? `<a href="${escapeHtml(result.pageUrl)}" target="_blank" rel="noopener noreferrer" title="Open source page"><i class="fa-solid fa-arrow-up-right-from-square"></i></a>` : ''}
+                </div>
+                ${result.author ? `<div class="cbs-author">by ${escapeHtml(result.author)}</div>` : ''}
+                ${result.description ? `<p>${escapeHtml(result.description)}</p>` : ''}
+                ${tags.length ? `<div class="cbs-tags">${tags.map(tag => `<span>${escapeHtml(tag)}</span>`).join('')}</div>` : ''}
+                ${metrics.length ? `<div class="cbs-metrics">${metrics.join('')}</div>` : ''}
+            </div>
+            <button class="menu_button menu_button_primary cbs-import" type="button" data-cbs-import="${index}">
+                <i class="fa-solid fa-cloud-arrow-down"></i>
+                <span>Import</span>
+            </button>
+        </article>
+    `;
+}
+
+/**
+ * @param {HTMLElement} root
+ * @param {string} message
+ */
+function renderEmpty(root, message) {
+    const container = root.querySelector('[data-cbs-results]');
+    if (container) {
+        container.innerHTML = message ? `<div class="cbs-empty">${escapeHtml(message)}</div>` : '';
+    }
+    renderPager(root, false);
+}
+
+/**
+ * @param {HTMLElement} root
+ * @param {boolean} hasMore
+ */
+function renderPager(root, hasMore) {
+    const pager = root.querySelector('[data-cbs-pager]');
+    const pageLabel = root.querySelector('[data-cbs-page]');
+    const prev = root.querySelector('[data-cbs-prev]');
+    const next = root.querySelector('[data-cbs-next]');
+    if (!pager || !pageLabel || !prev || !next) {
+        return;
+    }
+
+    pager.hidden = currentPage <= 1 && !hasMore;
+    pageLabel.textContent = `Page ${currentPage}`;
+    prev.toggleAttribute('disabled', currentPage <= 1);
+    next.toggleAttribute('disabled', !hasMore);
+}
+
+/**
+ * @param {HTMLElement} root
+ * @param {boolean} busy
+ */
+function setBusy(root, busy) {
+    const submit = root.querySelector('[data-cbs-submit]');
+    if (submit) {
+        submit.toggleAttribute('disabled', busy);
+        submit.classList.toggle('disabled', busy);
+    }
+}
+
+/**
+ * @param {HTMLElement} root
+ * @param {string} message
+ * @param {boolean} [isError]
+ */
+function setStatus(root, message, isError = false) {
+    const status = root.querySelector('[data-cbs-status]');
+    if (!status) {
+        return;
+    }
+
+    status.textContent = message;
+    status.classList.toggle('is-error', isError);
+}
+
+/**
+ * @returns {object|null}
+ */
+function getActiveSource() {
+    return sources.find(source => source.id === activeSourceId) || sources[0] || null;
+}

--- a/public/scripts/extensions/character-bot-sources/manifest.json
+++ b/public/scripts/extensions/character-bot-sources/manifest.json
@@ -1,0 +1,14 @@
+{
+    "display_name": "Character Bot Sources",
+    "loading_order": 20,
+    "requires": [],
+    "optional": [],
+    "js": "index.js",
+    "css": "style.css",
+    "author": "SillyBunny",
+    "version": "0.1.0",
+    "homePage": "https://github.com/platberlitz/SillyBunny",
+    "hooks": {
+        "activate": "init"
+    }
+}

--- a/public/scripts/extensions/character-bot-sources/style.css
+++ b/public/scripts/extensions/character-bot-sources/style.css
@@ -1,0 +1,307 @@
+#character_bot_sources_button {
+    min-width: fit-content;
+}
+
+.cbs-browser {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    color: var(--SmartThemeBodyColor);
+    text-align: left;
+}
+
+.cbs-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 4px 2px 2px;
+}
+
+.cbs-eyebrow {
+    color: var(--SmartThemeQuoteColor);
+    font-size: calc(var(--mainFontSize) * 0.72);
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.cbs-header h2 {
+    margin: 4px 0;
+    font-size: calc(var(--mainFontSize) * 1.45);
+    line-height: 1.15;
+}
+
+.cbs-header p {
+    max-width: 70ch;
+    margin: 0;
+    color: var(--SmartThemeEmColor);
+    font-size: calc(var(--mainFontSize) * 0.9);
+    line-height: 1.45;
+}
+
+.cbs-source-row {
+    display: flex;
+    gap: 8px;
+    padding-bottom: 2px;
+    overflow-x: auto;
+    scrollbar-width: thin;
+}
+
+.cbs-source {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 34px;
+    padding: 7px 12px;
+    border: 1px solid color-mix(in srgb, var(--SmartThemeBorderColor) 70%, transparent);
+    border-radius: var(--sb-radius-button, 14px);
+    background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 88%, var(--SmartThemeBodyColor) 12%);
+    color: var(--SmartThemeBodyColor);
+    cursor: pointer;
+    font: inherit;
+    white-space: nowrap;
+}
+
+.cbs-source small {
+    padding: 2px 6px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--SmartThemeBodyColor) 10%, transparent);
+    color: var(--SmartThemeEmColor);
+    font-size: calc(var(--mainFontSize) * 0.68);
+}
+
+.cbs-source.is-active {
+    border-color: color-mix(in srgb, var(--SmartThemeQuoteColor) 62%, transparent);
+    background: color-mix(in srgb, var(--SmartThemeQuoteColor) 18%, var(--SmartThemeBlurTintColor) 82%);
+}
+
+.cbs-source.is-active small {
+    color: var(--SmartThemeBodyColor);
+}
+
+.cbs-search {
+    display: grid;
+    grid-template-columns: minmax(180px, 1.4fr) minmax(140px, 0.8fr) auto auto;
+    align-items: end;
+    gap: 10px;
+}
+
+.cbs-field {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    min-width: 0;
+}
+
+.cbs-field span,
+.cbs-nsfw span {
+    color: var(--SmartThemeEmColor);
+    font-size: calc(var(--mainFontSize) * 0.78);
+}
+
+.cbs-field input {
+    width: 100%;
+}
+
+.cbs-nsfw {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    min-height: var(--sb-control-min-height, 30px);
+    padding-bottom: 4px;
+    white-space: nowrap;
+}
+
+.cbs-helper {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 4px 10px;
+    padding: 10px 12px;
+    border: 1px solid color-mix(in srgb, var(--SmartThemeBorderColor) 58%, transparent);
+    border-radius: var(--sb-radius-lg, 16px);
+    background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 76%, transparent);
+    font-size: calc(var(--mainFontSize) * 0.82);
+}
+
+.cbs-helper strong {
+    color: var(--SmartThemeQuoteColor);
+}
+
+.cbs-helper span,
+.cbs-helper code {
+    color: var(--SmartThemeEmColor);
+}
+
+.cbs-helper code {
+    grid-column: 1 / -1;
+    overflow-wrap: anywhere;
+}
+
+.cbs-status {
+    min-height: 1.2em;
+    color: var(--SmartThemeEmColor);
+    font-size: calc(var(--mainFontSize) * 0.82);
+}
+
+.cbs-status.is-error {
+    color: var(--fullred, #ff6f6f);
+}
+
+.cbs-results {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.cbs-empty {
+    padding: 22px 14px;
+    border: 1px dashed color-mix(in srgb, var(--SmartThemeBorderColor) 68%, transparent);
+    border-radius: var(--sb-radius-lg, 16px);
+    color: var(--SmartThemeEmColor);
+    text-align: center;
+}
+
+.cbs-card {
+    display: grid;
+    grid-template-columns: 72px minmax(0, 1fr) auto;
+    gap: 12px;
+    align-items: start;
+    padding: 12px;
+    border: 1px solid color-mix(in srgb, var(--SmartThemeBorderColor) 68%, transparent);
+    border-radius: var(--sb-radius-lg, 16px);
+    background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 86%, var(--SmartThemeBodyColor) 8%);
+}
+
+.cbs-thumb {
+    display: grid;
+    place-items: center;
+    width: 72px;
+    height: 96px;
+    overflow: hidden;
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--SmartThemeBorderColor) 34%, transparent);
+    color: var(--SmartThemeEmColor);
+}
+
+.cbs-thumb img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.cbs-card-main {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    min-width: 0;
+}
+
+.cbs-card-title-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.cbs-card h3 {
+    margin: 0;
+    overflow-wrap: anywhere;
+    font-size: calc(var(--mainFontSize) * 1.02);
+    line-height: 1.25;
+}
+
+.cbs-card-title-row a {
+    color: var(--SmartThemeQuoteColor);
+}
+
+.cbs-author,
+.cbs-metrics {
+    color: var(--SmartThemeEmColor);
+    font-size: calc(var(--mainFontSize) * 0.78);
+}
+
+.cbs-card p {
+    display: -webkit-box;
+    margin: 0;
+    overflow: hidden;
+    color: var(--SmartThemeBodyColor);
+    font-size: calc(var(--mainFontSize) * 0.86);
+    line-height: 1.4;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+}
+
+.cbs-tags,
+.cbs-metrics {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.cbs-tags span,
+.cbs-metrics span {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 7px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--SmartThemeBodyColor) 9%, transparent);
+}
+
+.cbs-metrics .cbs-nsfw-chip {
+    color: var(--fullred, #ff6f6f);
+}
+
+.cbs-import {
+    align-self: center;
+}
+
+.cbs-pager {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding-top: 2px;
+}
+
+.cbs-pager span {
+    color: var(--SmartThemeEmColor);
+    font-size: calc(var(--mainFontSize) * 0.82);
+}
+
+@media screen and (max-width: 720px) {
+    .cbs-browser {
+        gap: 12px;
+    }
+
+    .cbs-search {
+        grid-template-columns: 1fr;
+    }
+
+    .cbs-nsfw {
+        padding-bottom: 0;
+    }
+
+    .cbs-card {
+        grid-template-columns: 56px minmax(0, 1fr);
+    }
+
+    .cbs-thumb {
+        width: 56px;
+        height: 74px;
+    }
+
+    .cbs-import {
+        grid-column: 1 / -1;
+        width: 100%;
+    }
+}
+
+@media screen and (max-width: 460px) {
+    #character_bot_sources_button span {
+        display: none;
+    }
+
+    .cbs-helper {
+        grid-template-columns: 1fr;
+    }
+}

--- a/src/endpoints/character-bot-sources.js
+++ b/src/endpoints/character-bot-sources.js
@@ -1,0 +1,283 @@
+// SillyBunny: Character Bot Sources
+// Server-side search/listing aggregator for online character-card sources.
+// Card import is handled by the existing `/api/content/importURL` endpoint.
+import express from 'express';
+
+export const router = express.Router();
+
+const CHUB_PAGE_SIZE = 24;
+const DEFAULT_TIMEOUT_MS = 15000;
+const USER_AGENT = 'SillyBunny/CharacterBotSources';
+
+const SOURCES = Object.freeze({
+    chub: {
+        id: 'chub',
+        label: 'Chub.ai / Venus',
+        searchable: true,
+        urlHint: 'https://chub.ai/characters/<author>/<slug>',
+        helper: 'Search Chub/Venus directly, then import through SillyBunny.',
+    },
+    aicc: {
+        id: 'aicc',
+        label: 'AICharacterCards.com',
+        searchable: false,
+        urlHint: 'https://aicharactercards.com/charactercards/<category>/<author>/<card>/',
+        helper: 'Paste a card page URL. Public search is not exposed by this source.',
+    },
+    janitorai: {
+        id: 'janitorai',
+        label: 'JanitorAI',
+        searchable: false,
+        urlHint: 'https://janitorai.com/characters/<uuid>_character-name',
+        helper: 'Paste a JanitorAI character URL.',
+    },
+    janny: {
+        id: 'janny',
+        label: 'JannyAI',
+        searchable: false,
+        urlHint: 'https://jannyai.com/bots/<uuid>',
+        helper: 'Paste a JannyAI bot URL.',
+    },
+    risurealm: {
+        id: 'risurealm',
+        label: 'RisuRealm',
+        searchable: false,
+        urlHint: 'https://realm.risuai.net/character/<id>',
+        helper: 'Paste a RisuRealm character URL.',
+    },
+    pygmalion: {
+        id: 'pygmalion',
+        label: 'Pygmalion',
+        searchable: false,
+        urlHint: 'https://pygmalion.chat/character/<uuid>',
+        helper: 'Paste a Pygmalion character URL.',
+    },
+    direct: {
+        id: 'direct',
+        label: 'Direct PNG/JSON URL',
+        searchable: false,
+        urlHint: 'Any public PNG/JSON character card URL',
+        helper: 'Paste a direct card URL from an allowed import host.',
+    },
+});
+
+/**
+ * @param {string} url
+ * @param {RequestInit} [init]
+ * @returns {Promise<Response|null>}
+ */
+async function safeFetch(url, init = {}) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+
+    try {
+        const response = await fetch(url, {
+            ...init,
+            signal: controller.signal,
+            headers: {
+                'User-Agent': USER_AGENT,
+                ...(init.headers || {}),
+            },
+        });
+
+        if (!response.ok) {
+            console.warn(`[CharBotSources] ${url} -> HTTP ${response.status}`);
+            return null;
+        }
+
+        return response;
+    } catch (error) {
+        console.warn(`[CharBotSources] ${url} failed:`, error?.message || error);
+        return null;
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+/**
+ * @param {unknown[]} values
+ * @returns {string[]}
+ */
+function normaliseTags(values) {
+    if (!Array.isArray(values)) {
+        return [];
+    }
+
+    return values
+        .map(value => typeof value === 'string' ? value : value?.title || value?.name || '')
+        .map(value => String(value).trim())
+        .filter(Boolean)
+        .slice(0, 20);
+}
+
+/**
+ * @param {unknown} value
+ * @returns {number|null}
+ */
+function toFiniteNumber(value) {
+    const number = Number(value);
+    return Number.isFinite(number) ? number : null;
+}
+
+/**
+ * @param {object} fields
+ * @returns {object}
+ */
+function normalise(fields) {
+    return {
+        id: String(fields.id ?? ''),
+        source: String(fields.source ?? ''),
+        name: String(fields.name ?? 'Unknown'),
+        author: fields.author ? String(fields.author) : '',
+        description: fields.description ? String(fields.description).slice(0, 600) : '',
+        thumbnailUrl: fields.thumbnailUrl ? String(fields.thumbnailUrl) : '',
+        pageUrl: fields.pageUrl ? String(fields.pageUrl) : '',
+        importUrl: String(fields.importUrl ?? ''),
+        tags: normaliseTags(fields.tags),
+        nsfw: Boolean(fields.nsfw),
+        downloads: toFiniteNumber(fields.downloads),
+        stars: toFiniteNumber(fields.stars),
+    };
+}
+
+/**
+ * @param {object} json
+ * @param {number} page
+ * @returns {{results: object[], total: number, hasMore: boolean}}
+ */
+function mapChubSearchResponse(json, page) {
+    const data = json?.data || {};
+    const nodes = Array.isArray(data.nodes) ? data.nodes : [];
+    const results = nodes.map(node => {
+        const fullPath = String(node.fullPath || '').trim();
+        const pageUrl = fullPath ? `https://chub.ai/characters/${fullPath}` : '';
+        const downloads = toFiniteNumber(node.nChats) ?? toFiniteNumber(node.downloadCount) ?? toFiniteNumber(node.nMessages);
+
+        return normalise({
+            id: node.id ?? fullPath,
+            source: 'chub',
+            name: node.name || node.projectName || 'Unknown',
+            author: node.creatorName || (fullPath.includes('/') ? fullPath.split('/')[0] : ''),
+            description: node.tagline || node.description || '',
+            thumbnailUrl: node.avatar_url || node.max_res_url || '',
+            pageUrl,
+            importUrl: pageUrl,
+            tags: node.topics || node.tags || [],
+            nsfw: Boolean(node.nsfw_image || node.nsfw_only),
+            downloads,
+            stars: toFiniteNumber(node.starCount),
+        });
+    });
+
+    const total = Number.isFinite(Number(data.count)) ? Number(data.count) : results.length;
+    return {
+        results,
+        total,
+        hasMore: Number.isFinite(Number(data.count)) ? page * CHUB_PAGE_SIZE < total : results.length >= CHUB_PAGE_SIZE,
+    };
+}
+
+/**
+ * @param {{ query: string, page: number, nsfw: boolean, tags: string[] }} params
+ */
+async function searchChub({ query, page, nsfw, tags }) {
+    const params = new URLSearchParams({
+        first: String(CHUB_PAGE_SIZE),
+        page: String(Math.max(1, page)),
+        search: query || '',
+        nsfw: nsfw ? 'true' : 'false',
+        nsfl: 'false',
+        nsfw_only: 'false',
+        asc: 'false',
+        sort: 'download_count',
+        count: 'true',
+    });
+
+    if (tags.length) {
+        params.set('tags', tags.join(','));
+    }
+
+    const response = await safeFetch(`https://api.chub.ai/search?${params.toString()}`);
+    if (!response) {
+        return { results: [], total: 0, hasMore: false };
+    }
+
+    try {
+        return mapChubSearchResponse(await response.json(), Math.max(1, page));
+    } catch {
+        return { results: [], total: 0, hasMore: false };
+    }
+}
+
+/**
+ * @param {string} query
+ */
+function searchDirect(query) {
+    const trimmed = String(query || '').trim();
+    if (!/^https?:\/\//i.test(trimmed)) {
+        return { results: [], total: 0, hasMore: false };
+    }
+
+    let host = '';
+    try {
+        host = new URL(trimmed).host;
+    } catch {
+        return { results: [], total: 0, hasMore: false };
+    }
+
+    return {
+        results: [normalise({
+            id: trimmed,
+            source: 'direct',
+            name: `Import from ${host}`,
+            description: trimmed,
+            importUrl: trimmed,
+            pageUrl: trimmed,
+        })],
+        total: 1,
+        hasMore: false,
+    };
+}
+
+router.get('/list', (_request, response) => {
+    response.json({ sources: Object.values(SOURCES) });
+});
+
+router.post('/search', async (request, response) => {
+    const body = request.body || {};
+    const sourceId = String(body.source || 'chub').toLowerCase();
+    const source = SOURCES[sourceId];
+
+    if (!source) {
+        return response.status(400).json({ error: `Unknown source: ${sourceId}` });
+    }
+
+    const query = typeof body.query === 'string' ? body.query.trim() : '';
+    const page = Math.max(1, Number(body.page) || 1);
+    const nsfw = Boolean(body.nsfw);
+    const tags = Array.isArray(body.tags)
+        ? body.tags.map(tag => String(tag).trim()).filter(Boolean).slice(0, 20)
+        : [];
+
+    try {
+        const payload = sourceId === 'chub'
+            ? await searchChub({ query, page, nsfw, tags })
+            : searchDirect(query);
+
+        return response.json({
+            source: sourceId,
+            searchable: source.searchable,
+            ...payload,
+        });
+    } catch (error) {
+        console.error('[CharBotSources] search failed', error);
+        return response.status(500).json({ error: 'Search failed' });
+    }
+});
+
+export const __test = {
+    SOURCES,
+    normalise,
+    mapChubSearchResponse,
+    searchDirect,
+};

--- a/src/endpoints/content-manager.js
+++ b/src/endpoints/content-manager.js
@@ -1248,7 +1248,7 @@ router.post('/importURL', async (request, response) => {
         let type;
 
         const isChub = host.includes('chub.ai') || host.includes('characterhub.org');
-        const isJannnyContent = host.includes('janitorai');
+        const isJannnyContent = host.includes('janitorai') || host.includes('jannyai');
         const isPygmalionContent = host.includes('pygmalion.chat');
         const isAICharacterCardsContent = host.includes('aicharactercards.com');
         const isRisu = host.includes('realm.risuai.net');

--- a/src/server-startup.js
+++ b/src/server-startup.js
@@ -54,6 +54,8 @@ import { router as imageMetadataRouter } from './endpoints/image-metadata.js';
 import { router as volcengineRouter } from './endpoints/volcengine.js';
 import { router as serverAdminRouter } from './endpoints/server-admin.js';
 import { router as inChatAgentsRouter } from './endpoints/in-chat-agents.js';
+// SillyBunny: Character Bot Sources, online card browser/search aggregator.
+import { router as characterBotSourcesRouter } from './endpoints/character-bot-sources.js';
 
 /**
  * @typedef {object} ServerStartupResult
@@ -119,6 +121,7 @@ export function setupPrivateEndpoints(app) {
     app.use('/api/image-metadata', imageMetadataRouter);
     app.use('/api/server-admin', serverAdminRouter);
     app.use('/api/in-chat-agents', inChatAgentsRouter);
+    app.use('/api/character-bot-sources', characterBotSourcesRouter);
 }
 
 /**

--- a/tests/character-bot-sources.test.js
+++ b/tests/character-bot-sources.test.js
@@ -1,0 +1,83 @@
+import { describe, expect, test } from '@jest/globals';
+import { __test } from '../src/endpoints/character-bot-sources.js';
+
+describe('character bot sources helpers', () => {
+    test('keeps only verified sources searchable', () => {
+        expect(__test.SOURCES.chub.searchable).toBe(true);
+        expect(__test.SOURCES.aicc.searchable).toBe(false);
+        expect(__test.SOURCES.janitorai.searchable).toBe(false);
+        expect(__test.SOURCES.janny.searchable).toBe(false);
+        expect(__test.SOURCES.direct.searchable).toBe(false);
+    });
+
+    test('builds a synthetic import result for direct URLs', () => {
+        const payload = __test.searchDirect('https://example.com/cards/alice.png');
+
+        expect(payload.total).toBe(1);
+        expect(payload.hasMore).toBe(false);
+        expect(payload.results[0]).toMatchObject({
+            source: 'direct',
+            name: 'Import from example.com',
+            importUrl: 'https://example.com/cards/alice.png',
+            pageUrl: 'https://example.com/cards/alice.png',
+        });
+    });
+
+    test('rejects non-URL direct searches', () => {
+        expect(__test.searchDirect('alice').results).toEqual([]);
+        expect(__test.searchDirect('ftp://example.com/card.png').results).toEqual([]);
+    });
+
+    test('maps Chub search responses to the shared result shape', () => {
+        const payload = __test.mapChubSearchResponse({
+            data: {
+                count: 63,
+                nodes: [
+                    {
+                        id: 123,
+                        name: 'Alice',
+                        fullPath: 'Anonymous/alice-89fca9a6',
+                        tagline: 'A curious test card',
+                        topics: ['sfw', 'adventure'],
+                        avatar_url: 'https://avatars.example/alice.png',
+                        starCount: 7,
+                        nChats: 42,
+                        nsfw_image: false,
+                    },
+                ],
+            },
+        }, 1);
+
+        expect(payload.total).toBe(63);
+        expect(payload.hasMore).toBe(true);
+        expect(payload.results[0]).toMatchObject({
+            id: '123',
+            source: 'chub',
+            name: 'Alice',
+            author: 'Anonymous',
+            description: 'A curious test card',
+            thumbnailUrl: 'https://avatars.example/alice.png',
+            pageUrl: 'https://chub.ai/characters/Anonymous/alice-89fca9a6',
+            importUrl: 'https://chub.ai/characters/Anonymous/alice-89fca9a6',
+            tags: ['sfw', 'adventure'],
+            nsfw: false,
+            downloads: 42,
+            stars: 7,
+        });
+    });
+
+    test('trusts Chub exact counts for pagination', () => {
+        const payload = __test.mapChubSearchResponse({
+            data: {
+                count: 24,
+                nodes: Array.from({ length: 24 }, (_value, index) => ({
+                    id: index,
+                    name: `Card ${index}`,
+                    fullPath: `creator/card-${index}`,
+                })),
+            },
+        }, 1);
+
+        expect(payload.hasMore).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- Add a native Character Bot Sources browser in the Characters drawer.
- Add a private `/api/character-bot-sources` router with verified Chub search and URL-only imports for other sources.
- Reuse the existing URL import pipeline, including JannyAI host support, with focused helper tests.

## Verification
- `npm run test:unit --prefix tests -- tests/character-bot-sources.test.js`
- `npm run lint`