### PR TITLE
docs: clarify generated runtime config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@
 - `public/lib.js` is served through `src/middleware/webpack-serve.js` / `webpack.config.js`; Bun runtime intentionally disables Webpack minification for that vendor bundle.
 
 ## Config And Data Gotchas
-- Default config is `default/config.yaml`; startup creates or mutates `config.yaml` by adding missing keys and migrating old keys.
+- Checked-in default config is `default/config.yaml`; startup creates or mutates the generated root runtime config by adding missing keys and migrating old keys.
 - Config env vars use the upstream `SILLYTAVERN_` prefix via `keyToEnv()` (for example `SILLYTAVERN_DATAROOT`), despite this fork being named SillyBunny.
 - Do not commit tracked files under `data/default-user/**`; PR CI has a dedicated blocker for that path.
 - Default local port is `4444`; Docker uses `docker compose -f docker/docker-compose.yml up --build` and mounts config/data/plugins/extensions under `docker/`.

--- a/docs/frontend-build.md
+++ b/docs/frontend-build.md
@@ -16,7 +16,7 @@ as `script-0123456789ab.js`.
 
 ## Enable
 
-In `config.yaml`:
+In your generated root runtime config:
 
 ```yaml
 performance:


### PR DESCRIPTION
## What?
Clarifies that SillyBunny's checked-in config source is `default/config.yaml`, while user-facing runtime changes belong in the generated root runtime config.

## Why?
The previous wording pointed readers at `config.yaml` directly, which can be confusing because local runtime config is generated and mutated at startup rather than being the checked-in default source.

## How?
Updates the agent notes and frontend build docs to use generated runtime config wording.

## Testing?
- `git diff --check`

## Screenshots (optional)
Not applicable; documentation-only change.

## Anything Else?
This keeps the portable config clarification from local runtime notes and intentionally omits machine-specific workspace paths.