### PR TITLE
fix: compact guided generations mobile buttons

### DIFF
--- a/public/scripts/extensions/guided-generations/index.js
+++ b/public/scripts/extensions/guided-generations/index.js
@@ -1,5 +1,5 @@
 import { saveSettingsDebounced } from '../../../script.js';
-import { extension_settings, renderExtensionTemplateAsync } from '../../extensions.js';
+import { extensionNames, extension_settings, renderExtensionTemplateAsync } from '../../extensions.js';
 import { extensionName, getPresetsForApiType, getProfileApiType, getProfileList } from './scripts/shared.js';
 import { guidedImpersonate } from './scripts/guidedImpersonate.js';
 import { guidedResponse } from './scripts/guidedResponse.js';
@@ -7,6 +7,8 @@ import { guidedSwipe } from './scripts/guidedSwipe.js';
 import { simpleSend } from './scripts/simpleSend.js';
 
 const oldExtensionKey = 'GuidedGenerations-Extension';
+const oldExtensionName = 'third-party/GuidedGenerations-Extension';
+const oldExtensionWarningStorageKey = 'guided_generations_legacy_fork_warning_v1';
 
 const defaultSettings = {
     showGuidedResponse: true,
@@ -50,6 +52,27 @@ function loadSettings() {
 
     delete settings.showRecoverInputButton;
     extension_settings[extensionName] = settings;
+}
+
+function isOldExtensionInstalled() {
+    return extensionNames.some(name => String(name).toLowerCase() === oldExtensionName.toLowerCase());
+}
+
+function maybeWarnOldExtensionDeprecated() {
+    if (!extension_settings[oldExtensionKey] && !isOldExtensionInstalled()) {
+        return;
+    }
+
+    if (sessionStorage.getItem(oldExtensionWarningStorageKey) === 'true') {
+        return;
+    }
+
+    sessionStorage.setItem(oldExtensionWarningStorageKey, 'true');
+    toastr.warning(
+        'The old Guided Generations fork is deprecated and can conflict with the native Guided Generations port. Uninstall or disable the third-party fork.',
+        'Guided Generations fork deprecated',
+        { timeOut: 12000, extendedTimeOut: 20000, preventDuplicates: true },
+    );
 }
 
 function setElementValue(element, value) {
@@ -324,6 +347,7 @@ function startQrIntegration() {
 
 export async function init() {
     loadSettings();
+    maybeWarnOldExtensionDeprecated();
     await loadSettingsPanel();
     updateExtensionButtons();
     startQrIntegration();

--- a/public/scripts/extensions/guided-generations/style.css
+++ b/public/scripts/extensions/guided-generations/style.css
@@ -63,6 +63,11 @@
 
 @media screen and (max-width: 600px) {
     .gg-action-buttons-container {
+        --gg-mobile-action-size: clamp(28px, calc(var(--bottomFormBlockSize) * 0.5), 34px);
+        --gg-mobile-action-icon-size: clamp(13px, calc(var(--bottomFormIconSize, 20px) * 0.75), 16px);
+    }
+
+    .gg-action-buttons-container {
         padding: 0 6px 5px;
         flex-wrap: wrap;
     }
@@ -76,6 +81,20 @@
         width: 100%;
         justify-content: flex-end;
         order: 1;
+        gap: 4px;
+    }
+
+    .gg-action-button {
+        width: var(--gg-mobile-action-size) !important;
+        min-width: var(--gg-mobile-action-size) !important;
+        max-width: var(--gg-mobile-action-size) !important;
+        height: var(--gg-mobile-action-size) !important;
+        min-height: var(--gg-mobile-action-size) !important;
+        max-height: var(--gg-mobile-action-size) !important;
+        flex: 0 0 var(--gg-mobile-action-size) !important;
+        border-radius: 8px !important;
+        font-size: var(--gg-mobile-action-icon-size) !important;
+        padding: 0 !important;
     }
 
     .gg-profile-row {


### PR DESCRIPTION
## What?
Compacts the native Guided Generations action buttons on narrow mobile screens and warns when the deprecated third-party Guided Generations fork is still present.

## Why?
The baked native extension now owns this workflow, but the old fork can still load from third-party extensions and conflict with the native port. On mobile, the native action buttons also inherited the full composer button size and looked oversized beside the rest of the chat controls.

## How?
Adds mobile-only Guided Generations button sizing at about half the composer control size, with matching smaller icon sizing and tighter gaps. The native extension now checks for legacy fork settings or an installed `third-party/GuidedGenerations-Extension` entry and shows a one-time session warning toast telling users to uninstall or disable the fork.

## Testing?
- `git diff --check`
- `node --check public/scripts/extensions/guided-generations/index.js`
- Targeted ESLint on `public/scripts/extensions/guided-generations/index.js` using the existing dependency install
- `node scripts/check-frontend-budgets.js`

## Screenshots (optional)
Not included; CSS-only mobile sizing plus startup warning. Browser smoke was skipped to avoid starting a second app server before the dev isolation branch is finalized.

## Anything Else?
Separate from PR #64 avatar-shape cleanup.