### PR TITLE
fix: stabilize mobile shell interactions

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -132,6 +132,34 @@
         overflow-x: hidden !important;
         -webkit-overflow-scrolling: touch !important;
     }
+
+    #left-nav-panel.openDrawer,
+    #user-settings-block.openDrawer,
+    .sb-shell-root.openDrawer,
+    #right-nav-panel.openDrawer {
+        padding-bottom: env(keyboard-inset-height, 0px) !important;
+    }
+}
+
+@media screen and (min-width: 769px) and (max-width: 1180px) {
+    #sheld {
+        width: 100vw !important;
+        width: 100dvw !important;
+        max-width: 100dvw !important;
+        min-width: 0 !important;
+        margin: 0 !important;
+        left: 0 !important;
+        right: 0 !important;
+        transform: none !important;
+        box-sizing: border-box !important;
+    }
+
+    #chat {
+        width: 100% !important;
+        max-width: 100% !important;
+        min-width: 0 !important;
+        box-sizing: border-box !important;
+    }
 }
 
 @supports (-webkit-touch-callout: none) {

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -4995,6 +4995,10 @@ body.sb-shell-resizing * {
         min-width: 0;
     }
 
+    .sb-mobile-panel-copy :is(.sb-shell-kicker, .sb-shell-title) {
+        overflow-wrap: anywhere;
+    }
+
     .sb-mobile-panel-close {
         appearance: none;
         width: var(--sb-mobile-touch-target, 44px);
@@ -5022,6 +5026,7 @@ body.sb-shell-resizing * {
         line-height: 1;
         text-transform: uppercase;
         opacity: 0.66;
+        overflow-wrap: anywhere;
     }
 
     .sb-mobile-section-list {
@@ -5069,6 +5074,7 @@ body.sb-shell-resizing * {
         min-width: 0;
         justify-self: start;
         text-align: left;
+        overflow-wrap: anywhere;
     }
 
     .sb-nav-item::before {
@@ -5084,6 +5090,12 @@ body.sb-shell-resizing * {
 
     .sb-nav-item:hover {
         transform: translateY(-1px);
+    }
+
+    .sb-nav-item:focus-visible,
+    .sb-mobile-panel-close:focus-visible {
+        outline: 2px solid var(--sb-focus-ring, var(--SmartThemeQuoteColor));
+        outline-offset: 2px;
     }
 
 }

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -4956,13 +4956,13 @@ body.sb-shell-resizing * {
     #sb-mobile-nav-content {
         position: relative;
         isolation: isolate;
-        width: min(100%, 420px);
+        width: min(100%, 620px);
         max-height: calc(100dvh - var(--sb-topbar-layout-offset) - 32px);
         margin: 0 auto;
-        padding: 12px;
+        padding: 14px;
         display: flex;
         flex-direction: column;
-        gap: 10px;
+        gap: 12px;
         overflow-y: auto;
         border-radius: 20px;
         border: 1px solid color-mix(in srgb, var(--sb-shell-border) 88%, transparent);
@@ -4983,6 +4983,31 @@ body.sb-shell-resizing * {
         opacity: var(--sb-shell-surface-opacity);
     }
 
+    .sb-mobile-panel-header {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) var(--sb-mobile-touch-target, 44px);
+        gap: 12px;
+        align-items: start;
+        padding: 2px 2px 4px;
+    }
+
+    .sb-mobile-panel-copy {
+        min-width: 0;
+    }
+
+    .sb-mobile-panel-close {
+        appearance: none;
+        width: var(--sb-mobile-touch-target, 44px);
+        height: var(--sb-mobile-touch-target, 44px);
+        border: 1px solid color-mix(in srgb, var(--sb-shell-border) 85%, transparent);
+        border-radius: var(--sb-radius-md, 16px);
+        background: var(--sb-card-bg);
+        color: var(--SmartThemeBodyColor);
+        display: inline-grid;
+        place-items: center;
+        cursor: pointer;
+    }
+
     .sb-mobile-section {
         display: flex;
         flex-direction: column;
@@ -5001,7 +5026,7 @@ body.sb-shell-resizing * {
 
     .sb-mobile-section-list {
         display: grid;
-        grid-template-columns: 1fr;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
         gap: 8px;
     }
 
@@ -5064,6 +5089,10 @@ body.sb-shell-resizing * {
 }
 
 @media screen and (max-width: 450px) {
+    .sb-mobile-section-list {
+        grid-template-columns: 1fr;
+    }
+
     #sb-hamburger,
     #sb-api-toggle,
     #sb-home-toggle,

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -9917,7 +9917,14 @@ function buildMobileNav() {
         return;
     }
 
-    const overlay = createElement('div', { id: 'sb-mobile-nav' });
+    const overlay = createElement('div', {
+        id: 'sb-mobile-nav',
+        attrs: {
+            role: 'dialog',
+            'aria-modal': 'true',
+            'aria-labelledby': 'sb-mobile-nav-title',
+        },
+    });
     const content = createElement('div', { id: 'sb-mobile-nav-content' });
     overlay.hidden = true;
     overlay.setAttribute('aria-hidden', 'true');
@@ -9987,7 +9994,14 @@ function buildMobileNav() {
     });
     const headerCopy = createElement('div', { className: 'sb-mobile-panel-copy' });
     const eyebrow = createElement('div', { className: 'sb-shell-kicker', text: 'Workspace' });
-    const title = createElement('h2', { className: 'sb-shell-title', text: 'Quick Actions' });
+    const title = createElement('h2', {
+        id: 'sb-mobile-nav-title',
+        className: 'sb-shell-title',
+        text: 'Quick Actions',
+        attrs: {
+            tabindex: '-1',
+        },
+    });
     closeButton.innerHTML = '<i class="fa-solid fa-xmark" aria-hidden="true"></i>';
     closeButton.addEventListener('click', closeMobileNav);
     headerCopy.append(eyebrow, title);
@@ -9999,6 +10013,15 @@ function buildMobileNav() {
         if (event.target === overlay) {
             closeMobileNav();
         }
+    });
+    overlay.addEventListener('keydown', event => {
+        if (event.key !== 'Escape') {
+            return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        closeMobileNav();
     });
 
     document.body.appendChild(overlay);
@@ -10063,6 +10086,8 @@ function setMobileNavOpenState(isOpen) {
         sbState.mobileNav.lastOpenedAt = performance.now();
     }
 
+    const wasOpen = !overlay.hidden && overlay.getAttribute('aria-hidden') === 'false';
+
     overlay.hidden = !shouldOpen;
     overlay.classList.toggle('sb-nav-open', shouldOpen);
     overlay.setAttribute('aria-hidden', String(!shouldOpen));
@@ -10078,6 +10103,14 @@ function setMobileNavOpenState(isOpen) {
         : '<i class="fa-solid fa-bars" aria-hidden="true"></i>';
 
     queueMobileModalStateSync();
+
+    if (shouldOpen) {
+        window.requestAnimationFrame(() => {
+            overlay.querySelector('#sb-mobile-nav-title')?.focus?.({ preventScroll: true });
+        });
+    } else if (wasOpen && document.activeElement && overlay.contains(document.activeElement)) {
+        button.focus({ preventScroll: true });
+    }
 }
 
 function toggleMobileNav() {

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -74,6 +74,7 @@ const SB_STORAGE_PREFIX = 'sb-';
 const SB_STORAGE_WRITE_DEBOUNCE_MS = 120;
 const SB_MOBILE_NAV_OPEN_GRACE_MS = 450;
 const SB_SHELL_NAV_TOUCH_DRAG_THRESHOLD_PX = 6;
+const SB_MOBILE_ACTION_DEBOUNCE_MS = 140;
 const SB_SHELL_FOCUSABLE_SELECTOR = [
     'a[href]',
     'button:not([disabled])',
@@ -90,6 +91,22 @@ let sbStorageFlushTimer = 0;
 let sbStorageFlushEventsBound = false;
 const sbStorageCache = new Map();
 const sbStoragePendingWrites = new Map();
+
+function debounceAction(callback, wait = SB_MOBILE_ACTION_DEBOUNCE_MS) {
+    let lastRun = 0;
+
+    return function debouncedAction(event) {
+        const now = performance.now();
+        if (now - lastRun < wait) {
+            event?.preventDefault?.();
+            event?.stopPropagation?.();
+            return;
+        }
+
+        lastRun = now;
+        return callback.call(this, event);
+    };
+}
 
 function getShortcutTarget(side) {
     const stored = safeGetItem(side === 'left' ? SB_STORAGE_KEYS.shortcutLeft : SB_STORAGE_KEYS.shortcutRight);
@@ -2711,7 +2728,7 @@ function createProxyButton({ id, icon, label, title, className = '' }, onClick) 
 
     button.innerHTML = `<i class="fa-solid ${icon}" aria-hidden="true"></i><span>${label}</span>`;
     stopProxyPointerPropagation(button);
-    button.addEventListener('click', onClick);
+    button.addEventListener('click', debounceAction(onClick));
 
     return button;
 }
@@ -3335,11 +3352,25 @@ function bindChatDeleteVisualViewport(overlay) {
         animationFrame = 0;
         const fallbackWidth = window.innerWidth || document.documentElement.clientWidth || 0;
         const fallbackHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+        const isKeyboardClosed = Math.abs(readViewportNumber(visualViewport.height, fallbackHeight) - fallbackHeight) <= 2
+            && Math.abs(readViewportNumber(visualViewport.offsetTop) || 0) <= 2
+            && Math.abs(readViewportNumber(visualViewport.offsetLeft) || 0) <= 2;
+
+        if (isKeyboardClosed) {
+            overlay.style.removeProperty('--sb-chat-delete-vv-left');
+            overlay.style.removeProperty('--sb-chat-delete-vv-top');
+            overlay.style.removeProperty('--sb-chat-delete-vv-width');
+            overlay.style.removeProperty('--sb-chat-delete-vv-height');
+            overlay.classList.remove('sb-chat-delete-overlay--keyboard-open');
+            return;
+        }
+
         const viewportLeft = Math.max(0, readViewportNumber(visualViewport.offsetLeft));
         const viewportTop = Math.max(0, readViewportNumber(visualViewport.offsetTop));
         const viewportWidth = Math.max(1, readViewportNumber(visualViewport.width, fallbackWidth));
         const viewportHeight = Math.max(1, readViewportNumber(visualViewport.height, fallbackHeight));
 
+        overlay.classList.add('sb-chat-delete-overlay--keyboard-open');
         overlay.style.setProperty('--sb-chat-delete-vv-left', `${viewportLeft}px`);
         overlay.style.setProperty('--sb-chat-delete-vv-top', `${viewportTop}px`);
         overlay.style.setProperty('--sb-chat-delete-vv-width', `${viewportWidth}px`);
@@ -4447,7 +4478,7 @@ function createBottomChatButton({ icon, title, className = '' }, onClick) {
     });
 
     button.innerHTML = `<i class="fa-solid ${icon}" aria-hidden="true"></i>`;
-    button.addEventListener('click', onClick);
+    button.addEventListener('click', debounceAction(onClick));
 
     return button;
 }
@@ -9944,6 +9975,24 @@ function buildMobileNav() {
         sectionBlock.append(heading, list);
         content.appendChild(sectionBlock);
     }
+
+    const header = createElement('div', { className: 'sb-mobile-panel-header' });
+    const closeButton = createElement('button', {
+        className: 'sb-mobile-panel-close',
+        attrs: {
+            type: 'button',
+            title: 'Close navigation',
+            'aria-label': 'Close navigation',
+        },
+    });
+    const headerCopy = createElement('div', { className: 'sb-mobile-panel-copy' });
+    const eyebrow = createElement('div', { className: 'sb-shell-kicker', text: 'Workspace' });
+    const title = createElement('h2', { className: 'sb-shell-title', text: 'Quick Actions' });
+    closeButton.innerHTML = '<i class="fa-solid fa-xmark" aria-hidden="true"></i>';
+    closeButton.addEventListener('click', closeMobileNav);
+    headerCopy.append(eyebrow, title);
+    header.append(headerCopy, closeButton);
+    content.prepend(header);
 
     overlay.appendChild(content);
     overlay.addEventListener('click', event => {


### PR DESCRIPTION
## What?
Stabilizes mobile shell behavior around visual viewport changes, top/bottom bar button taps, workspace navigation, and tablet-width layouts.

## Why?
Android keyboard close/open paths and tablet breakpoints could leave overlays shifted or the main chat squeezed, and mobile shell buttons could double-fire on quick taps.

## How?
Adds keyboard-close cleanup for the visual viewport overlay state, uses a short click debounce for shell buttons, restyles the mobile workspace navigation sheet with a header and denser two-column actions, and adds tablet-specific width constraints for the main shell/chat area.

## Testing?
- `npm run lint -- --quiet`
- `npm run check:frontend-budgets`
- `git diff --check`

## Screenshots (optional)
Not included; no browser server was started for this split.

## Anything Else?
PR #59 already landed mobile composer auto-grow on staging, so this PR does not duplicate that part of the backlog.