### PR TITLE
fix: apply geechan review follow-ups

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5759,16 +5759,18 @@
                                     <small data-i18n="Show tags in responses">Show &lt;tags&gt; in responses</small>
                                 </label>
                                 <div class="flex-container alignitemscenter gap10">
-                                    <label for="ooc_context_depth" class="flex1" title="Keep OOC ((...)) blocks in the last N context messages. 0 strips all OOC blocks from prompt context." data-i18n="[title]Keep OOC blocks in the last N context messages. 0 strips all OOC blocks from prompt context.">
+                                    <label for="ooc_context_depth" class="flex1" title="Keep OOC ((...)) blocks in prompt context. -1 keeps all messages, 0 strips all messages, N keeps the last N messages." data-i18n="[title]Keep OOC blocks in prompt context. -1 keeps all messages, 0 strips all messages, N keeps the last N messages.">
                                         <small data-i18n="OOC context depth">OOC context depth</small>
+                                        <small class="opacity50p" data-i18n="-1 keeps all OOC blocks; 0 strips all; N keeps the last N messages.">-1 keeps all OOC blocks; 0 strips all; N keeps the last N messages.</small>
                                     </label>
-                                    <input id="ooc_context_depth" class="text_pole widthUnset" type="number" min="0" step="1" value="0" />
+                                    <input id="ooc_context_depth" class="text_pole widthUnset" type="number" min="-1" step="1" value="-1" />
                                 </div>
                                 <div class="flex-container alignitemscenter gap10">
-                                    <label for="html_context_depth" class="flex1" title="Keep raw HTML tags in the last N context messages. 0 strips HTML tags from prompt context." data-i18n="[title]Keep raw HTML tags in the last N context messages. 0 strips HTML tags from prompt context.">
+                                    <label for="html_context_depth" class="flex1" title="Keep raw HTML tags in prompt context. -1 keeps all messages, 0 strips all messages, N keeps the last N messages." data-i18n="[title]Keep raw HTML tags in prompt context. -1 keeps all messages, 0 strips all messages, N keeps the last N messages.">
                                         <small data-i18n="HTML tag context depth">HTML tag context depth</small>
+                                        <small class="opacity50p" data-i18n="-1 keeps all HTML tags; 0 strips all; N keeps the last N messages.">-1 keeps all HTML tags; 0 strips all; N keeps the last N messages.</small>
                                     </label>
-                                    <input id="html_context_depth" class="text_pole widthUnset" type="number" min="0" step="1" value="0" />
+                                    <input id="html_context_depth" class="text_pole widthUnset" type="number" min="-1" step="1" value="-1" />
                                 </div>
                                 <label class="checkbox_label" for="experimental_macro_engine" title="Experimental new Macro Engine.&NewLine;&NewLine;Allows nested macros to be resolved correctly and has a dedicated, logical replacement order.&NewLine;The new engine is designed to cleanly replace the old regex-based macro system.">
                                     <input id="experimental_macro_engine" type="checkbox" />

--- a/public/script.js
+++ b/public/script.js
@@ -118,6 +118,7 @@ import {
 import {
     extractOocBlocksForDisplay,
     hasTextOrArrayPayload,
+    shouldRetainContextAtDepth,
     restoreOocBlocksForDisplay,
     stripHtmlTagsFromContext,
     stripOocBlocksFromContext,
@@ -5486,11 +5487,9 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         }
 
         const contextDepth = Math.max(0, coreChat.length - index - 1);
-        const oocContextDepth = Math.max(0, Number(power_user.ooc_context_depth) || 0);
-        const htmlContextDepth = Math.max(0, Number(power_user.html_context_depth) || 0);
         const contextMessage = stripHtmlTagsFromContext(
-            stripOocBlocksFromContext(regexedMessage, contextDepth < oocContextDepth),
-            contextDepth < htmlContextDepth,
+            stripOocBlocksFromContext(regexedMessage, shouldRetainContextAtDepth(contextDepth, power_user.ooc_context_depth)),
+            shouldRetainContextAtDepth(contextDepth, power_user.html_context_depth),
         );
 
         return {

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -486,7 +486,7 @@ async function confirmDuplicateAgentAddition(agent) {
         POPUP_TYPE.CONFIRM,
         'Duplicate agent',
         {
-            okButton: 'Add Anyway',
+            okButton: 'Add Agent',
             cancelButton: 'Cancel',
         },
     ).show();

--- a/public/scripts/ooc-blocks.js
+++ b/public/scripts/ooc-blocks.js
@@ -3,6 +3,40 @@ const OOC_BLOCK_PLACEHOLDER_PREFIX = '\uE000SB_OOC_BLOCK_';
 const OOC_BLOCK_PLACEHOLDER_SUFFIX = '_\uE001';
 
 /**
+ * Normalizes prompt-context retention settings.
+ * -1 preserves every context message, 0 strips every context message, N preserves the last N messages.
+ * @param {number|string} value Retention setting value.
+ * @returns {number} Normalized context depth.
+ */
+export function normalizeContextRetentionDepth(value) {
+    if (value === null || value === undefined || value === '') {
+        return -1;
+    }
+
+    const numericValue = Number(value);
+    if (!Number.isFinite(numericValue)) {
+        return -1;
+    }
+
+    return Math.max(-1, Math.floor(numericValue));
+}
+
+/**
+ * Checks whether OOC or HTML tags should be retained for a prompt-context message.
+ * @param {number} messageDepth Zero-based distance from the latest context message.
+ * @param {number|string} retentionDepth Retention setting value.
+ * @returns {boolean} True when the message should keep the relevant content.
+ */
+export function shouldRetainContextAtDepth(messageDepth, retentionDepth) {
+    const normalizedDepth = normalizeContextRetentionDepth(retentionDepth);
+    if (normalizedDepth < 0) {
+        return true;
+    }
+
+    return Math.max(0, Number(messageDepth) || 0) < normalizedDepth;
+}
+
+/**
  * Replaces balanced OOC blocks with the supplied replacement.
  * @param {string} value Source text.
  * @param {(content: string, index: number) => string} replacer Replacement callback.

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -81,7 +81,7 @@ import { ToolManager } from './tool-calling.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { COMETAPI_IGNORE_PATTERNS, IGNORE_SYMBOL, MEDIA_DISPLAY, MEDIA_TYPE } from './constants.js';
 import { syncOpenRouterProvidersForModel, updateOpenRouterProvidersWarning } from './textgen-models.js';
-import { hasTextOrArrayPayload, stripHtmlTagsFromContext, stripOocBlocksFromContext } from './ooc-blocks.js';
+import { hasTextOrArrayPayload, shouldRetainContextAtDepth, stripHtmlTagsFromContext, stripOocBlocksFromContext } from './ooc-blocks.js';
 import { checkPostInterceptChatBudget } from './openai-prompt-budget.js';
 
 export {
@@ -709,11 +709,9 @@ function setOpenAIMessages(chat) {
 
         // remove caret return (waste of tokens)
         const contextDepth = Math.max(0, chat.length - j - 1);
-        const oocContextDepth = Math.max(0, Number(power_user.ooc_context_depth) || 0);
-        const htmlContextDepth = Math.max(0, Number(power_user.html_context_depth) || 0);
         content = stripHtmlTagsFromContext(
-            stripOocBlocksFromContext(content.replace(/\r/gm, ''), contextDepth < oocContextDepth),
-            contextDepth < htmlContextDepth,
+            stripOocBlocksFromContext(content.replace(/\r/gm, ''), shouldRetainContextAtDepth(contextDepth, power_user.ooc_context_depth)),
+            shouldRetainContextAtDepth(contextDepth, power_user.html_context_depth),
         );
 
         const name = chat[j].name;

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -33,6 +33,7 @@ import {
     settingsReady,
 } from '../script.js';
 import { isMobile, initMovingUI, favsToHotswap } from './RossAscends-mods.js';
+import { normalizeContextRetentionDepth } from './ooc-blocks.js';
 import {
     groups,
     resetSelectedGroup,
@@ -227,8 +228,8 @@ export const power_user = {
     },
     markdown_escape_strings: '',
     chat_truncation: 100,
-    ooc_context_depth: 0,
-    html_context_depth: 0,
+    ooc_context_depth: -1,
+    html_context_depth: -1,
     streaming_fps: 30,
     smooth_streaming: false,
     smooth_streaming_no_think: false,
@@ -3548,16 +3549,14 @@ jQuery(async () => {
         saveSettingsDebounced();
     });
 
-    const normalizeContextDepthInput = input => Math.max(0, Math.floor(Number(input) || 0));
-
     $('#ooc_context_depth').on('input', function () {
-        power_user.ooc_context_depth = normalizeContextDepthInput($(this).val());
+        power_user.ooc_context_depth = normalizeContextRetentionDepth($(this).val());
         $(this).val(power_user.ooc_context_depth);
         saveSettingsDebounced();
     });
 
     $('#html_context_depth').on('input', function () {
-        power_user.html_context_depth = normalizeContextDepthInput($(this).val());
+        power_user.html_context_depth = normalizeContextRetentionDepth($(this).val());
         $(this).val(power_user.html_context_depth);
         saveSettingsDebounced();
     });

--- a/tests/ooc-blocks.test.js
+++ b/tests/ooc-blocks.test.js
@@ -3,14 +3,16 @@ import { describe, test, expect } from '@jest/globals';
 import {
     extractOocBlocksForDisplay,
     hasTextOrArrayPayload,
+    normalizeContextRetentionDepth,
     renderOocBlock,
     restoreOocBlocksForDisplay,
+    shouldRetainContextAtDepth,
     stripHtmlTagsFromContext,
     stripOocBlocksFromContext,
 } from '../public/scripts/ooc-blocks.js';
 
 describe('OOC block handling', () => {
-    test('removes balanced OOC blocks from prompt context', () => {
+    test('strips OOC when prompt-context retention is disabled', () => {
         expect(stripOocBlocksFromContext('Visible ((do not prompt this)) text')).toBe('Visible text');
     });
 
@@ -62,5 +64,20 @@ describe('OOC block handling', () => {
         expect(hasTextOrArrayPayload('', [[], [{ id: 'tool-call' }]])).toBe(true);
         expect(hasTextOrArrayPayload(stripOocBlocksFromContext('((note only))'), [])).toBe(false);
         expect(hasTextOrArrayPayload('', [[], undefined])).toBe(false);
+    });
+
+    test('normalizes context retention depth with -1 as preserve-all default', () => {
+        expect(normalizeContextRetentionDepth(undefined)).toBe(-1);
+        expect(normalizeContextRetentionDepth('')).toBe(-1);
+        expect(normalizeContextRetentionDepth(-5)).toBe(-1);
+        expect(normalizeContextRetentionDepth(2.9)).toBe(2);
+    });
+
+    test('retains context content according to -1, 0, and last-N depths', () => {
+        expect(shouldRetainContextAtDepth(50, -1)).toBe(true);
+        expect(shouldRetainContextAtDepth(0, 0)).toBe(false);
+        expect(shouldRetainContextAtDepth(0, 2)).toBe(true);
+        expect(shouldRetainContextAtDepth(1, 2)).toBe(true);
+        expect(shouldRetainContextAtDepth(2, 2)).toBe(false);
     });
 });


### PR DESCRIPTION
## What?
Applies the pending Geechan review follow-ups for duplicate in-chat agent copy and OOC/HTML prompt-context retention behavior.

## Why?
The duplicate-agent confirmation repeated "Add anyway" in the body and button, and the OOC/HTML context-depth settings needed an explicit default policy. The confirmed SB behavior is now: `-1` keeps all messages in prompt context, `0` strips all OOC/HTML from prompt context, and positive values keep only the newest N context messages.

## How?
Renames the duplicate-agent confirmation OK button to `Add Agent`. Changes OOC and HTML context-depth defaults to `-1`, allows the settings inputs to accept `-1`, adds visible helper copy for the `-1 / 0 / N` semantics, and routes both standard and Chat Completions prompt assembly through a shared retention-depth helper so the two paths stay aligned.

## Testing?
- `npm run test:unit --prefix tests -- tests/ooc-blocks.test.js`
- `npm run lint`
- `npm run check:frontend-budgets`
- `git diff --check`

## Screenshots (optional)
Not included; this is settings copy plus prompt-context behavior wiring.

## Anything Else?
This is intentionally split from the Guided Generations fork-toast fix and the broader token-count refresh bug.