### PR TITLE
fix: polish in-chat agent rewrite metadata

### DIFF
--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -1435,13 +1435,36 @@ function describePromptTransformTarget(profileId = '', runner = '') {
     return 'the main model';
 }
 
+function getPromptTransformProfileLabel(profileId = '') {
+    return profileId ? getConnectionProfileDisplayName(profileId) : 'Main model';
+}
+
+function getPromptTransformModelLabel(agent, profileId = '') {
+    const modelOverride = String(agent?.modelOverride ?? '').trim();
+    if (modelOverride) {
+        return modelOverride;
+    }
+
+    return getPromptTransformProfileLabel(profileId);
+}
+
+function getPromptTransformRunMetadata(agent, profileId = '') {
+    return {
+        order: Number(agent?.injection?.order ?? 0),
+        profileLabel: getPromptTransformProfileLabel(profileId),
+        modelLabel: getPromptTransformModelLabel(agent, profileId),
+    };
+}
+
 function showPromptTransformRunningToast(agent, mode, profileId = '') {
     const agentName = agent?.name || 'In-Chat Agent';
     const modeLabel = describePromptTransformMode(mode);
     const targetLabel = describePromptTransformTarget(profileId, profileId ? 'profile' : 'main');
+    const metadata = getPromptTransformRunMetadata(agent, profileId);
     const cancelButtonClass = 'ica--toast-cancel-agent';
     const messageHtml = `
         <div>${escapeToastHtml(`Running ${modeLabel} via ${targetLabel}...`)}</div>
+        <div>${escapeToastHtml(`Order ${metadata.order} | Model: ${metadata.modelLabel}`)}</div>
         <button type="button" class="menu_button menu_button_icon caution ${cancelButtonClass}">
             <i class="fa-solid fa-stop"></i>
             <span>Cancel Agent</span>
@@ -1522,6 +1545,27 @@ function syncPromptTransformMessageState(message, messageIndex) {
     syncAssistantMessageTextToSwipe(message);
 }
 
+async function syncPromptTransformMessageStateAsync(message, messageIndex) {
+    syncPromptTransformMessageState(message, messageIndex);
+
+    if (!message || message.is_user || message.is_system) {
+        return;
+    }
+
+    const context = getContext();
+    const tokenCount = typeof context?.getTokenCountAsync === 'function'
+        ? await context.getTokenCountAsync(message.mes, 0)
+        : 0;
+
+    message.extra ??= {};
+    message.extra.token_count = tokenCount;
+
+    const swipeInfo = getActiveSwipeInfo(message, { create: true });
+    if (swipeInfo?.extra) {
+        swipeInfo.extra.token_count = tokenCount;
+    }
+}
+
 function syncAssistantMessageStateToSwipe(message, messageIndex) {
     if (!message || message.is_user || message.is_system) {
         return;
@@ -1600,6 +1644,9 @@ function updatePromptTransformHistory(message, run) {
         agentId: run.agentId,
         agentName: run.agentName,
         mode: run.mode,
+        order: run.order,
+        profileLabel: run.profileLabel,
+        modelLabel: run.modelLabel,
         beforeText: normalizeContentText(run.beforeText),
         afterText: normalizeContentText(run.nextMessageText),
         timestamp: run.timestamp,
@@ -2104,6 +2151,7 @@ async function runPromptTransformAgent(agent, message, generationType, messageTe
     const normalizedGenerationType = normalizeGenerationType(generationType);
     const promptTransformMode = getPromptTransformMode(agent);
     const profileId = resolveAgentConnectionProfile(agent);
+    const runMetadata = getPromptTransformRunMetadata(agent, profileId);
     const showNotifications = shouldShowPromptTransformNotifications(agent);
 
     if (!currentMessageText.trim()) {
@@ -2114,6 +2162,7 @@ async function runPromptTransformAgent(agent, message, generationType, messageTe
             status: 'skipped-empty-message',
             mode: promptTransformMode,
             profileId,
+            ...runMetadata,
             runner: 'none',
             timestamp: new Date().toISOString(),
             outputText: '',
@@ -2138,6 +2187,7 @@ async function runPromptTransformAgent(agent, message, generationType, messageTe
             status: 'skipped-empty-prompt',
             mode: promptTransformMode,
             profileId,
+            ...runMetadata,
             runner: 'none',
             timestamp: new Date().toISOString(),
             outputText: '',
@@ -2174,6 +2224,7 @@ async function runPromptTransformAgent(agent, message, generationType, messageTe
                 status: 'empty-response',
                 mode: promptTransformMode,
                 profileId: response.profileId,
+                ...getPromptTransformRunMetadata(agent, response.profileId),
                 runner: response.runner,
                 timestamp: new Date().toISOString(),
                 outputText: '',
@@ -2199,6 +2250,7 @@ async function runPromptTransformAgent(agent, message, generationType, messageTe
                 status: 'cancelled',
                 mode: promptTransformMode,
                 profileId: response.profileId,
+                ...getPromptTransformRunMetadata(agent, response.profileId),
                 runner: response.runner,
                 timestamp: new Date().toISOString(),
                 outputText: '',
@@ -2210,7 +2262,7 @@ async function runPromptTransformAgent(agent, message, generationType, messageTe
         const changed = nextMessageText !== currentMessageText;
         if (changed && applyToMessage) {
             message.mes = nextMessageText;
-            syncPromptTransformMessageState(message, messageIndex);
+            await syncPromptTransformMessageStateAsync(message, messageIndex);
         }
 
         console.info(`[InChatAgents] ${describePromptTransformMode(promptTransformMode)} agent "${agent.name}" ran via ${describePromptTransformTarget(response.profileId, response.runner)}${changed ? ' and changed the message.' : ' with no text change.'}`);
@@ -2222,6 +2274,7 @@ async function runPromptTransformAgent(agent, message, generationType, messageTe
             status: changed ? 'changed' : 'unchanged',
             mode: promptTransformMode,
             profileId: response.profileId,
+            ...getPromptTransformRunMetadata(agent, response.profileId),
             runner: response.runner,
             timestamp: new Date().toISOString(),
             outputText: promptOutputText,
@@ -2244,6 +2297,7 @@ async function runPromptTransformAgent(agent, message, generationType, messageTe
             mode: promptTransformMode,
             error: error instanceof Error ? error.message : String(error),
             profileId,
+            ...runMetadata,
             runner: 'error',
             timestamp: new Date().toISOString(),
             outputText: '',
@@ -2322,7 +2376,7 @@ async function runPromptTransformAppendBatch(agents, message, generationType, me
     const consolidated = consolidateAppendPromptTransformOutputs(currentMessageText, agents, results);
     if (consolidated.changed) {
         message.mes = consolidated.text;
-        syncPromptTransformMessageState(message, messageIndex);
+        await syncPromptTransformMessageStateAsync(message, messageIndex);
     }
 
     return {
@@ -2628,7 +2682,7 @@ async function processReceivedMessage(messageIndex, generationType, activationSn
     let currentPromptTransformText = unwrapAssistantResponseWrapper(message.mes);
     if (currentPromptTransformText !== normalizeContentText(message.mes)) {
         message.mes = currentPromptTransformText;
-        syncPromptTransformMessageState(message, messageIndex);
+        await syncPromptTransformMessageStateAsync(message, messageIndex);
         chatStateChanged = true;
         messageDisplayChanged = true;
     }
@@ -3370,7 +3424,7 @@ function onWorldInfoUpdatedToolSync() {
     syncToolAgentRegistrations();
 }
 
-export function undoPromptTransform(messageIndex) {
+export async function undoPromptTransform(messageIndex) {
     const message = chat[messageIndex];
     if (!message || message.is_user || message.is_system) {
         return false;
@@ -3384,13 +3438,13 @@ export function undoPromptTransform(messageIndex) {
 
     const lastEntry = history[history.length - 1];
     message.mes = lastEntry.beforeText;
-    syncPromptTransformMessageState(message, messageIndex);
+    await syncPromptTransformMessageStateAsync(message, messageIndex);
     saveChatDebounced();
     scheduleMessageRefresh(messageIndex, message);
     return true;
 }
 
-export function redoPromptTransform(messageIndex) {
+export async function redoPromptTransform(messageIndex) {
     const message = chat[messageIndex];
     if (!message || message.is_user || message.is_system) {
         return false;
@@ -3404,7 +3458,7 @@ export function redoPromptTransform(messageIndex) {
 
     const lastEntry = history[history.length - 1];
     message.mes = lastEntry.afterText;
-    syncPromptTransformMessageState(message, messageIndex);
+    await syncPromptTransformMessageStateAsync(message, messageIndex);
     saveChatDebounced();
     scheduleMessageRefresh(messageIndex, message);
     return true;
@@ -3492,7 +3546,7 @@ async function executeManualAgentRun(agentId, messageIndex, cancelRevision = age
 
     if (result.changed) {
         message.mes = result.nextMessageText;
-        syncPromptTransformMessageState(message, messageIndex);
+        await syncPromptTransformMessageStateAsync(message, messageIndex);
     }
 
     if (updatePromptTransformRuns(message, [result])) {

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -7,6 +7,7 @@ import { eventSource, event_types } from '../../events.js';
 import {
     areAgentsGloballyEnabled,
     getAgents,
+    getEnabledAgents,
     getAgentById,
     getAgentRegexScripts,
     loadAgents,
@@ -431,6 +432,66 @@ function buildAgentFromSnapshot(snapshot) {
         id: uuidv4(),
         enabled: false,
     };
+}
+
+globalThis.SillyBunnyAgents = Object.assign(globalThis.SillyBunnyAgents || {}, {
+    getEnabledAgents,
+});
+
+function getComparableAgentSnapshot(agent) {
+    const snapshot = structuredClone(agent || {});
+    delete snapshot.id;
+    delete snapshot.enabled;
+    delete snapshot.favorite;
+    return snapshot;
+}
+
+function stableAgentComparableValue(value) {
+    if (Array.isArray(value)) {
+        return value.map(stableAgentComparableValue);
+    }
+
+    if (value && typeof value === 'object') {
+        return Object.fromEntries(
+            Object.entries(value)
+                .sort(([a], [b]) => a.localeCompare(b))
+                .map(([key, entryValue]) => [key, stableAgentComparableValue(entryValue)]),
+        );
+    }
+
+    return value;
+}
+
+function getComparableAgentKey(agent) {
+    return JSON.stringify(stableAgentComparableValue(getComparableAgentSnapshot(agent)));
+}
+
+function hasIdenticalAgent(agent, existingAgents = getAgents()) {
+    const candidateKey = getComparableAgentKey(agent);
+    const candidateName = String(agent?.name ?? '').trim();
+
+    return existingAgents.some(existingAgent =>
+        String(existingAgent?.name ?? '').trim() === candidateName &&
+        getComparableAgentKey(existingAgent) === candidateKey,
+    );
+}
+
+async function confirmDuplicateAgentAddition(agent) {
+    if (!hasIdenticalAgent(agent)) {
+        return true;
+    }
+
+    const result = await new Popup(
+        'An identical agent is already active. Add anyway?',
+        POPUP_TYPE.CONFIRM,
+        'Duplicate agent',
+        {
+            okButton: 'Add Anyway',
+            cancelButton: 'Cancel',
+        },
+    ).show();
+
+    return result === POPUP_RESULT.AFFIRMATIVE;
 }
 
 function shouldMigratePathfinderAgentTools(agent, template) {
@@ -2118,6 +2179,11 @@ async function openTemplateBrowser() {
 
         card.on('click', async () => {
             const newAgent = buildAgentFromTemplate(tpl);
+            if (!await confirmDuplicateAgentAddition(newAgent)) {
+                toastr.info('Duplicate agent not added.');
+                return;
+            }
+
             await saveAgent(newAgent);
             renderAgentList();
             toastr.success(`Added "${tpl.name}" to your agents.`);
@@ -2607,6 +2673,7 @@ async function openPromptTransformHistoryPopup(messageIndex) {
         return `
             <div class="ica-transform-history-entry" data-index="${i}">
                 <h5>${escapeHtml(entry.agentName || 'Agent')} <small>(${escapeHtml(entry.mode || 'replace')})</small></h5>
+                <small>${escapeHtml(`Order ${entry.order ?? 'n/a'} | Model: ${entry.modelLabel || entry.profileLabel || 'Current model'}`)}</small>
                 <small>${timestamp}</small>
                 <div class="ica-transform-diff">${buildPromptTransformDiffMarkup(entry.beforeText ?? '', entry.afterText ?? '')}</div>
                 <div class="ica-transform-actions">
@@ -2622,18 +2689,18 @@ async function openPromptTransformHistoryPopup(messageIndex) {
         ${postGenerationEntries ? `<section class="ica-transform-history-section"><h4>Post-Generation Changes</h4>${postGenerationEntries}</section>` : ''}
     </div>`);
 
-    html.find('.ica-undo-btn').on('click', function () {
+    html.find('.ica-undo-btn').on('click', async function () {
         const idx = Number($(this).data('mesid'));
-        if (undoPromptTransform(idx)) {
+        if (await undoPromptTransform(idx)) {
             toastr.success('Transform undone.');
         } else {
             toastr.warning('Could not undo transform.');
         }
     });
 
-    html.find('.ica-redo-btn').on('click', function () {
+    html.find('.ica-redo-btn').on('click', async function () {
         const idx = Number($(this).data('mesid'));
-        if (redoPromptTransform(idx)) {
+        if (await redoPromptTransform(idx)) {
             toastr.success('Transform redone.');
         } else {
             toastr.warning('Could not redo transform.');


### PR DESCRIPTION
## What?
Polishes in-chat agent rewrite metadata, token accounting, undo/redo async handling, and duplicate template additions.

## Why?
Agent rewrites could leave message token counts stale and the transform UI did not expose enough run context. Adding identical agents from templates also had no confirmation step.

## How?
Refreshes message and active-swipe token counts after prompt-transform mutations through the existing extension context, records order/profile/model labels on prompt-transform run metadata, shows those labels in toasts/history rows, updates undo/redo handlers for async recounts, and prompts before adding an identical agent template.

## Testing?
- `npm run test:unit --prefix tests -- tests/in-chat-agents-runner.test.js tests/in-chat-agents-store.test.js`
- `npm run lint -- --quiet`
- `git diff --check`

## Screenshots (optional)
Not included; no browser server was started for this split.

## Anything Else?
This PR intentionally avoids touching the global chat badge code from PR #60, keeping the split focused on the in-chat-agents extension runtime.