### PR TITLE
fix: align iOS smooth streaming checks

### DIFF
--- a/public/scripts/logprobs.js
+++ b/public/scripts/logprobs.js
@@ -15,6 +15,7 @@ import { decodeTextTokens, getTokenizerBestMatch } from './tokenizers.js';
 import { power_user } from './power-user.js';
 import { callGenericPopup, POPUP_TYPE } from './popup.js';
 import { t } from './i18n.js';
+import { isSmoothStreamingEffectivelyEnabled } from './mobile-streaming.js';
 
 const TINTS = 4;
 const MAX_MESSAGE_LOGPROBS = 100;
@@ -81,7 +82,10 @@ function renderAlternativeTokensView() {
     renderTopLogprobs();
 
     const { messageLogprobs, continueFrom } = getActiveMessageLogprobData() || {};
-    const usingSmoothStreaming = isStreamingEnabled() && power_user.smooth_streaming;
+    const usingSmoothStreaming = isStreamingEnabled() && isSmoothStreamingEffectivelyEnabled({
+        smoothStreaming: power_user.smooth_streaming,
+        iosWebKitDisableSmoothStreaming: power_user.ios_webkit_disable_smooth_streaming,
+    });
     if (!messageLogprobs?.length || usingSmoothStreaming) {
         const emptyState = $('<div></div>');
         const noTokensMsg = !power_user.request_token_probabilities

--- a/public/scripts/mobile-streaming.js
+++ b/public/scripts/mobile-streaming.js
@@ -4,6 +4,22 @@ export const IOS_STREAMING_UPDATE_INTERVAL_MS = 250;
 export const IOS_REASONING_RENDER_INTERVAL_MS = 1500;
 
 /**
+ * Checks whether Smooth Streaming is effectively active for the current platform.
+ * @param {object} [options]
+ * @param {boolean} [options.smoothStreaming] Whether Smooth Streaming is enabled in settings
+ * @param {boolean} [options.iosWebKitDisableSmoothStreaming] Whether iOS WebKit should bypass Smooth Streaming
+ * @param {Navigator} [options.navigatorRef] Navigator-like object
+ * @returns {boolean}
+ */
+export function isSmoothStreamingEffectivelyEnabled({
+    smoothStreaming = false,
+    iosWebKitDisableSmoothStreaming = false,
+    navigatorRef = globalThis.navigator,
+} = {}) {
+    return Boolean(smoothStreaming) && !(Boolean(iosWebKitDisableSmoothStreaming) && isIOSWebKitPlatform(navigatorRef));
+}
+
+/**
  * Checks whether live streaming DOM work should be reduced for the current browser.
  * @param {Navigator} [navigatorRef] Navigator-like object
  * @param {object} [options]

--- a/public/scripts/sse-stream.js
+++ b/public/scripts/sse-stream.js
@@ -1,5 +1,5 @@
 import { power_user } from './power-user.js';
-import { isIOSWebKitPlatform } from './mobile-send-button.js';
+import { isSmoothStreamingEffectivelyEnabled } from './mobile-streaming.js';
 import { delay } from './utils.js';
 
 // Symbol for not primary swipe error
@@ -380,8 +380,10 @@ export class SmoothEventSourceStream extends EventSourceStream {
 }
 
 export function getEventSourceStream() {
-    const shouldBypassSmoothStreaming = power_user.ios_webkit_disable_smooth_streaming && isIOSWebKitPlatform();
-    if (power_user.smooth_streaming && !shouldBypassSmoothStreaming) {
+    if (isSmoothStreamingEffectivelyEnabled({
+        smoothStreaming: power_user.smooth_streaming,
+        iosWebKitDisableSmoothStreaming: power_user.ios_webkit_disable_smooth_streaming,
+    })) {
         return new SmoothEventSourceStream();
     }
 

--- a/tests/mobile-streaming.test.js
+++ b/tests/mobile-streaming.test.js
@@ -2,6 +2,7 @@ import {
     getStreamingUpdateInterval,
     IOS_REASONING_RENDER_INTERVAL_MS,
     IOS_STREAMING_UPDATE_INTERVAL_MS,
+    isSmoothStreamingEffectivelyEnabled,
     shouldRenderLiveReasoningContent,
 } from '../public/scripts/mobile-streaming.js';
 
@@ -32,6 +33,32 @@ describe('mobile streaming helpers', () => {
             navigatorRef: { platform: 'iPhone', maxTouchPoints: 1 },
             enabled: false,
         })).toBe(33);
+    });
+
+    test('reports effective Smooth Streaming after iOS WebKit bypasses', () => {
+        expect(isSmoothStreamingEffectivelyEnabled({
+            smoothStreaming: true,
+            iosWebKitDisableSmoothStreaming: true,
+            navigatorRef: { platform: 'Linux x86_64', maxTouchPoints: 1 },
+        })).toBe(true);
+
+        expect(isSmoothStreamingEffectivelyEnabled({
+            smoothStreaming: true,
+            iosWebKitDisableSmoothStreaming: true,
+            navigatorRef: { platform: 'iPhone', maxTouchPoints: 1 },
+        })).toBe(false);
+
+        expect(isSmoothStreamingEffectivelyEnabled({
+            smoothStreaming: true,
+            iosWebKitDisableSmoothStreaming: false,
+            navigatorRef: { platform: 'iPhone', maxTouchPoints: 1 },
+        })).toBe(true);
+
+        expect(isSmoothStreamingEffectivelyEnabled({
+            smoothStreaming: false,
+            iosWebKitDisableSmoothStreaming: true,
+            navigatorRef: { platform: 'iPhone', maxTouchPoints: 1 },
+        })).toBe(false);
     });
 
     test('skips repeated hidden live reasoning renders on reduced DOM platforms', () => {


### PR DESCRIPTION
## What?
Align the Token Probabilities panel with the effective Smooth Streaming state after the iOS WebKit bypass added in PR #62.

## Why?
PR #62 can disable Smooth Streaming at runtime on iOS while leaving the global Smooth Streaming setting enabled. The logprobs panel was still checking only the raw setting, so it could hide token probabilities with the Smooth Streaming warning even when the actual stream used the normal SSE path.

## How?
- Add a shared `isSmoothStreamingEffectivelyEnabled()` helper in `mobile-streaming.js`.
- Use that helper in both `getEventSourceStream()` and the logprobs panel.
- Cover desktop, iOS bypass, iOS opt-out, and disabled Smooth Streaming cases in the mobile streaming unit test.

## Testing?
- `npm run lint`
- `npm run test:unit --prefix tests -- tests/mobile-streaming.test.js`

## Screenshots (optional)
Not applicable; this is a logic consistency fix for stream/logprobs gating.

## Anything Else?
Follow-up for the PR #62 review finding after #62 was already merged.