### PR TITLE
fix: restore avatar preview and shape styling

### DIFF
--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -130,6 +130,13 @@
     --sb-message-radius: 22px;
 }
 
+.zoomed_avatar_container,
+.avatar_zoom_container,
+.zoomed_avatar,
+.avatar_zoom {
+    z-index: calc(var(--sb-z-modal-content) + 5) !important;
+}
+
 :root[data-sb-compact-mode='true'] {
     --sb-control-min-height: 32px;
     --sb-control-icon-physical-size: max(var(--sb-icon-control-size), var(--sb-control-min-height));

--- a/public/css/toggle-dependent.css
+++ b/public/css/toggle-dependent.css
@@ -50,6 +50,7 @@ body.hideChatAvatars .swipe_left {
 body.square-avatars .avatar,
 body.square-avatars .avatar img {
     border-radius: var(--avatar-base-border-radius) !important;
+    aspect-ratio: 1 / 1;
 }
 
 body.rounded-avatars .avatar,
@@ -170,6 +171,7 @@ body.big-avatars .bogus_folder_select .avatar {
 body.big-avatars .avatar {
     width: calc(var(--avatar-base-width) * var(--big-avatar-width-factor));
     height: calc(var(--avatar-base-height) * var(--big-avatar-height-factor));
+    aspect-ratio: 3 / 4;
     /* width: unset; */
     border-style: none;
     display: flex;
@@ -196,10 +198,11 @@ body.big-avatars #user_avatar_block .avatar img {
 body.big-avatars .avatar img {
     width: calc(var(--avatar-base-width) * var(--big-avatar-width-factor));
     height: calc(var(--avatar-base-height) * var(--big-avatar-height-factor));
+    aspect-ratio: 3 / 4;
     object-fit: cover;
     object-position: center;
     border: 1px solid var(--SmartThemeBorderColor);
-    border-radius: calc(var(--avatar-base-border-radius) * var(--big-avatar-border-factor));
+    border-radius: inherit;
 }
 
 body.big-avatars .bogus_folder_select_back .bogus_folder_back_placeholder {

--- a/public/style.css
+++ b/public/style.css
@@ -1559,7 +1559,7 @@ body.hideAllSwipeButtons :is(.swipe_left, .swipe_right),
     height: var(--avatar-base-height);
     object-fit: cover;
     object-position: center center;
-    border-radius: var(--avatar-base-border-radius-round);
+    border-radius: inherit;
     border: 1px solid var(--SmartThemeBorderColor);
     /*--black30a*/
     box-shadow: 0 0 5px var(--black50a);


### PR DESCRIPTION
## What?
Restores the avatar shape rules that are still relevant after the character menu rework: square avatars stay square, big avatars keep their 3:4 proportions, avatar images inherit their parent shape, and zoomed avatar overlays sit above the SillyBunny modal/content layers.

## Why?
Avatar shape modes could visually collapse back toward round defaults because image-level border radii did not reliably inherit the selected avatar mode. Zoomed avatars could also sit under newer shell/modal layers.

## How?
Keeps the fix scoped to existing shape-mode CSS and overlay stacking. The older character-editor preview visibility block was removed after the new character card menu added scoped editor preview sizing.

## Testing?
- `git diff --check`
- `node scripts/check-frontend-budgets.js`
- `node --check server.js`

## Screenshots (optional)
Not included; this is a small CSS cleanup rebased after the character menu rewrite. Browser smoke was skipped to keep the runtime checkout and default `localhost:4444` server untouched while the isolated dev worktree is being finalized.

## Anything Else?
Reworked from the original draft per review feedback after the new character card menu landed. The PR no longer changes editor preview visibility/sizing directly.