### PR TITLE
fix: reduce iOS streaming pressure

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5566,6 +5566,27 @@
                                 <i class="fa-solid fa-flask" data-i18n="[title]Experimental feature. May not work for all backends." title="Experimental feature. May not work for all backends."></i>
                             </label>
 
+                            <div name="IOSWebKitStreamingToggles">
+                                <h4><span data-i18n="iOS Streaming Stability">iOS Streaming Stability</span></h4>
+                                <small data-i18n="iOS Streaming Stability_desc">Controls iPhone and iPad WebKit safeguards for long streamed generations.</small>
+                                <label class="checkbox_label" for="ios_webkit_conservative_streaming" title="Use a lower live update rate and slower live reasoning refreshes on iOS WebKit." data-i18n="[title]Use a lower live update rate and slower live reasoning refreshes on iOS WebKit.">
+                                    <input id="ios_webkit_conservative_streaming" type="checkbox" />
+                                    <small data-i18n="Conservative iOS stream timing">Conservative iOS stream timing</small>
+                                </label>
+                                <label class="checkbox_label" for="ios_webkit_reduce_streaming_work" title="Defer token counts, metadata badges, and swipe metadata snapshots until the final streamed render on iOS WebKit." data-i18n="[title]Defer token counts, metadata badges, and swipe metadata snapshots until the final streamed render on iOS WebKit.">
+                                    <input id="ios_webkit_reduce_streaming_work" type="checkbox" />
+                                    <small data-i18n="Reduce live iOS stream work">Reduce live iOS stream work</small>
+                                </label>
+                                <label class="checkbox_label" for="ios_webkit_disable_smooth_streaming" title="Use normal SSE chunks instead of per-character smooth streaming on iOS WebKit." data-i18n="[title]Use normal SSE chunks instead of per-character smooth streaming on iOS WebKit.">
+                                    <input id="ios_webkit_disable_smooth_streaming" type="checkbox" />
+                                    <small data-i18n="Bypass iOS smooth streaming">Bypass iOS smooth streaming</small>
+                                </label>
+                                <label class="checkbox_label" for="ios_webkit_disable_stream_fade_in" title="Use the lighter live DOM patch path instead of stream fade-in segmentation on iOS WebKit." data-i18n="[title]Use the lighter live DOM patch path instead of stream fade-in segmentation on iOS WebKit.">
+                                    <input id="ios_webkit_disable_stream_fade_in" type="checkbox" />
+                                    <small data-i18n="Bypass iOS stream fade-in">Bypass iOS stream fade-in</small>
+                                </label>
+                            </div>
+
                             <label for="play_message_sound" class="checkbox_label" title="Play a sound when a message generation finishes." data-i18n="[title]Play a sound when a message generation finishes">
                                 <input id="play_message_sound" type="checkbox" />
                                 <audio id="audio_message_sound" src="sounds/message.mp3" hidden></audio>

--- a/public/script.js
+++ b/public/script.js
@@ -4451,7 +4451,8 @@ class StreamingProcessor {
     async onProgressStreaming(messageId, text, isFinal) {
         const isImpersonate = this.type == 'impersonate';
         const isContinue = this.type == 'continue';
-        const shouldReduceIntermediateStreamingWork = !isFinal && isIOSWebKitPlatform();
+        const isIOSWebKit = isIOSWebKitPlatform();
+        const shouldReduceIntermediateStreamingWork = !isFinal && isIOSWebKit && power_user.ios_webkit_reduce_streaming_work;
         const shouldPinMobileBottom = !isImpersonate && shouldPinMobileChatToBottom();
 
         if (!isImpersonate && !isContinue && Array.isArray(this.swipes) && this.swipes.length > 0) {
@@ -4551,7 +4552,9 @@ class StreamingProcessor {
             );
             if (this.messageTextDom instanceof HTMLElement) {
                 if (power_user.stream_fade_in) {
-                    applyStreamFadeIn(this.messageTextDom, formattedText);
+                    applyStreamFadeIn(this.messageTextDom, formattedText, {
+                        bypassFadeIn: isIOSWebKit && power_user.ios_webkit_disable_stream_fade_in,
+                    });
                 } else {
                     this.messageTextDom.innerHTML = formattedText;
                 }
@@ -4713,7 +4716,9 @@ class StreamingProcessor {
         this.stoppingStrings = getStoppingStrings(isImpersonate, isContinue, main_api);
 
         try {
-            const sw = new Stopwatch(getStreamingUpdateInterval(1000 / power_user.streaming_fps));
+            const sw = new Stopwatch(getStreamingUpdateInterval(1000 / power_user.streaming_fps, {
+                enabled: power_user.ios_webkit_conservative_streaming,
+            }));
             const timestamps = [];
             for await (const { text, swipes, logprobs, toolCalls, state } of this.generator()) {
                 const now = Date.now();

--- a/public/script.js
+++ b/public/script.js
@@ -4451,6 +4451,7 @@ class StreamingProcessor {
     async onProgressStreaming(messageId, text, isFinal) {
         const isImpersonate = this.type == 'impersonate';
         const isContinue = this.type == 'continue';
+        const shouldReduceIntermediateStreamingWork = !isFinal && isIOSWebKitPlatform();
         const shouldPinMobileBottom = !isImpersonate && shouldPinMobileChatToBottom();
 
         if (!isImpersonate && !isContinue && Array.isArray(this.swipes) && this.swipes.length > 0) {
@@ -4507,28 +4508,36 @@ class StreamingProcessor {
 
             // Token count update.
             const shouldRefreshTokenCount = isFinal && power_user.message_token_count_enabled;
-            const { outputTokens: currentTokenCount } = await updateMessageTokenAccounting(chat[messageId], {
-                reasoning: this.reasoningHandler.reasoning,
-                reasoningTokens: Math.max(getPositiveTokenCount(this.reasoningTokens), getPositiveTokenCount(chat[messageId].extra.reasoning_tokens)),
-                countOutput: shouldRefreshTokenCount,
-                countReasoning: shouldRefreshTokenCount,
-            });
+            let currentTokenCount = getPositiveTokenCount(chat[messageId].extra.token_count);
+            if (!shouldReduceIntermediateStreamingWork) {
+                const { outputTokens } = await updateMessageTokenAccounting(chat[messageId], {
+                    reasoning: this.reasoningHandler.reasoning,
+                    reasoningTokens: Math.max(getPositiveTokenCount(this.reasoningTokens), getPositiveTokenCount(chat[messageId].extra.reasoning_tokens)),
+                    countOutput: shouldRefreshTokenCount,
+                    countReasoning: shouldRefreshTokenCount,
+                });
+                currentTokenCount = outputTokens;
+            }
             if (shouldRefreshTokenCount) {
                 if (this.messageTokenCounterDom instanceof HTMLElement) {
                     this.messageTokenCounterDom.textContent = `${currentTokenCount}t`;
                 }
             }
 
-            updateMessageMetaBadges(this.messageDom, chat[messageId]);
+            if (!shouldReduceIntermediateStreamingWork) {
+                updateMessageMetaBadges(this.messageDom, chat[messageId]);
+            }
 
             if ((this.type == 'swipe' || this.type === 'continue') && Array.isArray(chat[messageId].swipes)) {
                 chat[messageId].swipes[chat[messageId].swipe_id] = processedText;
-                chat[messageId].swipe_info[chat[messageId].swipe_id] = {
-                    'send_date': chat[messageId].send_date,
-                    'gen_started': chat[messageId].gen_started,
-                    'gen_finished': chat[messageId].gen_finished,
-                    'extra': structuredClone(chat[messageId].extra),
-                };
+                if (!shouldReduceIntermediateStreamingWork) {
+                    chat[messageId].swipe_info[chat[messageId].swipe_id] = {
+                        'send_date': chat[messageId].send_date,
+                        'gen_started': chat[messageId].gen_started,
+                        'gen_finished': chat[messageId].gen_finished,
+                        'extra': structuredClone(chat[messageId].extra),
+                    };
+                }
             }
 
             const formattedText = messageFormatting(
@@ -4554,7 +4563,9 @@ class StreamingProcessor {
                 this.messageTimerDom.title = timePassed.timerTitle;
             }
 
-            this.setFirstSwipe(messageId);
+            if (!shouldReduceIntermediateStreamingWork) {
+                this.setFirstSwipe(messageId);
+            }
         }
 
         if (shouldPinMobileBottom) {

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -906,6 +906,8 @@ function expandMessageMedia(messageId, mediaIndex) {
         function getImageElement() {
             const img = document.createElement('img');
             img.src = mediaAttachment.url;
+            img.loading = 'lazy';
+            img.decoding = 'async';
             img.classList.add('img_enlarged');
             return img;
         }

--- a/public/scripts/mobile-streaming.js
+++ b/public/scripts/mobile-streaming.js
@@ -1,7 +1,7 @@
 import { isIOSWebKitPlatform } from './mobile-send-button.js';
 
-export const IOS_STREAMING_UPDATE_INTERVAL_MS = 125;
-export const IOS_REASONING_RENDER_INTERVAL_MS = 750;
+export const IOS_STREAMING_UPDATE_INTERVAL_MS = 250;
+export const IOS_REASONING_RENDER_INTERVAL_MS = 1500;
 
 /**
  * Checks whether live streaming DOM work should be reduced for the current browser.

--- a/public/scripts/mobile-streaming.js
+++ b/public/scripts/mobile-streaming.js
@@ -6,10 +6,12 @@ export const IOS_REASONING_RENDER_INTERVAL_MS = 1500;
 /**
  * Checks whether live streaming DOM work should be reduced for the current browser.
  * @param {Navigator} [navigatorRef] Navigator-like object
+ * @param {object} [options]
+ * @param {boolean} [options.enabled] Whether the iOS WebKit reduction is enabled
  * @returns {boolean}
  */
-export function shouldReduceStreamingDomWork(navigatorRef = globalThis.navigator) {
-    return isIOSWebKitPlatform(navigatorRef);
+export function shouldReduceStreamingDomWork(navigatorRef = globalThis.navigator, { enabled = true } = {}) {
+    return Boolean(enabled) && isIOSWebKitPlatform(navigatorRef);
 }
 
 /**
@@ -17,13 +19,14 @@ export function shouldReduceStreamingDomWork(navigatorRef = globalThis.navigator
  * @param {number} baseIntervalMs Requested streaming interval
  * @param {object} [options]
  * @param {Navigator} [options.navigatorRef] Navigator-like object
+ * @param {boolean} [options.enabled] Whether the iOS WebKit floor is enabled
  * @returns {number}
  */
-export function getStreamingUpdateInterval(baseIntervalMs, { navigatorRef = globalThis.navigator } = {}) {
+export function getStreamingUpdateInterval(baseIntervalMs, { navigatorRef = globalThis.navigator, enabled = true } = {}) {
     const interval = Number(baseIntervalMs);
     const normalizedInterval = Number.isFinite(interval) && interval > 0 ? interval : 1;
 
-    if (!shouldReduceStreamingDomWork(navigatorRef)) {
+    if (!shouldReduceStreamingDomWork(navigatorRef, { enabled })) {
         return normalizedInterval;
     }
 

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -232,6 +232,10 @@ export const power_user = {
     smooth_streaming_no_think: false,
     smooth_streaming_speed: 50,
     stream_fade_in: false,
+    ios_webkit_conservative_streaming: true,
+    ios_webkit_reduce_streaming_work: true,
+    ios_webkit_disable_smooth_streaming: true,
+    ios_webkit_disable_stream_fade_in: true,
 
     fast_ui_mode: true,
     avatar_style: avatar_styles.ROUND,
@@ -1869,6 +1873,10 @@ export async function loadPowerUserSettings(settings, data) {
     $('#smooth_streaming_speed').val(power_user.smooth_streaming_speed);
 
     $('#stream_fade_in').prop('checked', power_user.stream_fade_in);
+    $('#ios_webkit_conservative_streaming').prop('checked', power_user.ios_webkit_conservative_streaming);
+    $('#ios_webkit_reduce_streaming_work').prop('checked', power_user.ios_webkit_reduce_streaming_work);
+    $('#ios_webkit_disable_smooth_streaming').prop('checked', power_user.ios_webkit_disable_smooth_streaming);
+    $('#ios_webkit_disable_stream_fade_in').prop('checked', power_user.ios_webkit_disable_stream_fade_in);
 
     $('#font_scale').val(power_user.font_scale);
     $('#font_scale_counter').val(power_user.font_scale);
@@ -3559,6 +3567,26 @@ jQuery(async () => {
 
     $('#stream_fade_in').on('input', function () {
         power_user.stream_fade_in = !!$(this).prop('checked');
+        saveSettingsDebounced();
+    });
+
+    $('#ios_webkit_conservative_streaming').on('input', function () {
+        power_user.ios_webkit_conservative_streaming = !!$(this).prop('checked');
+        saveSettingsDebounced();
+    });
+
+    $('#ios_webkit_reduce_streaming_work').on('input', function () {
+        power_user.ios_webkit_reduce_streaming_work = !!$(this).prop('checked');
+        saveSettingsDebounced();
+    });
+
+    $('#ios_webkit_disable_smooth_streaming').on('input', function () {
+        power_user.ios_webkit_disable_smooth_streaming = !!$(this).prop('checked');
+        saveSettingsDebounced();
+    });
+
+    $('#ios_webkit_disable_stream_fade_in').on('input', function () {
+        power_user.ios_webkit_disable_stream_fade_in = !!$(this).prop('checked');
         saveSettingsDebounced();
     });
 

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -670,8 +670,11 @@ export class ReasoningHandler {
         setDatasetProperty(this.messageReasoningDetailsDom, 'type', this.type);
 
         const now = Date.now();
+        const shouldReduceReasoningDomWork = shouldReduceStreamingDomWork(globalThis.navigator, {
+            enabled: power_user.ios_webkit_conservative_streaming,
+        });
         const shouldRenderReasoning = shouldRenderLiveReasoningContent({
-            isReducedDomWork: shouldReduceStreamingDomWork(),
+            isReducedDomWork: shouldReduceReasoningDomWork,
             state: this.state,
             detailsOpen: Boolean(this.messageReasoningDetailsDom.open),
             hasRenderedContent: Boolean(this.messageReasoningContentDom.childNodes.length),
@@ -686,7 +689,11 @@ export class ReasoningHandler {
             const displayReasoning = messageFormatting(reasoning, '', false, false, messageId, {}, true);
 
             if (power_user.stream_fade_in) {
-                applyStreamFadeIn(this.messageReasoningContentDom, displayReasoning);
+                applyStreamFadeIn(this.messageReasoningContentDom, displayReasoning, {
+                    bypassFadeIn: shouldReduceStreamingDomWork(globalThis.navigator, {
+                        enabled: power_user.ios_webkit_disable_stream_fade_in,
+                    }),
+                });
             } else {
                 applyStreamDomPatch(this.messageReasoningContentDom, displayReasoning);
             }

--- a/public/scripts/sse-stream.js
+++ b/public/scripts/sse-stream.js
@@ -380,7 +380,8 @@ export class SmoothEventSourceStream extends EventSourceStream {
 }
 
 export function getEventSourceStream() {
-    if (power_user.smooth_streaming && !isIOSWebKitPlatform()) {
+    const shouldBypassSmoothStreaming = power_user.ios_webkit_disable_smooth_streaming && isIOSWebKitPlatform();
+    if (power_user.smooth_streaming && !shouldBypassSmoothStreaming) {
         return new SmoothEventSourceStream();
     }
 

--- a/public/scripts/sse-stream.js
+++ b/public/scripts/sse-stream.js
@@ -1,4 +1,5 @@
 import { power_user } from './power-user.js';
+import { isIOSWebKitPlatform } from './mobile-send-button.js';
 import { delay } from './utils.js';
 
 // Symbol for not primary swipe error
@@ -379,7 +380,7 @@ export class SmoothEventSourceStream extends EventSourceStream {
 }
 
 export function getEventSourceStream() {
-    if (power_user.smooth_streaming) {
+    if (power_user.smooth_streaming && !isIOSWebKitPlatform()) {
         return new SmoothEventSourceStream();
     }
 

--- a/public/scripts/util/stream-fadein.js
+++ b/public/scripts/util/stream-fadein.js
@@ -1,5 +1,4 @@
 import { morphdom } from '../../lib.js';
-import { isIOSWebKitPlatform } from '../mobile-send-button.js';
 
 /**
  * Check if the current browser supports native segmentation function.
@@ -74,9 +73,11 @@ export function applyStreamDomPatch(messageTextElement, htmlContent) {
  * Apply stream fade-in effect to the given message text element by morphing its content.
  * @param {HTMLElement} messageTextElement Message text element
  * @param {string} htmlContent New HTML content to apply
+ * @param {object} [options]
+ * @param {boolean} [options.bypassFadeIn] Use the lighter DOM patch path instead of segmenting text
  */
-export function applyStreamFadeIn(messageTextElement, htmlContent) {
-    if (isIOSWebKitPlatform()) {
+export function applyStreamFadeIn(messageTextElement, htmlContent, { bypassFadeIn = false } = {}) {
+    if (bypassFadeIn) {
         applyStreamDomPatch(messageTextElement, htmlContent);
         return;
     }

--- a/public/scripts/util/stream-fadein.js
+++ b/public/scripts/util/stream-fadein.js
@@ -1,4 +1,5 @@
 import { morphdom } from '../../lib.js';
+import { isIOSWebKitPlatform } from '../mobile-send-button.js';
 
 /**
  * Check if the current browser supports native segmentation function.
@@ -75,6 +76,11 @@ export function applyStreamDomPatch(messageTextElement, htmlContent) {
  * @param {string} htmlContent New HTML content to apply
  */
 export function applyStreamFadeIn(messageTextElement, htmlContent) {
+    if (isIOSWebKitPlatform()) {
+        applyStreamDomPatch(messageTextElement, htmlContent);
+        return;
+    }
+
     const targetElement = /** @type {HTMLElement} */ (messageTextElement.cloneNode());
     segmentTextInElement(targetElement, htmlContent);
     morphdom(messageTextElement, targetElement);

--- a/tests/mobile-streaming.test.js
+++ b/tests/mobile-streaming.test.js
@@ -27,6 +27,13 @@ describe('mobile streaming helpers', () => {
         })).toBe(500);
     });
 
+    test('allows iOS WebKit streaming floors to be disabled', () => {
+        expect(getStreamingUpdateInterval(33, {
+            navigatorRef: { platform: 'iPhone', maxTouchPoints: 1 },
+            enabled: false,
+        })).toBe(33);
+    });
+
     test('skips repeated hidden live reasoning renders on reduced DOM platforms', () => {
         expect(shouldRenderLiveReasoningContent({
             isReducedDomWork: true,

--- a/tests/mobile-streaming.test.js
+++ b/tests/mobile-streaming.test.js
@@ -6,6 +6,11 @@ import {
 } from '../public/scripts/mobile-streaming.js';
 
 describe('mobile streaming helpers', () => {
+    test('uses conservative iOS streaming floors', () => {
+        expect(IOS_STREAMING_UPDATE_INTERVAL_MS).toBe(250);
+        expect(IOS_REASONING_RENDER_INTERVAL_MS).toBe(1500);
+    });
+
     test('keeps desktop streaming intervals unchanged', () => {
         expect(getStreamingUpdateInterval(33, {
             navigatorRef: { platform: 'Linux x86_64', maxTouchPoints: 1 },
@@ -17,9 +22,9 @@ describe('mobile streaming helpers', () => {
             navigatorRef: { platform: 'iPhone', maxTouchPoints: 1 },
         })).toBe(IOS_STREAMING_UPDATE_INTERVAL_MS);
 
-        expect(getStreamingUpdateInterval(250, {
+        expect(getStreamingUpdateInterval(500, {
             navigatorRef: { platform: 'iPhone', maxTouchPoints: 1 },
-        })).toBe(250);
+        })).toBe(500);
     });
 
     test('skips repeated hidden live reasoning renders on reduced DOM platforms', () => {


### PR DESCRIPTION
## Summary
- Disable smooth streaming and stream fade-in segmentation on iOS WebKit while keeping live Markdown rendering.
- Reduce per-tick iOS streaming allocations by deferring token accounting, metadata badges, and swipe metadata clones until final render.
- Raise iOS streaming/reasoning throttles and add lazy/async hints for expanded chat media images.

## Tests
- npm run lint
- npm run test:unit --prefix tests -- tests/mobile-streaming.test.js
- npm run test:unit --prefix tests