### PR TITLE
feat: expand connection profile summaries

### DIFF
--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -89,6 +89,12 @@ const FANCY_NAMES = {
     'prompt-post-processing': 'Prompt Post-Processing',
     'secret-id': 'Secret',
     'regex-preset': 'Regex Preset',
+    'active-agents': 'Active Agents',
+    'samplers': 'Samplers',
+    'instruct-template': 'Instruct Template',
+    'context-template': 'Context Template',
+    'system-prompt': 'System Prompt',
+    'world-info-active-count': 'World Info Active Entries',
 };
 
 /**
@@ -198,6 +204,12 @@ const profilesProvider = () => [
  * @property {string} [api-url] Server URL
  * @property {string} [secret-id] Secret ID
  * @property {string} [regex-preset] Regex Preset ID
+ * @property {string} [active-agents] Active in-chat agents summary
+ * @property {string} [samplers] Sampler summary
+ * @property {string} [instruct-template] Instruct template name
+ * @property {string} [context-template] Context template name
+ * @property {string} [system-prompt] System prompt name
+ * @property {number|string} [world-info-active-count] Active World Info entries count
  * @property {string[]} [exclude] Commands to exclude
  */
 
@@ -268,6 +280,66 @@ async function readProfileFromCommands(mode, profile, cleanUp = false) {
             delete profile[command];
         }
     }
+
+    enrichProfileSnapshot(profile);
+}
+
+function readInputValue(selector) {
+    const element = document.querySelector(selector);
+    if (element instanceof HTMLInputElement || element instanceof HTMLSelectElement || element instanceof HTMLTextAreaElement) {
+        return String(element.value ?? '').trim();
+    }
+
+    return '';
+}
+
+function getActiveAgentsSummary() {
+    const agents = typeof globalThis.SillyBunnyAgents?.getEnabledAgents === 'function'
+        ? globalThis.SillyBunnyAgents.getEnabledAgents()
+        : [];
+
+    if (!Array.isArray(agents) || agents.length === 0) {
+        return NONE;
+    }
+
+    const summary = agents
+        .map(agent => `${agent.name || agent.id} (${agent.enabled === false ? 'disabled' : 'enabled'}, order ${agent.injection?.order ?? 0})`)
+        .join(', ');
+    return summary.length > 260 ? `${summary.slice(0, 257)}...` : summary;
+}
+
+function getSamplerSummary() {
+    const context = getContext();
+    const isChatCompletion = main_api === 'openai';
+    const settings = isChatCompletion ? context.chatCompletionSettings : context.textCompletionSettings;
+
+    if (!settings) {
+        return NONE;
+    }
+
+    const temperature = isChatCompletion ? settings.temp_openai : settings.temp;
+    const topP = isChatCompletion ? settings.top_p_openai : settings.top_p;
+    const topK = isChatCompletion ? settings.top_k_openai : settings.top_k;
+
+    return [
+        `Temperature: ${temperature ?? NONE}`,
+        `Top P: ${topP ?? NONE}`,
+        `Top K: ${topK ?? NONE}`,
+    ].join(', ');
+}
+
+function getWorldInfoActiveCount() {
+    const values = $('#world_info').val();
+    return Array.isArray(values) ? values.length : values ? 1 : 0;
+}
+
+function enrichProfileSnapshot(profile) {
+    profile['active-agents'] = getActiveAgentsSummary();
+    profile.samplers = getSamplerSummary();
+    profile['instruct-template'] = readInputValue('#instruct_presets') || profile.instruct || NONE;
+    profile['context-template'] = readInputValue('#context_presets') || profile.context || NONE;
+    profile['system-prompt'] = readInputValue('#sysprompt_select') || profile.sysprompt || NONE;
+    profile['world-info-active-count'] = String(getWorldInfoActiveCount());
 }
 
 /**

--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -284,9 +284,24 @@ async function readProfileFromCommands(mode, profile, cleanUp = false) {
     enrichProfileSnapshot(profile);
 }
 
-function readInputValue(selector) {
+function truncateSummary(value, maxLength = 260) {
+    const text = String(value ?? '').trim();
+    const chars = Array.from(text);
+    return chars.length > maxLength ? `${chars.slice(0, maxLength - 3).join('')}...` : text;
+}
+
+function readInputDisplayValue(selector) {
     const element = document.querySelector(selector);
-    if (element instanceof HTMLInputElement || element instanceof HTMLSelectElement || element instanceof HTMLTextAreaElement) {
+
+    if (element instanceof HTMLSelectElement) {
+        const selectedText = Array.from(element.selectedOptions)
+            .map(option => String(option.textContent ?? '').trim())
+            .filter(Boolean)
+            .join(', ');
+        return selectedText || String(element.value ?? '').trim();
+    }
+
+    if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
         return String(element.value ?? '').trim();
     }
 
@@ -302,10 +317,9 @@ function getActiveAgentsSummary() {
         return NONE;
     }
 
-    const summary = agents
-        .map(agent => `${agent.name || agent.id} (${agent.enabled === false ? 'disabled' : 'enabled'}, order ${agent.injection?.order ?? 0})`)
-        .join(', ');
-    return summary.length > 260 ? `${summary.slice(0, 257)}...` : summary;
+    return truncateSummary(agents
+        .map(agent => `${agent.name || agent.id} (order ${agent.injection?.order ?? 0})`)
+        .join(', '));
 }
 
 function getSamplerSummary() {
@@ -336,9 +350,9 @@ function getWorldInfoActiveCount() {
 function enrichProfileSnapshot(profile) {
     profile['active-agents'] = getActiveAgentsSummary();
     profile.samplers = getSamplerSummary();
-    profile['instruct-template'] = readInputValue('#instruct_presets') || profile.instruct || NONE;
-    profile['context-template'] = readInputValue('#context_presets') || profile.context || NONE;
-    profile['system-prompt'] = readInputValue('#sysprompt_select') || profile.sysprompt || NONE;
+    profile['instruct-template'] = readInputDisplayValue('#instruct_presets') || profile.instruct || NONE;
+    profile['context-template'] = readInputDisplayValue('#context_presets') || profile.context || NONE;
+    profile['system-prompt'] = readInputDisplayValue('#sysprompt_select') || profile.sysprompt || NONE;
     profile['world-info-active-count'] = String(getWorldInfoActiveCount());
 }
 

--- a/public/scripts/extensions/connection-manager/style.css
+++ b/public/scripts/extensions/connection-manager/style.css
@@ -15,11 +15,31 @@
 
 #connection_profile_details_content .profile-summary--two-col li {
     min-width: 0;
+    display: grid;
+    grid-template-columns: minmax(9rem, max-content) minmax(0, 1fr);
+    gap: 4px 8px;
+    overflow-wrap: anywhere;
+}
+
+#connection_profile_details_content .profile-summary-label {
+    min-width: 0;
+}
+
+#connection_profile_details_content .profile-summary-label::after {
+    content: ':';
+}
+
+#connection_profile_details_content .profile-summary-value {
+    min-width: 0;
     overflow-wrap: anywhere;
 }
 
 @media screen and (max-width: 700px) {
     #connection_profile_details_content .profile-summary--two-col {
+        grid-template-columns: 1fr;
+    }
+
+    #connection_profile_details_content .profile-summary--two-col li {
         grid-template-columns: 1fr;
     }
 }

--- a/public/scripts/extensions/connection-manager/style.css
+++ b/public/scripts/extensions/connection-manager/style.css
@@ -6,6 +6,24 @@
     margin: 0;
 }
 
+#connection_profile_details_content .profile-summary--two-col {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 6px 14px;
+    padding-left: 18px;
+}
+
+#connection_profile_details_content .profile-summary--two-col li {
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+
+@media screen and (max-width: 700px) {
+    #connection_profile_details_content .profile-summary--two-col {
+        grid-template-columns: 1fr;
+    }
+}
+
 #connection_profile_spinner {
     margin-left: 5px;
 }

--- a/public/scripts/extensions/connection-manager/view.html
+++ b/public/scripts/extensions/connection-manager/view.html
@@ -1,6 +1,9 @@
 <ul class="profile-summary--two-col">
     {{#each profile}}
-    <li><strong data-i18n="{{@key}}">{{@key}}:</strong>&nbsp;{{this}}</li>
+    <li>
+        <strong class="profile-summary-label" data-i18n="{{@key}}">{{@key}}</strong>
+        <span class="profile-summary-value">{{this}}</span>
+    </li>
     {{/each}}
 </ul>
 {{#if omitted}}

--- a/public/scripts/extensions/connection-manager/view.html
+++ b/public/scripts/extensions/connection-manager/view.html
@@ -1,4 +1,4 @@
-<ul>
+<ul class="profile-summary--two-col">
     {{#each profile}}
     <li><strong data-i18n="{{@key}}">{{@key}}:</strong>&nbsp;{{this}}</li>
     {{/each}}


### PR DESCRIPTION
## What?
Expands Connection Profiles saved summaries with active agent, sampler, template, system prompt, and World Info counts, then renders the summary in a two-column layout.

## Why?
Connection profile saves currently capture core command state but leave out important contextual settings that users need to compare before applying a profile.

## How?
Adds a snapshot enrichment pass after profile command reads, exposes enabled in-chat agents through a small global bridge, collects sampler/template/system prompt/world-info values from current UI/context, and styles the profile summary list with a two-column grid.

## Testing?
- `npm run lint -- --quiet`
- `npm run check:frontend-budgets`
- `git diff --check`

## Screenshots (optional)
Not included; no browser server was started for this split.

## Anything Else?
Values are summary metadata only; profile application remains command-driven and backwards-compatible.