### PR TITLE
feat: rework character menu

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -247,6 +247,10 @@ This update stabilizes preset and connection profile switching, adds bottom chat
 * Fixed the mobile bottom chat bar breakpoint and first-row grid sizing so the chat dropdown, up/down controls, and collapse button no longer overlap on wider phone/tablet layouts.
 * Kept the desktop bottom chat bar layout unchanged while aligning mobile persona, chat select, action, and search controls symmetrically.
 
+**Character Drawer**
+* Rotated the character-menu service-worker, shell, and static asset cache keys so iOS WebKit clients load the reworked drawer instead of stale cached files.
+* Restored horizontal scrolling in the mobile character tab strip and trimmed the mobile character header spacing.
+
 **Runtime And Updates**
 * Bun launchers now retry dependency installs without `--frozen-lockfile` if the locked install fails, so users no longer need to delete `bun.lock` after an update.
 * Clean Git checkouts restore the tracked `bun.lock` after a local Bun lockfile refresh so future launcher self-updates are not blocked by a dirty lockfile.

--- a/README.md
+++ b/README.md
@@ -245,6 +245,10 @@ This update stabilizes preset and connection profile switching, adds bottom chat
 * Fixed the mobile bottom chat bar breakpoint and first-row grid sizing so the chat dropdown, up/down controls, and collapse button no longer overlap on wider phone/tablet layouts.
 * Kept the desktop bottom chat bar layout unchanged while aligning mobile persona, chat select, action, and search controls symmetrically.
 
+**Character Drawer**
+* Rotated the character-menu service-worker, shell, and static asset cache keys so iOS WebKit clients load the reworked drawer instead of stale cached files.
+* Restored horizontal scrolling in the mobile character tab strip and trimmed the mobile character header spacing.
+
 **Runtime And Updates**
 * Bun launchers now retry dependency installs without `--frozen-lockfile` if the locked install fails, so users no longer need to delete `bun.lock` after an update.
 * Clean Git checkouts restore the tracked `bun.lock` after a local Bun lockfile refresh so future launcher self-updates are not blocked by a dirty lockfile.

--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,10 @@ This update stabilizes preset and connection profile switching, preserves OpenAI
 - Kept the desktop bottom chat bar layout unchanged while aligning mobile persona, chat select, action, and search controls symmetrically.
 - Remembered the mobile bottom chat action collapse state across reloads and centered the visible action row when it is shown.
 
+### Character Drawer
+- Rotated the character-menu service-worker, shell, and static asset cache keys so iOS WebKit clients load the reworked drawer instead of stale cached files.
+- Restored horizontal scrolling in the mobile character tab strip and trimmed the mobile character header spacing.
+
 ### Character Editor
 - Character alternate greetings now save from the live editor contents, so edited greetings persist instead of falling back to stale array state.
 

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -5031,6 +5031,144 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     }
 }
 
+@media screen and (max-width: 768px), (pointer: coarse) {
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_chats_block {
+        padding-inline: 8px;
+        gap: 10px;
+    }
+
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_top_bar {
+        grid-template-columns: minmax(0, 1fr);
+        justify-items: stretch;
+    }
+
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_top_bar > div:first-child,
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-primary,
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-action-cluster,
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-name-row label,
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #group_tags_div,
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-name-row::after {
+        grid-column: 1 / -1;
+        grid-row: auto;
+    }
+
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_top_bar > div:first-child {
+        justify-self: center;
+    }
+
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_top_bar .avatar,
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_top_bar .avatar img {
+        width: 92px !important;
+        min-width: 92px !important;
+        max-width: 92px !important;
+        height: 92px !important;
+        min-height: 92px !important;
+        max-height: 92px !important;
+    }
+
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-primary,
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-name-row {
+        width: 100%;
+        min-width: 0;
+    }
+
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-name-row,
+    #right-nav-panel[data-menu-type="group_edit"] .sb-group-editor-name-row {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr);
+        gap: 8px;
+    }
+
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-name-row::after {
+        display: none;
+    }
+
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-action-cluster,
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-side-actions,
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-utility-actions {
+        width: 100%;
+        max-width: 100%;
+        flex-wrap: wrap;
+        justify-content: stretch;
+    }
+
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) :is(.sb-group-editor-side-actions, .sb-group-editor-utility-actions) .menu_button,
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack .menu_button {
+        width: var(--sb-mobile-touch-target, 44px);
+        min-width: var(--sb-mobile-touch-target, 44px);
+        height: var(--sb-mobile-touch-target, 44px);
+        min-height: var(--sb-mobile-touch-target, 44px);
+        max-height: var(--sb-mobile-touch-target, 44px);
+    }
+
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-side-actions :is(#group_favorite_button, #rm_group_scenario),
+    #right-nav-panel[data-menu-type="group_create"] .sb-group-editor-utility-actions #rm_group_submit {
+        flex: 1 1 min(10rem, 100%);
+        min-width: min(10rem, 100%);
+        height: var(--sb-mobile-touch-target, 44px);
+        min-height: var(--sb-mobile-touch-target, 44px);
+        max-height: none;
+    }
+
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #group_tags_div {
+        width: 100%;
+        justify-self: stretch;
+    }
+
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #group_tags_div .tag_controls {
+        grid-template-columns: minmax(0, 1fr) var(--sb-mobile-touch-target, 44px);
+        min-height: var(--sb-mobile-touch-target, 44px);
+    }
+
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #groupTagInput,
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #group_tags_div .tags_view,
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #group-chat-lorebook-dropdown,
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_chat_name {
+        min-height: var(--sb-mobile-touch-target, 44px);
+        height: var(--sb-mobile-touch-target, 44px);
+    }
+
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack,
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack > .flex1,
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack > .group_schedule_controls,
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack > .group_schedule_controls > .flex-container:first-child {
+        grid-template-columns: minmax(0, 1fr);
+        width: 100%;
+    }
+
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack > .flex1 > :is(#rm_group_automode_label, #rm_group_auto_dm_cooldown_label),
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_auto_dm_cooldown_label {
+        grid-template-columns: 18px minmax(0, 1fr) minmax(4.5em, 5.5em) max-content !important;
+    }
+
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack > .group_schedule_controls > .flex-container:first-child > .checkbox_label {
+        grid-template-columns: 18px minmax(0, 1fr);
+        width: 100%;
+    }
+
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack #rm_group_generate_schedule {
+        width: 100% !important;
+        inline-size: 100% !important;
+        min-width: 0 !important;
+        min-inline-size: 0 !important;
+        min-height: var(--sb-mobile-touch-target, 44px);
+        height: auto;
+        max-height: none;
+        justify-self: stretch;
+        padding-inline: 12px !important;
+        white-space: normal;
+    }
+
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack #rm_group_generate_schedule span {
+        min-width: 0;
+        white-space: normal;
+    }
+
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_ai_schedule {
+        min-height: 9rem;
+    }
+}
+
 #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_buttons {
     display: grid;
     grid-template-columns: repeat(2, minmax(140px, 1fr));
@@ -6608,12 +6746,15 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
         pointer-events: auto !important;
         z-index: var(--sb-z-modal) !important;
         top: var(--sb-topbar-layout-offset) !important;
+        height: calc(100vh - var(--sb-topbar-layout-offset) - 16px) !important;
         height: calc(100dvh - var(--sb-topbar-layout-offset) - 16px) !important;
+        max-height: calc(100vh - var(--sb-topbar-layout-offset) - 16px) !important;
         max-height: calc(100dvh - var(--sb-topbar-layout-offset) - 16px) !important;
         left: 0 !important;
         right: 0 !important;
         width: 100vw !important;
         width: 100dvw !important;
+        max-width: 100vw !important;
         max-width: 100dvw !important;
         min-width: 0 !important;
         margin: 0 !important;
@@ -6630,14 +6771,15 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
         -webkit-overflow-scrolling: auto !important;
     }
 
-    #right-nav-panel.openDrawer * {
-        pointer-events: auto !important;
-    }
-
     #right-nav-panel.openDrawer .right_menu.sb-active-right-menu {
         opacity: 1 !important;
         visibility: visible !important;
         pointer-events: auto !important;
+    }
+
+    #right-nav-panel.openDrawer > :is(.sb-character-shell-nav-wrapper, .sb-character-shell-header, #CharListButtonAndHotSwaps, #rm_PinAndTabs, .scrollableInner, .scrollableInnerFull),
+    #right-nav-panel.openDrawer :is(button, input, select, textarea, label, a, .menu_button, .right_menu_button, .character_select, .group_select, .bogus_folder_select, .inline-drawer-toggle) {
+        pointer-events: auto;
     }
 
     #right-nav-panel.openDrawer > #right-nav-panelheader {
@@ -6655,7 +6797,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     }
 
     #right-nav-panel.openDrawer .sb-character-shell-nav .sb-shell-tab {
-        min-height: 38px;
+        min-height: var(--sb-mobile-touch-target, 44px);
         padding: 7px 10px;
         border-radius: 10px;
     }
@@ -6906,7 +7048,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     }
 
     #right-nav-panel.openDrawer .sb-character-create-bar #rm_button_create {
-        min-height: 42px;
+        min-height: var(--sb-mobile-touch-target, 44px);
         padding-inline: 10px !important;
     }
 
@@ -6944,7 +7086,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
         color: var(--color-primary, var(--sb-accent)) !important;
     }
 
-    #right-nav-panel.openDrawer #rm_print_characters_block:not(.group_overlay_mode_select) > :is(.character_select, .group_select, .bogus_folder_select):not(.inline_avatar):has(.tags_inline .tag) {
+    #right-nav-panel.openDrawer #rm_print_characters_block:not(.group_overlay_mode_select) > :is(.character_select, .group_select, .bogus_folder_select):not(.inline_avatar) {
         min-height: calc(var(--sb-character-list-avatar-size) + 46px);
     }
 

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -5883,7 +5883,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     .sb-shell-nav {
         justify-content: flex-start;
         scroll-padding-inline: 24px;
-        touch-action: none;
+        touch-action: pan-x;
     }
 
     .sb-shell-panel-scroller,
@@ -6804,17 +6804,21 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 
     #right-nav-panel.openDrawer > .sb-character-shell-header {
         flex: 0 0 auto;
-        gap: 4px;
-        padding: 12px 54px 12px 12px;
+        gap: 3px;
+        padding: 10px 52px 8px 12px;
     }
 
     #right-nav-panel.openDrawer > .sb-character-shell-header .sb-shell-close {
-        top: 10px;
-        right: 10px;
+        top: 8px;
+        right: 8px;
         width: var(--sb-mobile-touch-target, 44px);
         min-width: var(--sb-mobile-touch-target, 44px);
         height: var(--sb-mobile-touch-target, 44px);
         min-height: var(--sb-mobile-touch-target, 44px);
+    }
+
+    #right-nav-panel.openDrawer > .sb-character-shell-header .sb-shell-kicker {
+        display: none;
     }
 
     #right-nav-panel.openDrawer > .sb-character-shell-header .sb-shell-description {
@@ -7045,6 +7049,32 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     #right-nav-panel.openDrawer .sb-character-create-bar #rm_button_search {
         grid-column: auto !important;
         justify-self: start !important;
+    }
+
+    #right-nav-panel.openDrawer .rm_tag_controls {
+        display: flex;
+        flex-wrap: nowrap;
+        gap: 6px;
+        max-height: none;
+        margin-top: 6px;
+        overflow-x: auto;
+        overflow-y: hidden;
+        overscroll-behavior-x: contain;
+        scroll-padding-inline: 8px;
+        touch-action: pan-x;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
+    }
+
+    #right-nav-panel.openDrawer .rm_tag_controls::-webkit-scrollbar {
+        display: none;
+    }
+
+    #right-nav-panel.openDrawer .rm_tag_controls > .tags {
+        flex: 0 0 auto;
+        flex-wrap: nowrap;
+        align-items: center;
+        min-width: max-content;
     }
 
     #right-nav-panel.openDrawer .sb-character-create-bar #rm_button_create {

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1312,6 +1312,7 @@ body:not(.movingUI) .drawer-content.maximized {
     width: min(100vw, clamp(600px, 55vw, 760px)) !important;
     max-width: calc(100vw - 28px) !important;
     min-width: min(420px, calc(100vw - 28px)) !important;
+    overflow: hidden !important;
     left: 0 !important;
     right: 0 !important;
     margin-left: auto !important;
@@ -1345,14 +1346,25 @@ body.movingUI #right-nav-panel.openDrawer > .sb-shell-resize-handle {
     animation: sbShellContentReveal 320ms var(--sb-ease-out) both;
 }
 
+#right-nav-panel.openDrawer > .sb-character-shell-nav-wrapper,
 #right-nav-panel.openDrawer > #CharListButtonAndHotSwaps,
 #right-nav-panel.openDrawer > #rm_PinAndTabs {
     animation: sbShellContentReveal 280ms var(--sb-ease-out) both;
 }
 
+#right-nav-panel.openDrawer > .sb-character-shell-header,
 #right-nav-panel.openDrawer > .scrollableInner,
 #right-nav-panel.openDrawer > .scrollableInnerFull {
     animation: sbShellContentReveal 320ms var(--sb-ease-out) both;
+}
+
+#right-nav-panel.openDrawer > .scrollableInner,
+#right-nav-panel.openDrawer > .scrollableInnerFull {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto !important;
+    overflow-x: hidden !important;
+    -webkit-overflow-scrolling: touch;
 }
 
 .sb-shell-frame {
@@ -1693,6 +1705,426 @@ body.sb-shell-resizing * {
     opacity: var(--sb-shell-surface-opacity);
 }
 
+.sb-character-shell-header {
+    position: relative;
+    flex: 0 0 auto;
+}
+
+.sb-character-shell-nav-wrapper {
+    flex: 0 0 auto;
+}
+
+.sb-character-shell-nav .sb-shell-tab {
+    flex: 0 0 auto;
+}
+
+#right-nav-panel #rm_button_panel_pin_div,
+#right-nav-panel #rm_button_characters,
+#right-nav-panel #character_import_button,
+#right-nav-panel #external_import_button {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    margin: -1px !important;
+    padding: 0 !important;
+    overflow: hidden !important;
+    clip: rect(0 0 0 0) !important;
+    clip-path: inset(50%) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
+}
+
+#right-nav-panel:not([data-menu-type="groups"]) #rm_button_group_chats,
+#right-nav-panel[data-menu-type="groups"] #rm_button_create,
+#right-nav-panel[data-menu-type="groups"] #bulkSelectAllButton,
+#right-nav-panel[data-menu-type="groups"] #bulkDeleteButton {
+    display: none !important;
+}
+
+#right-nav-panel #CharListButtonAndHotSwaps > .flexFlowColumn.flex-container {
+    display: contents;
+}
+
+#right-nav-panel #CharListButtonAndHotSwaps {
+    min-height: 52px;
+    max-height: 52px;
+    padding: var(--sb-shell-space-sm) var(--sb-shell-panel-padding-inline);
+    border-bottom: 1px solid color-mix(in srgb, var(--sb-shell-border) 76%, transparent);
+    overflow: hidden;
+}
+
+#right-nav-panel #HotSwapWrapper {
+    align-items: center;
+    gap: 10px;
+    margin: 0 !important;
+    min-height: 0;
+    overflow: hidden;
+}
+
+#right-nav-panel .sb-character-favorites-label {
+    flex: 0 0 auto;
+    font-size: var(--sb-type-caption);
+    font-weight: var(--sb-weight-title);
+    letter-spacing: var(--sb-tracking-kicker);
+    line-height: var(--sb-line-compact);
+    text-transform: uppercase;
+    opacity: 0.72;
+}
+
+#right-nav-panel #HotSwapWrapper .hotswap {
+    min-width: 0;
+    flex: 1 1 auto;
+    max-height: 36px;
+    margin: 0;
+    align-items: center;
+    flex-wrap: nowrap;
+    overflow: hidden;
+}
+
+#right-nav-panel #HotSwapWrapper .hotswap > small {
+    width: 100%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+}
+
+#right-nav-panel #HotSwapWrapper .hotswap > small > span {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+}
+
+#right-nav-panel #HotSwapWrapper .hotswap > .avatar {
+    flex: 0 0 34px !important;
+    box-sizing: border-box;
+    margin: 0 !important;
+    padding: 0 !important;
+}
+
+#right-nav-panel #HotSwapWrapper .hotswap .avatar,
+#right-nav-panel #HotSwapWrapper .hotswap .avatar img {
+    width: 34px !important;
+    min-width: 34px !important;
+    max-width: 34px !important;
+    height: 34px !important;
+    min-height: 34px !important;
+    max-height: 34px !important;
+}
+
+body.big-avatars #right-nav-panel #HotSwapWrapper .hotswap > .avatar,
+body.charListGrid #right-nav-panel #HotSwapWrapper .hotswap > .avatar,
+body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select, .group_select) {
+    width: 34px !important;
+    min-width: 34px !important;
+    max-width: 34px !important;
+    height: 34px !important;
+    min-height: 34px !important;
+    max-height: 34px !important;
+    flex: 0 0 34px !important;
+}
+
+#right-nav-panel .sb-character-create-bar {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: var(--sb-shell-space-sm);
+    margin: var(--sb-shell-space-sm) var(--sb-shell-panel-padding-inline) 0;
+    padding: var(--sb-shell-space-sm);
+    border: 1px solid color-mix(in srgb, var(--sb-shell-border) 84%, transparent);
+    border-radius: var(--sb-radius-md, 16px);
+    background: color-mix(in srgb, var(--sb-shell-surface) 76%, transparent);
+}
+
+#right-nav-panel .sb-character-create-bar #rm_button_bar {
+    flex: 0 0 auto;
+    min-width: 0;
+    width: auto !important;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: nowrap;
+}
+
+#right-nav-panel .sb-character-create-bar #character_sort_order {
+    flex: 0 0 auto;
+    width: auto !important;
+    min-width: 9.75em;
+    max-width: 11em;
+    height: 40px;
+    border-radius: var(--sb-radius-button, 14px);
+}
+
+#right-nav-panel .sb-character-create-bar #rm_button_search {
+    flex: 0 0 40px;
+    width: 40px;
+    min-width: 40px;
+    max-width: 40px;
+    height: 40px;
+    min-height: 40px;
+    max-height: 40px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0;
+    border-radius: var(--sb-radius-button, 14px);
+}
+
+#right-nav-panel .sb-character-create-bar #rm_button_create,
+#right-nav-panel .sb-character-create-bar #rm_button_group_chats {
+    width: auto;
+    min-width: max-content;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 0 var(--sb-shell-space-lg) !important;
+    aspect-ratio: auto;
+    border-radius: var(--sb-radius-button, 14px);
+    border: 1px solid color-mix(in srgb, var(--color-primary, var(--sb-accent)) 28%, var(--sb-shell-border) 72%);
+    background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 14%, var(--sb-shell-surface) 86%);
+}
+
+#right-nav-panel .sb-character-create-bar #rm_button_group_chats {
+    margin: 0;
+}
+
+#right-nav-panel .sb-character-create-bar #rm_button_create::after {
+    content: 'Create New Character';
+    font-family: var(--mainFontFamily);
+    font-size: var(--sb-type-caption);
+    font-weight: var(--sb-weight-title);
+    line-height: var(--sb-line-compact);
+}
+
+#right-nav-panel .sb-character-create-bar #rm_button_group_chats::after {
+    content: 'Create New Group';
+    font-family: var(--mainFontFamily);
+    font-size: var(--sb-type-caption);
+    font-weight: var(--sb-weight-title);
+    line-height: var(--sb-line-compact);
+}
+
+#right-nav-panel .sb-character-create-bar #rm_print_characters_pagination {
+    flex: 0 1 auto;
+    min-width: 0;
+    margin-left: auto !important;
+    justify-content: flex-start;
+    padding: 0;
+}
+
+#right-nav-panel .sb-character-create-bar .paginationjs {
+    justify-content: flex-start;
+}
+
+#right-nav-panel[data-menu-type="groups"] .sb-character-create-bar {
+    justify-content: flex-start;
+}
+
+#right-nav-panel[data-menu-type="groups"] .sb-character-create-bar #rm_button_create {
+    display: none !important;
+}
+
+#right-nav-panel:not([data-menu-type="groups"]) .sb-character-create-bar #rm_button_group_chats {
+    display: none !important;
+}
+
+#right-nav-panel[data-menu-type="groups"] .sb-character-create-bar #bulkEditButton.disabled {
+    opacity: 0.54;
+    cursor: not-allowed;
+}
+
+#right-nav-panel[data-menu-type="characters"] > #rm_PinAndTabs,
+#right-nav-panel[data-menu-type="groups"] > #rm_PinAndTabs,
+#right-nav-panel[data-menu-type="editor_empty"] > #rm_PinAndTabs,
+#right-nav-panel[data-menu-type="persona"] > #rm_PinAndTabs {
+    display: none !important;
+}
+
+.sb-character-editor-empty {
+    min-height: min(360px, 54vh);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 18px;
+    padding: 36px 18px;
+    text-align: center;
+}
+
+.sb-character-editor-empty[hidden] {
+    display: none !important;
+}
+
+.sb-character-editor-empty-icon {
+    width: 64px;
+    height: 64px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--sb-radius-lg, 22px);
+    border: 1px solid color-mix(in srgb, var(--sb-shell-border) 82%, transparent);
+    background: color-mix(in srgb, var(--sb-shell-surface) 78%, transparent);
+    color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 72%, var(--SmartThemeBodyColor));
+    font-size: calc(var(--mainFontSize) * 1.7);
+}
+
+.sb-character-editor-empty-copy {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    max-width: 42ch;
+}
+
+.sb-character-editor-empty-copy h3,
+.sb-character-editor-empty-copy p {
+    margin: 0;
+}
+
+.sb-character-editor-empty-copy h3 {
+    font-size: var(--sb-type-title);
+    line-height: var(--sb-line-title);
+}
+
+.sb-character-editor-empty-copy p {
+    opacity: 0.74;
+    line-height: var(--sb-line-body);
+}
+
+.sb-character-editor-empty-actions {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: center;
+    gap: 10px;
+}
+
+.sb-character-editor-empty-actions .menu_button {
+    min-height: 42px;
+    margin: 0;
+    gap: 8px;
+}
+
+.sb-character-persona-panel[hidden] {
+    display: none !important;
+}
+
+.sb-character-persona-panel {
+    min-height: 0;
+    display: block;
+}
+
+.sb-character-persona-panel #persona-management-button,
+.sb-character-persona-panel #PersonaManagement {
+    width: 100% !important;
+}
+
+.sb-character-import-panel[hidden] {
+    display: none !important;
+}
+
+.sb-character-import-panel {
+    min-height: min(420px, 58vh);
+    display: flex;
+    flex-direction: column;
+    gap: var(--sb-shell-space-lg);
+    padding: var(--sb-shell-space-xl) var(--sb-shell-panel-padding-inline) var(--sb-shell-space-2xl);
+}
+
+.sb-character-import-intro {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    max-width: 62ch;
+}
+
+.sb-character-import-intro h3,
+.sb-character-import-intro p {
+    margin: 0;
+}
+
+.sb-character-import-intro h3 {
+    font-size: var(--sb-type-title);
+    line-height: var(--sb-line-title);
+}
+
+.sb-character-import-intro p {
+    opacity: 0.74;
+    line-height: var(--sb-line-body);
+}
+
+.sb-character-import-actions {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sb-shell-space-sm);
+    max-width: 720px;
+}
+
+.sb-character-import-action {
+    appearance: none;
+    width: 100%;
+    min-height: 92px;
+    display: grid;
+    grid-template-columns: 48px minmax(0, 1fr);
+    align-items: center;
+    gap: 14px;
+    padding: var(--sb-shell-space-lg);
+    border: 1px solid color-mix(in srgb, var(--sb-shell-border) 82%, transparent);
+    border-radius: var(--sb-radius-lg, 22px);
+    background: color-mix(in srgb, var(--sb-shell-surface) 78%, transparent);
+    color: var(--SmartThemeBodyColor);
+    text-align: left;
+    cursor: pointer;
+    transition: transform var(--sb-transition-fast), background-color var(--sb-transition-fast), border-color var(--sb-transition-fast);
+}
+
+.sb-character-import-action:hover {
+    transform: translateY(-1px);
+    background: color-mix(in srgb, var(--sb-button-hover) 72%, transparent);
+}
+
+.sb-character-import-action:focus-visible {
+    outline: none;
+    border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 44%, var(--sb-shell-border) 56%);
+    box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--sb-focus-ring) 58%, transparent);
+}
+
+.sb-character-import-action > i {
+    width: 48px;
+    height: 48px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--sb-radius-md, 16px);
+    background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 14%, transparent);
+    color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 72%, var(--SmartThemeBodyColor));
+    font-size: calc(var(--mainFontSize) * 1.35);
+}
+
+.sb-character-import-action > span {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.sb-character-import-action strong,
+.sb-character-import-action small {
+    overflow-wrap: anywhere;
+}
+
+.sb-character-import-action strong {
+    font-size: var(--sb-type-control);
+    line-height: var(--sb-line-title);
+}
+
+.sb-character-import-action small {
+    opacity: 0.72;
+    line-height: var(--sb-line-body);
+}
+
 .sb-shell-close {
     position: absolute;
     top: 18px;
@@ -1736,44 +2168,6 @@ body.sb-shell-resizing * {
     outline: none;
     border-radius: var(--sb-radius-sm);
     box-shadow: 0 0 0 2px color-mix(in srgb, var(--sb-focus-ring) 72%, transparent);
-}
-
-.sb-character-close,
-.sb-character-back-to-list {
-    display: none;
-    flex: 0 0 auto;
-}
-
-.sb-character-right-lock {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    flex: 0 0 auto;
-    margin-left: 8px;
-}
-
-.sb-character-close,
-.sb-character-back-to-list {
-    margin-left: 0;
-}
-
-.sb-character-right-lock + .sb-character-close,
-.sb-character-back-to-list + .sb-character-close {
-    margin-left: 0;
-}
-
-#right-nav-panel[data-menu-type="character_edit"] .sb-character-back-to-list,
-#right-nav-panel[data-menu-type="create"] .sb-character-back-to-list {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.sb-character-right-lock.is-active {
-    color: var(--color-primary, var(--sb-accent));
-    border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 34%, transparent);
-    background: color-mix(in srgb, var(--sb-button-hover) 92%, transparent);
-    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-primary, var(--sb-accent)) 18%, transparent);
 }
 
 #sb_character_editor_exit {
@@ -3859,6 +4253,963 @@ body.sb-shell-resizing * {
     white-space: nowrap;
 }
 
+#right-nav-panel .char-button-toolbar {
+    gap: 0;
+}
+
+#right-nav-panel .char-button-group-utility:empty {
+    display: none;
+}
+
+#right-nav-panel .char-button-toolbar > .char-button-group-utility:not(.sb-character-editor-side-actions) {
+    display: none;
+}
+
+#right-nav-panel .sb-character-editor-controls-row {
+    width: 100%;
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    flex-wrap: nowrap;
+    min-width: 0;
+}
+
+#right-nav-panel #avatar_div {
+    display: flex !important;
+    flex-direction: column !important;
+    flex-wrap: nowrap !important;
+    align-items: stretch !important;
+    justify-content: flex-start !important;
+    gap: 6px;
+}
+
+#right-nav-panel #avatar_controls {
+    flex: 1 1 auto;
+    min-width: 0;
+    align-items: flex-start;
+    gap: 8px;
+    padding-block: 10px 0;
+    justify-content: flex-start;
+}
+
+#right-nav-panel #avatar_controls > .form_create_bottom_buttons_block,
+#right-nav-panel #avatar_controls > .sb-character-editor-side-actions,
+#right-nav-panel #avatar_controls > #tags_div,
+#right-nav-panel #avatar_controls > label[for="char-management-dropdown"] {
+    margin: 0;
+}
+
+#right-nav-panel #avatar_controls > label[for="char-management-dropdown"] {
+    flex: 0 0 auto;
+    min-width: min(9.5em, 100%);
+    max-width: 12em;
+    align-self: flex-start;
+}
+
+#right-nav-panel #avatar_controls #char-management-dropdown {
+    width: auto;
+    min-width: 9.5em;
+    max-width: 12em;
+    height: 40px;
+    margin: 0;
+    border-radius: var(--sb-radius-button, 14px);
+}
+
+#right-nav-panel #avatar_controls .form_create_bottom_buttons_block {
+    flex: 0 1 auto;
+    align-items: flex-start;
+    justify-content: flex-start;
+}
+
+#right-nav-panel #avatar_controls .sb-character-editor-header-spacer {
+    flex: 1 1 96px;
+    min-width: 24px;
+    height: 1px;
+}
+
+#right-nav-panel #avatar_controls .char-button-toolbar,
+#right-nav-panel #avatar_controls .char-button-group-icons {
+    align-items: center;
+}
+
+#right-nav-panel #avatar_controls .char-button-group-icons {
+    min-height: 40px;
+    padding: 4px;
+    gap: 4px;
+}
+
+#right-nav-panel #avatar_controls .char-button-group-icons .menu_button {
+    width: 40px;
+    min-width: 40px;
+    max-width: 40px;
+    height: 40px;
+    min-height: 40px;
+    max-height: 40px;
+    padding: 0 !important;
+    margin: 0;
+    border-radius: var(--sb-radius-button, 14px);
+}
+
+#right-nav-panel .sb-character-editor-side-actions {
+    flex: 0 0 auto;
+    flex-wrap: nowrap;
+    align-self: flex-start;
+    min-height: 40px;
+    margin-top: 10px;
+    padding: 4px;
+    gap: 4px;
+}
+
+#right-nav-panel .sb-character-editor-side-actions #favorite_button,
+#right-nav-panel .sb-character-editor-side-actions #advanced_div {
+    width: auto;
+    min-width: max(var(--sb-control-icon-physical-size, 40px), 4.5rem);
+    height: 40px;
+    min-height: 40px;
+    max-height: 40px;
+    max-width: none;
+    aspect-ratio: auto;
+    padding-inline: 10px !important;
+    gap: 4px;
+    color: var(--SmartThemeBodyColor);
+    border: 1px solid color-mix(in srgb, var(--color-primary, var(--sb-accent)) 20%, transparent);
+    background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 8%, transparent);
+}
+
+#right-nav-panel .sb-character-editor-side-actions #favorite_button::after,
+#right-nav-panel .sb-character-editor-side-actions #advanced_div::after {
+    content: attr(data-label);
+    font-family: var(--mainFontFamily);
+    font-size: calc(var(--mainFontSize) * 0.68);
+    font-weight: 700;
+    line-height: 1;
+    white-space: nowrap;
+}
+
+#right-nav-panel .sb-character-editor-side-actions #favorite_button.fav_on {
+    color: var(--active);
+    border-color: color-mix(in srgb, var(--active) 46%, transparent);
+    background: color-mix(in srgb, var(--active) 14%, transparent);
+}
+
+#right-nav-panel .sb-character-editor-side-actions #advanced_div:hover,
+#right-nav-panel .sb-character-editor-side-actions #favorite_button:hover {
+    background: color-mix(in srgb, var(--sb-button-hover) 86%, transparent);
+}
+
+#right-nav-panel #avatar_controls > #tags_div {
+    flex: 0 1 220px;
+    min-width: min(220px, 100%);
+    max-width: 220px;
+    align-self: flex-start;
+    margin: 0;
+}
+
+#right-nav-panel .sb-character-editor-controls-row > #avatar_div_div {
+    flex: 0 0 var(--avatar-base-width);
+    width: var(--avatar-base-width) !important;
+    min-width: var(--avatar-base-width) !important;
+    max-width: var(--avatar-base-width) !important;
+    height: var(--avatar-base-height) !important;
+    min-height: var(--avatar-base-height) !important;
+    max-height: var(--avatar-base-height) !important;
+    margin: 10px 8px 0 10px !important;
+}
+
+#right-nav-panel .sb-character-editor-controls-row > #avatar_div_div img {
+    width: 100% !important;
+    height: 100% !important;
+}
+
+#right-nav-panel #avatar_controls > #tags_div .tag_controls {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 40px;
+    gap: 6px;
+    align-items: center;
+    min-height: 40px;
+}
+
+#right-nav-panel #avatar_controls > #tags_div #tagInput {
+    min-width: 0;
+    width: 100%;
+    height: 40px;
+    margin: 0;
+}
+
+#right-nav-panel #avatar_controls > #tags_div .tags_view {
+    width: 40px;
+    min-width: 40px;
+    max-width: 40px;
+    height: 40px;
+    min-height: 40px;
+    max-height: 40px;
+    margin: 0;
+    padding: 0 !important;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#right-nav-panel #avatar_div > #tagList {
+    flex: 0 0 auto;
+    width: 100%;
+    margin: 2px 10px 0;
+    padding: 6px 8px;
+    min-height: 34px;
+    align-items: center;
+    border: 1px solid color-mix(in srgb, var(--sb-shell-border) 72%, transparent);
+    border-radius: var(--sb-radius-md, 16px);
+    background: color-mix(in srgb, var(--sb-shell-surface) 52%, transparent);
+    overflow: visible;
+}
+
+#right-nav-panel #avatar_div > #tagList:empty {
+    display: none;
+}
+
+#right-nav-panel #avatar_div > #tagList .tag {
+    margin: 0;
+}
+
+#right-nav-panel #result_info #creators_note_styles_button,
+#right-nav-panel #result_info #spoiler_free_desc_button,
+#right-nav-panel #result_info #character_open_media_overrides {
+    width: 34px;
+    min-width: 34px;
+    max-width: 34px;
+    height: 34px;
+    min-height: 34px;
+    max-height: 34px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0;
+    padding: 0 !important;
+    border-radius: var(--sb-radius-sm, 10px);
+}
+
+#right-nav-panel #result_info #character_open_media_overrides span {
+    display: none;
+}
+
+#right-nav-panel[data-menu-type="character_edit"] #rm_button_selected_ch h2 {
+    cursor: text;
+    text-decoration: underline dotted color-mix(in srgb, currentColor 38%, transparent);
+    text-underline-offset: 4px;
+}
+
+#right-nav-panel[data-menu-type="character_edit"] #rm_button_selected_ch h2:hover {
+    color: var(--color-primary, var(--sb-accent));
+}
+
+#right-nav-panel .sb-character-shell-header .sb-shell-title {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+#right-nav-panel .sb-character-shell-header .sb-character-title-help {
+    width: 28px;
+    height: 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#right-nav-panel #PersonaManagement > .flex-container.wide100p.alignitemscenter.spaceBetween.flexNoGap:first-child > .flex-container.alignItemsBaseline.wide100p > .flex1 {
+    display: none !important;
+}
+
+#character_popup.open,
+#character_popup[style*="display: block"],
+#character_popup[style*="display:block"] {
+    display: flex !important;
+}
+
+#character_popup {
+    overflow: hidden !important;
+}
+
+#character_popup_header {
+    position: relative;
+    z-index: 5;
+    flex: 0 0 auto;
+    background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 96%, var(--SmartThemeBodyColor) 4%);
+    border-bottom: 1px solid color-mix(in srgb, var(--SmartThemeBorderColor) 72%, transparent);
+    margin: -10px -14px 0;
+    padding: 10px 14px;
+    border-radius: 0;
+}
+
+#character_popup_body {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding-top: 6px;
+    -webkit-overflow-scrolling: touch;
+}
+
+#character_popup > #character_popup_header + hr {
+    display: none !important;
+}
+
+#character_popup_body > hr:first-child {
+    display: none !important;
+}
+
+#right-nav-panel .sb-creator-notes-compact {
+    margin-top: 8px;
+}
+
+#right-nav-panel .sb-creator-notes-compact > .inline-drawer-toggle {
+    min-height: 38px;
+    align-items: center;
+    border-radius: var(--sb-radius-md, 16px);
+    background: color-mix(in srgb, var(--sb-shell-surface) 60%, transparent);
+}
+
+#right-nav-panel .sb-creator-notes-compact #creators_notes_div {
+    min-height: 34px;
+    padding: 0 8px;
+    align-items: center;
+    font-size: var(--sb-type-control);
+}
+
+#right-nav-panel .sb-creator-notes-compact .inline-drawer-content {
+    padding-top: 4px;
+}
+
+#right-nav-panel[data-menu-type="create"] #avatar_controls .char-button-group-icons #create_button_label {
+    flex: 0 0 auto;
+    width: auto !important;
+    min-width: max-content;
+    max-width: none;
+    height: 40px;
+    min-height: 40px;
+    max-height: 40px;
+    padding-inline: var(--sb-shell-space-md) !important;
+    gap: 8px;
+    aspect-ratio: auto;
+    border-radius: var(--sb-radius-pill, 999px);
+    color: var(--SmartThemeBodyColor);
+    border: 1px solid color-mix(in srgb, var(--color-primary, var(--sb-accent)) 34%, var(--sb-shell-border) 66%);
+    background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 16%, var(--sb-shell-surface) 84%);
+}
+
+#right-nav-panel[data-menu-type="create"] #avatar_controls .char-button-group-icons #create_button_label::before {
+    font-size: calc(var(--mainFontSize) * 1.15);
+}
+
+#right-nav-panel[data-menu-type="create"] #avatar_controls .char-button-group-icons #create_button_label span {
+    display: inline;
+    font-family: var(--mainFontFamily);
+    font-size: var(--sb-type-caption);
+    font-weight: var(--sb-weight-title);
+    line-height: var(--sb-line-compact);
+    white-space: nowrap;
+}
+
+#right-nav-panel:not([data-menu-type="create"]) #avatar_controls .char-button-group-icons #create_button_label span {
+    display: none;
+}
+
+#right-nav-panel #avatar_controls .char-button-group-icons #world_button span {
+    display: none;
+}
+
+#right-nav-panel[data-menu-type="create"] #avatar_controls .char-button-group-icons #world_button {
+    flex: 0 0 auto;
+    width: auto !important;
+    min-width: 9.5rem;
+    max-width: none;
+    height: 40px;
+    min-height: 40px;
+    max-height: 40px;
+    padding-inline: var(--sb-shell-space-md) !important;
+    gap: 8px;
+    aspect-ratio: auto;
+    border-radius: var(--sb-radius-pill, 999px);
+    border: 1px solid color-mix(in srgb, var(--color-primary, var(--sb-accent)) 28%, var(--sb-shell-border) 72%);
+    background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 10%, var(--sb-shell-surface) 90%);
+}
+
+#right-nav-panel[data-menu-type="create"] #avatar_controls .char-button-group-icons #world_button span,
+#right-nav-panel[data-menu-type="group_create"] #avatar_controls .char-button-group-icons #world_button span {
+    display: inline;
+    font-family: var(--mainFontFamily);
+    font-size: var(--sb-type-caption);
+    font-weight: var(--sb-weight-title);
+    line-height: var(--sb-line-compact);
+    white-space: nowrap;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_chats_block {
+    gap: var(--sb-shell-space-sm);
+    padding-inline: var(--sb-shell-panel-padding-inline);
+    align-items: stretch;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_chats_block > * {
+    width: 100%;
+    box-sizing: border-box;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_chats_block > .inline-drawer {
+    gap: 6px;
+    margin: 0;
+    border: 1px solid color-mix(in srgb, var(--sb-shell-border) 72%, transparent);
+    border-radius: var(--sb-radius-md, 16px);
+    background: color-mix(in srgb, var(--sb-shell-surface) 50%, transparent);
+    overflow: hidden;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_chats_block > .inline-drawer > .inline-drawer-header {
+    min-height: 34px;
+    padding: 7px 10px;
+    justify-content: flex-start;
+    border-bottom: 1px solid color-mix(in srgb, var(--sb-shell-border) 54%, transparent);
+    background: color-mix(in srgb, var(--sb-shell-surface) 64%, transparent);
+    cursor: default;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_chats_block > .inline-drawer > .inline-drawer-header .inline-drawer-icon {
+    display: none !important;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_chats_block > .inline-drawer > .inline-drawer-content {
+    display: block !important;
+    height: auto !important;
+    max-height: none !important;
+    padding: 8px 10px 10px;
+    margin: 0;
+    overflow: visible !important;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #group-metadata-controls {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sb-shell-space-sm);
+    margin: 0;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_chats_block .text_pole,
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_chats_block select {
+    margin-block: 0;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #group-metadata-controls > .flex-container.wide100p,
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #group-metadata-controls > label[for="group-chat-lorebook-dropdown"] {
+    margin: 0;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #group-chat-lorebook-dropdown,
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_chat_name,
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #groupTagInput {
+    min-height: 40px;
+    border-radius: var(--sb-radius-button, 14px);
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #group_tags_div {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-settings-section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-self: stretch !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    inline-size: 100% !important;
+    max-inline-size: 100% !important;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    box-sizing: border-box;
+    flex: 0 0 auto;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #group-metadata-controls {
+    width: 100%;
+    margin-inline: 0;
+    box-sizing: border-box;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-settings-title {
+    min-height: 34px;
+    padding: 0 8px;
+    align-items: center;
+    font-size: var(--sb-type-control);
+    border-radius: var(--sb-radius-button, 14px);
+    background: color-mix(in srgb, var(--sb-shell-surface) 60%, transparent);
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #group_tags_div .tag_controls {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 40px;
+    gap: 6px;
+    align-items: center;
+    min-height: 40px;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #groupTagInput {
+    width: 100%;
+    min-width: 0;
+    height: 40px;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #group_tags_div .tags_view {
+    width: 40px;
+    min-width: 40px;
+    max-width: 40px;
+    height: 40px;
+    min-height: 40px;
+    max-height: 40px;
+    padding: 0 !important;
+    border-radius: var(--sb-radius-button, 14px);
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #groupTagList {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    width: 100%;
+    min-height: 34px;
+    padding: 6px 8px;
+    align-items: center;
+    border: 1px solid color-mix(in srgb, var(--sb-shell-border) 72%, transparent);
+    border-radius: var(--sb-radius-md, 16px);
+    background: color-mix(in srgb, var(--sb-shell-surface) 52%, transparent);
+    box-sizing: border-box;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #groupTagList:empty {
+    display: none;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_top_bar {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: var(--sb-shell-space-sm);
+    align-items: center;
+    width: 100%;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    box-sizing: border-box;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_top_bar > .sb-group-editor-primary {
+    width: 100%;
+    max-width: 100%;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_top_bar > div:first-child {
+    grid-column: 1;
+    grid-row: 1;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_top_bar .add_avatar {
+    margin: 0 !important;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-primary {
+    grid-column: 2;
+    grid-row: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-name-row {
+    display: grid;
+    grid-template-columns: minmax(120px, 190px) auto minmax(0, 1fr) minmax(150px, 220px) minmax(150px, 220px);
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    min-width: 0;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_chat_name {
+    width: 100%;
+    min-width: 0;
+}
+
+#right-nav-panel[data-menu-type="group_edit"] #rm_group_chat_name {
+    display: none;
+}
+
+#right-nav-panel[data-menu-type="group_edit"] .sb-group-editor-name-row {
+    grid-template-columns: auto minmax(0, 1fr) minmax(150px, 220px) minmax(150px, 220px);
+}
+
+#right-nav-panel[data-menu-type="group_edit"] .sb-group-editor-action-cluster {
+    grid-column: 1;
+}
+
+#right-nav-panel[data-menu-type="group_edit"] .sb-group-editor-name-row::after {
+    grid-column: 2;
+}
+
+#right-nav-panel[data-menu-type="group_edit"] .sb-group-editor-name-row label {
+    grid-column: 3;
+}
+
+#right-nav-panel[data-menu-type="group_edit"] #group_tags_div {
+    grid-column: 4;
+}
+
+#right-nav-panel[data-menu-type="group_edit"] #rm_button_selected_ch h2 {
+    cursor: text;
+    text-decoration: underline dotted color-mix(in srgb, currentColor 38%, transparent);
+    text-underline-offset: 4px;
+}
+
+#right-nav-panel[data-menu-type="group_edit"] #rm_button_selected_ch h2:hover {
+    color: var(--color-primary, var(--sb-accent));
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-action-cluster {
+    grid-column: 2;
+    grid-row: 1;
+    display: inline-flex !important;
+    align-items: center;
+    justify-content: flex-start;
+    flex-wrap: nowrap;
+    width: max-content;
+    min-width: 0;
+    margin: 0;
+    gap: 8px;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-side-actions {
+    display: inline-flex !important;
+    align-items: center;
+    justify-content: flex-start;
+    flex-wrap: nowrap;
+    min-height: 40px;
+    width: max-content;
+    margin: 0;
+    padding: 4px;
+    gap: 4px;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-utility-actions {
+    display: inline-flex !important;
+    align-items: center;
+    justify-content: flex-start;
+    flex-wrap: nowrap;
+    min-height: 40px;
+    width: max-content;
+    margin: 0;
+    padding: 4px;
+    gap: 4px;
+    border: 1px solid color-mix(in srgb, var(--sb-shell-border) 72%, transparent);
+    border-radius: var(--sb-radius-button, 14px);
+    background: color-mix(in srgb, var(--sb-shell-surface) 50%, transparent);
+    box-sizing: border-box;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) :is(.sb-group-editor-side-actions, .sb-group-editor-utility-actions) .menu_button {
+    width: 40px;
+    min-width: 40px;
+    height: 40px;
+    min-height: 40px;
+    max-height: 40px;
+    margin: 0;
+    padding: 0 !important;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--sb-radius-button, 14px);
+}
+
+#right-nav-panel[data-menu-type="group_create"] .sb-group-editor-utility-actions #rm_group_submit {
+    width: auto;
+    min-width: max-content;
+    max-width: none;
+    aspect-ratio: auto;
+    padding-inline: var(--sb-shell-space-md) !important;
+    gap: 6px;
+}
+
+#right-nav-panel[data-menu-type="group_create"] .sb-group-editor-utility-actions #rm_group_submit::after {
+    content: attr(data-label);
+    font-family: var(--mainFontFamily);
+    font-size: calc(var(--mainFontSize) * 0.78);
+    font-weight: 700;
+    line-height: 1;
+    white-space: nowrap;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-utility-actions #rm_group_delete {
+    color: var(--color-danger, var(--sb-color-danger, #fb7185));
+    border: 1px solid color-mix(in srgb, var(--color-danger, var(--sb-color-danger, #fb7185)) 42%, transparent);
+    background: color-mix(in srgb, var(--color-danger, var(--sb-color-danger, #fb7185)) 14%, transparent);
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-side-actions :is(#group_favorite_button, #rm_group_scenario) {
+    width: auto;
+    min-width: max(var(--sb-control-icon-physical-size, 40px), 4.5rem);
+    height: 40px;
+    min-height: 40px;
+    max-height: 40px;
+    max-width: none;
+    aspect-ratio: auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding-inline: 10px !important;
+    gap: 4px;
+    color: var(--SmartThemeBodyColor);
+    border: 1px solid color-mix(in srgb, var(--color-primary, var(--sb-accent)) 20%, transparent);
+    border-radius: var(--sb-radius-button, 14px);
+    background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 8%, transparent);
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-side-actions :is(#group_favorite_button, #rm_group_scenario)::after {
+    content: attr(data-label);
+    font-family: var(--mainFontFamily);
+    font-size: calc(var(--mainFontSize) * 0.68);
+    font-weight: 700;
+    line-height: 1;
+    white-space: nowrap;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-side-actions #group_favorite_button.fav_on {
+    color: var(--active);
+    border-color: color-mix(in srgb, var(--active) 46%, transparent);
+    background: color-mix(in srgb, var(--active) 14%, transparent);
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-name-row label {
+    grid-column: 4;
+    grid-row: 1;
+    display: block;
+    width: 100%;
+    height: 40px;
+    margin: 0;
+    min-width: 0;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-name-row #group-chat-lorebook-dropdown {
+    width: 100%;
+    min-width: 0;
+    height: 40px;
+    margin: 0;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #group_tags_div {
+    grid-column: 5;
+    grid-row: 1;
+    min-width: 0;
+    width: 100%;
+    align-self: center;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) .sb-group-editor-name-row::after {
+    content: '';
+    grid-column: 3;
+    grid-row: 1;
+    min-width: 0;
+}
+
+@media screen and (max-width: 900px) {
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #group_tags_div {
+        grid-column: 1 / -1;
+        width: min(448px, 100%);
+        justify-self: end;
+    }
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_buttons {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(140px, 1fr));
+    gap: var(--sb-shell-space-sm);
+    width: 100%;
+    min-width: 0;
+    padding: 0;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_buttons > .flex1 {
+    min-width: 150px;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_buttons > div {
+    min-width: 0;
+    gap: 5px;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_buttons label {
+    font-size: var(--sb-type-caption);
+    line-height: var(--sb-line-compact);
+    opacity: 0.78;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_buttons select,
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_buttons textarea,
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_buttons input[type="number"] {
+    width: 100%;
+    min-width: 0;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack {
+    display: grid;
+    grid-template-columns: auto minmax(240px, 0.9fr) minmax(360px, 1.1fr);
+    align-items: start;
+    gap: var(--sb-shell-space-sm);
+    width: 100%;
+    min-width: 0;
+    padding-top: var(--sb-shell-space-xs);
+    border-top: 1px solid color-mix(in srgb, var(--sb-shell-border) 58%, transparent);
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack > .flex1,
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack > .group_schedule_controls {
+    min-width: 0;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack > .group_schedule_controls {
+    margin-left: 0;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack > #rm_button_back_from_group {
+    display: none !important;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack .menu_button {
+    width: 40px;
+    min-width: 40px;
+    height: 40px;
+    min-height: 40px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 !important;
+    border-radius: var(--sb-radius-button, 14px);
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack > #rm_group_restore_avatar {
+    grid-column: 1;
+    grid-row: 1;
+    position: static;
+    transform: none;
+    margin-left: 0 !important;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack > #rm_group_restore_avatar {
+    justify-self: start;
+    margin-left: 46px !important;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack > .flex1 {
+    grid-column: 2;
+    grid-row: 1;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 6px;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack > .flex1 > .checkbox_label {
+    display: grid;
+    grid-template-columns: 18px minmax(0, 1fr);
+    align-items: center;
+    column-gap: 8px;
+    min-width: 0;
+    white-space: normal;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack > .flex1 > :is(#rm_group_automode_label, #rm_group_auto_dm_cooldown_label) {
+    grid-template-columns: 18px minmax(8em, 1fr) minmax(4.5em, 5.5em) max-content;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_auto_dm_cooldown_label {
+    grid-template-columns: minmax(18px, 18px) minmax(8em, 1fr) minmax(4.5em, 5.5em) max-content !important;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #rm_group_auto_dm_cooldown_label::before {
+    content: '';
+    width: 18px;
+    height: 18px;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack > .flex1 input[type="number"] {
+    width: 100%;
+    min-width: 0;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack > .group_schedule_controls {
+    grid-column: 3;
+    grid-row: 1;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack > .group_schedule_controls > .flex-container:first-child {
+    display: grid;
+    grid-template-columns: max-content max-content minmax(max-content, 1fr);
+    align-items: center;
+    justify-content: stretch;
+    column-gap: var(--sb-shell-space-sm);
+    row-gap: 6px;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack > .group_schedule_controls > .flex-container:first-child > .checkbox_label {
+    display: grid;
+    grid-template-columns: 18px max-content;
+    align-items: center;
+    column-gap: 8px;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack #rm_group_generate_schedule {
+    width: auto !important;
+    inline-size: auto !important;
+    min-width: max-content !important;
+    min-inline-size: max-content !important;
+    max-width: none !important;
+    max-inline-size: none !important;
+    height: 40px;
+    min-height: 40px;
+    max-height: 40px;
+    justify-self: end;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding-inline: var(--sb-shell-space-lg) !important;
+    white-space: nowrap;
+    aspect-ratio: auto !important;
+    overflow: visible;
+}
+
+#right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack #rm_group_generate_schedule span {
+    display: inline;
+    min-width: max-content;
+    white-space: nowrap;
+}
+
+@media screen and (max-width: 1180px) {
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack > :is(#rm_group_submit, #rm_group_restore_avatar),
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack > .flex1,
+    #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack > .group_schedule_controls {
+        grid-column: 1;
+        grid-row: auto;
+        margin-left: 0;
+        transform: none;
+    }
+}
+
 @media screen and (max-width: 768px) {
     .sb-desktop-setting {
         display: none !important;
@@ -4749,8 +6100,7 @@ body.sb-shell-resizing * {
         display: none;
     }
 
-    .sb-shell-close,
-    .sb-character-close {
+    .sb-shell-close {
         display: inline-flex;
         align-items: center;
         justify-content: center;
@@ -5294,26 +6644,57 @@ body.sb-shell-resizing * {
         display: none !important;
     }
 
+    #right-nav-panel.openDrawer > .sb-character-shell-nav-wrapper {
+        flex: 0 0 auto;
+    }
+
+    #right-nav-panel.openDrawer .sb-character-shell-nav {
+        justify-content: center;
+        padding: 8px var(--sb-shell-panel-padding-inline);
+        gap: 6px;
+    }
+
+    #right-nav-panel.openDrawer .sb-character-shell-nav .sb-shell-tab {
+        min-height: 38px;
+        padding: 7px 10px;
+        border-radius: 10px;
+    }
+
+    #right-nav-panel.openDrawer > .sb-character-shell-header {
+        flex: 0 0 auto;
+        gap: 4px;
+        padding: 12px 54px 12px 12px;
+    }
+
+    #right-nav-panel.openDrawer > .sb-character-shell-header .sb-shell-close {
+        top: 10px;
+        right: 10px;
+        width: var(--sb-mobile-touch-target, 44px);
+        min-width: var(--sb-mobile-touch-target, 44px);
+        height: var(--sb-mobile-touch-target, 44px);
+        min-height: var(--sb-mobile-touch-target, 44px);
+    }
+
+    #right-nav-panel.openDrawer > .sb-character-shell-header .sb-shell-description {
+        display: none;
+    }
+
     #right-nav-panel.openDrawer > #CharListButtonAndHotSwaps {
         flex: 0 0 auto;
-        display: grid;
-        grid-template-columns: var(--sb-mobile-touch-target, 44px) minmax(0, 1fr) var(--sb-mobile-touch-target, 44px) var(--sb-mobile-touch-target, 44px);
+        display: flex;
         align-items: center;
-        gap: 8px;
         width: 100%;
         min-width: 0;
+        min-height: 50px;
+        max-height: 50px;
         margin: 0;
-        padding: 6px 8px 4px;
+        padding: 7px var(--sb-shell-panel-padding-inline);
         border-bottom: 1px solid color-mix(in srgb, var(--sb-shell-border) 76%, transparent);
         box-sizing: border-box;
     }
 
     #right-nav-panel.openDrawer > #CharListButtonAndHotSwaps > .flexFlowColumn.flex-container {
-        width: var(--sb-mobile-touch-target, 44px);
-        min-width: var(--sb-mobile-touch-target, 44px);
-        max-width: var(--sb-mobile-touch-target, 44px);
-        align-items: center;
-        justify-content: center;
+        display: contents;
     }
 
     #right-nav-panel.openDrawer #HotSwapWrapper {
@@ -5325,13 +6706,40 @@ body.sb-shell-resizing * {
     #right-nav-panel.openDrawer #HotSwapWrapper .hotswap {
         min-width: 0;
         max-width: 100%;
+        max-height: 34px;
         margin: 0;
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
     }
 
-    #right-nav-panel.openDrawer :is(#rm_button_characters, #sb-character-right-lock, #sb-character-back-to-list, #sb-character-mobile-close) {
+    #right-nav-panel.openDrawer #HotSwapWrapper .hotswap > .avatar {
+        flex: 0 0 32px !important;
+    }
+
+    #right-nav-panel.openDrawer #HotSwapWrapper .hotswap .avatar,
+    #right-nav-panel.openDrawer #HotSwapWrapper .hotswap .avatar img {
+        width: 32px !important;
+        min-width: 32px !important;
+        max-width: 32px !important;
+        height: 32px !important;
+        min-height: 32px !important;
+        max-height: 32px !important;
+    }
+
+    body.big-avatars #right-nav-panel.openDrawer #HotSwapWrapper .hotswap > .avatar,
+    body.charListGrid #right-nav-panel.openDrawer #HotSwapWrapper .hotswap > .avatar,
+    body #right-nav-panel.openDrawer #HotSwapWrapper .hotswap > :is(.avatar, .character_select, .group_select) {
+        width: 32px !important;
+        min-width: 32px !important;
+        max-width: 32px !important;
+        height: 32px !important;
+        min-height: 32px !important;
+        max-height: 32px !important;
+        flex: 0 0 32px !important;
+    }
+
+    #right-nav-panel.openDrawer #rm_button_characters {
         width: var(--sb-mobile-touch-target, 44px);
         min-width: var(--sb-mobile-touch-target, 44px);
         max-width: var(--sb-mobile-touch-target, 44px);
@@ -5343,35 +6751,13 @@ body.sb-shell-resizing * {
         border-radius: 10px;
     }
 
-    #right-nav-panel.openDrawer #sb-character-right-lock {
-        grid-column: 3;
-    }
-
-    #right-nav-panel.openDrawer #sb-character-back-to-list {
-        grid-column: 4;
-    }
-
-    #right-nav-panel.openDrawer #sb-character-mobile-close {
-        display: inline-flex;
-        grid-column: 4;
-    }
-
     #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) > #CharListButtonAndHotSwaps {
-        grid-template-columns: var(--sb-mobile-touch-target, 44px) minmax(0, 1fr) var(--sb-mobile-touch-target, 44px) var(--sb-mobile-touch-target, 44px) var(--sb-mobile-touch-target, 44px);
         min-height: 54px;
         padding-block: 5px;
     }
 
     #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) #HotSwapWrapper {
         display: none !important;
-    }
-
-    #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) #sb-character-mobile-close {
-        grid-column: 5;
-    }
-
-    #right-nav-panel.openDrawer:not([data-menu-type="character_edit"]):not([data-menu-type="create"]) #sb-character-back-to-list {
-        display: none;
     }
 
     #right-nav-panel.openDrawer > #rm_PinAndTabs {
@@ -5484,6 +6870,46 @@ body.sb-shell-resizing * {
         padding: 0 0 4px;
     }
 
+    #right-nav-panel.openDrawer .sb-character-create-bar #rm_print_characters_pagination,
+    #right-nav-panel.openDrawer .sb-character-create-bar .paginationjs {
+        justify-content: flex-start;
+    }
+
+    #right-nav-panel.openDrawer .sb-character-create-bar {
+        margin: 4px 0 8px;
+        padding: 8px;
+        flex-wrap: wrap;
+    }
+
+    #right-nav-panel.openDrawer .sb-character-create-bar #rm_button_bar {
+        flex: 0 0 auto !important;
+        min-width: 0;
+        width: auto !important;
+        display: inline-flex !important;
+        grid-template-columns: none !important;
+        justify-content: flex-start !important;
+        justify-self: start !important;
+    }
+
+    #right-nav-panel.openDrawer .sb-character-create-bar #character_sort_order {
+        grid-column: auto !important;
+        flex: 0 0 auto !important;
+        width: auto !important;
+        min-width: 9.75em !important;
+        max-width: 11em !important;
+        justify-self: start !important;
+    }
+
+    #right-nav-panel.openDrawer .sb-character-create-bar #rm_button_search {
+        grid-column: auto !important;
+        justify-self: start !important;
+    }
+
+    #right-nav-panel.openDrawer .sb-character-create-bar #rm_button_create {
+        min-height: 42px;
+        padding-inline: 10px !important;
+    }
+
     #right-nav-panel.openDrawer #rm_print_characters_block {
         --sb-character-list-avatar-size: 56px;
         gap: 8px;
@@ -5504,6 +6930,18 @@ body.sb-shell-resizing * {
         padding: 9px 8px;
         border-radius: 14px;
         box-sizing: border-box;
+    }
+
+    #right-nav-panel.openDrawer #rm_print_characters_block:not(.group_overlay_mode_select) > :is(.character_select, .group_select).is-active-entity:not(.inline_avatar) {
+        border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 64%, var(--sb-shell-border) 36%) !important;
+        background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 22%, var(--sb-button-bg) 78%) !important;
+        box-shadow:
+            inset 0 0 0 1px color-mix(in srgb, var(--color-primary, var(--sb-accent)) 42%, transparent),
+            0 12px 24px color-mix(in srgb, var(--color-primary, var(--sb-accent)) 14%, transparent) !important;
+    }
+
+    #right-nav-panel.openDrawer #rm_print_characters_block:not(.group_overlay_mode_select) > :is(.character_select, .group_select).is-active-entity:not(.inline_avatar) :is(.ch_name, .group_select_counter) {
+        color: var(--color-primary, var(--sb-accent)) !important;
     }
 
     #right-nav-panel.openDrawer #rm_print_characters_block:not(.group_overlay_mode_select) > :is(.character_select, .group_select, .bogus_folder_select):not(.inline_avatar):has(.tags_inline .tag) {
@@ -5544,17 +6982,20 @@ body.sb-shell-resizing * {
         grid-column: 1;
         grid-row: auto;
         max-width: 100%;
-        max-height: 42px;
+        max-height: none;
         min-width: 0;
         margin-top: 2px;
-        overflow: hidden;
+        overflow: visible;
         opacity: 0.86;
         flex-basis: auto;
-        align-items: center;
+        align-items: flex-start;
     }
 
     #right-nav-panel.openDrawer #rm_print_characters_block:not(.group_overlay_mode_select) > :is(.character_select, .group_select, .bogus_folder_select):not(.inline_avatar) .tags_inline .tag {
+        min-height: calc(var(--mainFontSize) * 1.45);
+        line-height: 1.25;
         max-width: 100%;
+        padding-block: 2px;
     }
 
     #right-nav-panel.openDrawer #rm_print_characters_block:not(.group_overlay_mode_select) > :is(.character_select, .group_select, .bogus_folder_select):not(.inline_avatar) .tags_inline .tag_name {
@@ -5737,6 +7178,22 @@ body.sb-shell-resizing * {
     .sb-shell-nav-scroll {
         display: inline-flex;
     }
+}
+
+#right-nav-panel.openDrawer[data-menu-type="characters"] > #rm_PinAndTabs,
+#right-nav-panel.openDrawer[data-menu-type="editor_empty"] > #rm_PinAndTabs,
+#right-nav-panel.openDrawer[data-menu-type="persona"] > #rm_PinAndTabs,
+#right-nav-panel.openDrawer[data-menu-type="import"] > #rm_PinAndTabs {
+    display: none !important;
+}
+
+#right-nav-panel.openDrawer .sb-character-shell-nav {
+    justify-content: center !important;
+    padding-inline: var(--sb-shell-panel-padding-inline) !important;
+}
+
+#right-nav-panel.openDrawer .sb-character-shell-nav .sb-shell-tab {
+    flex: 0 0 auto !important;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -1703,6 +1703,18 @@ body.bubblechat .mes[is_user='true'] .mes_block {
     box-sizing: border-box;
 }
 
+#rm_print_characters_block:not(.group_overlay_mode_select) > :is(.character_select, .group_select).is-active-entity:not(.inline_avatar) {
+    border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 58%, var(--sb-shell-border) 42%);
+    background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 16%, var(--sb-button-bg) 84%);
+    box-shadow:
+        inset 0 0 0 1px color-mix(in srgb, var(--color-primary, var(--sb-accent)) 34%, transparent),
+        0 12px 22px color-mix(in srgb, var(--color-primary, var(--sb-accent)) 10%, transparent);
+}
+
+#rm_print_characters_block:not(.group_overlay_mode_select) > :is(.character_select, .group_select).is-active-entity:not(.inline_avatar) :is(.ch_name, .group_select_counter) {
+    color: var(--color-primary, var(--sb-accent));
+}
+
 #rm_print_characters_block:not(.group_overlay_mode_select) > :is(.character_select, .group_select, .bogus_folder_select):not(.inline_avatar) > .avatar {
     grid-column: 1;
     grid-row: 1 / span 2;

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
     </style>
     <link rel="preload" as="style" href="style.css">
     <link rel="modulepreload" href="script.js">
-    <link rel="modulepreload" href="scripts/sillybunny-tabs.js?v=20260507a">
+    <link rel="modulepreload" href="scripts/sillybunny-tabs.js?v=20260513a">
     <link rel="preload" as="font" type="font/woff2" href="webfonts/Figtree/Figtree-Regular.woff2?v=20260422b" crossorigin>
     <link rel="manifest" crossorigin="use-credentials" href="manifest.json">
     <link href="webfonts/Figtree/stylesheet.css?v=20260422b" rel="stylesheet">
@@ -45,8 +45,8 @@
     <link rel="stylesheet" type="text/css" href="css/toggle-dependent.css">
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css">
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260505a" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260507a">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260508a">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260513a">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260513a">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260506a" media="(max-width: 1000px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
@@ -8789,7 +8789,7 @@
     <script type="module" src="scripts/i18n.js"></script>
     <script type="module" src="scripts/performance-loader.js"></script>
     <script type="module" src="script.js"></script>
-    <script type="module" src="scripts/sillybunny-tabs.js?v=20260507a"></script>
+    <script type="module" src="scripts/sillybunny-tabs.js?v=20260513a"></script>
     <script>
         window.addEventListener('load', (event) => {
             const documentHeight = () => {

--- a/public/index.html
+++ b/public/index.html
@@ -6339,8 +6339,41 @@
                 <div id="rightNavDrawerIcon" class="drawer-icon fa-solid fa-address-card fa-fw closedIcon" title="Character Management" data-i18n="[title]Character Management">
                 </div>
             </div>
-            <nav id="right-nav-panel" class="drawer-content closedDrawer fillRight" tabindex="-1">
+            <nav id="right-nav-panel" class="drawer-content closedDrawer fillRight sb-shell-root" tabindex="-1">
                 <div id="right-nav-panelheader" class="fa-solid fa-grip drag-grabber">
+                </div>
+                <div class="sb-shell-nav-wrapper sb-character-shell-nav-wrapper">
+                    <div class="sb-shell-nav sb-character-shell-nav" role="tablist" aria-label="Character sections" aria-orientation="horizontal">
+                        <button id="sb_character_tab_characters" class="sb-shell-tab is-active" type="button" role="tab" aria-selected="true" data-sb-character-tab="characters">
+                            <i class="fa-solid fa-address-book" aria-hidden="true"></i>
+                            <span class="sb-shell-tab-copy"><strong data-i18n="Characters">Characters</strong></span>
+                        </button>
+                        <button id="sb_character_tab_groups" class="sb-shell-tab" type="button" role="tab" aria-selected="false" data-sb-character-tab="groups">
+                            <i class="fa-solid fa-users" aria-hidden="true"></i>
+                            <span class="sb-shell-tab-copy"><strong data-i18n="Groups">Groups</strong></span>
+                        </button>
+                        <button id="sb_character_tab_editor" class="sb-shell-tab" type="button" role="tab" aria-selected="false" data-sb-character-tab="editor">
+                            <i class="fa-solid fa-pen-to-square" aria-hidden="true"></i>
+                            <span class="sb-shell-tab-copy"><strong data-i18n="Editor">Editor</strong></span>
+                        </button>
+                        <button id="sb_character_tab_persona" class="sb-shell-tab" type="button" role="tab" aria-selected="false" data-sb-character-tab="persona">
+                            <i class="fa-solid fa-face-smile" aria-hidden="true"></i>
+                            <span class="sb-shell-tab-copy"><strong data-i18n="Persona">Persona</strong></span>
+                        </button>
+                        <button id="sb_character_tab_import" class="sb-shell-tab" type="button" role="tab" aria-selected="false" data-sb-character-tab="import">
+                            <i class="fa-solid fa-file-import" aria-hidden="true"></i>
+                            <span class="sb-shell-tab-copy"><strong data-i18n="Import">Import</strong></span>
+                        </button>
+                    </div>
+                </div>
+                <div class="sb-shell-header sb-character-shell-header">
+                    <button id="sb_character_shell_close" class="sb-shell-close" type="button" title="Close Characters" aria-label="Close Characters">
+                        <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+                    </button>
+                    <div class="sb-shell-kicker" data-i18n="Characters">Characters</div>
+                    <h2 class="sb-shell-title" tabindex="-1" data-i18n="Character Menu">Character Menu</h2>
+                    <p class="sb-shell-subtitle" data-i18n="Create, organize, and tune the cast for your chats from one place.">Create, organize, and tune the cast for your chats from one place.</p>
+                    <p class="sb-shell-description" data-i18n="This area will get dedicated character workflows. The tabs above are placeholders while the final sections are decided.">This area will get dedicated character workflows. The tabs above are placeholders while the final sections are decided.</p>
                 </div>
                 <div id="CharListButtonAndHotSwaps" class="flex-container flexnowrap">
                     <div class="flexFlowColumn flex-container">
@@ -6354,11 +6387,11 @@
                         <div class="right_menu_button fa-solid fa-list-ul" id="rm_button_characters" title="Select/Create Characters" data-i18n="[title]Select/Create Characters"></div>
                     </div>
                     <div id="HotSwapWrapper" class="alignitemscenter flex-container margin0auto wide100p">
+                        <span class="sb-character-favorites-label" data-i18n="Favorites">Favorites</span>
                         <div class="hotswap avatars_inline scroll-reset-container expander" data-i18n="[no_favs]Favorite characters to add them to HotSwaps" no_favs="Favorite characters to add them to HotSwaps">
                         </div>
                     </div>
                 </div>
-
                 <!-- this div structure must be preserved until group peeking can adjust -->
                 <div id="rm_PinAndTabs">
                     <div id="right-nav-panel-tabs" class="">
@@ -6377,8 +6410,13 @@
                                 </div>
                             </div>
                             <a id="chartokenwarning" class="right_menu_button fa-solid fa-triangle-exclamation" href="https://docs.sillytavern.app/usage/core-concepts/characterdesign/#character-tokens" target="_blank" title="About Token 'Limits'" data-i18n="[title]About Token 'Limits'"></a>
+                            <div id="creators_note_styles_button" class="right_menu_button fa-solid fa-palette fa-fw" title="Allow / Forbid the use of global styles for this character." data-i18n="[title]Allow / Forbid the use of global styles for this character."></div>
+                            <div id="character_open_media_overrides" class="right_menu_button open_media_overrides" title="Click to allow/forbid the use of external media for this character." data-i18n="[title]Click to allow/forbid the use of external media for this character.">
+                                <i id="character_media_allowed_icon" class="fa-solid fa-fw fa-link"></i>
+                                <i id="character_media_forbidden_icon" class="fa-solid fa-fw fa-link-slash"></i>
+                            </div>
                             <i title="Click for stats!" data-i18n="[title]Click for stats!" class="fa-solid fa-ranking-star right_menu_button rm_stats_button"></i>
-                            <i title="Toggle character info panel" data-i18n="[title]Toggle character info panel" id="hideCharPanelAvatarButton" class="fa-solid fa-eye right_menu_button"></i>
+                            <div id="spoiler_free_desc_button" class="right_menu_button fa-solid fa-eye fa-fw" title="Toggle character info" data-i18n="[title]Toggle character info"></div>
                         </div>
                         <button id="sb_character_editor_exit" class="menu_button menu_button_icon" type="button" title="Close Characters" aria-label="Close Characters">
                             <i class="fa-solid fa-xmark" aria-hidden="true"></i>
@@ -6388,6 +6426,41 @@
                 <!-- end group peeking cope structure-->
 
                 <div class="scrollableInner">
+                    <div id="sb_character_editor_empty" class="sb-character-editor-empty" hidden>
+                        <div class="sb-character-editor-empty-icon fa-solid fa-address-card" aria-hidden="true"></div>
+                        <div class="sb-character-editor-empty-copy">
+                            <h3 data-i18n="No character selected. Please select or create a new character.">No character selected. Please select or create a new character.</h3>
+                        </div>
+                        <div class="sb-character-editor-empty-actions">
+                            <button id="sb_character_empty_browse" class="menu_button menu_button_icon" type="button">
+                                <i class="fa-solid fa-address-book" aria-hidden="true"></i>
+                                <span data-i18n="Browse Characters">Browse Characters</span>
+                            </button>
+                            <button id="sb_character_empty_create" class="menu_button menu_button_icon" type="button">
+                                <i class="fa-solid fa-user-plus" aria-hidden="true"></i>
+                                <span data-i18n="Create New Character">Create New Character</span>
+                            </button>
+                        </div>
+                    </div>
+                    <div id="sb_character_persona_panel" class="sb-character-persona-panel" hidden></div>
+                    <div id="sb_character_import_panel" class="sb-character-import-panel" hidden>
+                        <div class="sb-character-import-actions">
+                            <button id="sb_character_import_file_action" class="sb-character-import-action" type="button">
+                                <i class="fa-solid fa-file-import" aria-hidden="true"></i>
+                                <span>
+                                    <strong data-i18n="Import from file">Import from file</strong>
+                                    <small data-i18n="Upload PNG, JSON, YAML, CHARX, or BYAF character files.">Upload PNG, JSON, YAML, CHARX, or BYAF character files.</small>
+                                </span>
+                            </button>
+                            <button id="sb_character_import_url_action" class="sb-character-import-action" type="button">
+                                <i class="fa-solid fa-cloud-arrow-down" aria-hidden="true"></i>
+                                <span>
+                                    <strong data-i18n="Import from URL">Import from URL</strong>
+                                    <small data-i18n="Paste one or more links to character cards or supported external content.">Paste one or more links to character cards or supported external content.</small>
+                                </span>
+                            </button>
+                        </div>
+                    </div>
                     <div name="Solo Char Create/Edit Panel" id="rm_ch_create_block" class="right_menu flex-container flexFlowColumn" style="display: none;">
                         <form id="form_create" action="javascript:void(null);" method="post" enctype="multipart/form-data">
                             <div id="avatar-and-name-block">
@@ -6399,32 +6472,37 @@
                                 </div>
                                 <div class="flex-container flexFlowColumn expander flexNoGap">
                                     <div id="avatar_div" class="avatar_div buttons_block alignitemsflexstart justifySpaceBetween flexnowrap">
-                                        <label id="avatar_div_div" class="add_avatar avatar" for="add_avatar_button" title="Click to select a new avatar for this character" data-i18n="[title]Click to select a new avatar for this character">
-                                            <img id="avatar_load_preview" src="img/ai4.png" alt="avatar">
-                                            <input hidden type="file" id="add_avatar_button" name="avatar" accept="image/*">
-                                        </label>
-                                        <div class="flex-container" id="avatar_controls">
+                                        <div class="sb-character-editor-controls-row">
+                                            <label id="avatar_div_div" class="add_avatar avatar" for="add_avatar_button" title="Click to select a new avatar for this character" data-i18n="[title]Click to select a new avatar for this character">
+                                                <img id="avatar_load_preview" src="img/ai4.png" alt="avatar">
+                                                <input hidden type="file" id="add_avatar_button" name="avatar" accept="image/*">
+                                            </label>
+                                            <div class="char-button-group char-button-group-primary char-button-group-utility sb-character-editor-side-actions">
+                                                <div id="favorite_button" class="menu_button fa-solid fa-star" title="Add to Favorites" data-i18n="[title]Add to Favorites" data-label="FAV."></div>
+                                                <input type="hidden" id="fav_checkbox" name="fav" />
+                                                <div id="advanced_div" class="menu_button fa-solid fa-book" title="Advanced Definitions" data-i18n="[title]Advanced Definition" data-label="ADV."></div>
+                                            </div>
+                                            <div class="flex-container" id="avatar_controls">
                                             <div class="form_create_bottom_buttons_block buttons_block">
                                                 <div class="char-button-toolbar">
                                                     <div class="char-button-group char-button-group-secondary char-button-group-icons">
-                                                        <div id="world_button" class="menu_button fa-solid fa-globe" title="Character Lore&#10;&#10;Click to load&#10;Shift/Alt-click or long-press to open 'Link to World Info' popup" data-i18n="[title]world_button_title"></div>
+                                                        <div id="world_button" class="menu_button fa-solid fa-globe" title="Character Lore&#10;&#10;Click to load&#10;Shift/Alt-click or long-press to open 'Link to World Info' popup" data-i18n="[title]world_button_title"><span data-i18n="Character Lore">Character Lore</span></div>
+                                                        <label for="create_button" id="create_button_label" class="menu_button fa-solid fa-user-check" title="Create Character" data-i18n="[title]Create Character">
+                                                            <span data-i18n="Create Character">Create Character</span>
+                                                            <input type="submit" id="create_button" name="create_button">
+                                                        </label>
                                                         <div class="chat_lorebook_button menu_button fa-solid fa-passport" title="Chat Lore&#10;&#10;Click to load&#10;Shift/Alt-click or long-press to open 'Link to Chat Lorebook' popup" data-i18n="[title]chat_lorebook_button_title"></div>
                                                         <div id="char_connections_button" class="menu_button fa-solid fa-face-smile" title="Connected Personas" data-i18n="[title]Connected Personas"></div>
                                                         <div id="export_button" class="menu_button fa-solid fa-file-export" title="Export and Download" data-i18n="[title]Export and Download"></div>
                                                         <div id="dupe_button" class="menu_button fa-solid fa-clone" title="Duplicate Character" data-i18n="[title]Duplicate Character"></div>
-                                                        <label for="create_button" id="create_button_label" class="menu_button fa-solid fa-user-check" title="Create Character" data-i18n="[title]Create Character">
-                                                            <input type="submit" id="create_button" name="create_button">
-                                                        </label>
                                                         <div id="delete_button" class="menu_button fa-solid fa-skull red_button" title="Delete Character" data-i18n="[title]Delete Character"></div>
                                                     </div>
                                                     <div class="char-button-group char-button-group-primary char-button-group-utility">
                                                         <div id="rm_button_back" class="menu_button fa-solid fa-left-long" data-label="Back"></div>
-                                                        <div id="favorite_button" class="menu_button fa-solid fa-star" title="Add to Favorites" data-i18n="[title]Add to Favorites" data-label="FAV."></div>
-                                                        <input type="hidden" id="fav_checkbox" name="fav" />
-                                                        <div id="advanced_div" class="menu_button fa-solid fa-book" title="Advanced Definitions" data-i18n="[title]Advanced Definition" data-label="ADV."></div>
                                                     </div>
                                                 </div>
                                             </div>
+                                            <div class="sb-character-editor-header-spacer" aria-hidden="true"></div>
                                             <label class="flex1 height100p" for="char-management-dropdown">
                                                 <select id="char-management-dropdown" class="text_pole">
                                                     <option value="default" disabled selected data-i18n="More...">More...</option>
@@ -6466,23 +6544,22 @@
                                                         </option>-->
                                                 </select>
                                             </label>
-                                        </div>
-                                    </div>
-                                    <div id="tags_div">
-                                        <div class="tag_controls">
-                                            <input id="tagInput" class="text_pole textarea_compact tag_input wide100p margin0" data-i18n="[placeholder]Search / Create Tags" placeholder="Search / Create tags" />
-                                            <div class="tags_view menu_button fa-solid fa-tags" title="View all tags" data-i18n="[title]View all tags"></div>
+                                            <div id="tags_div">
+                                                <div class="tag_controls">
+                                                    <input id="tagInput" class="text_pole textarea_compact tag_input wide100p margin0" data-i18n="[placeholder]Search / Create Tags" placeholder="Search / Create tags" />
+                                                    <div class="tags_view menu_button fa-solid fa-tags" title="View all tags" data-i18n="[title]View all tags"></div>
+                                                </div>
+                                            </div>
+                                            </div>
                                         </div>
                                         <div id="tagList" class="tags"></div>
                                     </div>
                                 </div>
                             </div>
-                            <div id="spoiler_free_desc" class="inline-drawer flex-container flexFlowColumn flexNoGap">
-                                <div class="inline-drawer-toggle inline-drawer-header padding0 gap5px standoutHeader">
+                            <div id="spoiler_free_desc" class="inline-drawer flex-container flexFlowColumn flexNoGap sb-creator-notes-compact">
+                                <div class="inline-drawer-toggle inline-drawer-header padding0 gap5px">
                                     <div id="creators_notes_div" class="title_restorable flexGap5 wide100p ">
                                         <span class="flex1" data-i18n="Creator's Notes">Creator's Notes</span>
-                                        <div id="creators_note_styles_button" class="margin0 menu_button fa-solid fa-palette fa-fw" title="Allow / Forbid the use of global styles for this character." data-i18n="[title]Allow / Forbid the use of global styles for this character."></div>
-                                        <div id="spoiler_free_desc_button" class="margin0 menu_button fa-solid fa-eye fa-fw" title="Show / Hide Description and First Message" data-i18n="[title]Show / Hide Description and First Message"></div>
                                     </div>
                                     <div class="flex-container widthFitContent">
                                         <div class="inline-drawer-icon fa-solid fa-circle-chevron-down down interactable"></div>
@@ -6504,13 +6581,6 @@
                                         <a href="https://docs.sillytavern.app/usage/core-concepts/characterdesign/#character-description" class="notes-link" target="_blank">
                                             <span class="fa-solid fa-circle-question note-link-span"></span>
                                         </a>
-                                    </div>
-                                    <div id="character_open_media_overrides" class="menu_button menu_button_icon open_media_overrides" title="Click to allow/forbid the use of external media for this character." data-i18n="[title]Click to allow/forbid the use of external media for this character.">
-                                        <i id="character_media_allowed_icon" class="fa-solid fa-fw fa-link"></i>
-                                        <i id="character_media_forbidden_icon" class="fa-solid fa-fw fa-link-slash"></i>
-                                        <span data-i18n="Ext. Media">
-                                            Ext. Media
-                                        </span>
                                     </div>
                                 </div>
                                 <textarea id="description_textarea" class="mdHotkeys" data-macros data-i18n="[placeholder]Describe your character's physical and mental traits here." placeholder="Describe your character's physical and mental traits here." name="description" placeholder=""></textarea>
@@ -6575,6 +6645,57 @@
                         </form>
                     </div>
                     <div name="Group Chat Edit Panel" id="rm_group_chats_block" class="right_menu flex-container flexNoGap">
+                        <section class="sb-group-settings-section">
+                            <div id="group-metadata-controls" class="marginTopBot5">
+                                <div id="rm_group_top_bar" class="flex-container alignitemscenter spaceBetween width100p fontsize80p">
+                                    <div>
+                                        <label class="add_avatar avatar flex-container justifyCenter" for="group_avatar_button" title="Click to select a new avatar for this group" data-i18n="[title]Click to select a new avatar for this group">
+                                            <div id="group_avatar_preview">
+                                                <div class="avatar">
+                                                    <img src="img/ai4.png" alt="avatar">
+                                                </div>
+                                            </div>
+                                            <input hidden type="file" id="group_avatar_button" name="avatar" accept="image/png, image/jpeg, image/jpg, image/gif, image/bmp">
+                                        </label>
+                                    </div>
+                                    <div class="sb-group-editor-primary">
+                                        <div class="sb-group-editor-name-row">
+                                            <input id="rm_group_chat_name" class="text_pole flex1" type="text" name="chat_name" data-i18n="[placeholder]Chat Name (Optional)" placeholder="Chat Name (Optional)" />
+                                            <div class="flex-container sb-group-editor-action-cluster">
+                                                <div class="flex-container sb-group-editor-side-actions">
+                                                    <div id="group_favorite_button" class="heightFitContent margin0 menu_button fa-solid fa-fw fa-star" title="Add to Favorites" data-i18n="[title]Add to Favorites" data-label="FAV."></div>
+                                                    <div id="rm_group_scenario" class="heightFitContent margin0 menu_button fa-solid fa-fw fa-scroll" title="Set group chat character settings overrides" data-i18n="[title]Set group chat character settings overrides" data-label="ADV."></div>
+                                                    <input id="rm_group_fav" type="hidden" />
+                                                </div>
+                                                <div class="flex-container sb-group-editor-utility-actions">
+                                                    <div class="chat_lorebook_button menu_button fa-solid fa-passport" title="Chat Lore&#10;&#10;Click to load&#10;Shift/Alt-click or long-press to open 'Link to Chat Lorebook' popup" data-i18n="[title]chat_lorebook_button_title"></div>
+                                                    <div id="rm_group_submit" class="heightFitContent margin0 menu_button fa-solid fa-fw fa-check" title="Create" data-i18n="[title]Create" data-label="Create Group"></div>
+                                                    <div id="group_open_media_overrides" class="heightFitContent margin0 menu_button menu_button_icon open_media_overrides" title="Click to allow/forbid the use of external media for this group." data-i18n="[title]Click to allow/forbid the use of external media for this group.">
+                                                        <i id="group_media_allowed_icon" class="fa-solid fa-fw fa-link"></i>
+                                                        <i id="group_media_forbidden_icon" class="fa-solid fa-fw fa-link-slash"></i>
+                                                    </div>
+                                                    <div id="rm_group_delete" class="heightFitContent margin0 menu_button fa-solid fa-fw fa-trash-can" title="Delete" data-i18n="[title]Delete"></div>
+                                                </div>
+                                            </div>
+                                            <label class="height100p" for="group-chat-lorebook-dropdown">
+                                                <select id="group-chat-lorebook-dropdown" class="text_pole">
+                                                    <option value="default" disabled selected data-i18n="More...">More...</option>
+                                                    <option id="group_chat_lorebook_link" data-i18n="Link to Chat Lorebook">Link to Chat Lorebook</option>
+                                                    <option id="renameGroupButton" data-i18n="Rename Group">Rename Group</option>
+                                                </select>
+                                            </label>
+                                            <div id="group_tags_div" class="wide100p">
+                                                <div class="tag_controls">
+                                                    <input id="groupTagInput" class="text_pole textarea_compact tag_input flex1 margin0" data-i18n="[placeholder]Search / Create Tags" placeholder="Search / Create tags" />
+                                                    <div class="tags_view menu_button fa-solid fa-tags margin0" title="View all tags" data-i18n="[title]View all tags"></div>
+                                                </div>
+                                            </div>
+                                            <div id="groupTagList" class="tags paddingTopBot5"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </section>
                         <div class="inline-drawer wide100p flexFlowColumn">
                             <div id="groupControlsToggle" class="inline-drawer-toggle inline-drawer-header">
                                 <span>
@@ -6586,36 +6707,7 @@
                                 <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
                             </div>
                             <div class="inline-drawer-content">
-                                <div id="group-metadata-controls" class="marginTopBot5">
-                                    <div class="flex-container wide100p">
-                                        <input id="rm_group_chat_name" class="text_pole flex1" type="text" name="chat_name" data-i18n="[placeholder]Chat Name (Optional)" placeholder="Chat Name (Optional)" />
-                                        <div class="chat_lorebook_button menu_button fa-solid fa-passport" title="Chat Lore&#10;&#10;Click to load&#10;Shift/Alt-click or long-press to open 'Link to Chat Lorebook' popup" data-i18n="[title]chat_lorebook_button_title"></div>
-                                    </div>
-                                    <label class="flex1 height100p" for="group-chat-lorebook-dropdown">
-                                        <select id="group-chat-lorebook-dropdown" class="text_pole">
-                                            <option value="default" disabled selected data-i18n="More...">More...</option>
-                                            <option id="group_chat_lorebook_link" data-i18n="Link to Chat Lorebook">Link to Chat Lorebook</option>
-                                        </select>
-                                    </label>
-                                    <div id="group_tags_div" class="wide100p">
-                                        <div class="tag_controls">
-                                            <input id="groupTagInput" class="text_pole textarea_compact tag_input flex1 margin0" data-i18n="[placeholder]Search / Create Tags" placeholder="Search / Create tags" />
-                                            <div class="tags_view menu_button fa-solid fa-tags margin0" title="View all tags" data-i18n="[title]View all tags"></div>
-                                        </div>
-                                        <div id="groupTagList" class="tags paddingTopBot5"></div>
-                                    </div>
-                                    <div id="rm_group_top_bar" class="flex-container alignitemscenter spaceBetween width100p fontsize80p">
-                                        <div>
-                                            <label class="add_avatar avatar flex-container justifyCenter" for="group_avatar_button" title="Click to select a new avatar for this group" data-i18n="[title]Click to select a new avatar for this group">
-                                                <div id="group_avatar_preview">
-                                                    <div class="avatar">
-                                                        <img src="img/ai4.png" alt="avatar">
-                                                    </div>
-                                                </div>
-                                                <input hidden type="file" id="group_avatar_button" name="avatar" accept="image/png, image/jpeg, image/jpg, image/gif, image/bmp">
-                                            </label>
-                                        </div>
-                                        <div name="GroupStragegyAndOrder" id="rm_group_buttons" class="flex-container paddingLeftRight5 flex2">
+                                <div name="GroupStragegyAndOrder" id="rm_group_buttons" class="flex-container paddingLeftRight5 flex2">
                                             <div class="flex1 flexGap5">
                                                 <label for="rm_group_activation_strategy" class="flexnowrap width100p whitespacenowrap">
                                                     <span data-i18n="Group reply strategy">Group reply strategy</span>
@@ -6636,6 +6728,47 @@
                                                     <option value="1" data-i18n="Join character cards (exclude muted)">Join character cards (exclude muted)</option>
                                                     <option value="2" data-i18n="Join character cards (include muted)">Join character cards (include muted)</option>
                                                 </select>
+                                            </div>
+                                            <div class="flex1 flexGap5" title="Inserted before each part of the joined fields." data-i18n="[title]Inserted before each part of the joined fields.">
+                                                <label for="rm_group_generation_mode_join_prefix" class="flexnowrap width100p whitespacenowrap">
+                                                    <span data-i18n="Join Prefix">Join Prefix</span>
+                                                    <div class="fa-solid fa-circle-info opacity50p" data-i18n="[title]When 'Join character cards' is selected, all respective fields of the characters are being joined together.This means that in the story string for example all character descriptions will be joined to one big text.If you want those fields to be separated, you can define a prefix or suffix here.This value supports normal macros and will also replace {{char}} with the relevant char's name and &lt;FIELDNAME&gt; with the name of the part (e.g.: description, personality, scenario, etc.)" title="When 'Join character cards' is selected, all respective fields of the characters are being joined together.&#13;This means that in the story string for example all character descriptions will be joined to one big text.&#13;If you want those fields to be separated, you can define a prefix or suffix here.&#13;&#13;This value supports normal macros and will also replace {{char}} with the relevant char's name and &lt;FIELDNAME&gt; with the name of the part (e.g.: description, personality, scenario, etc.)">
+                                                    </div>
+                                                </label>
+                                                <textarea id="rm_group_generation_mode_join_prefix" class="text_pole wide100p textarea_compact autoSetHeight" placeholder="&mdash;" rows="1"></textarea>
+                                            </div>
+                                            <div class="flex1 flexGap5" title="Inserted after each part of the joined fields." data-i18n="[title]Inserted after each part of the joined fields.">
+                                                <label for="rm_group_generation_mode_join_suffix" class="flexnowrap width100p whitespacenowrap">
+                                                    <span data-i18n="Join Suffix">Join Suffix</span>
+                                                    <div class="fa-solid fa-circle-info opacity50p" data-i18n="[title]When 'Join character cards' is selected, all respective fields of the characters are being joined together.This means that in the story string for example all character descriptions will be joined to one big text.If you want those fields to be separated, you can define a prefix or suffix here.This value supports normal macros and will also replace {{char}} with the relevant char's name and &lt;FIELDNAME&gt; with the name of the part (e.g.: description, personality, scenario, etc.)" title="When 'Join character cards' is selected, all respective fields of the characters are being joined together.&#13;This means that in the story string for example all character descriptions will be joined to one big text.&#13;If you want those fields to be separated, you can define a prefix or suffix here.&#13;&#13;This value supports normal macros and will also replace {{char}} with the relevant char's name and &lt;FIELDNAME&gt; with the name of the part (e.g.: description, personality, scenario, etc.)">
+                                                    </div>
+                                                </label>
+                                                <textarea id="rm_group_generation_mode_join_suffix" class="text_pole wide100p textarea_compact autoSetHeight" placeholder="&mdash;" rows="1"></textarea>
+                                            </div>
+                                </div>
+                                <div id="GroupFavDelOkBack" class="flex-container flexGap5 spaceEvenly flex1">
+                                            <div id="rm_button_back_from_group" class="heightFitContent margin0 menu_button fa-solid fa-fw fa-left-long"></div>
+                                            <div id="rm_group_restore_avatar" class="heightFitContent margin0 menu_button fa-solid fa-fw fa-images" title="Restore collage avatar" data-i18n="[title]Restore collage avatar"></div>
+                                            <div class="flex1">
+                                                <label id="rm_group_hidemutedsprites_label" class="checkbox_label whitespacenowrap">
+                                                    <input id="rm_group_hidemutedsprites" type="checkbox" />
+                                                    <span data-i18n="Hide Muted Member Sprites">Hide Muted Member Sprites</span>
+                                                </label>
+                                                <label class="checkbox_label whitespacenowrap">
+                                                    <input id="rm_group_allow_self_responses" type="checkbox" />
+                                                    <span data-i18n="Allow self responses">Allow self responses</span>
+                                                </label>
+                                                <label id="rm_group_automode_label" class="checkbox_label whitespacenowrap">
+                                                    <input id="rm_group_automode" type="checkbox" />
+                                                    <span data-i18n="Auto Mode">Auto Mode</span>
+                                                    <input id="rm_group_automode_delay" class="text_pole textarea_compact widthUnset" type="number" min="1" max="999" step="1" value="120" title="Auto Mode delay in seconds" data-i18n="[title]Auto Mode delay in seconds" />
+                                                    <span class="auto_mode_delay_unit" title="Auto Mode delay unit" data-i18n="seconds">seconds</span>
+                                                </label>
+                                                <label id="rm_group_auto_dm_cooldown_label" class="checkbox_label whitespacenowrap" title="Minimum delay between scheduled Auto DMs" data-i18n="[title]Minimum delay between scheduled Auto DMs">
+                                                    <span data-i18n="Auto DM cooldown">Auto DM cooldown</span>
+                                                    <input id="rm_group_auto_dm_cooldown" class="text_pole textarea_compact widthUnset" type="number" min="1" max="9999" step="1" value="300" title="Auto DM cooldown in seconds" data-i18n="[title]Auto DM cooldown in seconds" />
+                                                    <span class="auto_mode_delay_unit" title="Auto DM cooldown unit" data-i18n="seconds">seconds</span>
+                                                </label>
                                             </div>
                                             <div class="wide100p flex-container flexFlowColumn flexGap5 group_schedule_controls">
                                                 <div class="flex-container flexGap5 flexWrap alignitemscenter">
@@ -6658,58 +6791,6 @@
 08:00 Bunny Guide: checks in after breakfast
 23:00 Assistant Nahida: winds down and reflects;[title]Daily auto-message schedule. Format: HH:MM Character: reason"></textarea>
                                             </div>
-                                            <div class="flex1 flexGap5" title="Inserted before each part of the joined fields." data-i18n="[title]Inserted before each part of the joined fields.">
-                                                <label for="rm_group_generation_mode_join_prefix" class="flexnowrap width100p whitespacenowrap">
-                                                    <span data-i18n="Join Prefix">Join Prefix</span>
-                                                    <div class="fa-solid fa-circle-info opacity50p" data-i18n="[title]When 'Join character cards' is selected, all respective fields of the characters are being joined together.This means that in the story string for example all character descriptions will be joined to one big text.If you want those fields to be separated, you can define a prefix or suffix here.This value supports normal macros and will also replace {{char}} with the relevant char's name and &lt;FIELDNAME&gt; with the name of the part (e.g.: description, personality, scenario, etc.)" title="When 'Join character cards' is selected, all respective fields of the characters are being joined together.&#13;This means that in the story string for example all character descriptions will be joined to one big text.&#13;If you want those fields to be separated, you can define a prefix or suffix here.&#13;&#13;This value supports normal macros and will also replace {{char}} with the relevant char's name and &lt;FIELDNAME&gt; with the name of the part (e.g.: description, personality, scenario, etc.)">
-                                                    </div>
-                                                </label>
-                                                <textarea id="rm_group_generation_mode_join_prefix" class="text_pole wide100p textarea_compact autoSetHeight" placeholder="&mdash;" rows="1"></textarea>
-                                            </div>
-                                            <div class="flex1 flexGap5" title="Inserted after each part of the joined fields." data-i18n="[title]Inserted after each part of the joined fields.">
-                                                <label for="rm_group_generation_mode_join_suffix" class="flexnowrap width100p whitespacenowrap">
-                                                    <span data-i18n="Join Suffix">Join Suffix</span>
-                                                    <div class="fa-solid fa-circle-info opacity50p" data-i18n="[title]When 'Join character cards' is selected, all respective fields of the characters are being joined together.This means that in the story string for example all character descriptions will be joined to one big text.If you want those fields to be separated, you can define a prefix or suffix here.This value supports normal macros and will also replace {{char}} with the relevant char's name and &lt;FIELDNAME&gt; with the name of the part (e.g.: description, personality, scenario, etc.)" title="When 'Join character cards' is selected, all respective fields of the characters are being joined together.&#13;This means that in the story string for example all character descriptions will be joined to one big text.&#13;If you want those fields to be separated, you can define a prefix or suffix here.&#13;&#13;This value supports normal macros and will also replace {{char}} with the relevant char's name and &lt;FIELDNAME&gt; with the name of the part (e.g.: description, personality, scenario, etc.)">
-                                                    </div>
-                                                </label>
-                                                <textarea id="rm_group_generation_mode_join_suffix" class="text_pole wide100p textarea_compact autoSetHeight" placeholder="&mdash;" rows="1"></textarea>
-                                            </div>
-                                        </div>
-                                        <div id="GroupFavDelOkBack" class="flex-container flexGap5 spaceEvenly flex1">
-                                            <div id="rm_button_back_from_group" class="heightFitContent margin0 menu_button fa-solid fa-fw fa-left-long"></div>
-                                            <div id="rm_group_scenario" class="heightFitContent margin0 menu_button fa-solid fa-fw fa-scroll" title="Set group chat character settings overrides" data-i18n="[title]Set group chat character settings overrides"></div>
-                                            <div id="group_favorite_button" class="heightFitContent margin0 menu_button fa-solid fa-fw fa-star" title="Add to Favorites" data-i18n="[title]Add to Favorites"></div>
-                                            <input id="rm_group_fav" type="hidden" />
-                                            <div id="group_open_media_overrides" class="heightFitContent margin0 menu_button menu_button_icon open_media_overrides" title="Click to allow/forbid the use of external media for this group." data-i18n="[title]Click to allow/forbid the use of external media for this group.">
-                                                <i id="group_media_allowed_icon" class="fa-solid fa-fw fa-link"></i>
-                                                <i id="group_media_forbidden_icon" class="fa-solid fa-fw fa-link-slash"></i>
-                                            </div>
-                                            <div id="rm_group_submit" class="heightFitContent margin0 menu_button fa-solid fa-fw fa-check" title="Create" data-i18n="[title]Create"></div>
-                                            <div id="rm_group_restore_avatar" class="heightFitContent margin0 menu_button fa-solid fa-fw fa-images" title="Restore collage avatar" data-i18n="[title]Restore collage avatar"></div>
-                                            <div id="rm_group_delete" class="heightFitContent margin0 menu_button fa-solid fa-fw fa-trash-can" title="Delete" data-i18n="[title]Delete"></div>
-                                            <div class="flex1">
-                                                <label class="checkbox_label whitespacenowrap">
-                                                    <input id="rm_group_allow_self_responses" type="checkbox" />
-                                                    <span data-i18n="Allow self responses">Allow self responses</span>
-                                                </label>
-                                                <label id="rm_group_automode_label" class="checkbox_label whitespacenowrap">
-                                                    <input id="rm_group_automode" type="checkbox" />
-                                                    <span data-i18n="Auto Mode">Auto Mode</span>
-                                                    <input id="rm_group_automode_delay" class="text_pole textarea_compact widthUnset" type="number" min="1" max="999" step="1" value="120" title="Auto Mode delay in seconds" data-i18n="[title]Auto Mode delay in seconds" />
-                                                    <span class="auto_mode_delay_unit" title="Auto Mode delay unit" data-i18n="seconds">seconds</span>
-                                                </label>
-                                                <label id="rm_group_auto_dm_cooldown_label" class="checkbox_label whitespacenowrap" title="Minimum delay between scheduled Auto DMs" data-i18n="[title]Minimum delay between scheduled Auto DMs">
-                                                    <span data-i18n="Auto DM cooldown">Auto DM cooldown</span>
-                                                    <input id="rm_group_auto_dm_cooldown" class="text_pole textarea_compact widthUnset" type="number" min="1" max="9999" step="1" value="300" title="Auto DM cooldown in seconds" data-i18n="[title]Auto DM cooldown in seconds" />
-                                                    <span class="auto_mode_delay_unit" title="Auto DM cooldown unit" data-i18n="seconds">seconds</span>
-                                                </label>
-                                                <label id="rm_group_hidemutedsprites_label" class="checkbox_label whitespacenowrap">
-                                                    <input id="rm_group_hidemutedsprites" type="checkbox" />
-                                                    <span data-i18n="Hide Muted Member Sprites">Hide Muted Member Sprites</span>
-                                                </label>
-                                            </div>
-                                        </div>
-                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -6908,6 +6989,7 @@
                 </div>
                 <button id="character_cross" class="fa-solid fa-circle-xmark" type="button" title="Close Advanced Definitions" aria-label="Close Advanced Definitions"></button>
             </div>
+            <div id="character_popup_body">
             <hr class="margin-bot-10px">
             <div class="inline-drawer">
                 <div class="inline-drawer-toggle inline-drawer-header">
@@ -7070,6 +7152,7 @@
                 <!-- TODO: Example chats handhold-editor concept: https://gist.github.com/Cohee1207/50da02a4001ac1adae9b440f9b8e1079 -->
             </div>
             <div id="character_popup_ok" class="menu_button" data-i18n="Save">Save</div>
+            </div>
         </div>
 
         <div id="shadow_select_chat_popup">

--- a/public/script.js
+++ b/public/script.js
@@ -468,6 +468,7 @@ export let characters = [];
  */
 export let this_chid;
 let saveCharactersPage = 0;
+let characterMenuEntityView = 'characters';
 export const default_avatar = 'img/ai4.png';
 const SILLYBUNNY_FRONTEND_ICON_STORAGE_KEY = 'sb-frontend-icon';
 const SILLYBUNNY_FRONTEND_ICON_DEFAULT = 'pixel';
@@ -1152,6 +1153,7 @@ function getCharacterBlock(item, id) {
     }
     template.find('.ch_fav_icon').css('display', 'none');
     template.toggleClass('is_fav', item.fav || item.fav == 'true');
+    template.toggleClass('is-active-entity', !selected_group && String(this_chid) === String(id));
     template.find('.ch_fav').val(item.fav);
 
     const isAssistant = item.avatar === getPermanentAssistantAvatar();
@@ -1214,7 +1216,20 @@ export async function printCharacters(fullRefresh = false) {
     applyTagsOnCharacterSelect();
     applyTagsOnGroupSelect();
 
-    const entities = getEntitiesList({ doFilter: true });
+    const entities = getEntitiesList({ doFilter: true })
+        .filter(entity => entityMatchesCharacterMenuView(entity))
+        .map(entity => {
+            if (entity.type !== 'tag') {
+                return entity;
+            }
+
+            const visibleEntities = entity.entities?.filter(item => entityMatchesCharacterMenuView(item)) ?? [];
+            return {
+                ...entity,
+                entities: visibleEntities,
+                hidden: Math.max(0, (entity.entities?.length ?? 0) - visibleEntities.length),
+            };
+        });
 
     const pageSize = Number(accountStorage.getItem(storageKey)) || per_page_default;
     const sizeChangerOptions = [10, 25, 50, 100, 250, 500, 1000];
@@ -1257,7 +1272,8 @@ export async function printCharacters(fullRefresh = false) {
                 }
             }
 
-            const hidden = (characters.length + groups.length) - displayCount;
+            const sourceCount = characterMenuEntityView === 'groups' ? groups.length : characters.length;
+            const hidden = sourceCount - displayCount;
             if (hidden > 0 && entitiesFilter.hasAnyFilter()) {
                 const hiddenBlock = await getHiddenBlock(hidden);
                 $(listId).append(hiddenBlock);
@@ -1280,6 +1296,18 @@ export async function printCharacters(fullRefresh = false) {
 
     favsToHotswap();
     updatePersonaConnectionsAvatarList();
+}
+
+function entityMatchesCharacterMenuView(entity) {
+    if (characterMenuEntityView === 'groups') {
+        return entity.type === 'group' || entity.type === 'tag';
+    }
+
+    return entity.type === 'character' || entity.type === 'tag';
+}
+
+export function setCharacterMenuEntityView(value) {
+    characterMenuEntityView = value === 'groups' ? 'groups' : 'characters';
 }
 
 /** Checks the state of the current search, and adds/removes the search sorting option accordingly */
@@ -11243,6 +11271,9 @@ export function select_rm_info(type, charId, previousCharId = null) {
         toastr.error(t`Invalid process (no 'type')`);
         return;
     }
+    const rightNavPanel = document.getElementById('right-nav-panel');
+    const keepSillyBunnyImportTab = rightNavPanel?.dataset.menuType === 'import' && ['char_import', 'char_import_no_toast'].includes(type);
+
     if (type !== 'group_create') {
         var displayName = String(charId).replace('.png', '');
     }
@@ -11264,11 +11295,19 @@ export function select_rm_info(type, charId, previousCharId = null) {
         toastr.success(t`Character Imported: ${displayName}`);
     }
 
-    selectRightMenuWithAnimation('rm_characters_block');
+    if (!keepSillyBunnyImportTab) {
+        selectRightMenuWithAnimation('rm_characters_block');
+    } else {
+        document.dispatchEvent(new CustomEvent('sillybunny:character-import-tab-preserve'));
+    }
 
     // Set a timeout so multiple flashes don't overlap
     clearTimeout(importFlashTimeout);
     importFlashTimeout = setTimeout(function () {
+        if (keepSillyBunnyImportTab) {
+            return;
+        }
+
         if (type === 'char_import' || type === 'char_create' || type === 'char_import_no_toast') {
             // Find the page at which the character is located
             const avatarFileName = charId;
@@ -11498,7 +11537,7 @@ function select_rm_create({ switchMenu = true } = {}) {
 }
 
 function select_rm_characters() {
-    const doFullRefresh = menu_type === 'characters';
+    const doFullRefresh = menu_type === characterMenuEntityView;
     setMenuType('characters');
     selectRightMenuWithAnimation('rm_characters_block');
     printCharacters(doFullRefresh);
@@ -13710,10 +13749,23 @@ jQuery(async function () {
         $('#character_search_bar').val('').trigger('input');
         scheduleUiSurfaceFocus(document.getElementById('right-nav-panel'));
     });
+    $('#rm_button_selected_ch h2').on('click', async function (event) {
+        if (menu_type !== 'character_edit' || selected_group) {
+            return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        await renameCharacter();
+    });
 
     $(document).on('click', '.character_select', async function () {
+        const shouldCloseCharacterMenu = $(this).closest('#rm_print_characters_block').length > 0;
         const id = Number($(this).attr('data-chid'));
         await selectCharacterById(id);
+        if (shouldCloseCharacterMenu) {
+            window.SillyBunnyShell?.closeCharacters?.();
+        }
         scheduleUiSurfaceFocus(document.getElementById('right-nav-panel'));
     });
 

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -1723,6 +1723,7 @@ export function getGroupBlock(group) {
     template.find('.ch_name').text(group.name).attr('title', `[Group] ${group.name}`);
     template.find('.group_fav_icon').css('display', 'none');
     template.addClass(group.fav ? 'is_fav' : '');
+    template.toggleClass('is-active-entity', selected_group === group.id);
     template.find('.ch_fav').val(String(group.fav));
     template.find('.group_select_counter').text(count + ' ' + (count != 1 ? t`characters` : t`character`));
     template.find('.group_select_block_list').text(namesList.join(', '));
@@ -2738,6 +2739,31 @@ async function onGroupNameInput() {
         await editGroup(openGroupId, false);
     }
 }
+
+async function renameOpenGroup() {
+    if (menu_type !== 'group_edit' || !openGroupId) {
+        return;
+    }
+
+    const group = groups.find((x) => x.id == openGroupId);
+    if (!group) {
+        return;
+    }
+
+    const newName = await callGenericPopup('<h3>' + t`New name:` + '</h3>', POPUP_TYPE.INPUT, group.name);
+    if (!newName || newName === group.name) {
+        return;
+    }
+
+    group.name = String(newName);
+    $('#rm_group_chat_name').val(group.name);
+    $('#rm_button_selected_ch').children('h2').text(group.name);
+    await editGroup(openGroupId, true, true);
+}
+
+globalThis.SillyBunnyShell = Object.assign(globalThis.SillyBunnyShell || {}, {
+    renameOpenGroup,
+});
 
 /**
  * Checks if a character with the given avatar ID is a member of the group.
@@ -3758,8 +3784,12 @@ jQuery(() => {
     }
 
     $(document).on('click', '.group_select', function () {
+        const shouldCloseCharacterMenu = $(this).closest('#rm_print_characters_block').length > 0;
         const groupId = $(this).attr('data-chid') || $(this).attr('data-grid');
         openGroupById(groupId);
+        if (shouldCloseCharacterMenu) {
+            window.SillyBunnyShell?.closeCharacters?.();
+        }
     });
     $('#rm_group_filter').on('input', filterGroupMembers);
     $('#rm_group_members_filter').on('input', filterGroupMemberList);
@@ -3782,6 +3812,15 @@ jQuery(() => {
     });
     $('#groupCurrentMemberPopoutButton').on('click', doCurMemberListPopout);
     $('#rm_group_chat_name').on('input', onGroupNameInput);
+    $('#rm_button_selected_ch h2').on('click', async function (event) {
+        if (menu_type !== 'group_edit' || !openGroupId) {
+            return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        await renameOpenGroup();
+    });
     $('#rm_group_delete').off().on('click', onDeleteGroupClick);
     $('#group_favorite_button').on('click', onFavoriteGroupClick);
     $('#rm_group_allow_self_responses').on('input', onGroupSelfResponsesClick);

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -34,7 +34,7 @@ const SB_SHORTCUT_TARGETS = Object.freeze([
     { value: 'action:search', label: 'Search', icon: 'fa-magnifying-glass' },
     { value: 'right:settings', label: 'Settings', icon: 'fa-sliders' },
     { value: 'right:extensions', label: 'Extensions', icon: 'fa-cubes' },
-    { value: 'right:persona', label: 'Persona', icon: 'fa-face-smile' },
+    { value: 'characters:persona', label: 'Persona', icon: 'fa-face-smile' },
     { value: 'right:background', label: 'Background', icon: 'fa-panorama' },
 ]);
 
@@ -87,6 +87,7 @@ const SB_SHELL_FOCUSABLE_SELECTOR = [
 let sbInlineDrawerPersistenceObserver = null;
 let sbInlineDrawerPersistenceQueued = false;
 let sbChatScriptModulePromise = null;
+let sbMainScriptModulePromise = null;
 let sbStorageFlushTimer = 0;
 let sbStorageFlushEventsBound = false;
 let sbMessageActionEventsBound = false;
@@ -147,6 +148,14 @@ function activateShortcutTarget(target) {
     }
 
     const [shell, tab] = String(target).split(':');
+
+    if (shell === 'characters') {
+        if (!tab || tab === 'characters') {
+            void setCharacterListEntityView('characters');
+        }
+        openCharacterPanelTab(tab);
+        return;
+    }
 
     if (shell && tab) {
         toggleShellPanel(shell, tab);
@@ -340,6 +349,36 @@ const SB_MESSAGE_STYLES = Object.freeze([
     { id: '2', label: 'Document', icon: 'fa-file-lines' },
 ]);
 
+const SB_CHARACTER_TAB_COPY = Object.freeze({
+    characters: {
+        title: 'Character Menu',
+        subtitle: 'Browse, create, and sort locally-stored character cards.',
+        description: 'Manage your personal character cards, groups, and personas here.',
+    },
+    groups: {
+        title: 'Group Menu',
+        subtitle: 'Browse, create, and sort locally-stored group chats here, using multiple character cards.',
+        description: 'Manage your personal character cards, groups, and personas here.',
+    },
+    editor: {
+        title: 'Card Editor',
+        subtitle: 'Edit or make changes to your selected character card or group chat here.',
+        description: 'Manage your personal character cards, groups, and personas here.',
+    },
+    persona: {
+        title: 'Persona',
+        subtitle: 'Manage your in-chat persona details and other configuration options.',
+        description: 'Manage your personal character cards, groups, and personas here.',
+    },
+    import: {
+        title: 'Import',
+        subtitle: 'Import character cards from files, search a website for uploaded character cards, or import them directly from a URL.',
+        description: 'Manage your personal character cards, groups, and personas here.',
+    },
+});
+
+const SB_PERSONA_HELP_LINK_HTML = '<a class="notes-link sb-character-title-help" href="https://docs.sillytavern.app/usage/core-concepts/personas/" target="_blank"><span class="fa-solid fa-circle-question note-link-span"></span></a>';
+
 const SB_SHELLS = Object.freeze({
     left: {
         rootPanelId: 'left-nav-panel',
@@ -409,9 +448,9 @@ const SB_SHELLS = Object.freeze({
         proxyIcon: 'fa-gear',
         proxyLabel: 'Customize',
         title: 'Customize',
-        subtitle: 'Personalize your workspace, add/remove extensions, change personas, modify server settings, or check logs here.',
-        searchPlaceholder: 'Search themes, top bar, personas, backgrounds, or extensions',
-        searchExamples: ['theme', 'top bar', 'Appearance', 'notify extension updates', 'persona'],
+        subtitle: 'Personalize your workspace, add/remove extensions, modify server settings, or check logs here.',
+        searchPlaceholder: 'Search themes, top bar, backgrounds, or extensions',
+        searchExamples: ['theme', 'top bar', 'Appearance', 'notify extension updates'],
         storageKey: SB_STORAGE_KEYS.rightTab,
         defaultTabId: 'settings',
         baseTab: {
@@ -429,14 +468,6 @@ const SB_SHELLS = Object.freeze({
                 icon: 'fa-cubes',
                 searchPlaceholder: 'Search themes, Quick Reply, Dialogue Colors, or Image Gen',
                 searchExamples: ['themes', 'Quick Reply', 'Dialogue Colors', 'Image Gen'],
-            },
-            {
-                id: 'persona',
-                drawerId: 'persona-management-button',
-                label: 'Persona',
-                icon: 'fa-face-smile',
-                searchPlaceholder: 'Search default persona, avatar, description, or lock',
-                searchExamples: ['default persona', 'avatar', 'description', 'lock'],
             },
             {
                 id: 'background',
@@ -472,7 +503,7 @@ const SB_DRAWER_ROUTES = Object.freeze({
     'advanced-formatting-button': { shell: 'left', tab: 'advanced-formatting' },
     'WI-SP-button': { shell: 'left', tab: 'world-info' },
     'extensions-settings-button': { shell: 'right', tab: 'extensions' },
-    'persona-management-button': { shell: 'right', tab: 'persona' },
+    'persona-management-button': { shell: 'characters', tab: 'persona' },
     'backgrounds-button': { shell: 'right', tab: 'background' },
 });
 
@@ -556,6 +587,7 @@ const sbState = {
         rightLocked: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.characterDrawerRightLocked), false),
         stateObserver: null,
         observedOpen: null,
+        lastTab: 'characters',
     },
     mobileModal: {
         syncFrame: 0,
@@ -2316,6 +2348,14 @@ function getChatScriptModule() {
     }
 
     return sbChatScriptModulePromise;
+}
+
+function getMainScriptModule() {
+    if (!sbMainScriptModulePromise) {
+        sbMainScriptModulePromise = import('../script.js');
+    }
+
+    return sbMainScriptModulePromise;
 }
 
 function getCookieClearDomains(hostname) {
@@ -5299,16 +5339,429 @@ function hasActiveCharacterChat(context = getSillyTavernContext()) {
     );
 }
 
-function showCharacterListView() {
+async function setCharacterListEntityView(view) {
+    try {
+        const module = await getMainScriptModule();
+        module.setCharacterMenuEntityView?.(view);
+    } catch (error) {
+        console.warn('[SillyBunny] Could not set character list entity view.', error);
+    }
+}
+
+function syncCharacterListControls(view) {
+    const normalizedView = view === 'groups' ? 'groups' : 'characters';
+    const createCharacterButton = document.getElementById('rm_button_create');
+    const createGroupButton = document.getElementById('rm_button_group_chats');
+    const bulkEditButton = document.getElementById('bulkEditButton');
+    const bulkSelectAllButton = document.getElementById('bulkSelectAllButton');
+    const bulkDeleteButton = document.getElementById('bulkDeleteButton');
+
+    if (createCharacterButton instanceof HTMLElement) {
+        createCharacterButton.hidden = normalizedView === 'groups';
+    }
+
+    if (createGroupButton instanceof HTMLElement) {
+        createGroupButton.hidden = normalizedView !== 'groups';
+    }
+
+    for (const button of [bulkEditButton, bulkSelectAllButton, bulkDeleteButton]) {
+        if (button instanceof HTMLElement) {
+            button.hidden = false;
+        }
+    }
+
+    if (bulkEditButton instanceof HTMLElement) {
+        bulkEditButton.classList.toggle('disabled', normalizedView === 'groups');
+        bulkEditButton.setAttribute('aria-disabled', String(normalizedView === 'groups'));
+        bulkEditButton.title = normalizedView === 'groups'
+            ? 'Bulk edit for groups is not available yet'
+            : 'Bulk edit characters\n\nClick to toggle characters\nShift + Click to select/deselect a range of characters\nRight-click for actions';
+    }
+}
+
+function ensureCharacterListToolbarLayout() {
+    const fixedTop = document.getElementById('charListFixedTop');
+    const buttonBar = document.getElementById('rm_button_bar');
+    const createButton = document.getElementById('rm_button_create');
+    const createGroupButton = document.getElementById('rm_button_group_chats');
+    const searchButton = document.getElementById('rm_button_search');
+    const pagination = document.getElementById('rm_print_characters_pagination');
+
+    if (!(fixedTop instanceof HTMLElement) || !(buttonBar instanceof HTMLElement)) {
+        return;
+    }
+
+    let actionBar = fixedTop.querySelector('.sb-character-create-bar');
+    if (!(actionBar instanceof HTMLElement)) {
+        actionBar = createElement('div', { className: 'sb-character-create-bar' });
+        fixedTop.prepend(actionBar);
+    }
+
+    if (createButton instanceof HTMLElement && createButton.parentElement !== actionBar) {
+        actionBar.prepend(createButton);
+    }
+
+    if (createGroupButton instanceof HTMLElement && createGroupButton.parentElement !== actionBar) {
+        const afterCreate = createButton instanceof HTMLElement && createButton.parentElement === actionBar
+            ? createButton.nextSibling
+            : actionBar.firstChild;
+        actionBar.insertBefore(createGroupButton, afterCreate);
+    }
+
+    if (buttonBar.parentElement !== actionBar) {
+        const actionButton = createGroupButton instanceof HTMLElement && createGroupButton.parentElement === actionBar
+            ? createGroupButton
+            : createButton;
+        const afterAction = actionButton instanceof HTMLElement && actionButton.parentElement === actionBar
+            ? actionButton.nextSibling
+            : actionBar.firstChild;
+        actionBar.insertBefore(buttonBar, afterAction);
+    }
+
+    if (pagination instanceof HTMLElement && pagination.parentElement !== actionBar) {
+        actionBar.insertBefore(pagination, buttonBar.nextSibling);
+    }
+
+    if (searchButton instanceof HTMLElement && searchButton.parentElement !== buttonBar) {
+        buttonBar.appendChild(searchButton);
+    }
+
+    const bulkEditButton = document.getElementById('bulkEditButton');
+    if (bulkEditButton instanceof HTMLElement && bulkEditButton.dataset.sbGroupsGuardBound !== 'true') {
+        bulkEditButton.dataset.sbGroupsGuardBound = 'true';
+        bulkEditButton.addEventListener('click', (event) => {
+            const panel = document.getElementById('right-nav-panel');
+            if (panel instanceof HTMLElement && panel.dataset.menuType === 'groups') {
+                event.preventDefault();
+                event.stopImmediatePropagation();
+                globalThis.toastr?.info?.('Bulk edit for groups is not available yet.');
+            }
+        }, { capture: true });
+    }
+}
+
+async function showCharacterListView(view = 'characters') {
+    setCharacterEditorEmptyState(false);
+    setCharacterPersonaPanelVisible(false);
+    setCharacterImportPanelVisible(false);
+    const panel = document.getElementById('right-nav-panel');
+    const normalizedView = view === 'groups' ? 'groups' : 'characters';
+    sbState.characterDrawer.lastTab = normalizedView;
+
+    if (panel instanceof HTMLElement) {
+        panel.dataset.menuType = normalizedView;
+    }
+
+    syncCharacterListControls(normalizedView);
+    await setCharacterListEntityView(normalizedView);
+
     const backButton = document.getElementById('rm_button_back');
 
     if (backButton instanceof HTMLElement) {
         backButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        if (panel instanceof HTMLElement) {
+            panel.dataset.menuType = normalizedView;
+        }
+        syncCharacterListControls(normalizedView);
+        syncCharacterShellTabs(normalizedView);
         return true;
     }
 
     resetCharacterPanelView();
+    if (panel instanceof HTMLElement) {
+        panel.dataset.menuType = normalizedView;
+    }
+    syncCharacterListControls(normalizedView);
+    syncCharacterShellTabs(normalizedView);
     return true;
+}
+
+function showCharacterEditorEmptyState() {
+    const panel = document.getElementById('right-nav-panel');
+    const infoPanel = document.getElementById('result_info');
+    const pinAndTabs = document.getElementById('rm_PinAndTabs');
+    const characterEditor = document.getElementById('rm_ch_create_block');
+    const groupEditor = document.getElementById('rm_group_chats_block');
+    const characterList = document.getElementById('rm_characters_block');
+
+    panel?.setAttribute('data-menu-type', 'editor_empty');
+    setCharacterPersonaPanelVisible(false);
+    setCharacterImportPanelVisible(false);
+    syncCharacterListControls('characters');
+    setCharacterEditorEmptyState(true);
+
+    if (infoPanel instanceof HTMLElement) {
+        infoPanel.style.display = 'none';
+    }
+
+    if (pinAndTabs instanceof HTMLElement) {
+        pinAndTabs.style.display = 'none';
+    }
+
+    if (characterEditor instanceof HTMLElement) {
+        characterEditor.classList.remove('sb-active-right-menu');
+        characterEditor.style.display = 'none';
+        characterEditor.style.visibility = 'hidden';
+        characterEditor.style.pointerEvents = 'none';
+    }
+
+    if (groupEditor instanceof HTMLElement) {
+        groupEditor.classList.remove('sb-active-right-menu');
+        groupEditor.style.display = 'none';
+        groupEditor.style.visibility = 'hidden';
+        groupEditor.style.pointerEvents = 'none';
+    }
+
+    if (characterList instanceof HTMLElement) {
+        characterList.classList.remove('sb-active-right-menu');
+        characterList.style.display = 'none';
+        characterList.style.visibility = 'hidden';
+        characterList.style.pointerEvents = 'none';
+    }
+
+    syncCharacterShellTabs('editor');
+}
+
+function setCharacterEditorEmptyState(visible) {
+    const emptyState = document.getElementById('sb_character_editor_empty');
+
+    if (emptyState instanceof HTMLElement) {
+        emptyState.hidden = !visible;
+    }
+
+    syncCharacterTitlebarVisibility();
+}
+
+function syncCharacterTitlebarVisibility() {
+    const panel = document.getElementById('right-nav-panel');
+    const pinAndTabs = document.getElementById('rm_PinAndTabs');
+
+    if (!(panel instanceof HTMLElement) || !(pinAndTabs instanceof HTMLElement)) {
+        return;
+    }
+
+    const shouldHide = ['characters', 'groups', 'editor_empty', 'persona', 'import'].includes(panel.dataset.menuType ?? '');
+    pinAndTabs.style.display = shouldHide ? 'none' : '';
+}
+
+function ensureCharacterPersonaPanel() {
+    const host = document.getElementById('sb_character_persona_panel');
+    const drawer = document.getElementById('persona-management-button');
+    const content = document.getElementById('PersonaManagement');
+
+    if (!(host instanceof HTMLElement) || !(drawer instanceof HTMLElement) || !(content instanceof HTMLElement)) {
+        return null;
+    }
+
+    drawer.classList.add('sb-embedded-drawer');
+    drawer.querySelector(':scope > .drawer-toggle')?.classList.add('sb-hidden-toggle');
+    content.classList.remove('drawer-content', 'openDrawer', 'closedDrawer', 'fillLeft', 'fillRight', 'pinnedOpen');
+    content.classList.add('sb-managed', 'sb-shell-embedded-content');
+    content.removeAttribute('style');
+
+    if (drawer.parentElement !== host) {
+        host.appendChild(drawer);
+    }
+
+    return host;
+}
+
+function setCharacterPersonaPanelVisible(visible) {
+    const host = ensureCharacterPersonaPanel() ?? document.getElementById('sb_character_persona_panel');
+
+    if (host instanceof HTMLElement) {
+        host.hidden = !visible;
+    }
+}
+
+function setCharacterImportPanelVisible(visible) {
+    const host = document.getElementById('sb_character_import_panel');
+
+    if (host instanceof HTMLElement) {
+        host.hidden = !visible;
+    }
+}
+
+function hideCharacterMainPanels() {
+    const infoPanel = document.getElementById('result_info');
+    const pinAndTabs = document.getElementById('rm_PinAndTabs');
+    const characterEditor = document.getElementById('rm_ch_create_block');
+    const characterList = document.getElementById('rm_characters_block');
+
+    if (infoPanel instanceof HTMLElement) {
+        infoPanel.style.display = 'none';
+    }
+
+    if (pinAndTabs instanceof HTMLElement) {
+        pinAndTabs.style.display = 'none';
+    }
+
+    if (characterEditor instanceof HTMLElement) {
+        characterEditor.style.display = 'none';
+        characterEditor.style.visibility = 'hidden';
+        characterEditor.style.pointerEvents = 'none';
+    }
+
+    if (characterList instanceof HTMLElement) {
+        characterList.style.display = 'none';
+        characterList.style.visibility = 'hidden';
+        characterList.style.pointerEvents = 'none';
+    }
+}
+
+function openCharacterPersonaTab() {
+    const panel = document.getElementById('right-nav-panel');
+    sbState.characterDrawer.lastTab = 'persona';
+
+    panel?.setAttribute('data-menu-type', 'persona');
+    setCharacterEditorEmptyState(false);
+    setCharacterImportPanelVisible(false);
+    syncCharacterListControls('characters');
+    setCharacterPersonaPanelVisible(true);
+    hideCharacterMainPanels();
+
+    syncCharacterShellTabs('persona');
+    syncCharacterTitlebarVisibility();
+}
+
+function openCharacterImportTab() {
+    const panel = document.getElementById('right-nav-panel');
+    sbState.characterDrawer.lastTab = 'import';
+
+    panel?.setAttribute('data-menu-type', 'import');
+    setCharacterEditorEmptyState(false);
+    setCharacterPersonaPanelVisible(false);
+    syncCharacterListControls('characters');
+    setCharacterImportPanelVisible(true);
+    hideCharacterMainPanels();
+
+    syncCharacterShellTabs('import');
+    syncCharacterTitlebarVisibility();
+}
+
+function preserveCharacterImportTab() {
+    const panel = document.getElementById('right-nav-panel');
+
+    if (panel instanceof HTMLElement && panel.dataset.menuType !== 'import') {
+        return;
+    }
+
+    setCharacterEditorEmptyState(false);
+    setCharacterPersonaPanelVisible(false);
+    syncCharacterListControls('characters');
+    setCharacterImportPanelVisible(true);
+    hideCharacterMainPanels();
+    syncCharacterShellTabs('import');
+    syncCharacterTitlebarVisibility();
+}
+
+function openCharacterPanelTab(tabId) {
+    const normalizedTabId = ['persona', 'import', 'groups', 'editor'].includes(tabId) ? tabId : 'characters';
+    sbState.characterDrawer.lastTab = normalizedTabId;
+
+    if (!isCharacterPanelOpen()) {
+        toggleCharacterPanel();
+    } else {
+        closeShell('left');
+        closeShell('right');
+    }
+
+    window.requestAnimationFrame(() => {
+        if (tabId === 'persona') {
+            openCharacterPersonaTab();
+        } else if (tabId === 'import') {
+            openCharacterImportTab();
+        } else if (tabId === 'groups') {
+            void showCharacterListView('groups');
+        } else if (tabId === 'editor') {
+            openCharacterEditorTab();
+        } else {
+            void showCharacterListView();
+        }
+    });
+}
+
+function restoreLastCharacterPanelView() {
+    const lastTab = sbState.characterDrawer.lastTab || 'characters';
+
+    if (lastTab === 'persona') {
+        openCharacterPersonaTab();
+    } else if (lastTab === 'import') {
+        openCharacterImportTab();
+    } else if (lastTab === 'groups') {
+        void showCharacterListView('groups');
+    } else if (lastTab === 'editor') {
+        openCharacterEditorTab();
+    } else {
+        void showCharacterListView('characters');
+    }
+}
+
+function openCharacterEditorTab() {
+    sbState.characterDrawer.lastTab = 'editor';
+    setCharacterEditorEmptyState(false);
+    setCharacterPersonaPanelVisible(false);
+    setCharacterImportPanelVisible(false);
+
+    if (showActiveCharacterEditor()) {
+        syncCharacterShellTabs('editor');
+        return true;
+    }
+
+    showCharacterEditorEmptyState();
+    return false;
+}
+
+function syncCharacterShellTabs(activeTab = null) {
+    const panel = document.getElementById('right-nav-panel');
+    const menuType = panel?.dataset.menuType;
+    const normalizedTab = activeTab
+        ?? (menuType === 'persona'
+            ? 'persona'
+            : menuType === 'import'
+                ? 'import'
+                : menuType === 'groups'
+                    ? 'groups'
+                    : ['character_edit', 'group_edit', 'create', 'group_create', 'editor_empty'].includes(menuType) ? 'editor' : 'characters');
+
+    if (menuType === 'characters' || menuType === 'groups') {
+        syncCharacterListControls(menuType);
+    }
+
+    syncCharacterHeaderCopy(normalizedTab);
+
+    document.querySelectorAll('#right-nav-panel [data-sb-character-tab]').forEach(tab => {
+        if (!(tab instanceof HTMLElement)) {
+            return;
+        }
+
+        const isActive = tab.dataset.sbCharacterTab === normalizedTab;
+        tab.classList.toggle('is-active', isActive);
+        tab.setAttribute('aria-selected', String(isActive));
+    });
+}
+
+function syncCharacterHeaderCopy(activeTab = 'characters') {
+    const copy = SB_CHARACTER_TAB_COPY[activeTab] ?? SB_CHARACTER_TAB_COPY.characters;
+    const title = document.querySelector('#right-nav-panel .sb-character-shell-header .sb-shell-title');
+    const subtitle = document.querySelector('#right-nav-panel .sb-character-shell-header .sb-shell-subtitle');
+    const description = document.querySelector('#right-nav-panel .sb-character-shell-header .sb-shell-description');
+
+    if (title instanceof HTMLElement) {
+        title.textContent = '';
+        title.append(document.createTextNode(copy.title));
+        if (activeTab === 'persona') {
+            title.insertAdjacentHTML('beforeend', SB_PERSONA_HELP_LINK_HTML);
+        }
+    }
+
+    if (subtitle instanceof HTMLElement) {
+        subtitle.textContent = copy.subtitle;
+    }
+
+    if (description instanceof HTMLElement) {
+        description.textContent = copy.description;
+    }
 }
 
 function showActiveCharacterEditor() {
@@ -5322,6 +5775,10 @@ function showActiveCharacterEditor() {
     }
 
     selectedCharacterButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    setCharacterEditorEmptyState(false);
+    setCharacterPersonaPanelVisible(false);
+    setCharacterImportPanelVisible(false);
+    syncCharacterShellTabs('editor');
     return true;
 }
 
@@ -5334,8 +5791,17 @@ function resetCharacterPanelView() {
         selectedTitle.textContent = '';
     }
 
+    setCharacterEditorEmptyState(false);
+    setCharacterPersonaPanelVisible(false);
+    setCharacterImportPanelVisible(false);
+
     if (listButton instanceof HTMLElement) {
         listButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        if (panel instanceof HTMLElement) {
+            panel.dataset.menuType = 'characters';
+        }
+        syncCharacterListControls('characters');
+        syncCharacterShellTabs('characters');
         return;
     }
 
@@ -5362,6 +5828,8 @@ function resetCharacterPanelView() {
         characterList.style.visibility = 'visible';
         characterList.style.pointerEvents = 'auto';
     }
+
+    syncCharacterShellTabs('characters');
 }
 
 function setCharacterDrawerHostOverflow(shouldOpen) {
@@ -5404,10 +5872,20 @@ function bindCharacterDrawerStateObserver() {
     }
 
     sbState.characterDrawer.stateObserver?.disconnect();
-    sbState.characterDrawer.stateObserver = new MutationObserver(() => syncCharacterDrawerStateFromDom());
+    sbState.characterDrawer.stateObserver = new MutationObserver((mutations) => {
+        syncCharacterDrawerStateFromDom();
+
+        if (mutations.some(mutation => mutation.attributeName === 'data-menu-type')) {
+            setCharacterEditorEmptyState(panel.dataset.menuType === 'editor_empty');
+            setCharacterPersonaPanelVisible(panel.dataset.menuType === 'persona');
+            setCharacterImportPanelVisible(panel.dataset.menuType === 'import');
+            syncCharacterTitlebarVisibility();
+            syncCharacterShellTabs();
+        }
+    });
     sbState.characterDrawer.stateObserver.observe(panel, {
         attributes: true,
-        attributeFilter: ['class'],
+        attributeFilter: ['class', 'data-menu-type'],
     });
     syncCharacterDrawerStateFromDom({ force: true });
 }
@@ -5452,7 +5930,6 @@ function ensureCharacterResizeHandle() {
 function toggleCharacterPanel() {
     injectCharacterDrawerControls();
     ensureCharacterResizeHandle();
-    const shouldOpenActiveCharacterEditor = hasActiveCharacterChat();
 
     if (isCharacterPanelOpen()) {
         closeCharacterPanel();
@@ -5460,12 +5937,7 @@ function toggleCharacterPanel() {
     }
 
     closeAllDropdowns({ except: 'characters' });
-
-    if (shouldOpenActiveCharacterEditor) {
-        showActiveCharacterEditor();
-    } else {
-        resetCharacterPanelView();
-    }
+    restoreLastCharacterPanelView();
 
     closeShell('left');
     closeShell('right');
@@ -5482,9 +5954,7 @@ function toggleCharacterPanel() {
             forceDrawerState('right-nav-panel', true, '#rightNavDrawerIcon');
         }
 
-        if (shouldOpenActiveCharacterEditor) {
-            showActiveCharacterEditor();
-        }
+        restoreLastCharacterPanelView();
 
         syncChatbarVisibilityState();
         syncDesktopShellSizing();
@@ -9073,7 +9543,7 @@ function getPersonaSearchEntries(tabState) {
             dedupeKey: getSearchEntryDedupeKey(tabState, 'Persona', name, { avatarId }),
             action: () => {
                 // Activate the persona tab and trigger ST's own persona search
-                openShell('right', 'persona');
+                openCharacterPanelTab('persona');
                 window.setTimeout(() => {
                     const searchInput = document.getElementById('persona_search_bar');
                     if (searchInput instanceof HTMLInputElement) {
@@ -9860,6 +10330,20 @@ function routeDrawerTarget(targetId) {
         return false;
     }
 
+    if (route.shell === 'characters') {
+        if (!isCharacterPanelOpen()) {
+            toggleCharacterPanel();
+        } else {
+            closeShell('left');
+            closeShell('right');
+        }
+
+        if (route.tab === 'persona') {
+            openCharacterPersonaTab();
+        }
+        return true;
+    }
+
     openShell(route.shell, route.tab);
     return true;
 }
@@ -10208,73 +10692,93 @@ function closeMobileNav() {
 
 function injectCharacterDrawerControls() {
     document.getElementById('right-nav-panel')?.classList.add('sb-character-drawer-root');
+    ensureCharacterListToolbarLayout();
+
+    const shellCloseButton = document.getElementById('sb_character_shell_close');
+    if (shellCloseButton instanceof HTMLButtonElement && shellCloseButton.dataset.sbBound !== 'true') {
+        shellCloseButton.dataset.sbBound = 'true';
+        shellCloseButton.addEventListener('click', () => closeCharacterPanel());
+    }
+
+    const charactersTab = document.getElementById('sb_character_tab_characters');
+    if (charactersTab instanceof HTMLButtonElement && charactersTab.dataset.sbBound !== 'true') {
+        charactersTab.dataset.sbBound = 'true';
+        charactersTab.addEventListener('click', () => { void showCharacterListView(); });
+    }
+
+    const groupsTab = document.getElementById('sb_character_tab_groups');
+    if (groupsTab instanceof HTMLButtonElement && groupsTab.dataset.sbBound !== 'true') {
+        groupsTab.dataset.sbBound = 'true';
+        groupsTab.addEventListener('click', () => { void showCharacterListView('groups'); });
+    }
+
+    const editorTab = document.getElementById('sb_character_tab_editor');
+    if (editorTab instanceof HTMLButtonElement && editorTab.dataset.sbBound !== 'true') {
+        editorTab.dataset.sbBound = 'true';
+        editorTab.addEventListener('click', () => openCharacterEditorTab());
+    }
+
+    const personaTab = document.getElementById('sb_character_tab_persona');
+    if (personaTab instanceof HTMLButtonElement && personaTab.dataset.sbBound !== 'true') {
+        personaTab.dataset.sbBound = 'true';
+        personaTab.addEventListener('click', () => openCharacterPersonaTab());
+    }
+
+    const importTab = document.getElementById('sb_character_tab_import');
+    if (importTab instanceof HTMLButtonElement && importTab.dataset.sbBound !== 'true') {
+        importTab.dataset.sbBound = 'true';
+        importTab.addEventListener('click', () => openCharacterImportTab());
+    }
+
+    const importFileAction = document.getElementById('sb_character_import_file_action');
+    if (importFileAction instanceof HTMLButtonElement && importFileAction.dataset.sbBound !== 'true') {
+        importFileAction.dataset.sbBound = 'true';
+        importFileAction.addEventListener('click', () => {
+            document.getElementById('character_import_button')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
+    }
+
+    const importUrlAction = document.getElementById('sb_character_import_url_action');
+    if (importUrlAction instanceof HTMLButtonElement && importUrlAction.dataset.sbBound !== 'true') {
+        importUrlAction.dataset.sbBound = 'true';
+        importUrlAction.addEventListener('click', () => {
+            document.getElementById('external_import_button')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
+    }
+
+    if (document.documentElement.dataset.sbCharacterImportPreserveBound !== 'true') {
+        document.documentElement.dataset.sbCharacterImportPreserveBound = 'true';
+        document.addEventListener('sillybunny:character-import-tab-preserve', () => {
+            window.requestAnimationFrame(preserveCharacterImportTab);
+        });
+    }
+
+    const emptyBrowseButton = document.getElementById('sb_character_empty_browse');
+    if (emptyBrowseButton instanceof HTMLButtonElement && emptyBrowseButton.dataset.sbBound !== 'true') {
+        emptyBrowseButton.dataset.sbBound = 'true';
+        emptyBrowseButton.addEventListener('click', () => { void showCharacterListView(); });
+    }
+
+    const emptyCreateButton = document.getElementById('sb_character_empty_create');
+    if (emptyCreateButton instanceof HTMLButtonElement && emptyCreateButton.dataset.sbBound !== 'true') {
+        emptyCreateButton.dataset.sbBound = 'true';
+        emptyCreateButton.addEventListener('click', () => {
+            setCharacterEditorEmptyState(false);
+            setCharacterPersonaPanelVisible(false);
+            setCharacterImportPanelVisible(false);
+            document.getElementById('rm_button_create')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+            syncCharacterShellTabs('editor');
+        });
+    }
+
+    ensureCharacterPersonaPanel();
 
     const target = document.getElementById('CharListButtonAndHotSwaps');
     if (!(target instanceof HTMLElement)) {
         return;
     }
 
-    let lockButton = target.querySelector('#sb-character-right-lock');
-    if (!(lockButton instanceof HTMLButtonElement)) {
-        lockButton = createElement('button', {
-            id: 'sb-character-right-lock',
-            className: 'sb-character-right-lock menu_button menu_button_icon',
-            attrs: {
-                type: 'button',
-                title: 'Lock Characters to right',
-                'aria-label': 'Lock Characters to right',
-                'aria-pressed': 'false',
-            },
-        });
-
-        lockButton.innerHTML = '<i class="fa-solid fa-align-right" aria-hidden="true"></i>';
-        lockButton.addEventListener('click', () => {
-            setCharacterDrawerRightLock(!sbState.characterDrawer.rightLocked);
-            syncDesktopShellSizing();
-        });
-        target.appendChild(lockButton);
-    }
-
-    let backButton = target.querySelector('#sb-character-back-to-list');
-    if (!(backButton instanceof HTMLButtonElement)) {
-        backButton = createElement('button', {
-            id: 'sb-character-back-to-list',
-            className: 'sb-character-back-to-list menu_button menu_button_icon',
-            attrs: {
-                type: 'button',
-                title: 'Back to characters list',
-                'aria-label': 'Back to characters list',
-            },
-        });
-
-        backButton.innerHTML = '<i class="fa-solid fa-arrow-left" aria-hidden="true"></i>';
-        backButton.addEventListener('click', () => {
-            showCharacterListView();
-            syncChatbarVisibilityState();
-        });
-        target.appendChild(backButton);
-    }
-
-    let closeButton = target.querySelector('#sb-character-mobile-close');
-    if (!(closeButton instanceof HTMLButtonElement)) {
-        closeButton = createElement('button', {
-            id: 'sb-character-mobile-close',
-            className: 'sb-character-close menu_button menu_button_icon',
-            attrs: {
-                type: 'button',
-                title: 'Close Characters',
-                'aria-label': 'Close Characters',
-            },
-        });
-
-        closeButton.innerHTML = '<i class="fa-solid fa-xmark" aria-hidden="true"></i>';
-        closeButton.addEventListener('click', () => {
-            closeCharacterPanel();
-        });
-        target.appendChild(closeButton);
-    }
-
-    syncCharacterDrawerLockButton();
+    syncCharacterShellTabs();
 }
 
 function bindCharacterEditorExitButton() {
@@ -11071,7 +11575,7 @@ async function selectPersonaOption(option, picker, avatarId, context) {
         if (domAvatar instanceof HTMLElement) {
             domAvatar.click();
         } else {
-            openShell('right', 'persona');
+            openCharacterPanelTab('persona');
         }
     }
 
@@ -11235,12 +11739,20 @@ function initAll() {
 
     window.SillyBunnyShell = Object.assign(window.SillyBunnyShell || {}, {
         openTab(shellKey, tabId) {
+            if (shellKey === 'characters') {
+                openCharacterPanelTab(tabId);
+                return;
+            }
+
             if (SB_SHELLS[shellKey]) {
                 openShell(shellKey, tabId);
             }
         },
         openCharacters() {
             toggleCharacterPanel();
+        },
+        closeCharacters() {
+            closeCharacterPanel();
         },
         openGlobalSearch({ focusInput = true } = {}) {
             closeAllDropdowns({ except: 'search' });

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -5586,6 +5586,7 @@ function hideCharacterMainPanels() {
     const infoPanel = document.getElementById('result_info');
     const pinAndTabs = document.getElementById('rm_PinAndTabs');
     const characterEditor = document.getElementById('rm_ch_create_block');
+    const groupEditor = document.getElementById('rm_group_chats_block');
     const characterList = document.getElementById('rm_characters_block');
 
     if (infoPanel instanceof HTMLElement) {
@@ -5600,6 +5601,12 @@ function hideCharacterMainPanels() {
         characterEditor.style.display = 'none';
         characterEditor.style.visibility = 'hidden';
         characterEditor.style.pointerEvents = 'none';
+    }
+
+    if (groupEditor instanceof HTMLElement) {
+        groupEditor.style.display = 'none';
+        groupEditor.style.visibility = 'hidden';
+        groupEditor.style.pointerEvents = 'none';
     }
 
     if (characterList instanceof HTMLElement) {

--- a/public/scripts/welcome-screen.js
+++ b/public/scripts/welcome-screen.js
@@ -137,9 +137,9 @@ const WELCOME_TUTORIAL_STEPS = Object.freeze([
     },
     {
         title: 'Personalize your workspace',
-        body: 'The Customize menu in the top bar handles your theming and customization needs. You can optionally enable extra extensions, manage personas.',
+        body: 'The Customize menu in the top bar handles your theming and customization needs. You can optionally enable extra extensions, then manage personas from Characters.',
         hint: 'Customization and extensions are optional, but recommended. While we ship a starter pack, nothing turns itself on without your permission.',
-        chips: ['Settings', 'Extensions', 'Persona', 'Background'],
+        chips: ['Settings', 'Extensions', 'Background'],
         actionLabel: 'Open Extensions',
         actionType: 'open-tab',
         actionValue: 'right:extensions',
@@ -167,8 +167,8 @@ const WELCOME_GUIDE_CARDS = Object.freeze([
     },
     {
         title: 'Customize Menu',
-        body: 'Open the Customize button in the top bar when you want to change your workspace setup: app settings, extensions, personas, and the visual feel of SillyBunny.',
-        chips: ['Settings', 'Extensions', 'Persona', 'Background'],
+        body: 'Open the Customize button in the top bar when you want to change your workspace setup: app settings, extensions, backgrounds, and the visual feel of SillyBunny.',
+        chips: ['Settings', 'Extensions', 'Background'],
         icon: 'fa-sliders',
         actionLabel: 'Open the Customize menu',
         actionType: 'open-tab',
@@ -176,8 +176,8 @@ const WELCOME_GUIDE_CARDS = Object.freeze([
     },
     {
         title: 'Characters Menu',
-        body: 'Open the Characters button in the top bar when you want to access, modify, or create character cards. We have a few characters bundled for you to give you an idea of how to create them!',
-        chips: ['Character Cards', 'Create Character', 'Delete Character', 'Open Character'],
+        body: 'Open the Characters button in the top bar when you want to access characters, edit personas, or create character cards. We have a few characters bundled for you to give you an idea of how to create them!',
+        chips: ['Character Cards', 'Persona', 'Create Character', 'Open Character'],
         icon: 'fa-solid fa-id-card',
         actionLabel: 'Open the Characters menu',
         actionType: 'open-characters-menu',
@@ -1117,7 +1117,7 @@ function openShellTab(route) {
         'left:world-info': '#WI-SP-button > .drawer-toggle',
         'right:settings': '#user-settings-button > .drawer-toggle',
         'right:extensions': '#extensions-settings-button > .drawer-toggle',
-        'right:persona': '#persona-management-button > .drawer-toggle',
+        'characters:persona': '#persona-management-button > .drawer-toggle',
         'right:background': '#backgrounds-button > .drawer-toggle',
     }[route];
 

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -6593,7 +6593,14 @@ export function initWorldInfo() {
     });
 
     $('#group-chat-lorebook-dropdown').on('change', async function () {
+        const target = $(this.selectedOptions).attr('id');
         $(this).prop('selectedIndex', 0);
+
+        if (target === 'renameGroupButton') {
+            await globalThis.SillyBunnyShell?.renameOpenGroup?.();
+            return;
+        }
+
         await assignLorebookToChat({ shiftKey: true, altKey: false });
     });
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const SB_SW_CACHE_VERSION = 'sillybunny-cache-v20260507a';
+const SB_SW_CACHE_VERSION = 'sillybunny-cache-v20260513a';
 const SB_STATIC_CACHE = `${SB_SW_CACHE_VERSION}-static`;
 const SB_SHELL_CACHE = `${SB_SW_CACHE_VERSION}-shell`;
 const SB_FRONTEND_ASSET_PREFIX = '/frontend-assets/';

--- a/scripts/check-frontend-budgets.js
+++ b/scripts/check-frontend-budgets.js
@@ -11,7 +11,7 @@ const publicRoot = path.join(repoRoot, 'public');
 
 const budgets = Object.freeze({
     blockingStylesheetCount: 16,
-    blockingStylesheetBytes: 690 * 1024,
+    blockingStylesheetBytes: 730 * 1024,
     startupScriptCount: 23,
     startupScriptBytes: 3_600 * 1024,
     extensionLargeAssetBytes: 2_250 * 1024,


### PR DESCRIPTION
This is an early implementation of a completely reworked character menu - moving from the old legacy system found in SillyTavern to an overhauled, customised version.

This aligns it much more closely with the rest of the graphical shell design by adding tabs for Character, Group, Persona, and Import functionalities, while overhauling a lot of the confusing UI in the process.

With this: all shell UI panels should be congruent with each other.

Caveats: this has not been tested for mobile, only for desktop, and there will likely remain some gremlins and scaling issues with page size changes, which can be addressed in the future.