### PR TITLE
fix: persist guided generations fork warning

### DIFF
--- a/public/scripts/extensions/guided-generations/index.js
+++ b/public/scripts/extensions/guided-generations/index.js
@@ -4,11 +4,14 @@ import { extensionName, getPresetsForApiType, getProfileApiType, getProfileList 
 import { guidedImpersonate } from './scripts/guidedImpersonate.js';
 import { guidedResponse } from './scripts/guidedResponse.js';
 import { guidedSwipe } from './scripts/guidedSwipe.js';
+import {
+    markOldExtensionWarningDismissed,
+    shouldWarnOldExtensionDeprecated,
+} from './scripts/legacyForkWarning.js';
 import { simpleSend } from './scripts/simpleSend.js';
 
 const oldExtensionKey = 'GuidedGenerations-Extension';
 const oldExtensionName = 'third-party/GuidedGenerations-Extension';
-const oldExtensionWarningStorageKey = 'guided_generations_legacy_fork_warning_v1';
 
 const defaultSettings = {
     showGuidedResponse: true,
@@ -54,24 +57,22 @@ function loadSettings() {
     extension_settings[extensionName] = settings;
 }
 
-function isOldExtensionInstalled() {
-    return extensionNames.some(name => String(name).toLowerCase() === oldExtensionName.toLowerCase());
-}
-
 function maybeWarnOldExtensionDeprecated() {
-    if (!extension_settings[oldExtensionKey] && !isOldExtensionInstalled()) {
+    if (!shouldWarnOldExtensionDeprecated(extensionNames, oldExtensionName)) {
         return;
     }
 
-    if (sessionStorage.getItem(oldExtensionWarningStorageKey) === 'true') {
-        return;
-    }
-
-    sessionStorage.setItem(oldExtensionWarningStorageKey, 'true');
     toastr.warning(
         'The old Guided Generations fork is deprecated and can conflict with the native Guided Generations port. Uninstall or disable the third-party fork.',
         'Guided Generations fork deprecated',
-        { timeOut: 12000, extendedTimeOut: 20000, preventDuplicates: true },
+        {
+            timeOut: 0,
+            extendedTimeOut: 0,
+            tapToDismiss: false,
+            closeButton: true,
+            preventDuplicates: true,
+            onCloseClick: () => markOldExtensionWarningDismissed(),
+        },
     );
 }
 
@@ -353,4 +354,9 @@ export async function init() {
     startQrIntegration();
 }
 
-export { defaultSettings, loadSettings, updateExtensionButtons, updateSettingsUI };
+export {
+    defaultSettings,
+    loadSettings,
+    updateExtensionButtons,
+    updateSettingsUI,
+};

--- a/public/scripts/extensions/guided-generations/scripts/legacyForkWarning.js
+++ b/public/scripts/extensions/guided-generations/scripts/legacyForkWarning.js
@@ -1,0 +1,21 @@
+const oldExtensionWarningStorageKey = 'guided_generations_legacy_fork_warning_v1';
+
+function isOldExtensionInstalled(extensionNames, oldExtensionName) {
+    return extensionNames.some(name => String(name).toLowerCase() === oldExtensionName.toLowerCase());
+}
+
+function shouldWarnOldExtensionDeprecated(extensionNames, oldExtensionName, storage = globalThis.localStorage) {
+    return isOldExtensionInstalled(extensionNames, oldExtensionName)
+        && storage?.getItem?.(oldExtensionWarningStorageKey) !== 'true';
+}
+
+function markOldExtensionWarningDismissed(storage = globalThis.localStorage) {
+    storage?.setItem?.(oldExtensionWarningStorageKey, 'true');
+}
+
+export {
+    isOldExtensionInstalled,
+    markOldExtensionWarningDismissed,
+    oldExtensionWarningStorageKey,
+    shouldWarnOldExtensionDeprecated,
+};

--- a/tests/guided-generations-toast.test.js
+++ b/tests/guided-generations-toast.test.js
@@ -1,0 +1,36 @@
+import { jest } from '@jest/globals';
+import {
+    markOldExtensionWarningDismissed,
+    oldExtensionWarningStorageKey,
+    shouldWarnOldExtensionDeprecated,
+} from '../public/scripts/extensions/guided-generations/scripts/legacyForkWarning.js';
+
+describe('Guided Generations legacy fork warning', () => {
+    const oldExtensionName = 'third-party/GuidedGenerations-Extension';
+
+    function createStorage(value = null) {
+        return {
+            getItem: jest.fn(() => value),
+            setItem: jest.fn(),
+        };
+    }
+
+    test('does not warn from migrated settings when the fork is uninstalled', () => {
+        expect(shouldWarnOldExtensionDeprecated([], oldExtensionName, createStorage())).toBe(false);
+    });
+
+    test('warns when a separate Guided Generations fork is still installed', () => {
+        expect(shouldWarnOldExtensionDeprecated([oldExtensionName], oldExtensionName, createStorage())).toBe(true);
+    });
+
+    test('keeps warning until the user explicitly dismisses it', () => {
+        const storage = createStorage();
+        markOldExtensionWarningDismissed(storage);
+
+        expect(storage.setItem).toHaveBeenCalledWith(oldExtensionWarningStorageKey, 'true');
+    });
+
+    test('does not warn after explicit dismissal', () => {
+        expect(shouldWarnOldExtensionDeprecated([oldExtensionName], oldExtensionName, createStorage('true'))).toBe(false);
+    });
+});


### PR DESCRIPTION
## What?
Fixes the Guided Generations legacy-fork warning so it only appears when a separate `third-party/GuidedGenerations-Extension` fork is still installed, and makes the warning sticky until the user closes it with the X button.

## Why?
Users who already uninstalled the old fork could still see the toast because stale migrated settings were treated as proof that the fork was installed. The warning also timed out automatically, so users could miss the conflict notice and keep wondering why Guided Generations behavior was broken.

## How?
Moves the legacy-fork warning decision into a small helper, keys the warning off discovered extension names instead of old settings, switches dismissal persistence from session storage to local storage, and only writes the dismissal flag from the toast close-button handler. The toast now uses `timeOut: 0`, `tapToDismiss: false`, and `closeButton: true`.

## Testing?
- `npm run test:unit --prefix tests -- tests/guided-generations-toast.test.js`
- `npm run lint`
- `git diff --check`

## Screenshots (optional)
Not included; behavior is covered by the focused unit test and follows the existing sticky-toast pattern used elsewhere in the app.

## Anything Else?
This PR is intentionally split from the Geechan review follow-up and the broader token-count refresh bug.
