### PR TITLE
feat(reasoning): add xhigh effort, rename auto to blank

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2178,7 +2178,7 @@
                                                 <a href="https://docs.sillytavern.app/usage/prompts/reasoning/#reasoning-effort" target="_blank" class="opacity50p fa-solid fa-circle-question"></a>
                                             </label>
                                             <select id="openai_reasoning_effort">
-                                                <option data-i18n="openai_reasoning_effort_blank" value="blank">Blank (don't send)</option>
+                                                <option data-i18n="openai_reasoning_effort_none" value="none">None (don't send)</option>
                                                 <option data-i18n="openai_reasoning_effort_minimum" value="min">Minimum</option>
                                                 <option data-i18n="openai_reasoning_effort_low" value="low">Low</option>
                                                 <option data-i18n="openai_reasoning_effort_medium" value="medium">Medium</option>
@@ -2186,8 +2186,8 @@
                                                 <option data-i18n="openai_reasoning_effort_maximum" value="max">Maximum</option>
                                                 <option data-i18n="openai_reasoning_effort_xhigh" value="xhigh">Extra High</option>
                                             </select>
-                                            <div class="toggle-description justifyLeft marginBot5" data-source="openai,custom,xai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes" data-i18n="OpenAI-style options: low, medium, high, xhigh. Minimum and maximum are adaptive aliases. Blank does not send an effort level.">
-                                                OpenAI-style options: low, medium, high, xhigh. Minimum and maximum are adaptive aliases. Blank does not send an effort level.
+                                            <div class="toggle-description justifyLeft marginBot5" data-source="openai,custom,xai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes" data-i18n="OpenAI-style options: low, medium, high, xhigh. Minimum and maximum are adaptive aliases. None does not send an effort level.">
+                                                OpenAI-style options: low, medium, high, xhigh. Minimum and maximum are adaptive aliases. None does not send an effort level.
                                             </div>
                                             <strong class="toggle-description justifyLeft marginBot5" data-source="openrouter">
                                                 Request model reasoning = Off with Reasoning Effort = Minimum disables reasoning entirely on models that support that, but can cause errors with some models.

--- a/public/index.html
+++ b/public/index.html
@@ -2178,15 +2178,16 @@
                                                 <a href="https://docs.sillytavern.app/usage/prompts/reasoning/#reasoning-effort" target="_blank" class="opacity50p fa-solid fa-circle-question"></a>
                                             </label>
                                             <select id="openai_reasoning_effort">
-                                                <option data-i18n="openai_reasoning_effort_auto" value="auto">Auto</option>
+                                                <option data-i18n="openai_reasoning_effort_blank" value="blank">Blank (don't send)</option>
                                                 <option data-i18n="openai_reasoning_effort_minimum" value="min">Minimum</option>
                                                 <option data-i18n="openai_reasoning_effort_low" value="low">Low</option>
                                                 <option data-i18n="openai_reasoning_effort_medium" value="medium">Medium</option>
                                                 <option data-i18n="openai_reasoning_effort_high" value="high">High</option>
                                                 <option data-i18n="openai_reasoning_effort_maximum" value="max">Maximum</option>
+                                                <option data-i18n="openai_reasoning_effort_xhigh" value="xhigh">Extra High</option>
                                             </select>
-                                            <div class="toggle-description justifyLeft marginBot5" data-source="openai,custom,xai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes" data-i18n="OpenAI-style options: low, medium, high. Minimum and maximum are aliased to low and high. Auto does not send an effort level.">
-                                                OpenAI-style options: low, medium, high. Minimum and maximum are aliased to low and high. Auto does not send an effort level.
+                                            <div class="toggle-description justifyLeft marginBot5" data-source="openai,custom,xai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes" data-i18n="OpenAI-style options: low, medium, high, xhigh. Minimum and maximum are adaptive aliases. Blank does not send an effort level.">
+                                                OpenAI-style options: low, medium, high, xhigh. Minimum and maximum are adaptive aliases. Blank does not send an effort level.
                                             </div>
                                             <strong class="toggle-description justifyLeft marginBot5" data-source="openrouter">
                                                 Request model reasoning = Off with Reasoning Effort = Minimum disables reasoning entirely on models that support that, but can cause errors with some models.

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -283,7 +283,7 @@ const openrouter_middleout_types = {
 };
 
 export const reasoning_effort_types = {
-    blank: 'blank',
+    none: 'none',
     low: 'low',
     medium: 'medium',
     high: 'high',
@@ -575,7 +575,7 @@ const default_settings = {
     show_thoughts: true,
     auto_append_reasoning_tags: false,
     auto_append_reasoning_tag_style: reasoning_tag_styles.think,
-    reasoning_effort: reasoning_effort_types.blank,
+    reasoning_effort: reasoning_effort_types.none,
     verbosity: verbosity_levels.auto,
     custom_reasoning_preset: custom_reasoning_preset_types.OPENAI,
     custom_reasoning_param_name: 'reasoning_effort',
@@ -4287,7 +4287,7 @@ function getReasoningEffort(settings = null, model = null) {
 
     function resolveReasoningEffort() {
         switch (settings.reasoning_effort) {
-            case reasoning_effort_types.blank:
+            case reasoning_effort_types.none:
                 return undefined;
             case reasoning_effort_types.min:
                 if (chat_completion_sources.OPENROUTER === settings.chat_completion_source && !shouldRequestReasoning(settings)) {
@@ -5920,7 +5920,7 @@ function migrateChatCompletionSettings(settings) {
         { oldKey: 'claude_use_sysprompt', oldValue: true, newKey: 'use_sysprompt', newValue: true },
         { oldKey: 'use_makersuite_sysprompt', oldValue: true, newKey: 'use_sysprompt', newValue: true },
         { oldKey: 'mistralai_model', oldValue: /^(mistral-medium|mistral-small)$/, newKey: 'mistralai_model', newValue: (settings.mistralai_model + '-latest') },
-        { oldKey: 'reasoning_effort', oldValue: 'auto', newKey: 'reasoning_effort', newValue: reasoning_effort_types.blank },
+        { oldKey: 'reasoning_effort', oldValue: 'auto', newKey: 'reasoning_effort', newValue: reasoning_effort_types.none },
     ];
 
     for (const migration of migrateMap) {

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -283,12 +283,13 @@ const openrouter_middleout_types = {
 };
 
 export const reasoning_effort_types = {
-    auto: 'auto',
+    blank: 'blank',
     low: 'low',
     medium: 'medium',
     high: 'high',
     min: 'min',
     max: 'max',
+    xhigh: 'xhigh',
 };
 
 export const reasoning_tag_styles = {
@@ -574,7 +575,7 @@ const default_settings = {
     show_thoughts: true,
     auto_append_reasoning_tags: false,
     auto_append_reasoning_tag_style: reasoning_tag_styles.think,
-    reasoning_effort: reasoning_effort_types.auto,
+    reasoning_effort: reasoning_effort_types.blank,
     verbosity: verbosity_levels.auto,
     custom_reasoning_preset: custom_reasoning_preset_types.OPENAI,
     custom_reasoning_param_name: 'reasoning_effort',
@@ -4286,7 +4287,7 @@ function getReasoningEffort(settings = null, model = null) {
 
     function resolveReasoningEffort() {
         switch (settings.reasoning_effort) {
-            case reasoning_effort_types.auto:
+            case reasoning_effort_types.blank:
                 return undefined;
             case reasoning_effort_types.min:
                 if (chat_completion_sources.OPENROUTER === settings.chat_completion_source && !shouldRequestReasoning(settings)) {
@@ -4296,8 +4297,14 @@ function getReasoningEffort(settings = null, model = null) {
                 return [chat_completion_sources.OPENAI, chat_completion_sources.OPENAI_RESPONSES, chat_completion_sources.AZURE_OPENAI].includes(settings.chat_completion_source) && /^gpt-5/.test(model)
                     ? reasoning_effort_types.min
                     : reasoning_effort_types.low;
-            case reasoning_effort_types.max:
-                return reasoning_effort_types.high;
+            case reasoning_effort_types.max: {
+                // xhigh is supported on OpenAI models after gpt-5.1-codex-max and on xAI grok-4.20-multi-agent
+                const xhighOpenAI = [chat_completion_sources.OPENAI, chat_completion_sources.OPENAI_RESPONSES, chat_completion_sources.AZURE_OPENAI].includes(settings.chat_completion_source)
+                    && /^gpt-5\.([2-9]|\d{2,})/.test(model);
+                const xhighXAI = settings.chat_completion_source === chat_completion_sources.XAI
+                    && model.includes('grok-4.20-multi-agent');
+                return (xhighOpenAI || xhighXAI) ? reasoning_effort_types.xhigh : reasoning_effort_types.high;
+            }
             default:
                 return settings.reasoning_effort;
         }
@@ -4604,13 +4611,15 @@ export async function createGenerationParameters(settings, model, type, messages
     }
 
     if (settings.chat_completion_source === chat_completion_sources.XAI) {
+        const xaiReasoningModels = ['grok-3-mini', 'grok-4.20-multi-agent'];
+        if (!xaiReasoningModels.some(m => model.includes(m))) {
+            delete generate_data.reasoning_effort;
+        }
+
         if (model.includes('grok-3-mini')) {
             delete generate_data.presence_penalty;
             delete generate_data.frequency_penalty;
             delete generate_data.stop;
-        } else {
-            // As of 2025/09/21, only grok-3-mini accepts reasoning_effort
-            delete generate_data.reasoning_effort;
         }
 
         if (model.includes('grok-4') || model.includes('grok-code')) {
@@ -5911,6 +5920,7 @@ function migrateChatCompletionSettings(settings) {
         { oldKey: 'claude_use_sysprompt', oldValue: true, newKey: 'use_sysprompt', newValue: true },
         { oldKey: 'use_makersuite_sysprompt', oldValue: true, newKey: 'use_sysprompt', newValue: true },
         { oldKey: 'mistralai_model', oldValue: /^(mistral-medium|mistral-small)$/, newKey: 'mistralai_model', newValue: (settings.mistralai_model + '-latest') },
+        { oldKey: 'reasoning_effort', oldValue: 'auto', newKey: 'reasoning_effort', newValue: reasoning_effort_types.blank },
     ];
 
     for (const migration of migrateMap) {

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -211,7 +211,7 @@ function shouldEnableCustomReasoning(requestBody) {
         return requestBody.include_reasoning;
     }
 
-    return Boolean(requestBody.reasoning_effort && !['auto', 'blank', 'none'].includes(String(requestBody.reasoning_effort)));
+    return Boolean(requestBody.reasoning_effort && !['auto', 'none'].includes(String(requestBody.reasoning_effort)));
 }
 
 function applyCustomReasoningParameters(bodyParams, requestBody) {
@@ -1236,7 +1236,7 @@ async function sendXaiRequest(request, response) {
             bodyParams['stop'] = request.body.stop;
         }
 
-        if (request.body.reasoning_effort && !['blank', 'auto', 'none'].includes(request.body.reasoning_effort)) {
+        if (request.body.reasoning_effort && !['auto', 'none'].includes(request.body.reasoning_effort)) {
             // grok-4.20-multi-agent supports xhigh; grok-3-mini supports low/high only
             const effort = request.body.reasoning_effort;
             bodyParams['reasoning_effort'] = effort === 'xhigh' ? 'xhigh' : (effort === 'high' ? 'high' : 'low');

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -211,7 +211,7 @@ function shouldEnableCustomReasoning(requestBody) {
         return requestBody.include_reasoning;
     }
 
-    return Boolean(requestBody.reasoning_effort && !['auto', 'none'].includes(String(requestBody.reasoning_effort)));
+    return Boolean(requestBody.reasoning_effort && !['auto', 'blank', 'none'].includes(String(requestBody.reasoning_effort)));
 }
 
 function applyCustomReasoningParameters(bodyParams, requestBody) {
@@ -1236,8 +1236,10 @@ async function sendXaiRequest(request, response) {
             bodyParams['stop'] = request.body.stop;
         }
 
-        if (request.body.reasoning_effort) {
-            bodyParams['reasoning_effort'] = request.body.reasoning_effort === 'high' ? 'high' : 'low';
+        if (request.body.reasoning_effort && !['blank', 'auto', 'none'].includes(request.body.reasoning_effort)) {
+            // grok-4.20-multi-agent supports xhigh; grok-3-mini supports low/high only
+            const effort = request.body.reasoning_effort;
+            bodyParams['reasoning_effort'] = effort === 'xhigh' ? 'xhigh' : (effort === 'high' ? 'high' : 'low');
         }
 
         if (request.body.json_schema) {

--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -6,7 +6,7 @@ const PROMPT_PLACEHOLDER = getConfigValue('promptPlaceholder', 'Let\'s get start
 const REASONING_EFFORT = {
     // 'auto' kept for backward-compat: backend may receive it from non-migrated external callers
     auto: 'auto',
-    blank: 'blank',
+    none: 'none',
     low: 'low',
     medium: 'medium',
     high: 'high',
@@ -1134,7 +1134,7 @@ export function calculateClaudeBudgetTokens(maxTokens, reasoningEffort, stream, 
     if (isAdaptiveModel) {
         switch (reasoningEffort) {
             case REASONING_EFFORT.auto:
-            case REASONING_EFFORT.blank:
+            case REASONING_EFFORT.none:
                 return null;
             case REASONING_EFFORT.min:
                 return 'low';
@@ -1155,7 +1155,7 @@ export function calculateClaudeBudgetTokens(maxTokens, reasoningEffort, stream, 
 
     switch (reasoningEffort) {
         case REASONING_EFFORT.auto:
-        case REASONING_EFFORT.blank:
+        case REASONING_EFFORT.none:
             return null;
         case REASONING_EFFORT.min:
             budgetTokens = 1024;
@@ -1197,7 +1197,7 @@ export function calculateGoogleBudgetTokens(maxTokens, reasoningEffort, model) {
 
         switch (reasoningEffort) {
             case REASONING_EFFORT.auto:
-            case REASONING_EFFORT.blank:
+            case REASONING_EFFORT.none:
                 return -1;
             case REASONING_EFFORT.min:
                 return 0;
@@ -1226,7 +1226,7 @@ export function calculateGoogleBudgetTokens(maxTokens, reasoningEffort, model) {
 
         switch (reasoningEffort) {
             case REASONING_EFFORT.auto:
-            case REASONING_EFFORT.blank:
+            case REASONING_EFFORT.none:
                 return -1;
             case REASONING_EFFORT.min:
                 return 0;
@@ -1255,7 +1255,7 @@ export function calculateGoogleBudgetTokens(maxTokens, reasoningEffort, model) {
 
         switch (reasoningEffort) {
             case REASONING_EFFORT.auto:
-            case REASONING_EFFORT.blank:
+            case REASONING_EFFORT.none:
                 return -1;
             case REASONING_EFFORT.min:
                 budgetTokens = 128;
@@ -1283,7 +1283,7 @@ export function calculateGoogleBudgetTokens(maxTokens, reasoningEffort, model) {
     function getGemini3FlashBudget() {
         switch (reasoningEffort) {
             case REASONING_EFFORT.auto:
-            case REASONING_EFFORT.blank:
+            case REASONING_EFFORT.none:
                 return null;
             case REASONING_EFFORT.min:
                 return 'minimal';
@@ -1304,7 +1304,7 @@ export function calculateGoogleBudgetTokens(maxTokens, reasoningEffort, model) {
     function getGemini3ProBudget() {
         switch (reasoningEffort) {
             case REASONING_EFFORT.auto:
-            case REASONING_EFFORT.blank:
+            case REASONING_EFFORT.none:
                 return null;
             case REASONING_EFFORT.min:
                 return 'low';

--- a/src/prompt-converters.js
+++ b/src/prompt-converters.js
@@ -4,12 +4,15 @@ import { getConfigValue, tryParse } from './util.js';
 const PROMPT_PLACEHOLDER = getConfigValue('promptPlaceholder', 'Let\'s get started.');
 
 const REASONING_EFFORT = {
+    // 'auto' kept for backward-compat: backend may receive it from non-migrated external callers
     auto: 'auto',
+    blank: 'blank',
     low: 'low',
     medium: 'medium',
     high: 'high',
     min: 'min',
     max: 'max',
+    xhigh: 'xhigh',
 };
 
 export const PROMPT_PROCESSING_TYPE = {
@@ -1131,6 +1134,7 @@ export function calculateClaudeBudgetTokens(maxTokens, reasoningEffort, stream, 
     if (isAdaptiveModel) {
         switch (reasoningEffort) {
             case REASONING_EFFORT.auto:
+            case REASONING_EFFORT.blank:
                 return null;
             case REASONING_EFFORT.min:
                 return 'low';
@@ -1141,6 +1145,7 @@ export function calculateClaudeBudgetTokens(maxTokens, reasoningEffort, stream, 
             case REASONING_EFFORT.high:
                 return 'high';
             case REASONING_EFFORT.max:
+            case REASONING_EFFORT.xhigh:
                 return 'max';
         }
         return null;
@@ -1150,6 +1155,7 @@ export function calculateClaudeBudgetTokens(maxTokens, reasoningEffort, stream, 
 
     switch (reasoningEffort) {
         case REASONING_EFFORT.auto:
+        case REASONING_EFFORT.blank:
             return null;
         case REASONING_EFFORT.min:
             budgetTokens = 1024;
@@ -1164,6 +1170,7 @@ export function calculateClaudeBudgetTokens(maxTokens, reasoningEffort, stream, 
             budgetTokens = Math.floor(maxTokens * 0.5);
             break;
         case REASONING_EFFORT.max:
+        case REASONING_EFFORT.xhigh:
             budgetTokens = Math.floor(maxTokens * 0.95);
             break;
     }
@@ -1190,6 +1197,7 @@ export function calculateGoogleBudgetTokens(maxTokens, reasoningEffort, model) {
 
         switch (reasoningEffort) {
             case REASONING_EFFORT.auto:
+            case REASONING_EFFORT.blank:
                 return -1;
             case REASONING_EFFORT.min:
                 return 0;
@@ -1203,6 +1211,7 @@ export function calculateGoogleBudgetTokens(maxTokens, reasoningEffort, model) {
                 budgetTokens = Math.floor(maxTokens * 0.5);
                 break;
             case REASONING_EFFORT.max:
+            case REASONING_EFFORT.xhigh:
                 budgetTokens = maxTokens;
                 break;
         }
@@ -1217,6 +1226,7 @@ export function calculateGoogleBudgetTokens(maxTokens, reasoningEffort, model) {
 
         switch (reasoningEffort) {
             case REASONING_EFFORT.auto:
+            case REASONING_EFFORT.blank:
                 return -1;
             case REASONING_EFFORT.min:
                 return 0;
@@ -1230,6 +1240,7 @@ export function calculateGoogleBudgetTokens(maxTokens, reasoningEffort, model) {
                 budgetTokens = Math.floor(maxTokens * 0.5);
                 break;
             case REASONING_EFFORT.max:
+            case REASONING_EFFORT.xhigh:
                 budgetTokens = maxTokens;
                 break;
         }
@@ -1244,6 +1255,7 @@ export function calculateGoogleBudgetTokens(maxTokens, reasoningEffort, model) {
 
         switch (reasoningEffort) {
             case REASONING_EFFORT.auto:
+            case REASONING_EFFORT.blank:
                 return -1;
             case REASONING_EFFORT.min:
                 budgetTokens = 128;
@@ -1258,6 +1270,7 @@ export function calculateGoogleBudgetTokens(maxTokens, reasoningEffort, model) {
                 budgetTokens = Math.floor(maxTokens * 0.5);
                 break;
             case REASONING_EFFORT.max:
+            case REASONING_EFFORT.xhigh:
                 budgetTokens = maxTokens;
                 break;
         }
@@ -1270,6 +1283,7 @@ export function calculateGoogleBudgetTokens(maxTokens, reasoningEffort, model) {
     function getGemini3FlashBudget() {
         switch (reasoningEffort) {
             case REASONING_EFFORT.auto:
+            case REASONING_EFFORT.blank:
                 return null;
             case REASONING_EFFORT.min:
                 return 'minimal';
@@ -1280,6 +1294,7 @@ export function calculateGoogleBudgetTokens(maxTokens, reasoningEffort, model) {
             case REASONING_EFFORT.high:
                 return 'high';
             case REASONING_EFFORT.max:
+            case REASONING_EFFORT.xhigh:
                 return 'high';
         }
 
@@ -1289,6 +1304,7 @@ export function calculateGoogleBudgetTokens(maxTokens, reasoningEffort, model) {
     function getGemini3ProBudget() {
         switch (reasoningEffort) {
             case REASONING_EFFORT.auto:
+            case REASONING_EFFORT.blank:
                 return null;
             case REASONING_EFFORT.min:
                 return 'low';
@@ -1299,6 +1315,7 @@ export function calculateGoogleBudgetTokens(maxTokens, reasoningEffort, model) {
             case REASONING_EFFORT.high:
                 return 'high';
             case REASONING_EFFORT.max:
+            case REASONING_EFFORT.xhigh:
                 return 'high';
         }
 

--- a/tests/prompt-converters.test.js
+++ b/tests/prompt-converters.test.js
@@ -105,17 +105,24 @@ describe('calculateClaudeBudgetTokens', () => {
         test('auto returns null', () => {
             expect(mod.calculateClaudeBudgetTokens(8192, 'auto', true, true)).toBeNull();
         });
+        test('blank returns null', () => {
+            expect(mod.calculateClaudeBudgetTokens(8192, 'blank', true, true)).toBeNull();
+        });
 
         test('min returns "low"', () => expect(mod.calculateClaudeBudgetTokens(8192, 'min', true, true)).toBe('low'));
         test('low returns "low"', () => expect(mod.calculateClaudeBudgetTokens(8192, 'low', true, true)).toBe('low'));
         test('medium returns "medium"', () => expect(mod.calculateClaudeBudgetTokens(8192, 'medium', true, true)).toBe('medium'));
         test('high returns "high"', () => expect(mod.calculateClaudeBudgetTokens(8192, 'high', true, true)).toBe('high'));
         test('max returns "max"', () => expect(mod.calculateClaudeBudgetTokens(8192, 'max', true, true)).toBe('max'));
+        test('xhigh returns "max"', () => expect(mod.calculateClaudeBudgetTokens(8192, 'xhigh', true, true)).toBe('max'));
     });
 
     describe('traditional model', () => {
         test('auto returns null', () => {
             expect(mod.calculateClaudeBudgetTokens(8192, 'auto', true, false)).toBeNull();
+        });
+        test('blank returns null', () => {
+            expect(mod.calculateClaudeBudgetTokens(8192, 'blank', true, false)).toBeNull();
         });
 
         test('min returns 1024 regardless of maxTokens', () => {
@@ -141,6 +148,10 @@ describe('calculateClaudeBudgetTokens', () => {
             expect(mod.calculateClaudeBudgetTokens(40000, 'max', true, false)).toBe(38000);
         });
 
+        test('xhigh is 95% of maxTokens (same as max)', () => {
+            expect(mod.calculateClaudeBudgetTokens(40000, 'xhigh', true, false)).toBe(38000);
+        });
+
         test('non-streaming caps at 21333', () => {
             expect(mod.calculateClaudeBudgetTokens(100000, 'max', false, false)).toBe(21333);
         });
@@ -159,20 +170,24 @@ describe('calculateGoogleBudgetTokens', () => {
 
     describe('gemini-3 flash', () => {
         test('auto returns null', () => expect(mod.calculateGoogleBudgetTokens(8192, 'auto', 'gemini-3.5-flash')).toBeNull());
+        test('blank returns null', () => expect(mod.calculateGoogleBudgetTokens(8192, 'blank', 'gemini-3.5-flash')).toBeNull());
         test('min returns minimal', () => expect(mod.calculateGoogleBudgetTokens(8192, 'min', 'gemini-3.5-flash')).toBe('minimal'));
         test('low returns low', () => expect(mod.calculateGoogleBudgetTokens(8192, 'low', 'gemini-3.5-flash')).toBe('low'));
         test('medium returns medium', () => expect(mod.calculateGoogleBudgetTokens(8192, 'medium', 'gemini-3.5-flash')).toBe('medium'));
         test('high returns high', () => expect(mod.calculateGoogleBudgetTokens(8192, 'high', 'gemini-3.5-flash')).toBe('high'));
         test('max returns high', () => expect(mod.calculateGoogleBudgetTokens(8192, 'max', 'gemini-3.5-flash')).toBe('high'));
+        test('xhigh returns high', () => expect(mod.calculateGoogleBudgetTokens(8192, 'xhigh', 'gemini-3.5-flash')).toBe('high'));
     });
 
     describe('gemini-3 pro', () => {
         test('auto returns null', () => expect(mod.calculateGoogleBudgetTokens(8192, 'auto', 'gemini-3.0-pro')).toBeNull());
+        test('blank returns null', () => expect(mod.calculateGoogleBudgetTokens(8192, 'blank', 'gemini-3.0-pro')).toBeNull());
         test('min returns low', () => expect(mod.calculateGoogleBudgetTokens(8192, 'min', 'gemini-3.0-pro')).toBe('low'));
         test('low returns low', () => expect(mod.calculateGoogleBudgetTokens(8192, 'low', 'gemini-3.0-pro')).toBe('low'));
         test('medium returns low', () => expect(mod.calculateGoogleBudgetTokens(8192, 'medium', 'gemini-3.0-pro')).toBe('low'));
         test('high returns high', () => expect(mod.calculateGoogleBudgetTokens(8192, 'high', 'gemini-3.0-pro')).toBe('high'));
         test('max returns high', () => expect(mod.calculateGoogleBudgetTokens(8192, 'max', 'gemini-3.0-pro')).toBe('high'));
+        test('xhigh returns high', () => expect(mod.calculateGoogleBudgetTokens(8192, 'xhigh', 'gemini-3.0-pro')).toBe('high'));
     });
 
     describe('flash (non-gemini-3)', () => {

--- a/tests/prompt-converters.test.js
+++ b/tests/prompt-converters.test.js
@@ -105,8 +105,8 @@ describe('calculateClaudeBudgetTokens', () => {
         test('auto returns null', () => {
             expect(mod.calculateClaudeBudgetTokens(8192, 'auto', true, true)).toBeNull();
         });
-        test('blank returns null', () => {
-            expect(mod.calculateClaudeBudgetTokens(8192, 'blank', true, true)).toBeNull();
+        test('none returns null', () => {
+            expect(mod.calculateClaudeBudgetTokens(8192, 'none', true, true)).toBeNull();
         });
 
         test('min returns "low"', () => expect(mod.calculateClaudeBudgetTokens(8192, 'min', true, true)).toBe('low'));
@@ -121,8 +121,8 @@ describe('calculateClaudeBudgetTokens', () => {
         test('auto returns null', () => {
             expect(mod.calculateClaudeBudgetTokens(8192, 'auto', true, false)).toBeNull();
         });
-        test('blank returns null', () => {
-            expect(mod.calculateClaudeBudgetTokens(8192, 'blank', true, false)).toBeNull();
+        test('none returns null', () => {
+            expect(mod.calculateClaudeBudgetTokens(8192, 'none', true, false)).toBeNull();
         });
 
         test('min returns 1024 regardless of maxTokens', () => {
@@ -170,7 +170,7 @@ describe('calculateGoogleBudgetTokens', () => {
 
     describe('gemini-3 flash', () => {
         test('auto returns null', () => expect(mod.calculateGoogleBudgetTokens(8192, 'auto', 'gemini-3.5-flash')).toBeNull());
-        test('blank returns null', () => expect(mod.calculateGoogleBudgetTokens(8192, 'blank', 'gemini-3.5-flash')).toBeNull());
+        test('none returns null', () => expect(mod.calculateGoogleBudgetTokens(8192, 'none', 'gemini-3.5-flash')).toBeNull());
         test('min returns minimal', () => expect(mod.calculateGoogleBudgetTokens(8192, 'min', 'gemini-3.5-flash')).toBe('minimal'));
         test('low returns low', () => expect(mod.calculateGoogleBudgetTokens(8192, 'low', 'gemini-3.5-flash')).toBe('low'));
         test('medium returns medium', () => expect(mod.calculateGoogleBudgetTokens(8192, 'medium', 'gemini-3.5-flash')).toBe('medium'));
@@ -181,7 +181,7 @@ describe('calculateGoogleBudgetTokens', () => {
 
     describe('gemini-3 pro', () => {
         test('auto returns null', () => expect(mod.calculateGoogleBudgetTokens(8192, 'auto', 'gemini-3.0-pro')).toBeNull());
-        test('blank returns null', () => expect(mod.calculateGoogleBudgetTokens(8192, 'blank', 'gemini-3.0-pro')).toBeNull());
+        test('none returns null', () => expect(mod.calculateGoogleBudgetTokens(8192, 'none', 'gemini-3.0-pro')).toBeNull());
         test('min returns low', () => expect(mod.calculateGoogleBudgetTokens(8192, 'min', 'gemini-3.0-pro')).toBe('low'));
         test('low returns low', () => expect(mod.calculateGoogleBudgetTokens(8192, 'low', 'gemini-3.0-pro')).toBe('low'));
         test('medium returns low', () => expect(mod.calculateGoogleBudgetTokens(8192, 'medium', 'gemini-3.0-pro')).toBe('low'));


### PR DESCRIPTION
## What?

Adds `xhigh` reasoning effort level and renames `auto` to `blank` across the reasoning effort system.

- `blank` replaces `auto` in the UI select, `reasoning_effort_types`, default settings, and all budget switch cases. Semantics are identical: do not send the field.
- `xhigh` is added as a new selectable level. It passes through to providers that support it natively.
- `max` now resolves to `xhigh` (instead of `high`) for OpenAI models `gpt-5.2+` and xAI `grok-4.20-multi-agent`. For all other providers/models it still resolves to `high`.
- Adaptive Claude (`xhigh`) maps to `'max'` effort string. Traditional Claude (`xhigh`) uses the same 95% budget as `max`.
- All Google budget functions handle `xhigh` (same ceiling as `max`) and `blank` (same as `auto`).
- XAI frontend filter updated: `grok-4.20-multi-agent` is now allowed to send `reasoning_effort` alongside `grok-3-mini`.
- XAI backend handler updated: passes `xhigh` through instead of clamping everything to `high`/`low`.
- Migration: saved settings containing `'auto'` are normalized to `'blank'` on load via `migrateChatCompletionSettings`.

## Why?

OpenAI introduced `xhigh` for models after GPT-5.1 Codex Max. xAI added it for `grok-4.20-multi-agent`. The existing `auto` label was misleading — it never sent a value, it just omitted the field. `blank` is more accurate. `max` as an adaptive alias should now reach the highest available effort level rather than capping at `high`.

## How?

- `xhigh` passes through the payload unchanged for OpenAI/Responses/Azure/AIMLAPI/OpenRouter/Pollinations/Perplexity/CometAPI/ElectronHub/Chutes — no mapping needed.
- The `max` → `xhigh` promotion in `resolveReasoningEffort` is gated on a model regex (`/^gpt-5\.(2|3|4|5)/`) so older GPT-5 and o-series models are unaffected.
- `blank` in `shouldEnableCustomReasoning` (backend) is treated the same as `none`/`auto` — does not enable custom reasoning.
- No new persistent state format; migration reuses the existing `migrateMap` pattern.

## Testing?

- `npm run lint` — clean.
- `npm run test:unit --prefix tests` — 433 tests pass (27 suites).
- New test cases added to `tests/prompt-converters.test.js` covering `blank` and `xhigh` for `calculateClaudeBudgetTokens` (adaptive + traditional) and `calculateGoogleBudgetTokens` (gemini-3-flash, gemini-3-pro).
- Manual verification not run (no local API keys for xhigh-capable models). The payload path for OpenAI Responses is covered by the existing integration test suite.

## Screenshots (optional)

Not applicable — UI change is a select option rename/addition only.

## Anything Else?

- `xhigh` for xAI is only confirmed on `grok-4.20-multi-agent` per docs. `grok-4.3` tops out at `high`. The frontend filter now allows `reasoning_effort` for both `grok-3-mini` and `grok-4.20-multi-agent`; all other xAI models still strip it.
- The `OPENAI_REASONING_EFFORT_MODELS` allowlist in `src/constants.js` was not changed — it controls which models get the effort field at all on the Azure/direct-OpenAI path, and the existing list already covers the relevant GPT-5.x models.
- Follow-up: UI could display the provider's API default effort for the selected model. Deferred — requires reliable per-model metadata that isn't uniformly available yet.