### PR TITLE
fix: hide disabled extension message actions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7891,9 +7891,9 @@
                         <div class="mes_buttons">
                             <div title="Message Actions" class="mes_button extraMesButtonsHint fa-solid fa-ellipsis" data-i18n="[title]Message Actions"></div>
                             <div class="extraMesButtons">
-                                <div title="Translate message" class="mes_button mes_translate fa-solid fa-language" data-i18n="[title]Translate message"></div>
-                                <div title="Generate Image" class="mes_button sd_message_gen fa-solid fa-paintbrush" data-i18n="[title]Generate Image"></div>
-                                <div title="Narrate" class="mes_button mes_narrate fa-solid fa-bullhorn" data-i18n="[title]Narrate"></div>
+                                <div title="Translate message" class="mes_button mes_translate fa-solid fa-language" data-i18n="[title]Translate message" data-requires-extension="translate"></div>
+                                <div title="Generate Image" class="mes_button sd_message_gen fa-solid fa-paintbrush" data-i18n="[title]Generate Image" data-requires-extension="stable-diffusion"></div>
+                                <div title="Narrate" class="mes_button mes_narrate fa-solid fa-bullhorn" data-i18n="[title]Narrate" data-requires-extension="tts"></div>
                                 <div title="Prompt" class="mes_button mes_prompt fa-solid fa-square-poll-horizontal " data-i18n="[title]Prompt" style="display: none;"></div>
                                 <div title="View agent changes" class="mes_button mes_view_agent_changes fa-solid fa-file-lines" data-i18n="[title]View agent changes" style="display: none;"></div>
                                 <div title="Exclude message from prompts" class="mes_button mes_hide fa-solid fa-eye" data-i18n="[title]Exclude message from prompts"></div>

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -88,6 +88,7 @@ let sbInlineDrawerPersistenceQueued = false;
 let sbChatScriptModulePromise = null;
 let sbStorageFlushTimer = 0;
 let sbStorageFlushEventsBound = false;
+let sbMessageActionEventsBound = false;
 const sbStorageCache = new Map();
 const sbStoragePendingWrites = new Map();
 
@@ -2223,6 +2224,57 @@ function getSillyTavernContext() {
     } catch {
         return null;
     }
+}
+
+function isExtensionEnabled(name) {
+    const context = getSillyTavernContext();
+    const disabledExtensions = context?.extensionSettings?.disabledExtensions;
+
+    if (!Array.isArray(disabledExtensions)) {
+        return true;
+    }
+
+    const normalizedName = String(name || '').replace(/^third-party\//i, '').toLowerCase();
+    return !disabledExtensions.some(disabled => {
+        const normalizedDisabled = String(disabled || '').replace(/^third-party\//i, '').toLowerCase();
+        return normalizedDisabled === normalizedName;
+    });
+}
+
+function syncMessageActionExtensionVisibility(root = document) {
+    if (typeof root === 'number') {
+        root = document.querySelector(`.mes[mesid="${root}"]`) || document;
+    }
+
+    if (!root?.querySelectorAll) {
+        return;
+    }
+
+    root.querySelectorAll('[data-requires-extension]').forEach(button => {
+        if (!(button instanceof HTMLElement)) {
+            return;
+        }
+
+        const requiredExtension = button.dataset.requiresExtension;
+        button.classList.toggle('displayNone', !isExtensionEnabled(requiredExtension));
+    });
+}
+
+function bindMessageActionExtensionEvents() {
+    if (sbMessageActionEventsBound) {
+        return;
+    }
+
+    const context = getSillyTavernContext();
+    if (!context?.eventSource || !context?.event_types) {
+        return;
+    }
+
+    sbMessageActionEventsBound = true;
+    context.eventSource.on(context.event_types.EXTENSION_SETTINGS_LOADED, () => syncMessageActionExtensionVisibility());
+    context.eventSource.on(context.event_types.SETTINGS_UPDATED, () => syncMessageActionExtensionVisibility());
+    context.eventSource.on(context.event_types.USER_MESSAGE_RENDERED, data => syncMessageActionExtensionVisibility(data?.element || data));
+    context.eventSource.on(context.event_types.CHARACTER_MESSAGE_RENDERED, data => syncMessageActionExtensionVisibility(data?.element || data));
 }
 
 function getChatScriptModule() {
@@ -11058,6 +11110,8 @@ function initAll() {
     bindTopbarDragEvents();
     bindChatbarEvents();
     bindClearCookiesAndCacheButton();
+    bindMessageActionExtensionEvents();
+    syncMessageActionExtensionVisibility();
     scheduleChatbarRefresh(0);
     interceptDrawerOpeners();
     bindWorldInfoRoute();
@@ -11166,9 +11220,13 @@ if (document.readyState === 'loading') {
 // slow networks where DOMContentLoaded fires but scripts haven't set up UI).
 const ctx = getSillyTavernContext();
 if (ctx?.eventSource && ctx?.event_types) {
+    bindMessageActionExtensionEvents();
     ctx.eventSource.on(ctx.event_types.APP_READY, () => {
         if (!sbState.initialized) {
             initAll();
+        } else {
+            bindMessageActionExtensionEvents();
+            syncMessageActionExtensionVisibility();
         }
     });
 }

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -91,6 +91,10 @@ let sbStorageFlushEventsBound = false;
 let sbMessageActionEventsBound = false;
 const sbStorageCache = new Map();
 const sbStoragePendingWrites = new Map();
+const SB_EXTENSION_ALIASES = {
+    'stable-diffusion': ['stable-diffusion', 'sd'],
+    'sd': ['stable-diffusion', 'sd'],
+};
 
 function getShortcutTarget(side) {
     const stored = safeGetItem(side === 'left' ? SB_STORAGE_KEYS.shortcutLeft : SB_STORAGE_KEYS.shortcutRight);
@@ -2234,11 +2238,16 @@ function isExtensionEnabled(name) {
         return true;
     }
 
-    const normalizedName = String(name || '').replace(/^third-party\//i, '').toLowerCase();
+    const normalizedName = normalizeExtensionName(name);
+    const aliases = new Set(SB_EXTENSION_ALIASES[normalizedName] ?? [normalizedName]);
     return !disabledExtensions.some(disabled => {
-        const normalizedDisabled = String(disabled || '').replace(/^third-party\//i, '').toLowerCase();
-        return normalizedDisabled === normalizedName;
+        const normalizedDisabled = normalizeExtensionName(disabled);
+        return aliases.has(normalizedDisabled);
     });
+}
+
+function normalizeExtensionName(name) {
+    return String(name || '').replace(/^third-party\//i, '').toLowerCase();
 }
 
 function syncMessageActionExtensionVisibility(root = document) {
@@ -2256,7 +2265,14 @@ function syncMessageActionExtensionVisibility(root = document) {
         }
 
         const requiredExtension = button.dataset.requiresExtension;
-        button.classList.toggle('displayNone', !isExtensionEnabled(requiredExtension));
+        const isEnabled = isExtensionEnabled(requiredExtension);
+        button.classList.toggle('displayNone', !isEnabled);
+        button.toggleAttribute('aria-hidden', !isEnabled);
+        if (!isEnabled) {
+            button.setAttribute('tabindex', '-1');
+        } else if (button.getAttribute('tabindex') === '-1') {
+            button.removeAttribute('tabindex');
+        }
     });
 }
 


### PR DESCRIPTION
## What?
Hides message action buttons when their backing extension is disabled.

## Why?
Translate, image generation, and narration buttons could appear even when their extensions were inactive, leaving visible controls that could not actually work.

## How?
Adds `data-requires-extension` metadata to those message action buttons and wires SillyBunny shell initialization/render events to toggle those buttons based on `extensionSettings.disabledExtensions`.

## Testing?
- `npm run lint -- --quiet`
- `npm run check:frontend-budgets`
- `git diff --check`

## Screenshots (optional)
Not included; no browser server was started for this split.

## Anything Else?
Extension names are matched case-insensitively and ignore a `third-party/` prefix.