### PR TITLE
Fix input history controls in chat composer

### DIFF
--- a/public/scripts/extensions/input-history/index.js
+++ b/public/scripts/extensions/input-history/index.js
@@ -29,6 +29,37 @@ let arrowsWrap;
 let btnHistory;
 /**@type {HTMLElement} */
 let historyMenu;
+/**@type {MutationObserver} */
+let buttonPlacementObserver;
+
+const placeButtonWrap = () => {
+    if (!buttonWrap) return;
+
+    const guidedContainer = document.querySelector('#gg-action-button-container');
+    if (guidedContainer) {
+        if (buttonWrap.parentElement !== guidedContainer || guidedContainer.firstElementChild !== buttonWrap) {
+            guidedContainer.prepend(buttonWrap);
+        }
+        buttonWrap.classList.remove('stih--standalone');
+        return;
+    }
+
+    const sendForm = document.querySelector('#send_form');
+    const nonQrFormItems = document.querySelector('#nonQRFormItems');
+    if (!sendForm || !nonQrFormItems) return;
+
+    if (buttonWrap.parentElement !== sendForm || buttonWrap.nextElementSibling !== nonQrFormItems) {
+        sendForm.insertBefore(buttonWrap, nonQrFormItems);
+    }
+    buttonWrap.classList.add('stih--standalone');
+};
+
+const startButtonPlacementObserver = () => {
+    if (buttonPlacementObserver) return;
+
+    buttonPlacementObserver = new MutationObserver(() => placeButtonWrap());
+    buttonPlacementObserver.observe(document.querySelector('#send_form') ?? document.body, { childList: true, subtree: true });
+};
 
 
 SlashCommandParser.addCommandObject(SlashCommand.fromProps({ name: 'inputhistory-config',
@@ -147,7 +178,7 @@ const showHistoryMenu = async () => {
             renderItem(c);
         }
         await waitForFrame();
-        document.querySelector('#nonQRFormItems').append(historyMenu);
+        buttonWrap.append(historyMenu);
         await waitForFrame();
         historyMenu.classList.add('stih--active');
     }
@@ -165,6 +196,7 @@ const updateButtons = () => {
                 const prev = document.createElement('div'); {
                     prev.classList.add('stih--button');
                     prev.classList.add('menu_button');
+                    prev.classList.add('menu_button_icon');
                     prev.classList.add('fa-solid');
                     prev.classList.add('fa-chevron-up');
                     prev.title = 'Previous input';
@@ -174,6 +206,7 @@ const updateButtons = () => {
                 const next = document.createElement('div'); {
                     next.classList.add('stih--button');
                     next.classList.add('menu_button');
+                    next.classList.add('menu_button_icon');
                     next.classList.add('fa-solid');
                     next.classList.add('fa-chevron-down');
                     next.title = 'Next input';
@@ -186,6 +219,7 @@ const updateButtons = () => {
                 btnHistory = his;
                 his.classList.add('stih--button');
                 his.classList.add('menu_button');
+                his.classList.add('menu_button_icon');
                 his.classList.add('stih--menuTrigger');
                 his.classList.add('fa-solid');
                 his.classList.add('fa-clock-rotate-left');
@@ -193,9 +227,10 @@ const updateButtons = () => {
                 his.addEventListener('click', () => showInputHistory());
                 wrap.append(his);
             }
-            ta.insertAdjacentElement('afterend', wrap);
+            startButtonPlacementObserver();
         }
     }
+    placeButtonWrap();
     buttonWrap.classList[settings.showButtons ? 'remove' : 'add']('stih--hidden');
     arrowsWrap.classList[settings.showArrowButtons ? 'remove' : 'add']('stih--hidden');
     btnHistory.classList[settings.showHistoryButton ? 'remove' : 'add']('stih--hidden');

--- a/public/scripts/extensions/input-history/style.css
+++ b/public/scripts/extensions/input-history/style.css
@@ -1,15 +1,27 @@
 .stih--buttons {
-  order: 3;
-  display: flex;
-  margin-left: -5px;
-}
-.stih--buttons .stih--button {
-  flex: 1 1 auto;
+  position: relative;
   display: flex;
   align-items: center;
-  height: auto;
+  gap: 5px;
+  margin-right: auto;
+}
+.stih--buttons.stih--standalone {
+  order: 0;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0 8px 6px;
+}
+.stih--buttons .stih--button {
+  flex: 0 0 var(--bottomFormBlockSize);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  width: var(--bottomFormBlockSize);
+  min-width: var(--bottomFormBlockSize);
+  height: var(--bottomFormBlockSize);
   margin: 0;
-  font-size: 0.5em;
+  padding: 0;
   background-color: transparent;
   opacity: 0.5;
   transition: 200ms;
@@ -20,11 +32,11 @@
 }
 .stih--buttons .stih--arrows {
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  gap: 5px;
 }
 .stih--buttons .stih--arrows .stih--button {
-  padding-top: 0;
-  padding-bottom: 0;
+  padding: 0;
 }
 .stih--history {
   filter: drop-shadow(1px 1px 2px var(--black50a));
@@ -35,19 +47,19 @@
   aspect-ratio: unset;
   padding: 5px;
   display: flex;
-  flex-direction: column-reverse;
+  flex-direction: column;
   background-color: var(--secondaryBg, var(--SmartThemeBlurTintColor));
   container-type: inline-size;
   position: absolute;
-  bottom: 100%;
-  right: 0;
+  top: calc(100% + 4px);
+  left: 0;
   min-height: 2em;
   max-height: calc(50dvh);
-  width: 100%;
+  width: min(420px, calc(100vw - 16px));
   transition: 200ms;
-  transform-origin: calc(100% - 0.5em) calc(100% + 0.5em);
+  transform-origin: 0 0;
   scale: 1 0;
-  font-size: 0.5em;
+  font-size: calc(var(--bottomFormIconSize, 20px) * 0.5);
 }
 .stih--history.stih--active {
   scale: 1;
@@ -96,6 +108,44 @@
   font-size: calc(0.9em / 0.75);
   color: var(--SmartThemeBodyColor);
 }
-html > body #nonQRFormItems .stih--hidden {
+html > body .stih--buttons.stih--hidden,
+html > body .stih--buttons .stih--hidden,
+html > body .stih--history .stih--hidden {
   display: none;
+}
+
+@media screen and (max-width: 600px) {
+  .stih--buttons,
+  .stih--buttons.stih--standalone {
+    --stih-mobile-action-size: clamp(28px, calc(var(--bottomFormBlockSize) * 0.5), 34px);
+    --stih-mobile-action-icon-size: clamp(13px, calc(var(--bottomFormIconSize, 20px) * 0.75), 16px);
+    gap: 4px;
+  }
+
+  .stih--buttons.stih--standalone {
+    padding: 0 6px 5px;
+  }
+
+  .stih--buttons .stih--arrows {
+    gap: 4px;
+  }
+
+  .stih--buttons .stih--button {
+    flex: 0 0 var(--stih-mobile-action-size) !important;
+    width: var(--stih-mobile-action-size) !important;
+    min-width: var(--stih-mobile-action-size) !important;
+    max-width: var(--stih-mobile-action-size) !important;
+    height: var(--stih-mobile-action-size) !important;
+    min-height: var(--stih-mobile-action-size) !important;
+    max-height: var(--stih-mobile-action-size) !important;
+    border-radius: 8px !important;
+    font-size: var(--stih-mobile-action-icon-size) !important;
+    padding: 0 !important;
+  }
+
+  .gg-action-buttons-container:has(> .stih--buttons) .gg-regular-buttons-container {
+    flex: 0 0 auto;
+    width: auto;
+    order: 0;
+  }
 }


### PR DESCRIPTION
## Summary
- Move input history controls into the top composer action row, sharing the Guided Generations row when it exists and falling back to a standalone row above the textarea.
- Restyle the controls to match the Guided Generations icon sizing, including compact 28-34px mobile buttons with 8px radius.
- Flatten the history chevrons into a row and make the history menu open downward from the controls.

## Verification
- npm run lint initially failed because the environment resolved global ESLint 10 while the repo uses .eslintrc.cjs.
- npm install
- npm run lint -- --quiet
- git diff --check