### PR TITLE
feat: add OOC and HTML context depth controls

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5776,6 +5776,18 @@
                                     <input id="encode_tags" type="checkbox" />
                                     <small data-i18n="Show tags in responses">Show &lt;tags&gt; in responses</small>
                                 </label>
+                                <div class="flex-container alignitemscenter gap10">
+                                    <label for="ooc_context_depth" class="flex1" title="Keep OOC ((...)) blocks in the last N context messages. 0 strips all OOC blocks from prompt context." data-i18n="[title]Keep OOC blocks in the last N context messages. 0 strips all OOC blocks from prompt context.">
+                                        <small data-i18n="OOC context depth">OOC context depth</small>
+                                    </label>
+                                    <input id="ooc_context_depth" class="text_pole widthUnset" type="number" min="0" step="1" value="0" />
+                                </div>
+                                <div class="flex-container alignitemscenter gap10">
+                                    <label for="html_context_depth" class="flex1" title="Keep raw HTML tags in the last N context messages. 0 strips HTML tags from prompt context." data-i18n="[title]Keep raw HTML tags in the last N context messages. 0 strips HTML tags from prompt context.">
+                                        <small data-i18n="HTML tag context depth">HTML tag context depth</small>
+                                    </label>
+                                    <input id="html_context_depth" class="text_pole widthUnset" type="number" min="0" step="1" value="0" />
+                                </div>
                                 <label class="checkbox_label" for="experimental_macro_engine" title="Experimental new Macro Engine.&NewLine;&NewLine;Allows nested macros to be resolved correctly and has a dedicated, logical replacement order.&NewLine;The new engine is designed to cleanly replace the old regex-based macro system.">
                                     <input id="experimental_macro_engine" type="checkbox" />
                                     <small data-i18n="Experimental Macro Engine">Experimental Macro Engine</small>

--- a/public/script.js
+++ b/public/script.js
@@ -119,6 +119,7 @@ import {
     extractOocBlocksForDisplay,
     hasTextOrArrayPayload,
     restoreOocBlocksForDisplay,
+    stripHtmlTagsFromContext,
     stripOocBlocksFromContext,
 } from './scripts/ooc-blocks.js';
 
@@ -5456,9 +5457,17 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             regexedMessage = `${regexedMessage}\n\n${titles.join('\n\n')}`;
         }
 
+        const contextDepth = Math.max(0, coreChat.length - index - 1);
+        const oocContextDepth = Math.max(0, Number(power_user.ooc_context_depth) || 0);
+        const htmlContextDepth = Math.max(0, Number(power_user.html_context_depth) || 0);
+        const contextMessage = stripHtmlTagsFromContext(
+            stripOocBlocksFromContext(regexedMessage, contextDepth < oocContextDepth),
+            contextDepth < htmlContextDepth,
+        );
+
         return {
             ...chatItem,
-            mes: stripOocBlocksFromContext(regexedMessage),
+            mes: contextMessage,
             index,
         };
     }));

--- a/public/scripts/ooc-blocks.js
+++ b/public/scripts/ooc-blocks.js
@@ -75,10 +75,35 @@ function escapeHtml(value) {
 /**
  * Removes user-visible out-of-character blocks from text before prompt assembly.
  * @param {string} text Source text.
+ * @param {boolean} [preserve=false] Whether to keep OOC blocks in this context message.
  * @returns {string} Text without balanced ((...)) blocks.
  */
-export function stripOocBlocksFromContext(text) {
+export function stripOocBlocksFromContext(text, preserve = false) {
+    if (preserve) {
+        return String(text ?? '');
+    }
+
     return replaceBalancedOocBlocks(text, () => '')
+        .replace(/[ \t]{2,}/g, ' ')
+        .replace(/[ \t]+\n/g, '\n')
+        .replace(/\n{3,}/g, '\n\n')
+        .trim();
+}
+
+/**
+ * Strips raw HTML tags from older prompt-context messages.
+ * @param {string} text Source text.
+ * @param {boolean} [preserve=false] Whether to keep HTML tags in this context message.
+ * @returns {string} Text with HTML tags removed unless preserved.
+ */
+export function stripHtmlTagsFromContext(text, preserve = false) {
+    const source = String(text ?? '');
+    if (preserve) {
+        return source;
+    }
+
+    return source
+        .replace(/<\/?[a-z][a-z0-9:-]*(?:\s[^>]*)?>/gi, ' ')
         .replace(/[ \t]{2,}/g, ' ')
         .replace(/[ \t]+\n/g, '\n')
         .replace(/\n{3,}/g, '\n\n')

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -81,7 +81,7 @@ import { ToolManager } from './tool-calling.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { COMETAPI_IGNORE_PATTERNS, IGNORE_SYMBOL, MEDIA_DISPLAY, MEDIA_TYPE } from './constants.js';
 import { syncOpenRouterProvidersForModel, updateOpenRouterProvidersWarning } from './textgen-models.js';
-import { hasTextOrArrayPayload, stripOocBlocksFromContext } from './ooc-blocks.js';
+import { hasTextOrArrayPayload, stripHtmlTagsFromContext, stripOocBlocksFromContext } from './ooc-blocks.js';
 import { checkPostInterceptChatBudget } from './openai-prompt-budget.js';
 
 export {
@@ -708,7 +708,13 @@ function setOpenAIMessages(chat) {
         }
 
         // remove caret return (waste of tokens)
-        content = stripOocBlocksFromContext(content.replace(/\r/gm, ''));
+        const contextDepth = Math.max(0, chat.length - j - 1);
+        const oocContextDepth = Math.max(0, Number(power_user.ooc_context_depth) || 0);
+        const htmlContextDepth = Math.max(0, Number(power_user.html_context_depth) || 0);
+        content = stripHtmlTagsFromContext(
+            stripOocBlocksFromContext(content.replace(/\r/gm, ''), contextDepth < oocContextDepth),
+            contextDepth < htmlContextDepth,
+        );
 
         const name = chat[j].name;
         const media = chat[j]?.extra?.media;

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -227,6 +227,8 @@ export const power_user = {
     },
     markdown_escape_strings: '',
     chat_truncation: 100,
+    ooc_context_depth: 0,
+    html_context_depth: 0,
     streaming_fps: 30,
     smooth_streaming: false,
     smooth_streaming_no_think: false,
@@ -1864,6 +1866,8 @@ export async function loadPowerUserSettings(settings, data) {
 
     $('#chat_truncation').val(power_user.chat_truncation);
     $('#chat_truncation_counter').val(power_user.chat_truncation);
+    $('#ooc_context_depth').val(power_user.ooc_context_depth);
+    $('#html_context_depth').val(power_user.html_context_depth);
 
     $('#streaming_fps').val(power_user.streaming_fps);
     $('#streaming_fps_counter').val(power_user.streaming_fps);
@@ -3541,6 +3545,18 @@ jQuery(async () => {
     $('#chat_truncation').on('input', function () {
         power_user.chat_truncation = Number($('#chat_truncation').val());
         $('#chat_truncation_counter').val(power_user.chat_truncation);
+        saveSettingsDebounced();
+    });
+
+    $('#ooc_context_depth').on('input', function () {
+        power_user.ooc_context_depth = Math.max(0, Number($(this).val()) || 0);
+        $(this).val(power_user.ooc_context_depth);
+        saveSettingsDebounced();
+    });
+
+    $('#html_context_depth').on('input', function () {
+        power_user.html_context_depth = Math.max(0, Number($(this).val()) || 0);
+        $(this).val(power_user.html_context_depth);
         saveSettingsDebounced();
     });
 

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -3548,14 +3548,16 @@ jQuery(async () => {
         saveSettingsDebounced();
     });
 
+    const normalizeContextDepthInput = input => Math.max(0, Math.floor(Number(input) || 0));
+
     $('#ooc_context_depth').on('input', function () {
-        power_user.ooc_context_depth = Math.max(0, Number($(this).val()) || 0);
+        power_user.ooc_context_depth = normalizeContextDepthInput($(this).val());
         $(this).val(power_user.ooc_context_depth);
         saveSettingsDebounced();
     });
 
     $('#html_context_depth').on('input', function () {
-        power_user.html_context_depth = Math.max(0, Number($(this).val()) || 0);
+        power_user.html_context_depth = normalizeContextDepthInput($(this).val());
         $(this).val(power_user.html_context_depth);
         saveSettingsDebounced();
     });

--- a/tests/ooc-blocks.test.js
+++ b/tests/ooc-blocks.test.js
@@ -5,6 +5,7 @@ import {
     hasTextOrArrayPayload,
     renderOocBlock,
     restoreOocBlocksForDisplay,
+    stripHtmlTagsFromContext,
     stripOocBlocksFromContext,
 } from '../public/scripts/ooc-blocks.js';
 
@@ -19,6 +20,15 @@ describe('OOC block handling', () => {
 
     test('keeps unclosed OOC text intact instead of swallowing the rest of the prompt', () => {
         expect(stripOocBlocksFromContext('Visible ((unfinished note')).toBe('Visible ((unfinished note');
+    });
+
+    test('can preserve OOC blocks for recent context messages', () => {
+        expect(stripOocBlocksFromContext('Visible ((keep this)) text', true)).toBe('Visible ((keep this)) text');
+    });
+
+    test('strips or preserves HTML tags for prompt context', () => {
+        expect(stripHtmlTagsFromContext('Visible <strong>tagged</strong> text')).toBe('Visible tagged text');
+        expect(stripHtmlTagsFromContext('Visible <strong>tagged</strong> text', true)).toBe('Visible <strong>tagged</strong> text');
     });
 
     test('extracts and restores OOC display blocks in source order', () => {


### PR DESCRIPTION
## What?
Adds user-configurable OOC and raw HTML context-depth controls for prompt assembly.

## Why?
The current prompt builders strip all user-visible OOC blocks and raw HTML tags from context, but users may want the most recent N messages to preserve those details while older context stays clean.

## How?
Adds `ooc_context_depth` and `html_context_depth` power-user settings, UI number inputs beside tag handling, preservation-aware OOC/HTML stripping helpers, and applies the depth checks in both text-completion and chat-completion prompt assembly.

## Testing?
- `npm run test:unit --prefix tests -- tests/ooc-blocks.test.js`
- `npm run lint -- --quiet`
- `npm run check:frontend-budgets`
- `git diff --check`

## Screenshots (optional)
Not included; settings UI is a small form-control addition and no browser server was started.

## Anything Else?
Default depth is `0`, preserving existing behavior for current users.