### PR TITLE
feat: improve Pathfinder settings and retrieval

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -5258,6 +5258,8 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     const isInstruct = power_user.instruct.enabled && main_api !== 'openai';
     const isImpersonate = type == 'impersonate';
     const shouldConsumeUserInput = type !== 'regenerate' && type !== 'swipe' && type !== 'quiet' && !isImpersonate && !dryRun && !depth && !suppressUserMessage;
+    let textareaText = '';
+    let renderedUserMessage = false;
 
     if (!(dryRun || depth || type == 'regenerate' || type == 'swipe' || type == 'quiet')) {
         const interruptedByCommand = await processCommands(String($('#send_textarea').val()));
@@ -5267,6 +5269,62 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             unblockGeneration(type);
             return Promise.resolve();
         }
+    }
+
+    const lastMessage = chat[chat.length - 1];
+
+    if (!selected_group) {
+        if (shouldConsumeUserInput) {
+            is_send_press = true;
+            textareaText = String($('#send_textarea').val());
+            $('#send_textarea').val('')[0].dispatchEvent(new Event('input', { bubbles: true }));
+        } else {
+            textareaText = '';
+            if (chat.length && lastMessage.is_user) {
+                //do nothing? why does this check exist?
+            } else if (type !== 'quiet' && type !== 'swipe' && !isImpersonate && !dryRun && !depth && chat.length) {
+                if (type === 'regenerate') {
+                    requestMobileChatBottomPin();
+                }
+                deleteItemizedPromptForMessage(chat.length - 1);
+                chat.length = chat.length - 1;
+                await removeLastMessage();
+                await eventSource.emit(event_types.MESSAGE_DELETED, chat.length);
+            }
+        }
+
+        if (!dryRun) {
+            deactivateSendButtons();
+        }
+    }
+
+    let { messageBias, promptBias, isUserPromptBias } = getBiasStrings(textareaText, type);
+
+    // These generation types should not attach pending files to the chat
+    const noAttachTypes = [
+        'regenerate',
+        'swipe',
+        'impersonate',
+        'quiet',
+        'continue',
+    ];
+
+    if ((textareaText != '' || (hasPendingFileAttachment() && !noAttachTypes.includes(type))) && !automatic_trigger && type !== 'quiet' && !dryRun && !depth && !selected_group) {
+        // If user message contains no text other than bias - send as a system message
+        if (messageBias && !removeMacros(textareaText)) {
+            sendSystemMessage(system_message_types.GENERIC, ' ', { bias: messageBias });
+        } else {
+            await sendMessageAsUser(textareaText, messageBias);
+        }
+        renderedUserMessage = true;
+    } else if (textareaText == '' && !automatic_trigger && !dryRun && [undefined, 'normal'].includes(type) && main_api == 'openai' && oai_settings.send_if_empty.trim().length > 0 && !depth && !suppressUserMessage && !selected_group) {
+        // Use send_if_empty if set and the user message is empty. Only when sending messages normally
+        await sendMessageAsUser(oai_settings.send_if_empty.trim(), messageBias);
+        renderedUserMessage = true;
+    }
+
+    if (renderedUserMessage && shouldBatchMobileChatRendering()) {
+        await waitForNextFrame();
     }
 
     // Occurs only if the generation is not aborted due to slash commands execution
@@ -5336,28 +5394,6 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         return Promise.resolve();
     }
 
-    const lastMessage = chat[chat.length - 1];
-
-    let textareaText;
-    if (shouldConsumeUserInput) {
-        is_send_press = true;
-        textareaText = String($('#send_textarea').val());
-        $('#send_textarea').val('')[0].dispatchEvent(new Event('input', { bubbles: true }));
-    } else {
-        textareaText = '';
-        if (chat.length && lastMessage.is_user) {
-            //do nothing? why does this check exist?
-        } else if (type !== 'quiet' && type !== 'swipe' && !isImpersonate && !dryRun && !depth && chat.length) {
-            if (type === 'regenerate') {
-                requestMobileChatBottomPin();
-            }
-            deleteItemizedPromptForMessage(chat.length - 1);
-            chat.length = chat.length - 1;
-            await removeLastMessage();
-            await eventSource.emit(event_types.MESSAGE_DELETED, chat.length);
-        }
-    }
-
     const isContinue = type == 'continue';
 
     // Rewrite the generation timer to account for the time passed for all the continuations.
@@ -5372,43 +5408,9 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
         }
     }
 
-    if (!dryRun) {
-        deactivateSendButtons();
-    }
-
-    let { messageBias, promptBias, isUserPromptBias } = getBiasStrings(textareaText, type);
-    let renderedUserMessage = false;
-
     //*********************************
     //PRE FORMATING STRING
     //*********************************
-
-    // These generation types should not attach pending files to the chat
-    const noAttachTypes = [
-        'regenerate',
-        'swipe',
-        'impersonate',
-        'quiet',
-        'continue',
-    ];
-    //for normal messages sent from user..
-    if ((textareaText != '' || (hasPendingFileAttachment() && !noAttachTypes.includes(type))) && !automatic_trigger && type !== 'quiet' && !dryRun && !depth) {
-        // If user message contains no text other than bias - send as a system message
-        if (messageBias && !removeMacros(textareaText)) {
-            sendSystemMessage(system_message_types.GENERIC, ' ', { bias: messageBias });
-        } else {
-            await sendMessageAsUser(textareaText, messageBias);
-        }
-        renderedUserMessage = true;
-    } else if (textareaText == '' && !automatic_trigger && !dryRun && [undefined, 'normal'].includes(type) && main_api == 'openai' && oai_settings.send_if_empty.trim().length > 0 && !depth && !suppressUserMessage) {
-        // Use send_if_empty if set and the user message is empty. Only when sending messages normally
-        await sendMessageAsUser(oai_settings.send_if_empty.trim(), messageBias);
-        renderedUserMessage = true;
-    }
-
-    if (renderedUserMessage && shouldBatchMobileChatRendering()) {
-        await waitForNextFrame();
-    }
 
     if (!dryRun) {
         // Ping after rendering the local user message so slow WebKit networking cannot delay the visible send.

--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -105,6 +105,7 @@ let currentMainGenerationType = 'normal';
 let postProcessingGenerationRunId = 0;
 let swipeNavigationPending = false;
 const activePathfinderRetrievalAbortControllers = new Set();
+let activePathfinderRetrievalToast = null;
 
 /** Track which tool names were registered by the agent system so we can cleanly unregister only our own. */
 const agentRegisteredToolNames = new Set();
@@ -200,6 +201,7 @@ export function cancelAgentGeneration() {
     clearDeferredPostProcessing();
     clearMissedGenerationEndRecoveryCheck();
     clearAllPromptTransformRunningToasts();
+    clearPathfinderRetrievalToast();
     abortActivePathfinderRetrieval('Pathfinder retrieval cancelled by user.');
 
     const stopped = internalPromptTransformDepth > 0 || activeManualAgentRun ? stopGeneration() : false;
@@ -222,6 +224,28 @@ function abortActivePathfinderRetrieval(reason = 'Pathfinder retrieval cancelled
     }
 
     activePathfinderRetrievalAbortControllers.clear();
+}
+
+function showPathfinderRetrievalToast() {
+    if (activePathfinderRetrievalToast) {
+        return;
+    }
+
+    activePathfinderRetrievalToast = toastr.info('Pathfinder is processing lore for this reply...', 'Please wait', { timeOut: 0, extendedTimeOut: 0 });
+}
+
+function clearPathfinderRetrievalToast() {
+    if (!activePathfinderRetrievalToast) {
+        return;
+    }
+
+    toastr.clear(activePathfinderRetrievalToast);
+    activePathfinderRetrievalToast = null;
+}
+
+function shouldShowPathfinderRetrievalToast(pathfinderAgent) {
+    const settings = pathfinderAgent?.settings ?? {};
+    return Boolean(settings.pipelineEnabled || settings.sidecarEnabled);
 }
 
 async function processManualAgentRunQueue() {
@@ -2618,6 +2642,7 @@ function onGenerationStopped() {
     clearMissedGenerationEndRecoveryCheck();
     clearDeferredPostProcessing();
     clearAllPromptTransformRunningToasts();
+    clearPathfinderRetrievalToast();
     takePendingPreGenerationInterceptRuns();
     abortActivePathfinderRetrieval('Pathfinder retrieval cancelled because generation stopped.');
 }
@@ -2667,8 +2692,12 @@ async function onGenerationAfterCommands(generationType, _options, dryRun) {
         activePathfinderRetrievalAbortControllers.add(retrievalAbortController);
 
         try {
+            if (shouldShowPathfinderRetrievalToast(pathfinderAgent)) {
+                showPathfinderRetrievalToast();
+            }
             await runSidecarRetrieval(setExtensionPrompt, extension_prompt_types, extension_prompt_roles, retrievalAbortController.signal);
         } finally {
+            clearPathfinderRetrievalToast();
             activePathfinderRetrievalAbortControllers.delete(retrievalAbortController);
         }
 

--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -26,6 +26,7 @@ import {
     getEnabledToolAgents,
     getGlobalSettings,
     getPromptTransformMode,
+    saveAgent,
     isToolAgent,
     normalizePreProcessMaxTokens,
     normalizePromptTransformMaxTokens,
@@ -38,11 +39,11 @@ import {
     getToolFormatter,
 } from './tool-action-registry.js';
 import {
-    getAllEntryUids as pfGetAllEntryUids,
     getSettings as getPathfinderRuntimeSettings,
-    getTree as pfGetTree,
     setSettings as setPathfinderRuntimeSettings,
 } from './pathfinder/tree-store.js';
+import { getPathfinderToolDefinitions } from './pathfinder/tool-definitions.js';
+import { getContextualLorebooks } from './pathfinder/pathfinder-tool-bridge.js';
 import { PATHFINDER_RETRIEVAL_PROMPT_KEYS, runSidecarRetrieval } from './pathfinder/sidecar-retrieval.js';
 import { markAutoSummaryComplete, shouldAutoSummarize } from './pathfinder/auto-summary.js';
 
@@ -69,6 +70,7 @@ const BODY_GENERATING_FLAG_GRACE_MS = 1500;
 const DEFERRED_POST_PROCESSING_RETRY_MS = 50;
 const LATEST_ASSISTANT_POST_PROCESSING_FALLBACK_WINDOW_MS = 30000;
 const MISSED_GENERATION_END_RECOVERY_MS = 200;
+const PATHFINDER_SUMMARIZE_TOOL_NAME = 'Pathfinder_Summarize';
 
 /** @type {{ generationType: string, activeAgentIds: string[] } | null} */
 let pendingGenerationSnapshot = null;
@@ -325,11 +327,34 @@ export function getPathfinderRuntimeAgent(agents = getEnabledToolAgents()) {
     return agents.find(isPathfinderToolAgent) ?? null;
 }
 
+function getAgentToolByName(agent, toolName) {
+    return Array.isArray(agent?.tools)
+        ? agent.tools.find(tool => tool?.name === toolName)
+        : null;
+}
+
+function isPathfinderToolEnabledForAgent(agent, toolName) {
+    const states = agent?.settings?.toolStates;
+    if (states && typeof states === 'object' && Object.prototype.hasOwnProperty.call(states, toolName)) {
+        return states[toolName] !== false;
+    }
+
+    const savedTool = getAgentToolByName(agent, toolName);
+    return savedTool?.enabled !== false;
+}
+
+function getPathfinderToolStateMap(agent) {
+    return Object.fromEntries(
+        getPathfinderToolDefinitions().map(tool => [tool.name, isPathfinderToolEnabledForAgent(agent, tool.name)]),
+    );
+}
+
 function syncPathfinderRuntimeSettings(agent = getPathfinderRuntimeAgent()) {
     const currentRuntimeSettings = getPathfinderRuntimeSettings();
     const nextRuntimeSettings = agent?.settings
         ? {
             ...agent.settings,
+            toolStates: getPathfinderToolStateMap(agent),
             pipelinePrompts: currentRuntimeSettings.pipelinePrompts,
             pipelines: currentRuntimeSettings.pipelines,
         }
@@ -342,21 +367,73 @@ function syncPathfinderRuntimeSettings(agent = getPathfinderRuntimeAgent()) {
 }
 
 function getRegisterableAgentTools(agent) {
-    const enabledTools = (agent.tools ?? []).filter(tool => tool.enabled !== false);
+    if (isPathfinderToolAgent(agent)) {
+        const enabledTools = getPathfinderToolDefinitions()
+            .filter(tool => isPathfinderToolEnabledForAgent(agent, tool.name));
 
-    if (!isPathfinderToolAgent(agent) || agent?.settings?.sidecarEnabled) {
-        return enabledTools;
+        if (agent?.settings?.sidecarEnabled) {
+            return enabledTools;
+        }
+
+        return enabledTools.filter(tool => tool.name === PATHFINDER_SUMMARIZE_TOOL_NAME);
     }
 
-    return enabledTools.filter(tool => tool.name === 'Pathfinder_Summarize');
+    return (agent.tools ?? []).filter(tool => tool.enabled !== false);
 }
 
 function isPathfinderSummarizeToolEnabled(agent) {
-    const summarizeTool = Array.isArray(agent?.tools)
-        ? agent.tools.find(tool => tool?.name === 'Pathfinder_Summarize')
-        : null;
+    return isPathfinderToolEnabledForAgent(agent, PATHFINDER_SUMMARIZE_TOOL_NAME);
+}
 
-    return summarizeTool?.enabled !== false;
+export function getToolRecursionState() {
+    return {
+        depth: toolRecursionDepth,
+        limit: ToolManager.RECURSE_LIMIT ?? 5,
+        registeredToolNames: [...agentRegisteredToolNames],
+    };
+}
+
+export async function syncPathfinderAgentLorebooksForCurrentChat(agent = getPathfinderRuntimeAgent(), { persist = false } = {}) {
+    if (!agent || !isPathfinderToolAgent(agent)) {
+        return false;
+    }
+
+    const existingSettings = {
+        ...getPathfinderRuntimeSettings(),
+        ...(agent.settings || {}),
+    };
+    if (existingSettings.autoSyncLorebooksOnChatChange === false) {
+        return false;
+    }
+
+    const contextualBooks = Array.from(new Set(getContextualLorebooks().filter(Boolean)));
+    const currentBooks = Array.isArray(existingSettings.enabledLorebooks) ? existingSettings.enabledLorebooks : [];
+    const sameBooks = currentBooks.length === contextualBooks.length && currentBooks.every((book, index) => book === contextualBooks[index]);
+    const selectedLorebook = contextualBooks[0] ?? '';
+
+    if (sameBooks && (existingSettings.selectedLorebook ?? '') === selectedLorebook) {
+        return false;
+    }
+
+    const nextSettings = {
+        ...existingSettings,
+        enabledLorebooks: contextualBooks,
+        selectedLorebook,
+    };
+    agent.settings = {
+        ...(agent.settings || {}),
+        ...nextSettings,
+    };
+    setPathfinderRuntimeSettings(nextSettings);
+
+    if (persist) {
+        await saveAgent(agent);
+    }
+
+    console.info('[Pathfinder] Synced enabled lorebooks to the current chat context.', {
+        lorebooks: contextualBooks,
+    });
+    return true;
 }
 
 /**
@@ -3343,43 +3420,12 @@ function onChatCompletionSettingsReady(data) {
 
 /**
  * Handles WORLDINFO_ENTRIES_LOADED for tool-category agents.
- * Suppresses keyword-based scanning for lorebooks managed by tool agents
- * (e.g., Pathfinder) to prevent double-injection.
+ * Pathfinder now leaves native World Info activation intact and de-dupes its
+ * own injected retrieval context against naturally activated entries instead.
  * @param {object} data World info data with globalLore, characterLore, etc.
  */
 function onWorldInfoEntriesLoaded(data) {
-    if (!areAgentsGloballyEnabled()) {
-        return;
-    }
-
-    const enabledToolAgents = getEnabledToolAgents();
-    if (enabledToolAgents.length === 0) return;
-
-    const managedUids = getPfManagedEntryUids(enabledToolAgents);
-    if (managedUids.size === 0) return;
-
-    const loreArrayKeys = ['globalLore', 'characterLore', 'chatLore', 'personaLore'];
-    for (const key of loreArrayKeys) {
-        if (!Array.isArray(data[key])) continue;
-        data[key] = data[key].filter(entry => {
-            if (!entry) return true;
-            return !managedUids.has(entry.uid);
-        });
-    }
-}
-
-function getPfManagedEntryUids(toolAgents) {
-    const uids = new Set();
-    for (const agent of toolAgents) {
-        const books = agent.settings?.enabledLorebooks ?? [];
-        for (const bookName of books) {
-            const tree = pfGetTree(bookName);
-            if (tree) {
-                for (const uid of pfGetAllEntryUids(tree)) uids.add(uid);
-            }
-        }
-    }
-    return uids;
+    void data;
 }
 
 let _onChatChangedToolSync = false;
@@ -3398,7 +3444,13 @@ function onChatChangedToolSync() {
     requestAnimationFrame(() => {
         _onChatChangedToolSync = false;
         toolRecursionDepth = 0;
-        syncToolAgentRegistrations();
+        void (async () => {
+            const pathfinderAgent = getPathfinderRuntimeAgent();
+            if (pathfinderAgent) {
+                await syncPathfinderAgentLorebooksForCurrentChat(pathfinderAgent, { persist: true });
+            }
+            syncToolAgentRegistrations();
+        })();
     });
 }
 

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -61,6 +61,7 @@ import {
 } from './regex-scripts.js';
 import { initPathfinder } from './pathfinder-init.js';
 import { openPathfinderSettings, isPathfinderAgent } from './pathfinder-settings-ui.js';
+import { getPathfinderToolDefinitions } from './pathfinder/tool-definitions.js';
 import { buildFallbackPromptText, extractProfileResponseText } from './llm-utils.js';
 import {
     buildConnectionProfileNameMap,
@@ -69,6 +70,7 @@ import {
 } from './profile-utils.js';
 
 const MODULE_NAME = 'in-chat-agents';
+const PATHFINDER_EXTENSIONS_HOST_ID = 'extension_settings_in_chat_agents_pathfinder';
 
 let collapsedCategories = new Set();
 
@@ -87,6 +89,7 @@ let selectModeActive = false;
 /** Set of agent IDs currently selected in select mode. */
 const selectedAgentIds = new Set();
 let suppressCardClickUntil = 0;
+let pathfinderExtensionsMountPromise = null;
 
 const REMOVED_BUNDLED_TEMPLATE_IDS = new Set([
     'tpl-anti-slop-regex',
@@ -495,7 +498,7 @@ async function confirmDuplicateAgentAddition(agent) {
 }
 
 function shouldMigratePathfinderAgentTools(agent, template) {
-    if (!template || shouldSkipBundledTemplateMigrations(agent)) {
+    if (!template) {
         return false;
     }
 
@@ -505,7 +508,24 @@ function shouldMigratePathfinderAgentTools(agent, template) {
 
     const templateTools = Array.isArray(template?.tools) ? template.tools : [];
     const agentTools = Array.isArray(agent?.tools) ? agent.tools : [];
-    return templateTools.length > 0 && agentTools.length === 0;
+    const agentToolNames = new Set(agentTools.map(tool => tool?.name).filter(Boolean));
+    const expectedToolNames = new Set([...templateTools, ...getPathfinderToolDefinitions()].map(tool => tool?.name).filter(Boolean));
+    const toolStates = agent?.settings?.toolStates;
+    const hasAllToolStates = toolStates && typeof toolStates === 'object' && [...expectedToolNames].every(name => Object.hasOwn(toolStates, name));
+
+    return expectedToolNames.size > 0 && ([...expectedToolNames].some(name => !agentToolNames.has(name)) || !hasAllToolStates);
+}
+
+function getDefaultPathfinderTools(template) {
+    const toolsByName = new Map();
+    const templateTools = Array.isArray(template?.tools) ? template.tools : [];
+    for (const tool of [...templateTools, ...getPathfinderToolDefinitions()]) {
+        if (tool?.name && !toolsByName.has(tool.name)) {
+            toolsByName.set(tool.name, tool);
+        }
+    }
+
+    return [...toolsByName.values()];
 }
 
 async function migratePathfinderAgentToolsFromTemplate() {
@@ -517,7 +537,25 @@ async function migratePathfinderAgentToolsFromTemplate() {
             continue;
         }
 
-        agent.tools = structuredClone(template.tools);
+        const existingTools = Array.isArray(agent.tools) ? agent.tools : [];
+        const existingToolNames = new Set(existingTools.map(tool => tool?.name).filter(Boolean));
+        const defaultTools = getDefaultPathfinderTools(template);
+        const missingTools = defaultTools
+            .filter(tool => tool?.name && !existingToolNames.has(tool.name))
+            .map(tool => structuredClone(tool));
+        const toolStates = { ...(agent.settings?.toolStates || {}) };
+        for (const tool of [...existingTools, ...missingTools]) {
+            if (!tool?.name || Object.hasOwn(toolStates, tool.name)) {
+                continue;
+            }
+            toolStates[tool.name] = tool.enabled !== false;
+        }
+
+        agent.tools = [...existingTools, ...missingTools];
+        agent.settings = {
+            ...(agent.settings || {}),
+            toolStates,
+        };
         agent.sourceTemplateId = agent.sourceTemplateId || template.id;
         await saveAgent(agent);
         migratedCount++;
@@ -2717,11 +2755,111 @@ async function openPromptTransformHistoryPopup(messageIndex) {
 
 // ===================== Pathfinder Editor =====================
 
+function getPathfinderSettingsAgent() {
+    return getAgents().find(isPathfinderAgent) ?? null;
+}
+
+function ensurePathfinderExtensionsHost() {
+    const parent = document.getElementById('extensions_settings2') ?? document.getElementById('extensions_settings');
+    if (!parent) {
+        return null;
+    }
+
+    let host = document.getElementById(PATHFINDER_EXTENSIONS_HOST_ID);
+    if (!host) {
+        host = document.createElement('div');
+        host.id = PATHFINDER_EXTENSIONS_HOST_ID;
+        host.className = 'extension_container pf--extensions-host';
+        host.innerHTML = `
+            <div class="inline-drawer">
+                <div class="inline-drawer-toggle inline-drawer-header">
+                    <b><i class="fa-solid fa-route"></i> Pathfinder</b>
+                    <div class="inline-drawer-icon fa-solid fa-circle-chevron-down down"></div>
+                </div>
+                <div class="inline-drawer-content pf--extensions-body" style="display:none"></div>
+            </div>
+        `;
+        parent.append(host);
+    }
+
+    return host;
+}
+
+async function mountPathfinderSettingsInExtensions() {
+    const host = ensurePathfinderExtensionsHost();
+    if (!host) {
+        console.warn('[Pathfinder] Could not mount settings in Extensions drawer because #extensions_settings was not found.');
+        return null;
+    }
+
+    const body = host.querySelector('.pf--extensions-body');
+    if (!body) {
+        return null;
+    }
+
+    const agent = getPathfinderSettingsAgent();
+    body.innerHTML = '';
+
+    if (!agent) {
+        body.innerHTML = '<div class="pf--extensions-empty">Pathfinder agent is not available. Reload In-Chat Agents or restore the bundled Pathfinder template.</div>';
+        return host;
+    }
+
+    const settingsPanel = await openPathfinderSettings(agent);
+    if (!settingsPanel) {
+        body.innerHTML = '<div class="pf--extensions-empty">Could not load Pathfinder settings.</div>';
+        return host;
+    }
+
+    settingsPanel.addClass('pf--settings-embedded');
+    body.append(settingsPanel[0]);
+    return host;
+}
+
+function schedulePathfinderExtensionsMount() {
+    pathfinderExtensionsMountPromise = mountPathfinderSettingsInExtensions()
+        .catch(error => {
+            console.warn('[Pathfinder] Failed to mount settings in Extensions drawer:', error);
+            return null;
+        });
+
+    return pathfinderExtensionsMountPromise;
+}
+
+function openPathfinderExtensionsDrawer(host) {
+    const clickEvent = () => new (globalThis.MouseEvent ?? Event)('click', { bubbles: true });
+    const drawer = document.getElementById('extensions-settings-button');
+    const drawerContent = drawer?.querySelector(':scope > .drawer-content');
+    if (drawer && drawerContent?.classList.contains('closedDrawer')) {
+        drawer.querySelector(':scope > .drawer-toggle')?.dispatchEvent(clickEvent());
+    }
+
+    const inlineDrawer = host?.querySelector('.inline-drawer');
+    const inlineContent = inlineDrawer?.querySelector(':scope > .inline-drawer-content');
+    const inlineIcon = inlineDrawer?.querySelector(':scope > .inline-drawer-header .inline-drawer-icon');
+    if (inlineDrawer && inlineContent && inlineIcon?.classList.contains('down')) {
+        inlineDrawer.querySelector(':scope > .inline-drawer-toggle')?.dispatchEvent(clickEvent());
+    }
+
+    globalThis.setTimeout(() => {
+        host?.scrollIntoView({ block: 'start', behavior: 'smooth' });
+        host?.querySelector('input, button, select, textarea')?.focus?.({ preventScroll: true });
+    }, 100);
+}
+
 /**
  * Opens the Pathfinder-specific settings editor
  * @param {Object} agent - The Pathfinder agent
  */
 async function openPathfinderEditor(agent) {
+    const existingHost = document.getElementById(PATHFINDER_EXTENSIONS_HOST_ID);
+    if (existingHost) {
+        const host = await (pathfinderExtensionsMountPromise ?? schedulePathfinderExtensionsMount());
+        openPathfinderExtensionsDrawer(host ?? existingHost);
+        toastr.info('Pathfinder settings are in the Extensions drawer.');
+        return;
+    }
+
     const originalAgentState = JSON.stringify(agent);
     const template = findTemplateForAgent(agent);
     const settingsPanel = await openPathfinderSettings(agent, async (updatedAgent) => {
@@ -3194,6 +3332,7 @@ async function refinePromptWithAI(currentPrompt, category, phase, connectionProf
 
     // Render the panel
     renderAgentList();
+    schedulePathfinderExtensionsMount();
 
     // Wire up toolbar
     $('#ica--globalEnabled').on('click', () => {

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -2811,8 +2811,10 @@ async function mountPathfinderSettingsInExtensions() {
         return host;
     }
 
-    settingsPanel.addClass('pf--settings-embedded');
-    body.append(settingsPanel[0]);
+    settingsPanel.filter('#pf--settings').addClass('pf--settings-embedded');
+    for (const node of settingsPanel.toArray()) {
+        body.append(node);
+    }
     return host;
 }
 

--- a/public/scripts/extensions/in-chat-agents/pathfinder-init.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder-init.js
@@ -3,15 +3,16 @@ import { initEntryManagerAPIs } from './pathfinder/entry-manager.js';
 import { initActivityFeed } from './pathfinder/activity-feed.js';
 import { initAutoSummary } from './pathfinder/auto-summary.js';
 import { initCommands } from './pathfinder/commands.js';
+import { getPathfinderToolDefinitions } from './pathfinder/tool-definitions.js';
 
-import { getDefinition as getSearchDef, registerActions as registerSearchActions } from './pathfinder/tools/search.js';
-import { getDefinition as getRememberDef, registerActions as registerRememberActions } from './pathfinder/tools/remember.js';
-import { getDefinition as getUpdateDef, registerActions as registerUpdateActions } from './pathfinder/tools/update.js';
-import { getDefinition as getForgetDef, registerActions as registerForgetActions } from './pathfinder/tools/forget.js';
-import { getDefinition as getSummarizeDef, registerActions as registerSummarizeActions } from './pathfinder/tools/summarize.js';
-import { getDefinition as getReorganizeDef, registerActions as registerReorganizeActions } from './pathfinder/tools/reorganize.js';
-import { getDefinition as getMergeSplitDef, registerActions as registerMergeSplitActions } from './pathfinder/tools/merge-split.js';
-import { getDefinition as getNotebookDef, registerActions as registerNotebookActions } from './pathfinder/tools/notebook.js';
+import { registerActions as registerSearchActions } from './pathfinder/tools/search.js';
+import { registerActions as registerRememberActions } from './pathfinder/tools/remember.js';
+import { registerActions as registerUpdateActions } from './pathfinder/tools/update.js';
+import { registerActions as registerForgetActions } from './pathfinder/tools/forget.js';
+import { registerActions as registerSummarizeActions } from './pathfinder/tools/summarize.js';
+import { registerActions as registerReorganizeActions } from './pathfinder/tools/reorganize.js';
+import { registerActions as registerMergeSplitActions } from './pathfinder/tools/merge-split.js';
+import { registerActions as registerNotebookActions } from './pathfinder/tools/notebook.js';
 
 import { buildTreeFromMetadata, buildTreeWithLLM } from './pathfinder/tree-builder.js';
 import { runDiagnostics } from './pathfinder/diagnostics.js';
@@ -21,19 +22,6 @@ import { initializePromptStore } from './pathfinder/prompts/prompt-store.js';
 import { getDefaultPrompts, getDefaultPipelines } from './pathfinder/prompts/default-prompts.js';
 
 let initialized = false;
-
-export function getPathfinderToolDefinitions() {
-    return [
-        getSearchDef(),
-        getRememberDef(),
-        getUpdateDef(),
-        getForgetDef(),
-        getSummarizeDef(),
-        getReorganizeDef(),
-        getMergeSplitDef(),
-        getNotebookDef(),
-    ];
-}
 
 export function initPathfinder(context) {
     if (initialized) return;
@@ -78,6 +66,7 @@ export async function buildPathfinderTree(bookName, bookData, useLLM = false, ll
 export { runDiagnostics };
 export { getSettings as getPathfinderSettings, setSettings as setPathfinderSettings };
 export { isLorebookEnabled, setLorebookEnabled };
+export { getPathfinderToolDefinitions };
 
 // Export pipeline-related functions for external use
 export { initPromptEditorUI, refreshPromptEditorUI } from './pathfinder/prompts/prompt-editor-ui.js';

--- a/public/scripts/extensions/in-chat-agents/pathfinder-init.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder-init.js
@@ -41,8 +41,12 @@ export function initPathfinder(context) {
     // Initialize pipeline prompt store with defaults
     initializePromptStore(getDefaultPrompts(), getDefaultPipelines());
 
-    if (context?.loadWorldInfo && context?.createWorldInfoEntry && context?.saveWorldInfo) {
+    const entryManagerAPIs = ['loadWorldInfo', 'createWorldInfoEntry', 'saveWorldInfo'];
+    const missingEntryManagerAPIs = entryManagerAPIs.filter(api => !context?.[api]);
+    if (missingEntryManagerAPIs.length === 0) {
         initEntryManagerAPIs(context.loadWorldInfo, context.createWorldInfoEntry, context.saveWorldInfo);
+    } else {
+        console.error(`[Pathfinder] Missing context APIs for lorebook writes: ${missingEntryManagerAPIs.join(', ')}`);
     }
 
     if (context?.eventSource && context?.eventTypes) {

--- a/public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js
@@ -31,7 +31,7 @@ import { getDefaultPrompts } from './pathfinder/prompts/default-prompts.js';
 import { clearFeed, getFeedItems } from './pathfinder/activity-feed.js';
 import { getSummaryMemoryState, onSummaryMemoryChanged, saveSummaryMemoryContent } from './pathfinder/summary-memory-store.js';
 import { sidecarGenerate } from './pathfinder/llm-sidecar.js';
-import { createSummaryMemoryEntry } from './pathfinder/tools/summarize.js';
+import { createSeparateSummaryMemoryEntry, createSummaryMemoryEntry, deriveSummaryLorebookTitle } from './pathfinder/tools/summarize.js';
 
 const MODULE_NAME = 'in-chat-agents';
 const PATHFINDER_LOG_PREFIX = '[Pathfinder]';
@@ -608,6 +608,7 @@ function renderSummaryMemoryEditor() {
     const indicator = settingsEl.find('#pf--summary-injection-indicator');
     const meta = settingsEl.find('#pf--summary-meta');
     const hasSummary = Boolean(summary.content || summary.uid);
+    const currentContent = String(textarea.val() || summary.content || '').trim();
 
     if (document.activeElement !== textarea[0]) {
         textarea.val(summary.content || '');
@@ -615,6 +616,7 @@ function renderSummaryMemoryEditor() {
 
     textarea.prop('disabled', !hasSummary);
     settingsEl.find('#pf--summary-save').prop('disabled', !hasSummary);
+    settingsEl.find('#pf--summary-save-entry').prop('disabled', !currentContent);
     settingsEl.find('#pf--summary-create').toggle(!hasSummary).prop('disabled', hasSummary);
 
     indicator.removeClass('pf--summary-indicator-missing pf--summary-indicator-not-injected pf--summary-indicator-injected');
@@ -636,6 +638,22 @@ function renderSummaryMemoryEditor() {
     const updated = summary.updatedAt ? `Updated ${formatSummaryTimestamp(summary.updatedAt)}` : 'Not saved yet';
     const injected = summary.injectedAt ? `Last injected ${formatSummaryTimestamp(summary.injectedAt)}${summary.injectedMode ? ` via ${summary.injectedMode}` : ''}` : 'Not injected by retrieval yet';
     meta.text(`${title} — ${location}. ${updated}. ${injected}.`);
+}
+
+function getSummaryEditorDraft() {
+    const summary = getSummaryMemoryState();
+    const content = String(settingsEl.find('#pf--summary-content').val() || summary.content || '').trim();
+    return {
+        title: deriveSummaryLorebookTitle({
+            title: summary.title,
+            content,
+            arc: summary.arc,
+        }),
+        content,
+        significance: summary.significance || 'medium',
+        arc: summary.arc || '',
+        book: summary.bookName || getPathfinderSettings().selectedLorebook || '',
+    };
 }
 
 function getRecentChatForSummary(maxMessages = 24) {
@@ -890,10 +908,40 @@ function bindEvents() {
         const status = settingsEl.find('#pf--summary-save-status');
         try {
             await saveSummaryMemoryContent(settingsEl.find('#pf--summary-content').val());
+            renderSummaryMemoryEditor();
             status.text('Saved!').removeClass('error').addClass('success');
             setTimeout(() => status.text(''), 3000);
         } catch (err) {
             status.text(`Save failed: ${err.message}`).removeClass('success').addClass('error');
+        }
+    });
+
+    settingsEl.find('#pf--summary-content').on('input', renderSummaryMemoryEditor);
+
+    settingsEl.find('#pf--summary-save-entry').on('click', async () => {
+        const status = settingsEl.find('#pf--summary-save-status');
+        const button = settingsEl.find('#pf--summary-save-entry');
+        const draft = getSummaryEditorDraft();
+        if (!draft.content) {
+            status.text('Write or create a summary first.').removeClass('success').addClass('error');
+            return;
+        }
+
+        button.prop('disabled', true);
+        status.text('Saving entry...').removeClass('success error');
+
+        try {
+            const result = await createSeparateSummaryMemoryEntry(draft);
+            setPathfinderToolEnabled('Pathfinder_Summarize', true);
+            settingsEl.find('#pf--enable-summarize-tool').prop('checked', true);
+            await updateAgentSettings();
+            syncToolAgentRegistrations();
+            status.text(`Saved "${result.summaryTitle}"`).removeClass('error').addClass('success');
+            setTimeout(() => status.text(''), 4000);
+        } catch (err) {
+            status.text(`Entry save failed: ${err.message}`).removeClass('success').addClass('error');
+        } finally {
+            renderSummaryMemoryEditor();
         }
     });
 

--- a/public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js
@@ -25,14 +25,13 @@ import {
 } from './pathfinder/tree-store.js';
 import { buildTreeFromMetadata } from './pathfinder/tree-builder.js';
 import { syncToolAgentRegistrations } from './agent-runner.js';
-import { ALL_TOOL_NAMES } from './pathfinder/pathfinder-tool-bridge.js';
+import { ALL_TOOL_NAMES, getContextualLorebookDetails } from './pathfinder/pathfinder-tool-bridge.js';
 import { getPrompt, savePrompt } from './pathfinder/prompts/prompt-store.js';
 import { getDefaultPrompts } from './pathfinder/prompts/default-prompts.js';
 import { clearFeed, getFeedItems } from './pathfinder/activity-feed.js';
 import { getSummaryMemoryState, onSummaryMemoryChanged, saveSummaryMemoryContent } from './pathfinder/summary-memory-store.js';
 import { sidecarGenerate } from './pathfinder/llm-sidecar.js';
 import { createSummaryMemoryEntry } from './pathfinder/tools/summarize.js';
-import { getContextualLorebookDetails } from './pathfinder/pathfinder-tool-bridge.js';
 
 const MODULE_NAME = 'in-chat-agents';
 const PATHFINDER_LOG_PREFIX = '[Pathfinder]';
@@ -54,6 +53,57 @@ function ensureEnabledLorebooks(settings) {
     }
 
     return settings.enabledLorebooks;
+}
+
+function addUniqueLorebookName(names, name) {
+    const bookName = String(name ?? '').trim();
+    if (bookName && !names.includes(bookName)) {
+        names.push(bookName);
+    }
+}
+
+function getActiveLorebookNames(settings, lorebooks = []) {
+    const names = [...ensureEnabledLorebooks(settings)];
+
+    if (settings.autoUseAttachedLorebook || settings.autoSyncLorebooksOnChatChange !== false) {
+        for (const book of lorebooks) {
+            if (book.attached) {
+                addUniqueLorebookName(names, book.name);
+            }
+        }
+    }
+
+    if (settings.includeContextualLorebooks !== false) {
+        for (const source of getContextualLorebookDetails()) {
+            addUniqueLorebookName(names, source.name);
+        }
+    }
+
+    return names;
+}
+
+function getEffectiveLorebooks(lorebooks, settings) {
+    const allBooks = Array.isArray(lorebooks) ? lorebooks : [];
+    const booksByName = new Map(allBooks.map(book => [book.name, book]));
+
+    for (const source of getContextualLorebookDetails()) {
+        if (!source.name || booksByName.has(source.name)) {
+            continue;
+        }
+
+        const sourceTypes = Array.isArray(source.types) ? new Set(source.types) : new Set([source.type || 'attached']);
+        booksByName.set(source.name, {
+            name: source.name,
+            entries: '?',
+            attached: true,
+            sourceTypes,
+            type: formatLorebookSourceLabel(sourceTypes),
+        });
+    }
+
+    return getActiveLorebookNames(settings, allBooks)
+        .map(name => booksByName.get(name) ?? { name, entries: '?', attached: false, type: 'lorebook' })
+        .filter(book => book?.name);
 }
 
 export function normalizeSummaryIntervalInput(value) {
@@ -120,10 +170,14 @@ async function syncAutoAttachedLorebooks(lorebooks, settings) {
     const enabledLorebooks = [...ensureEnabledLorebooks(settings)];
     const attachedLorebooks = lorebooks.filter(book => book.attached).map(book => book.name);
     const syncedLorebooks = Array.from(new Set(attachedLorebooks));
+    const selectedLorebook = syncedLorebooks[0] ?? '';
     const autoSyncChanged = settings.autoSyncLorebooksOnChatChange
-        && (enabledLorebooks.length !== syncedLorebooks.length || enabledLorebooks.some((name, index) => name !== syncedLorebooks[index]));
+        && (enabledLorebooks.length !== syncedLorebooks.length
+            || enabledLorebooks.some((name, index) => name !== syncedLorebooks[index])
+            || (settings.selectedLorebook ?? '') !== selectedLorebook);
     if (settings.autoSyncLorebooksOnChatChange) {
         settings.enabledLorebooks = syncedLorebooks;
+        settings.selectedLorebook = selectedLorebook;
         setPathfinderSettings(settings);
     }
 
@@ -140,6 +194,9 @@ async function syncAutoAttachedLorebooks(lorebooks, settings) {
 
     if (!settings.autoSyncLorebooksOnChatChange) {
         settings.enabledLorebooks = Array.from(new Set([...enabledLorebooks, ...attachedLorebooks]));
+        if (!settings.selectedLorebook || !settings.enabledLorebooks.includes(settings.selectedLorebook)) {
+            settings.selectedLorebook = settings.enabledLorebooks[0] ?? '';
+        }
     }
     attachedLorebooks.forEach(bookName => setLorebookEnabled(bookName, true));
     setPathfinderSettings(settings);
@@ -207,7 +264,7 @@ export async function openPathfinderSettings(agent) {
  */
 async function getAvailableLorebooks() {
     const ctx = getContext();
-    if (!ctx) {
+    if (!ctx && !globalThis.window?.SillyTavern?.getContext?.() && (!Array.isArray(world_names) || world_names.length === 0)) {
         console.warn(`${PATHFINDER_LOG_PREFIX} Could not resolve the current context while gathering lorebooks.`);
         return [];
     }
@@ -285,10 +342,10 @@ async function refreshLorebookList() {
     settingsEl.find('#pf--auto-use-attached').prop('checked', Boolean(settings.autoUseAttachedLorebook));
     const autoEnabledLorebooks = await syncAutoAttachedLorebooks(lorebooks, settings);
     if (autoEnabledLorebooks.length > 0) {
-        updateAgentSettings();
+        await updateAgentSettings();
         updateStatusBanner();
     }
-    const enabledBooks = ensureEnabledLorebooks(getPathfinderSettings());
+    const enabledBooks = getActiveLorebookNames(getPathfinderSettings(), lorebooks);
 
     if (lorebooks.length === 0) {
         logPathfinder('No lorebooks were available for the current character/chat context.');
@@ -332,6 +389,7 @@ async function refreshLorebookList() {
 
             if (checked && !s.enabledLorebooks.includes(bookName)) {
                 s.enabledLorebooks.push(bookName);
+                s.selectedLorebook = s.selectedLorebook || bookName;
                 setLorebookEnabled(bookName, true);
                 logPathfinder(`Lorebook "${bookName}" enabled.`, {
                     source: book.type,
@@ -340,6 +398,9 @@ async function refreshLorebookList() {
                 await ensureLorebookTree(bookName);
             } else if (!checked) {
                 s.enabledLorebooks = s.enabledLorebooks.filter(b => b !== bookName);
+                if (s.selectedLorebook === bookName) {
+                    s.selectedLorebook = s.enabledLorebooks[0] ?? '';
+                }
                 setLorebookEnabled(bookName, false);
                 logPathfinder(`Lorebook "${bookName}" disabled.`, {
                     source: book.type,
@@ -439,12 +500,10 @@ function renderPermissionMatrix(lorebooks = null) {
         return;
     }
 
-    const allBooks = Array.isArray(lorebooks) ? lorebooks : [];
-    const enabledBooks = ensureEnabledLorebooks(getPathfinderSettings());
-    const books = allBooks.filter(book => enabledBooks.includes(book.name));
+    const books = getEffectiveLorebooks(lorebooks, getPathfinderSettings());
 
     if (books.length === 0) {
-        matrix.html('<div class="pf--empty-state pf--permission-empty"><i class="fa-solid fa-lock-open"></i><span>Select a lorebook to set read, write, and delete permissions.</span></div>');
+        matrix.html('<div class="pf--empty-state pf--permission-empty"><i class="fa-solid fa-lock-open"></i><span>Select a lorebook above, or attach one to the current character/chat with auto-select enabled.</span></div>');
         return;
     }
 
@@ -984,7 +1043,8 @@ function bindEvents() {
 function updateStatusBanner() {
     const banner = settingsEl.find('#pf--status-banner');
     const s = getPathfinderSettings();
-    const hasBooks = (s.enabledLorebooks || []).length > 0;
+    const activeBooks = getActiveLorebookNames(s);
+    const hasBooks = activeBooks.length > 0;
     const hasMode = s.sidecarEnabled || s.pipelineEnabled;
     const masterEnabled = currentAgent ? isAgentEnabledForCurrentScope(currentAgent) : false;
 
@@ -997,7 +1057,7 @@ function updateStatusBanner() {
         banner.removeClass('pf--status-disabled').addClass('pf--status-ready');
         banner.find('.pf--status-icon i').removeClass('fa-circle-xmark').addClass('fa-circle-check');
         banner.find('.pf--status-text strong').text('Pathfinder is ready');
-        banner.find('.pf--status-text span').text(`${s.enabledLorebooks.length} lorebook(s) enabled`);
+        banner.find('.pf--status-text span').text(`${activeBooks.length} lorebook(s) available`);
     } else if (hasBooks) {
         banner.removeClass('pf--status-disabled').addClass('pf--status-ready');
         banner.find('.pf--status-icon i').removeClass('fa-circle-xmark').addClass('fa-circle-check');

--- a/public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js
@@ -16,9 +16,16 @@ import {
     setLorebookEnabled,
     listConnectionProfiles,
     normalizeAutoSummaryInterval,
+    isPathfinderToolEnabled as isRuntimePathfinderToolEnabled,
+    setPathfinderToolEnabled as setRuntimePathfinderToolEnabled,
+    setBookPermission,
+    canReadBook,
+    canWriteBook,
+    canDeleteBook,
 } from './pathfinder/tree-store.js';
 import { buildTreeFromMetadata } from './pathfinder/tree-builder.js';
 import { syncToolAgentRegistrations } from './agent-runner.js';
+import { ALL_TOOL_NAMES } from './pathfinder/pathfinder-tool-bridge.js';
 import { getPrompt, savePrompt } from './pathfinder/prompts/prompt-store.js';
 import { getDefaultPrompts } from './pathfinder/prompts/default-prompts.js';
 import { clearFeed, getFeedItems } from './pathfinder/activity-feed.js';
@@ -106,20 +113,34 @@ async function ensureLorebookTree(bookName) {
 }
 
 async function syncAutoAttachedLorebooks(lorebooks, settings) {
-    if (!settings.autoUseAttachedLorebook) {
+    if (!settings.autoUseAttachedLorebook && !settings.autoSyncLorebooksOnChatChange) {
         return [];
     }
 
-    const enabledLorebooks = ensureEnabledLorebooks(settings);
+    const enabledLorebooks = [...ensureEnabledLorebooks(settings)];
     const attachedLorebooks = lorebooks.filter(book => book.attached).map(book => book.name);
+    const syncedLorebooks = Array.from(new Set(attachedLorebooks));
+    const autoSyncChanged = settings.autoSyncLorebooksOnChatChange
+        && (enabledLorebooks.length !== syncedLorebooks.length || enabledLorebooks.some((name, index) => name !== syncedLorebooks[index]));
+    if (settings.autoSyncLorebooksOnChatChange) {
+        settings.enabledLorebooks = syncedLorebooks;
+        setPathfinderSettings(settings);
+    }
+
     const newLorebooks = attachedLorebooks.filter(name => !enabledLorebooks.includes(name));
 
     if (attachedLorebooks.length === 0) {
         logPathfinder('Auto-use attached lorebooks is enabled, but no attached lorebooks were found.');
+        if (autoSyncChanged) {
+            logPathfinder('Cleared stale Pathfinder lorebooks for a chat with no attached lorebooks.');
+            return enabledLorebooks;
+        }
         return [];
     }
 
-    settings.enabledLorebooks = Array.from(new Set([...enabledLorebooks, ...attachedLorebooks]));
+    if (!settings.autoSyncLorebooksOnChatChange) {
+        settings.enabledLorebooks = Array.from(new Set([...enabledLorebooks, ...attachedLorebooks]));
+    }
     attachedLorebooks.forEach(bookName => setLorebookEnabled(bookName, true));
     setPathfinderSettings(settings);
 
@@ -128,6 +149,11 @@ async function syncAutoAttachedLorebooks(lorebooks, settings) {
         for (const bookName of newLorebooks) {
             await ensureLorebookTree(bookName);
         }
+    }
+
+    if (autoSyncChanged) {
+        const removedLorebooks = enabledLorebooks.filter(name => !syncedLorebooks.includes(name));
+        return Array.from(new Set([...newLorebooks, ...removedLorebooks]));
     }
 
     return newLorebooks;
@@ -272,6 +298,7 @@ async function refreshLorebookList() {
                 <span>No lorebooks found. Create a lorebook in World Info first.</span>
             </div>
         `);
+        renderPermissionMatrix([]);
         return;
     }
 
@@ -323,16 +350,32 @@ async function refreshLorebookList() {
             setPathfinderSettings(s);
             updateAgentSettings();
             updateStatusBanner();
+            renderPermissionMatrix(lorebooks);
         });
 
         listEl.append(item);
     }
+
+    renderPermissionMatrix(lorebooks);
 }
 
 
 function setPathfinderToolEnabled(toolName, enabled) {
-    if (!currentAgent?.tools) {
+    setRuntimePathfinderToolEnabled(toolName, enabled);
+    if (!currentAgent) {
         return;
+    }
+
+    if (!currentAgent.settings || typeof currentAgent.settings !== 'object') {
+        currentAgent.settings = {};
+    }
+    currentAgent.settings.toolStates = {
+        ...(currentAgent.settings.toolStates || {}),
+        [toolName]: Boolean(enabled),
+    };
+
+    if (!Array.isArray(currentAgent.tools)) {
+        currentAgent.tools = [];
     }
 
     const tool = currentAgent.tools.find(t => t.name === toolName);
@@ -342,12 +385,82 @@ function setPathfinderToolEnabled(toolName, enabled) {
 }
 
 function isPathfinderToolEnabled(toolName) {
-    if (!Array.isArray(currentAgent?.tools)) {
-        return false;
+    const fallbackTool = Array.isArray(currentAgent?.tools)
+        ? currentAgent.tools.find(t => t.name === toolName)
+        : null;
+
+    if (currentAgent?.settings?.toolStates && Object.hasOwn(currentAgent.settings.toolStates, toolName)) {
+        return currentAgent.settings.toolStates[toolName] !== false;
     }
 
-    const tool = currentAgent?.tools?.find(t => t.name === toolName);
-    return tool?.enabled !== false;
+    return isRuntimePathfinderToolEnabled(toolName, fallbackTool?.enabled !== false);
+}
+
+function getToolLabel(toolName) {
+    switch (toolName) {
+        case 'Pathfinder_Search': return 'Search - Browse waypoint map';
+        case 'Pathfinder_Remember': return 'Remember - Create new entries';
+        case 'Pathfinder_Update': return 'Update - Edit existing entries';
+        case 'Pathfinder_Forget': return 'Forget - Disable/delete entries';
+        case 'Pathfinder_Summarize': return 'Summarize - Write memory summaries';
+        case 'Pathfinder_Reorganize': return 'Reorganize - Move entries and waypoints';
+        case 'Pathfinder_MergeSplit': return 'Merge/Split - Combine or divide entries';
+        case 'Pathfinder_Notebook': return 'Notebook - Private AI scratchpad';
+        default: return toolName;
+    }
+}
+
+function renderToolToggles() {
+    const toolList = settingsEl.find('.pf--tool-list');
+    if (!toolList.length) {
+        return;
+    }
+
+    toolList.empty();
+    for (const toolName of ALL_TOOL_NAMES) {
+        if (toolName === 'Pathfinder_Summarize') {
+            continue;
+        }
+
+        const item = $(`
+            <label class="checkbox_label">
+                <input type="checkbox" data-tool="${escapeHtml(toolName)}" />
+                <span>${escapeHtml(getToolLabel(toolName))}</span>
+            </label>
+        `);
+        item.find('input').prop('checked', isPathfinderToolEnabled(toolName));
+        toolList.append(item);
+    }
+}
+
+function renderPermissionMatrix(lorebooks = null) {
+    const matrix = settingsEl.find('#pf--permission-matrix');
+    if (!matrix.length) {
+        return;
+    }
+
+    const allBooks = Array.isArray(lorebooks) ? lorebooks : [];
+    const enabledBooks = ensureEnabledLorebooks(getPathfinderSettings());
+    const books = allBooks.filter(book => enabledBooks.includes(book.name));
+
+    if (books.length === 0) {
+        matrix.html('<div class="pf--empty-state pf--permission-empty"><i class="fa-solid fa-lock-open"></i><span>Select a lorebook to set read, write, and delete permissions.</span></div>');
+        return;
+    }
+
+    const rows = books.map(book => `
+        <div class="pf--permission-row" data-book="${escapeHtml(book.name)}">
+            <div class="pf--permission-book">
+                <strong>${escapeHtml(book.name)}</strong>
+                <span>${escapeHtml(book.type || 'lorebook')}</span>
+            </div>
+            <label class="checkbox_label"><input type="checkbox" data-permission="read" ${canReadBook(book.name) ? 'checked' : ''} /><span>Read</span></label>
+            <label class="checkbox_label"><input type="checkbox" data-permission="write" ${canWriteBook(book.name) ? 'checked' : ''} /><span>Write</span></label>
+            <label class="checkbox_label"><input type="checkbox" data-permission="delete" ${canDeleteBook(book.name) ? 'checked' : ''} /><span>Delete</span></label>
+        </div>
+    `).join('');
+
+    matrix.html(rows);
 }
 
 function readPromptMaxTokens() {
@@ -375,6 +488,8 @@ function loadSettingsIntoUI() {
     settingsEl.find('#pf--enable-tools').prop('checked', s.sidecarEnabled || false);
     settingsEl.find('#pf--mandatory-tools').prop('checked', s.mandatoryTools || false);
     settingsEl.find('#pf--auto-use-attached').prop('checked', s.autoUseAttachedLorebook || false);
+    settingsEl.find('#pf--auto-sync-lorebooks').prop('checked', s.autoSyncLorebooksOnChatChange !== false);
+    settingsEl.find('#pf--dedupe-natural-activation').prop('checked', s.dedupeNaturalActivation !== false);
     settingsEl.find('#pf--auto-summary').prop('checked', s.autoSummary || false);
     settingsEl.find('#pf--auto-summary-interval').val(s.autoSummaryInterval ?? 20);
 
@@ -384,12 +499,11 @@ function loadSettingsIntoUI() {
     populateConnectionProfiles();
 
     // Load tool states from agent
-    if (currentAgent?.tools) {
-        for (const tool of currentAgent.tools) {
-            const checkbox = settingsEl.find(`input[data-tool="${tool.name}"]`);
-            checkbox.prop('checked', tool.enabled !== false);
-        }
-    }
+    renderToolToggles();
+    settingsEl.find('input[data-tool]').each(function () {
+        const toolName = $(this).data('tool');
+        $(this).prop('checked', isPathfinderToolEnabled(toolName));
+    });
 }
 
 /**
@@ -587,6 +701,21 @@ function bindEvents() {
         updateStatusBanner();
     });
 
+    settingsEl.find('#pf--auto-sync-lorebooks').on('change', async function () {
+        const enabled = $(this).prop('checked');
+        const s = getPathfinderSettings();
+        s.autoSyncLorebooksOnChatChange = enabled;
+        setPathfinderSettings(s);
+        logPathfinder(`Chat-context lorebook auto-sync ${enabled ? 'enabled' : 'disabled'}.`);
+
+        if (enabled) {
+            await refreshLorebookList();
+        }
+
+        await updateAgentSettings();
+        updateStatusBanner();
+    });
+
     // Mode toggles
     settingsEl.find('#pf--enable-tools').on('change', function () {
         const enabled = $(this).prop('checked');
@@ -657,6 +786,14 @@ function bindEvents() {
         s.connectionProfile = $(this).val();
         setPathfinderSettings(s);
         logPathfinder('Pipeline connection profile changed.', { connectionProfile: s.connectionProfile || 'main-model' });
+        updateAgentSettings();
+    });
+
+    settingsEl.find('#pf--dedupe-natural-activation').on('change', function () {
+        const s = getPathfinderSettings();
+        s.dedupeNaturalActivation = $(this).prop('checked');
+        setPathfinderSettings(s);
+        logPathfinder('Natural World Info activation dedupe changed.', { dedupeNaturalActivation: s.dedupeNaturalActivation });
         updateAgentSettings();
     });
 
@@ -731,20 +868,30 @@ function bindEvents() {
         updateAgentSettings();
     });
 
-    settingsEl.find('.pf--tool-list input[data-tool]').on('change', async function () {
+    settingsEl.on('change', '.pf--tool-list input[data-tool]', async function () {
         const toolName = $(this).data('tool');
         const enabled = $(this).prop('checked');
 
-        if (currentAgent?.tools) {
-            const tool = currentAgent.tools.find(t => t.name === toolName);
-            if (tool) {
-                tool.enabled = enabled;
-            }
-        }
+        setPathfinderToolEnabled(toolName, enabled);
 
         logPathfinder('Tool availability changed.', { toolName, enabled });
         await updateAgentSettings();
         syncToolAgentRegistrations();
+    });
+
+    settingsEl.on('change', '#pf--permission-matrix input[data-permission]', async function () {
+        const row = $(this).closest('.pf--permission-row');
+        const bookName = row.data('book');
+        const permission = $(this).data('permission');
+        const enabled = $(this).prop('checked');
+
+        if (!bookName || !permission) {
+            return;
+        }
+
+        setBookPermission(bookName, permission, enabled ? 'readwrite' : 'none');
+        logPathfinder('Lorebook permission changed.', { bookName, permission, enabled });
+        await updateAgentSettings();
     });
 
     // Collapsible sections
@@ -795,6 +942,21 @@ function bindEvents() {
         } catch (err) {
             output.text('Error running diagnostics: ' + err.message);
             console.warn(`${PATHFINDER_LOG_PREFIX} Pathfinder diagnostics failed.`, err);
+        }
+    });
+
+    settingsEl.find('#pf--copy-diagnostics').on('click', async () => {
+        const text = settingsEl.find('#pf--diagnostics-output').text() || '';
+        try {
+            await navigator.clipboard.writeText(text);
+            toastr.success('Pathfinder diagnostics copied.');
+        } catch {
+            const textarea = $('<textarea>').val(text).css({ position: 'fixed', left: '-9999px', top: '0' });
+            $('body').append(textarea);
+            textarea[0].select();
+            document.execCommand('copy');
+            textarea.remove();
+            toastr.success('Pathfinder diagnostics copied.');
         }
     });
 
@@ -943,6 +1105,10 @@ function formatRetrievalDetail(item, { detailed = false } = {}) {
 
     if (metadata.reason) {
         lines.push(`  Note: ${metadata.reason.replace(/-/g, ' ')}`);
+    }
+
+    if (metadata.skippedNaturalActivationCount > 0) {
+        lines.push(`  Skipped native World Info activations: ${formatCount(metadata.skippedNaturalActivationCount, 'entry')}`);
     }
 
     if (stageResults.length > 0) {

--- a/public/scripts/extensions/in-chat-agents/pathfinder-settings.html
+++ b/public/scripts/extensions/in-chat-agents/pathfinder-settings.html
@@ -283,9 +283,13 @@
                         <i class="fa-solid fa-save"></i>
                         <span>Save Summary</span>
                     </button>
+                    <button type="button" id="pf--summary-save-entry" class="menu_button menu_button_icon">
+                        <i class="fa-solid fa-book-medical"></i>
+                        <span>Save as Entry</span>
+                    </button>
                     <span id="pf--summary-save-status" class="pf--prompt-status"></span>
                 </div>
-                <div class="pf--setting-help">Saving updates the actual lorebook summary entry. The indicator shows whether that latest summary was selected and injected by Pathfinder retrieval.</div>
+                <div class="pf--setting-help">Save Summary updates the tracked memory summary. Save as Entry creates a separate lorebook entry with a title derived from the summary text.</div>
             </div>
         </div>
     </div>

--- a/public/scripts/extensions/in-chat-agents/pathfinder-settings.html
+++ b/public/scripts/extensions/in-chat-agents/pathfinder-settings.html
@@ -63,6 +63,13 @@
             </label>
             <div class="pf--setting-help">When enabled, Pathfinder auto-selects lorebooks attached to the active character card or chat.</div>
         </div>
+        <div class="pf--setting-group pf--lorebook-toggle">
+            <label class="checkbox_label">
+                <input type="checkbox" id="pf--auto-sync-lorebooks" />
+                <span>Reset selections to the current chat/character lorebooks on chat change</span>
+            </label>
+            <div class="pf--setting-help">Prevents a previous chat's lorebook from staying selected when the new chat has no attached lorebook.</div>
+        </div>
     </div>
 
     <!-- Step 2: Choose Mode -->
@@ -172,6 +179,14 @@
                     <option value="">Use main model</option>
                 </select>
                 <div class="pf--setting-help">Use a faster/cheaper model for the pipeline (e.g., Haiku, GPT-4o-mini)</div>
+            </div>
+
+            <div class="pf--setting-group">
+                <label class="checkbox_label">
+                    <input type="checkbox" id="pf--dedupe-natural-activation" />
+                    <span>Skip entries already activated by World Info</span>
+                </label>
+                <div class="pf--setting-help">Keeps keyword/constant lore active naturally, then removes those entries from Pathfinder's injected context.</div>
             </div>
         </div>
     </div>
@@ -285,12 +300,14 @@
             <div class="pf--setting-group">
                 <label class="pf--setting-label">Enabled Tools</label>
                 <div class="pf--tool-list">
-                    <label class="checkbox_label"><input type="checkbox" data-tool="Pathfinder_Search" checked /><span>Search - Browse waypoint map</span></label>
-                    <label class="checkbox_label"><input type="checkbox" data-tool="Pathfinder_Remember" checked /><span>Remember - Create new entries</span></label>
-                    <label class="checkbox_label"><input type="checkbox" data-tool="Pathfinder_Update" checked /><span>Update - Edit existing entries</span></label>
-                    <label class="checkbox_label"><input type="checkbox" data-tool="Pathfinder_Forget" checked /><span>Forget - Disable/delete entries</span></label>
-                    <label class="checkbox_label"><input type="checkbox" data-tool="Pathfinder_Notebook" checked /><span>Notebook - Private AI scratchpad</span></label>
+                    <div class="pf--empty-state pf--tool-loading"><i class="fa-solid fa-wrench"></i><span>Loading tool toggles...</span></div>
                 </div>
+            </div>
+
+            <div class="pf--setting-group">
+                <label class="pf--setting-label">Lorebook Permissions</label>
+                <div class="pf--setting-help">Limit what Tool Mode can read, edit, or delete per selected lorebook. Write permission allows creating, updating, disabling, and reorganizing entries. Delete permission is only needed for hard deletes.</div>
+                <div id="pf--permission-matrix" class="pf--permission-matrix"></div>
             </div>
 
             <div class="pf--setting-group">
@@ -313,10 +330,16 @@
             <div id="pf--diagnostics-output" class="pf--diagnostics-output">
                 Click "Run Diagnostics" to check your Pathfinder configuration.
             </div>
-            <button type="button" id="pf--run-diagnostics" class="menu_button">
-                <i class="fa-solid fa-stethoscope"></i>
-                <span>Run Diagnostics</span>
-            </button>
+            <div class="pf--diagnostics-actions">
+                <button type="button" id="pf--run-diagnostics" class="menu_button menu_button_icon">
+                    <i class="fa-solid fa-stethoscope"></i>
+                    <span>Run Diagnostics</span>
+                </button>
+                <button type="button" id="pf--copy-diagnostics" class="menu_button menu_button_icon">
+                    <i class="fa-solid fa-copy"></i>
+                    <span>Copy Diagnostics</span>
+                </button>
+            </div>
         </div>
     </div>
 
@@ -367,8 +390,32 @@
     text-align: left;
 }
 
+.pf--settings.pf--settings-embedded {
+    max-height: none;
+    overflow: visible;
+    padding: 0;
+}
+
 .pf--settings * {
     text-align: left;
+}
+
+.pf--extensions-host .inline-drawer-header b {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.pf--extensions-body {
+    padding: 10px 0;
+}
+
+.pf--extensions-empty {
+    padding: 12px;
+    border: 1px solid var(--SmartThemeBorderColor, rgba(255, 255, 255, 0.1));
+    border-radius: 8px;
+    background: var(--SmartThemeBlurTintColor, rgba(0, 0, 0, 0.2));
+    font-size: 12px;
 }
 
 /* Status Banner */
@@ -902,6 +949,49 @@
     border-radius: 4px;
 }
 
+.pf--permission-matrix {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.pf--permission-row {
+    display: grid;
+    grid-template-columns: minmax(150px, 1fr) repeat(3, minmax(78px, max-content));
+    align-items: center;
+    gap: 10px;
+    padding: 10px;
+    background: rgba(0, 0, 0, 0.15);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 6px;
+}
+
+.pf--permission-book {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.pf--permission-book strong,
+.pf--permission-book span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.pf--permission-book span {
+    font-size: 11px;
+    opacity: 0.7;
+}
+
+.pf--permission-row .checkbox_label {
+    margin: 0;
+    padding: 0;
+    min-height: 0;
+}
+
 /* Prompt Editor */
 .pf--prompt-actions {
     display: flex;
@@ -949,7 +1039,14 @@
     text-align: left !important;
 }
 
-#pf--run-diagnostics {
+.pf--diagnostics-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+#pf--run-diagnostics,
+#pf--copy-diagnostics {
     display: inline-flex;
     align-self: flex-start;
     width: fit-content;
@@ -961,7 +1058,8 @@
     margin-right: auto;
 }
 
-#pf--run-diagnostics span {
+#pf--run-diagnostics span,
+#pf--copy-diagnostics span {
     min-width: 0;
     overflow-wrap: anywhere;
     text-align: center;
@@ -1006,6 +1104,11 @@
     .pf--prompt-status {
         flex: 1 1 100%;
         margin-left: 0;
+    }
+
+    .pf--permission-row {
+        grid-template-columns: 1fr;
+        align-items: flex-start;
     }
 }
 </style>

--- a/public/scripts/extensions/in-chat-agents/pathfinder-settings.html
+++ b/public/scripts/extensions/in-chat-agents/pathfinder-settings.html
@@ -521,7 +521,7 @@
 
 .pf--settings .checkbox_label {
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     gap: 8px;
     min-height: var(--sb-control-min-height, 30px);
     line-height: 1.35;
@@ -529,7 +529,8 @@
 
 .pf--settings .checkbox_label input[type="checkbox"] {
     flex: 0 0 auto;
-    margin-top: 2px;
+    align-self: center;
+    margin: 0;
 }
 
 .pf--settings .checkbox_label span {
@@ -1012,10 +1013,14 @@
 }
 
 .pf--tool-list .checkbox_label {
+    display: grid;
+    grid-template-columns: max-content minmax(0, 1fr);
+    align-items: center;
     padding: 7px 10px;
     background: var(--pf-control-bg);
     border: 1px solid color-mix(in srgb, var(--pf-border) 76%, transparent);
     border-radius: var(--pf-radius-sm);
+    column-gap: 10px;
 }
 
 .pf--permission-matrix {

--- a/public/scripts/extensions/in-chat-agents/pathfinder-settings.html
+++ b/public/scripts/extensions/in-chat-agents/pathfinder-settings.html
@@ -331,9 +331,7 @@
             <strong>Diagnostics</strong>
         </div>
         <div class="pf--section-body pf--diagnostics-panel" style="display: none;">
-            <div id="pf--diagnostics-output" class="pf--diagnostics-output">
-                Click "Run Diagnostics" to check your Pathfinder configuration.
-            </div>
+            <div id="pf--diagnostics-output" class="pf--diagnostics-output">Click "Run Diagnostics" to check your Pathfinder configuration.</div>
             <div class="pf--diagnostics-actions">
                 <button type="button" id="pf--run-diagnostics" class="menu_button menu_button_icon">
                     <i class="fa-solid fa-stethoscope"></i>

--- a/public/scripts/extensions/in-chat-agents/pathfinder-settings.html
+++ b/public/scripts/extensions/in-chat-agents/pathfinder-settings.html
@@ -376,11 +376,39 @@
 </div>
 
 <style>
+.pf--extensions-host,
+.pf--settings {
+    --pf-accent: var(--color-primary, var(--sb-accent, var(--SmartThemeQuoteColor, oklch(79% 0.035 99))));
+    --pf-on-accent: var(--sb-on-solid-accent, oklch(22% 0.012 100));
+    --pf-surface: var(--color-surface, var(--sb-card-bg, var(--SmartThemeBlurTintColor, oklch(25% 0.012 260 / 0.94))));
+    --pf-surface-strong: var(--color-surface-strong, var(--sb-surface-elevated, oklch(29% 0.012 260 / 0.96)));
+    --pf-surface-soft: var(--sb-surface-elevated-soft, color-mix(in srgb, var(--pf-surface) 94%, var(--pf-accent) 6%));
+    --pf-surface-hover: var(--color-surface-hover, var(--sb-surface-hover, oklch(34% 0.012 260 / 0.96)));
+    --pf-control-bg: color-mix(in srgb, var(--pf-surface-strong) 92%, var(--pf-accent) 8%);
+    --pf-border: var(--sb-shell-border, color-mix(in srgb, var(--SmartThemeBorderColor, oklch(78% 0.01 100 / 0.24)) 78%, transparent));
+    --pf-border-strong: color-mix(in srgb, var(--pf-accent) 48%, var(--pf-border));
+    --pf-text: var(--SmartThemeBodyColor, oklch(84% 0.012 100));
+    --pf-text-muted: var(--sb-muted-fg, color-mix(in srgb, var(--pf-text) 68%, transparent));
+    --pf-muted-bg: var(--sb-muted-bg, color-mix(in srgb, var(--pf-surface-strong) 78%, var(--pf-text) 5%));
+    --pf-positive: var(--sb-positive-fg, oklch(78% 0.065 112));
+    --pf-positive-bg: var(--sb-positive-bg, color-mix(in srgb, var(--pf-positive) 14%, var(--pf-surface)));
+    --pf-warning: var(--sb-warning-fg, oklch(82% 0.08 88));
+    --pf-warning-bg: var(--sb-warning-bg, color-mix(in srgb, var(--pf-warning) 14%, var(--pf-surface)));
+    --pf-danger: var(--sb-danger-fg, oklch(74% 0.13 18));
+    --pf-danger-bg: var(--sb-danger-bg, color-mix(in srgb, var(--pf-danger) 12%, var(--pf-surface)));
+    --pf-radius-sm: var(--sb-radius-sm, 10px);
+    --pf-radius-md: var(--sb-radius-md, 14px);
+    --pf-radius-lg: var(--sb-radius-lg, 18px);
+    --pf-shadow-card: 0 10px 26px color-mix(in srgb, var(--SmartThemeShadowColor, oklch(12% 0.01 260)) 14%, transparent);
+    --pf-shadow-raised: 0 16px 38px color-mix(in srgb, var(--SmartThemeShadowColor, oklch(12% 0.01 260)) 22%, transparent);
+    --pf-ease: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
 .pf--settings {
     display: flex;
     flex-direction: column;
-    gap: 16px;
-    padding: 10px 0;
+    gap: 14px;
+    padding: 8px 0 10px;
     max-height: calc(100vh - 200px);
     max-height: calc(100dvh - 200px);
     overflow-y: auto;
@@ -388,6 +416,7 @@
     overscroll-behavior: contain;
     -webkit-overflow-scrolling: touch;
     text-align: left;
+    color: var(--pf-text);
 }
 
 .pf--settings.pf--settings-embedded {
@@ -411,10 +440,11 @@
 }
 
 .pf--extensions-empty {
-    padding: 12px;
-    border: 1px solid var(--SmartThemeBorderColor, rgba(255, 255, 255, 0.1));
-    border-radius: 8px;
-    background: var(--SmartThemeBlurTintColor, rgba(0, 0, 0, 0.2));
+    padding: 12px 14px;
+    border: 1px solid var(--pf-border);
+    border-radius: var(--pf-radius-md);
+    background: var(--pf-surface-soft);
+    color: var(--pf-text-muted);
     font-size: 12px;
 }
 
@@ -423,38 +453,43 @@
     display: flex;
     align-items: center;
     gap: 12px;
-    padding: 12px 16px;
-    border-radius: 8px;
-    border: 1px solid;
+    padding: 12px 14px;
+    border-radius: var(--pf-radius-md);
+    border: 1px solid var(--pf-border);
+    background: var(--pf-surface-strong);
+    box-shadow: var(--pf-shadow-card);
     text-align: left;
 }
 
 .pf--status-disabled {
-    background: rgba(239, 68, 68, 0.1);
-    border-color: rgba(239, 68, 68, 0.3);
+    background: linear-gradient(180deg, color-mix(in srgb, var(--pf-muted-bg) 95%, var(--pf-accent) 5%), var(--pf-surface));
+    border-color: color-mix(in srgb, var(--pf-border) 72%, var(--pf-accent) 18%);
 }
 
 .pf--status-disabled .pf--status-icon {
-    color: #ef4444;
+    color: var(--pf-text-muted);
+    background: var(--pf-muted-bg);
 }
 
 .pf--status-ready {
-    background: rgba(34, 197, 94, 0.1);
-    border-color: rgba(34, 197, 94, 0.3);
+    background: linear-gradient(180deg, color-mix(in srgb, var(--pf-positive-bg) 92%, var(--pf-accent) 8%), var(--pf-surface));
+    border-color: color-mix(in srgb, var(--pf-positive) 42%, var(--pf-border));
 }
 
 .pf--status-ready .pf--status-icon {
-    color: #22c55e;
+    color: var(--pf-positive);
+    background: color-mix(in srgb, var(--pf-positive-bg) 86%, transparent);
 }
 
 .pf--status-icon {
-    font-size: 24px;
+    font-size: 18px;
     display: flex;
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
-    width: 24px;
-    height: 24px;
+    width: 36px;
+    height: 36px;
+    border-radius: 999px;
 }
 
 .pf--status-text {
@@ -465,11 +500,12 @@
 
 .pf--status-text strong {
     font-size: 14px;
+    line-height: 1.2;
 }
 
 .pf--status-text span {
     font-size: 12px;
-    opacity: 0.8;
+    color: var(--pf-text-muted);
 }
 
 /* Master enable */
@@ -507,10 +543,11 @@
 
 /* Quick Start */
 .pf--quickstart {
-    background: var(--SmartThemeBlurTintColor, rgba(100, 100, 255, 0.1));
-    border: 1px solid var(--SmartThemeBorderColor, rgba(100, 100, 255, 0.2));
-    border-radius: 8px;
+    background: linear-gradient(180deg, color-mix(in srgb, var(--pf-surface-strong) 92%, var(--pf-accent) 8%), var(--pf-surface));
+    border: 1px solid color-mix(in srgb, var(--pf-border) 76%, var(--pf-accent) 18%);
+    border-radius: var(--pf-radius-lg);
     overflow: hidden;
+    box-shadow: var(--pf-shadow-card);
 }
 
 .pf--quickstart-header {
@@ -518,18 +555,20 @@
     align-items: center;
     gap: 8px;
     padding: 10px 14px;
-    background: rgba(0, 0, 0, 0.1);
+    background: color-mix(in srgb, var(--pf-surface-strong) 92%, var(--pf-accent) 8%);
+    border-bottom: 1px solid color-mix(in srgb, var(--pf-border) 70%, transparent);
     font-size: 14px;
 }
 
 .pf--quickstart-header i {
-    color: var(--SmartThemeQuoteColor, #8b5cf6);
+    color: var(--pf-accent);
 }
 
 .pf--quickstart-body {
     padding: 12px 14px;
     font-size: 13px;
     line-height: 1.5;
+    color: var(--pf-text-muted);
 }
 
 .pf--quickstart-body p {
@@ -547,15 +586,16 @@
 
 /* Sections */
 .pf--section {
-    background: var(--SmartThemeBlurTintColor, rgba(0, 0, 0, 0.2));
-    border: 1px solid var(--SmartThemeBorderColor, rgba(255, 255, 255, 0.1));
-    border-radius: 8px;
+    background: var(--pf-surface);
+    border: 1px solid var(--pf-border);
+    border-radius: var(--pf-radius-lg);
     padding: 14px;
+    box-shadow: var(--pf-shadow-card);
 }
 
 .pf--section-primary {
-    border-color: var(--SmartThemeQuoteColor, #8b5cf6);
-    border-width: 2px;
+    background: linear-gradient(180deg, color-mix(in srgb, var(--pf-accent) 8%, var(--pf-surface-strong)), var(--pf-surface));
+    border-color: var(--pf-border-strong);
 }
 
 .pf--section-header {
@@ -565,6 +605,7 @@
     gap: 10px;
     margin-bottom: 10px;
     font-size: 14px;
+    line-height: 1.25;
     text-align: left;
 }
 
@@ -574,7 +615,7 @@
 }
 
 .pf--collapsible-header:hover {
-    opacity: 0.8;
+    color: var(--pf-accent);
 }
 
 .pf--chevron {
@@ -593,30 +634,32 @@
     justify-content: center;
     width: 22px;
     height: 22px;
-    background: var(--SmartThemeQuoteColor, #8b5cf6);
-    color: white;
+    background: var(--pf-accent);
+    color: var(--pf-on-accent);
     border-radius: 50%;
     font-size: 12px;
     font-weight: bold;
+    box-shadow: 0 4px 12px color-mix(in srgb, var(--pf-accent) 26%, transparent);
 }
 
 .pf--required {
-    color: #ef4444;
+    color: var(--pf-danger);
     font-size: 12px;
 }
 
 .pf--badge {
-    background: var(--SmartThemeQuoteColor, #8b5cf6);
-    color: white;
+    background: color-mix(in srgb, var(--pf-accent) 82%, var(--pf-surface-strong));
+    color: var(--pf-on-accent);
     padding: 2px 8px;
     border-radius: 10px;
     font-size: 10px;
     text-transform: uppercase;
+    letter-spacing: 0.03em;
 }
 
 .pf--section-desc {
     font-size: 12px;
-    opacity: 0.8;
+    color: var(--pf-text-muted);
     margin-bottom: 12px;
     line-height: 1.4;
 }
@@ -660,12 +703,13 @@
     line-height: 1.55;
     font-size: 12px;
     padding: 12px;
-    border-radius: 8px;
-    background: rgba(0, 0, 0, 0.2);
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: var(--pf-radius-md);
+    background: color-mix(in srgb, var(--pf-surface-strong) 88%, var(--pf-text) 3%);
+    border: 1px solid color-mix(in srgb, var(--pf-border) 84%, transparent);
     max-height: 320px;
     overflow: auto;
     tab-size: 2;
+    color: var(--pf-text-muted);
 }
 
 .pf--retrieval-log-output {
@@ -687,19 +731,22 @@
     align-items: center;
     gap: 10px;
     padding: 10px 12px;
-    background: rgba(0, 0, 0, 0.2);
-    border-radius: 6px;
+    background: var(--pf-control-bg);
+    border: 1px solid color-mix(in srgb, var(--pf-border) 74%, transparent);
+    border-radius: var(--pf-radius-md);
     cursor: pointer;
-    transition: background 0.15s;
+    transition: background 0.18s var(--pf-ease), border-color 0.18s var(--pf-ease), transform 0.18s var(--pf-ease);
 }
 
 .pf--lorebook-item:hover {
-    background: rgba(0, 0, 0, 0.3);
+    background: var(--pf-surface-hover);
+    border-color: color-mix(in srgb, var(--pf-border) 68%, var(--pf-accent) 16%);
 }
 
 .pf--lorebook-item.selected {
-    background: rgba(34, 197, 94, 0.2);
-    border: 1px solid rgba(34, 197, 94, 0.4);
+    background: color-mix(in srgb, var(--pf-accent) 18%, var(--pf-surface-strong));
+    border-color: color-mix(in srgb, var(--pf-accent) 62%, var(--pf-border));
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--pf-accent) 18%, transparent);
 }
 
 .pf--lorebook-item input[type="checkbox"] {
@@ -720,7 +767,7 @@
 
 .pf--lorebook-meta {
     font-size: 11px;
-    opacity: 0.7;
+    color: var(--pf-text-muted);
 }
 
 .pf--lorebook-toggle {
@@ -734,7 +781,7 @@
     gap: 8px;
     padding: 20px;
     text-align: center;
-    opacity: 0.6;
+    color: var(--pf-text-muted);
 }
 
 .pf--empty-state i {
@@ -749,20 +796,34 @@
 }
 
 .pf--mode-card {
-    background: rgba(0, 0, 0, 0.2);
-    border: 2px solid transparent;
-    border-radius: 8px;
+    background: var(--pf-surface-strong);
+    border: 1px solid color-mix(in srgb, var(--pf-border) 72%, transparent);
+    border-radius: var(--pf-radius-lg);
     overflow: hidden;
-    transition: border-color 0.15s;
+    box-shadow: var(--pf-shadow-card);
+    transition: background 0.18s var(--pf-ease), border-color 0.18s var(--pf-ease), box-shadow 0.18s var(--pf-ease), transform 0.18s var(--pf-ease);
+}
+
+.pf--mode-card:hover {
+    background: var(--pf-surface-hover);
+    border-color: color-mix(in srgb, var(--pf-border) 70%, var(--pf-accent) 18%);
 }
 
 .pf--mode-card.active {
-    border-color: var(--SmartThemeQuoteColor, #8b5cf6);
+    background: linear-gradient(180deg, color-mix(in srgb, var(--pf-accent) 30%, var(--pf-surface-strong)), color-mix(in srgb, var(--pf-accent) 16%, var(--pf-surface)));
+    border-color: color-mix(in srgb, var(--pf-accent) 72%, var(--pf-border));
+    box-shadow: var(--pf-shadow-raised), inset 0 0 0 1px color-mix(in srgb, var(--pf-accent) 18%, transparent);
 }
 
 .pf--mode-card-header {
     padding: 10px 12px;
-    background: rgba(0, 0, 0, 0.2);
+    background: color-mix(in srgb, var(--pf-surface) 72%, var(--pf-text) 4%);
+    border-bottom: 1px solid color-mix(in srgb, var(--pf-border) 70%, transparent);
+}
+
+.pf--mode-card.active .pf--mode-card-header {
+    background: color-mix(in srgb, var(--pf-accent) 24%, var(--pf-surface-strong));
+    border-bottom-color: color-mix(in srgb, var(--pf-accent) 34%, transparent);
 }
 
 .pf--mode-card-header .checkbox_label {
@@ -772,6 +833,11 @@
 
 .pf--mode-card-header i {
     margin-right: 6px;
+    color: var(--pf-accent);
+}
+
+.pf--mode-card.active .pf--mode-card-header i {
+    color: var(--pf-on-accent);
 }
 
 .pf--mode-card-body {
@@ -782,6 +848,7 @@
 .pf--mode-card-body p {
     margin: 0 0 10px 0;
     line-height: 1.4;
+    color: var(--pf-text-muted);
 }
 
 .pf--mode-card-body ul {
@@ -797,14 +864,14 @@
 .pf--mode-card-body li i {
     width: 16px;
     margin-right: 6px;
-    opacity: 0.7;
+    color: var(--pf-accent);
 }
 
 .pf--mode-requirement,
 .pf--mode-info {
     margin-top: 10px;
-    padding: 8px;
-    border-radius: 4px;
+    padding: 8px 10px;
+    border-radius: var(--pf-radius-sm);
     font-size: 11px;
     display: flex;
     align-items: flex-start;
@@ -812,13 +879,13 @@
 }
 
 .pf--mode-requirement {
-    background: rgba(239, 68, 68, 0.1);
-    color: #fca5a5;
+    background: var(--pf-danger-bg);
+    color: var(--pf-danger);
 }
 
 .pf--mode-info {
-    background: rgba(59, 130, 246, 0.1);
-    color: #93c5fd;
+    background: color-mix(in srgb, var(--pf-accent) 12%, var(--pf-surface));
+    color: var(--pf-accent);
 }
 
 /* Dual mode warning */
@@ -827,10 +894,10 @@
     align-items: center;
     gap: 10px;
     padding: 10px 14px;
-    background: rgba(245, 158, 11, 0.15);
-    border: 1px solid rgba(245, 158, 11, 0.3);
-    border-radius: 6px;
-    color: #fcd34d;
+    background: var(--pf-warning-bg);
+    border: 1px solid color-mix(in srgb, var(--pf-warning) 34%, var(--pf-border));
+    border-radius: var(--pf-radius-md);
+    color: var(--pf-warning);
     font-size: 12px;
     margin-bottom: 12px;
 }
@@ -857,14 +924,15 @@
 
 .pf--setting-help {
     font-size: 11px;
-    opacity: 0.7;
+    color: var(--pf-text-muted);
     margin-top: 4px;
 }
 
 .pf--setting-help code {
-    background: rgba(0, 0, 0, 0.3);
-    padding: 1px 4px;
-    border-radius: 3px;
+    background: var(--pf-muted-bg);
+    border: 1px solid color-mix(in srgb, var(--pf-border) 80%, transparent);
+    padding: 1px 5px;
+    border-radius: 5px;
     font-size: 10px;
 }
 
@@ -896,26 +964,26 @@
 }
 
 .pf--summary-indicator-injected {
-    background: rgba(34, 197, 94, 0.18);
-    border: 1px solid rgba(34, 197, 94, 0.35);
-    color: #86efac;
+    background: var(--pf-positive-bg);
+    border: 1px solid color-mix(in srgb, var(--pf-positive) 34%, var(--pf-border));
+    color: var(--pf-positive);
 }
 
 .pf--summary-indicator-not-injected {
-    background: rgba(245, 158, 11, 0.16);
-    border: 1px solid rgba(245, 158, 11, 0.35);
-    color: #fcd34d;
+    background: var(--pf-warning-bg);
+    border: 1px solid color-mix(in srgb, var(--pf-warning) 34%, var(--pf-border));
+    color: var(--pf-warning);
 }
 
 .pf--summary-indicator-missing {
-    background: rgba(148, 163, 184, 0.15);
-    border: 1px solid rgba(148, 163, 184, 0.3);
-    color: #cbd5e1;
+    background: var(--pf-muted-bg);
+    border: 1px solid color-mix(in srgb, var(--pf-border) 86%, transparent);
+    color: var(--pf-text-muted);
 }
 
 .pf--summary-meta {
     font-size: 11px;
-    opacity: 0.75;
+    color: var(--pf-text-muted);
     margin-top: 5px;
 }
 
@@ -944,9 +1012,10 @@
 }
 
 .pf--tool-list .checkbox_label {
-    padding: 6px 10px;
-    background: rgba(0, 0, 0, 0.15);
-    border-radius: 4px;
+    padding: 7px 10px;
+    background: var(--pf-control-bg);
+    border: 1px solid color-mix(in srgb, var(--pf-border) 76%, transparent);
+    border-radius: var(--pf-radius-sm);
 }
 
 .pf--permission-matrix {
@@ -962,9 +1031,9 @@
     align-items: center;
     gap: 10px;
     padding: 10px;
-    background: rgba(0, 0, 0, 0.15);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 6px;
+    background: var(--pf-control-bg);
+    border: 1px solid color-mix(in srgb, var(--pf-border) 78%, transparent);
+    border-radius: var(--pf-radius-md);
 }
 
 .pf--permission-book {
@@ -983,7 +1052,7 @@
 
 .pf--permission-book span {
     font-size: 11px;
-    opacity: 0.7;
+    color: var(--pf-text-muted);
 }
 
 .pf--permission-row .checkbox_label {
@@ -1008,17 +1077,17 @@
 }
 
 .pf--prompt-status.success {
-    color: #22c55e;
+    color: var(--pf-positive);
 }
 
 .pf--prompt-status.error {
-    color: #ef4444;
+    color: var(--pf-danger);
 }
 
 /* Diagnostics */
 .pf--diagnostics-output {
-    background: rgba(0, 0, 0, 0.3);
-    border-radius: 6px;
+    background: color-mix(in srgb, var(--pf-surface-strong) 84%, var(--pf-text) 4%);
+    border-radius: var(--pf-radius-md);
     padding: 12px;
     font-family: monospace;
     font-size: 11px;

--- a/public/scripts/extensions/in-chat-agents/pathfinder-settings.html
+++ b/public/scripts/extensions/in-chat-agents/pathfinder-settings.html
@@ -607,7 +607,7 @@
     display: flex;
     align-items: center;
     justify-content: flex-start;
-    gap: 10px;
+    gap: 6px;
     margin-bottom: 10px;
     font-size: 14px;
     line-height: 1.25;
@@ -655,9 +655,9 @@
 .pf--badge {
     background: color-mix(in srgb, var(--pf-accent) 82%, var(--pf-surface-strong));
     color: var(--pf-on-accent);
-    padding: 2px 8px;
-    border-radius: 10px;
-    font-size: 10px;
+    padding: 1px 6px;
+    border-radius: 8px;
+    font-size: 9px;
     text-transform: uppercase;
     letter-spacing: 0.03em;
 }

--- a/public/scripts/extensions/in-chat-agents/pathfinder/diagnostics.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/diagnostics.js
@@ -1,8 +1,8 @@
-import { getSettings, getTree, getAllEntryUids } from './tree-store.js';
+import { canDeleteBook, canReadBook, canWriteBook, getSettings, getTree, getAllEntryUids } from './tree-store.js';
 import { ALL_TOOL_NAMES, getActiveTunnelVisionBooks, getContextualLorebooks } from './pathfinder-tool-bridge.js';
 import { getFeedItems } from './activity-feed.js';
 import { getEnabledToolAgents } from '../agent-store.js';
-import { getPathfinderRuntimeAgent, syncToolAgentRegistrations } from '../agent-runner.js';
+import { getPathfinderRuntimeAgent, getToolRecursionState, syncToolAgentRegistrations } from '../agent-runner.js';
 
 function getRegisteredPathfinderTools(ToolManager) {
     const tools = ToolManager?.tools instanceof Map
@@ -16,9 +16,21 @@ function getRegisteredPathfinderTools(ToolManager) {
     );
 }
 
-function getEnabledPathfinderTools(pathfinderAgent, registeredTools = []) {
+function formatNameList(names, fallback = 'none') {
+    return names.length > 0 ? names.join(', ') : fallback;
+}
+
+function getEnabledPathfinderTools(pathfinderAgent, registeredTools = [], settings = getSettings()) {
     if (!pathfinderAgent) {
         return [];
+    }
+
+    const toolStates = settings?.toolStates;
+    if (toolStates && typeof toolStates === 'object') {
+        const configuredNames = ALL_TOOL_NAMES.filter(name => Object.prototype.hasOwnProperty.call(toolStates, name));
+        if (configuredNames.length > 0) {
+            return configuredNames.filter(name => toolStates[name] !== false);
+        }
     }
 
     const agentTools = Array.isArray(pathfinderAgent?.tools) ? pathfinderAgent.tools : [];
@@ -77,6 +89,19 @@ function getLastPipelineRunMessage(settings) {
     }
 
     return `Enabled (${pipelineId} pipeline). Last run injected ${selectedCount} entr${selectedCount === 1 ? 'y' : 'ies'}${candidateCount > 0 ? ` from ${candidateCount} candidate(s)` : ''}.`;
+}
+
+function getToolRegistrationDetail(enabledTools, registeredTools) {
+    const missingTools = enabledTools.filter(name => !registeredTools.includes(name));
+    const recursion = getToolRecursionState();
+    const recursionLimit = Number(recursion?.limit ?? 0) || 0;
+    const recursionText = recursionLimit > 0 ? ` Recursion: ${recursion.depth}/${recursionLimit}.` : '';
+
+    return {
+        missingTools,
+        recursionText,
+        registeredText: `Registered: ${formatNameList(registeredTools)}. Enabled: ${formatNameList(enabledTools)}.`,
+    };
 }
 
 function getPipelineStageSummary(stageResults = []) {
@@ -152,18 +177,19 @@ export async function runDiagnostics() {
         const enabledAgents = getEnabledToolAgents();
         const pathfinderAgent = getPathfinderRuntimeAgent(enabledAgents);
         const registeredTools = getRegisteredPathfinderTools(ToolManager);
-        const enabledPathfinderToolNames = getEnabledPathfinderTools(pathfinderAgent, registeredTools);
+        const enabledPathfinderToolNames = getEnabledPathfinderTools(pathfinderAgent, registeredTools, s);
+        const registrationDetail = getToolRegistrationDetail(enabledPathfinderToolNames, registeredTools);
 
         if (enabledPathfinderToolNames.length > 0 && enabledPathfinderToolNames.every(name => registeredTools.includes(name))) {
             if (isToolCallingSupported) {
                 results['Tool Registration'] = {
                     ok: true,
-                    message: `All ${enabledPathfinderToolNames.length} enabled Pathfinder tool(s) registered and active`,
+                    message: `All ${enabledPathfinderToolNames.length} enabled Pathfinder tool(s) registered and active. ${registrationDetail.registeredText}${registrationDetail.recursionText}`,
                 };
             } else {
                 results['Tool Registration'] = {
                     ok: false,
-                    message: `${registeredTools.length} Pathfinder tool(s) registered, but tool calling is not supported for the current API/settings. Enable "Function Calling" in OpenAI settings and ensure the current model supports tools.`,
+                    message: `${registeredTools.length} Pathfinder tool(s) registered, but tool calling is not supported for the current API/settings. ${registrationDetail.registeredText} Enable "Function Calling" in OpenAI settings and ensure the current model supports tools.`,
                 };
             }
         } else if (!pathfinderAgent) {
@@ -191,7 +217,7 @@ export async function runDiagnostics() {
         } else {
             results['Tool Registration'] = {
                 ok: false,
-                message: `Partial: ${registeredTools.length}/${enabledPathfinderToolNames.length} enabled Pathfinder tools registered. Some Pathfinder tool toggles may be disabled or not yet refreshed.`,
+                message: `Partial: ${registeredTools.length}/${enabledPathfinderToolNames.length} enabled Pathfinder tools registered. Missing: ${formatNameList(registrationDetail.missingTools)}. ${registrationDetail.registeredText}${registrationDetail.recursionText}`,
             };
         }
     } else {
@@ -210,6 +236,32 @@ export async function runDiagnostics() {
                 : 'Tool calling is NOT supported. Enable "Function Calling" in OpenAI settings and ensure the current model supports tools.',
         };
     }
+
+    const readableBooks = activeBooks.filter(canReadBook);
+    const writableBooks = activeBooks.filter(canWriteBook);
+    const deletableBooks = activeBooks.filter(canDeleteBook);
+    results['Tool Permissions'] = {
+        ok: activeBooks.length === 0 || readableBooks.length > 0,
+        message: activeBooks.length === 0
+            ? 'No active lorebooks, permissions will apply after selecting a book.'
+            : `Read: ${formatNameList(readableBooks)}. Write: ${formatNameList(writableBooks)}. Delete: ${formatNameList(deletableBooks)}.`,
+    };
+
+    results['Lorebook Auto-Sync'] = {
+        ok: true,
+        message: s.autoSyncLorebooksOnChatChange === false
+            ? `Disabled. Contextual lorebooks detected: ${formatNameList(contextualBooks)}.`
+            : `Enabled. Pathfinder will reset selected lorebooks to current chat context (${formatNameList(contextualBooks)}).`,
+    };
+
+    const lastPipelineDetail = getFeedItems().find(item => item?.type === 'pathfinder_retrieval_detail' && item.mode === 'pipeline');
+    const skippedNaturalCount = Number(lastPipelineDetail?.metadata?.skippedNaturalActivationCount ?? 0) || 0;
+    results['World Info Dedupe'] = {
+        ok: true,
+        message: s.dedupeNaturalActivation === false
+            ? 'Disabled. Pathfinder may inject entries that World Info also activates naturally.'
+            : `Enabled. Last pipeline skipped ${skippedNaturalCount} naturally activated entr${skippedNaturalCount === 1 ? 'y' : 'ies'}.`,
+    };
 
     // Check connection profile
     results['Connection Profile'] = {

--- a/public/scripts/extensions/in-chat-agents/pathfinder/entry-manager.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/entry-manager.js
@@ -1,3 +1,4 @@
+import { createWorldInfoEntry as createWorldInfoEntryFallback } from '../../../world-info.js';
 import { getTree, saveTree, findNodeById, addEntryToNode, removeEntryFromTree, createTreeNode, isTrackerTitle, setTrackerUid } from './tree-store.js';
 
 let _loadWorldInfo = null;
@@ -19,7 +20,14 @@ async function loadWI(name) {
 async function createWIE(name, data) {
     if (_createWorldInfoEntry) return _createWorldInfoEntry(name, data);
     const ctx = window?.SillyTavern?.getContext?.();
-    return ctx?.createWorldInfoEntry?.(name, data);
+    if (ctx?.createWorldInfoEntry) return ctx.createWorldInfoEntry(name, data);
+    return createWorldInfoEntryFallback(name, data);
+}
+
+function assertCreatedEntry(newEntry, bookName) {
+    if (!newEntry || newEntry.uid === undefined) {
+        throw new Error(`Could not create a new entry in "${bookName}". Lorebook may be missing or unwritable.`);
+    }
 }
 
 async function saveWI(name, data, immediate) {
@@ -32,6 +40,7 @@ export async function createEntry(bookName, title, content, keys = []) {
     const bookData = await loadWI(bookName);
     if (!bookData) throw new Error(`Lorebook "${bookName}" not found.`);
     const newEntry = await createWIE(bookName, bookData);
+    assertCreatedEntry(newEntry, bookName);
     newEntry.content = content;
     newEntry.comment = title;
     newEntry.key = keys.length > 0 ? keys : [title.replace(/^\[.*?\]\s*/, '').split(/[:|]/)[0].trim().toLowerCase()];
@@ -173,6 +182,7 @@ export async function splitEntry(bookName, uid, splitTitle1, content1, splitTitl
     original.content = content1;
     original.comment = splitTitle1 || original.comment;
     const newEntry = await createWIE(bookName, bookData);
+    assertCreatedEntry(newEntry, bookName);
     newEntry.content = content2;
     newEntry.comment = splitTitle2 || 'Split entry';
     newEntry.key = original.key ? [...original.key] : [splitTitle2?.toLowerCase() || 'split'];

--- a/public/scripts/extensions/in-chat-agents/pathfinder/pathfinder-tool-bridge.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/pathfinder-tool-bridge.js
@@ -1,4 +1,4 @@
-import { getSettings, getTree, isLorebookEnabled, canReadBook, canWriteBook } from './tree-store.js';
+import { getSettings, getTree, isLorebookEnabled, canReadBook, canWriteBook, canDeleteBook } from './tree-store.js';
 
 const CHAT_LOREBOOK_METADATA_KEY = 'world_info';
 
@@ -144,6 +144,12 @@ export function getWritableBooks() {
     return books;
 }
 
+export function getDeletableBooks() {
+    const books = getActiveTunnelVisionBooks().filter(b => canDeleteBook(b));
+    logPathfinderToolBridge('Deletable lorebooks resolved for Pathfinder.', { books });
+    return books;
+}
+
 export function resolveTargetBook(requestedBook, writableBooks = null) {
     const books = writableBooks ?? getWritableBooks();
     if (books.length === 0) return null;
@@ -226,9 +232,17 @@ export async function getEntryContent(bookName, uid) {
                 });
                 return {
                     uid: entry.uid,
+                    world: entry.world || bookName,
                     comment: entry.comment || entry.key?.[0] || '',
                     content: entry.content || '',
                     key: entry.key || [],
+                    keysecondary: entry.keysecondary || [],
+                    selective: entry.selective ?? false,
+                    selectiveLogic: entry.selectiveLogic ?? 0,
+                    caseSensitive: entry.caseSensitive,
+                    matchWholeWords: entry.matchWholeWords,
+                    constant: entry.constant ?? false,
+                    decorators: entry.decorators || [],
                     disable: entry.disable ?? false,
                 };
             }
@@ -267,9 +281,17 @@ export async function getAllEntriesWithContent(bookName) {
             .filter(entry => entry && !entry.disable)
             .map(entry => ({
                 uid: entry.uid,
+                world: entry.world || bookName,
                 comment: entry.comment || entry.key?.[0] || '',
                 content: entry.content || '',
                 key: entry.key || [],
+                keysecondary: entry.keysecondary || [],
+                selective: entry.selective ?? false,
+                selectiveLogic: entry.selectiveLogic ?? 0,
+                caseSensitive: entry.caseSensitive,
+                matchWholeWords: entry.matchWholeWords,
+                constant: entry.constant ?? false,
+                decorators: entry.decorators || [],
             }));
         logPathfinderToolBridge(`Fetched lorebook contents for "${bookName}".`, {
             entryCount: entries.length,

--- a/public/scripts/extensions/in-chat-agents/pathfinder/sidecar-retrieval.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/sidecar-retrieval.js
@@ -1,3 +1,5 @@
+import { chat, substituteParams } from '../../../../script.js';
+import { parseRegexFromString, world_info_logic, world_info_match_whole_words } from '../../../world-info.js';
 import { getTree, findNodeById, getAllEntryUids, getSettings } from './tree-store.js';
 import { getReadableBooks, getEntryContent } from './pathfinder-tool-bridge.js';
 import { sidecarGenerate } from './llm-sidecar.js';
@@ -12,6 +14,118 @@ export const PATHFINDER_RETRIEVAL_PROMPT_KEYS = Object.freeze([
     RETRIEVAL_PROMPT_KEY,
     PIPELINE_RETRIEVAL_KEY,
 ]);
+
+function clearRetrievalPrompt(setExtensionPrompt, key, extensionPromptTypes, extensionPromptRoles) {
+    setExtensionPrompt(
+        key,
+        '',
+        extensionPromptTypes?.IN_PROMPT ?? 0,
+        4,
+        false,
+        extensionPromptRoles?.SYSTEM ?? 0,
+    );
+}
+
+function getRecentChatText(limit = 10) {
+    const ctx = globalThis.window?.SillyTavern?.getContext?.();
+    const messages = Array.isArray(ctx?.chat) ? ctx.chat : chat;
+    return messages
+        .slice(-limit)
+        .map(message => String(message?.mes ?? message?.content ?? message ?? ''))
+        .join('\n');
+}
+
+function transformForEntry(value, entry) {
+    return entry?.caseSensitive ? String(value ?? '') : String(value ?? '').toLowerCase();
+}
+
+function escapeRegexLiteral(value) {
+    return String(value ?? '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function matchesWorldInfoKey(haystack, key, entry) {
+    const substituted = substituteParams(String(key ?? '')).trim();
+    if (!substituted) {
+        return false;
+    }
+
+    const keyRegex = parseRegexFromString(substituted);
+    if (keyRegex) {
+        return keyRegex.test(haystack);
+    }
+
+    const transformedHaystack = transformForEntry(haystack, entry);
+    const transformedKey = transformForEntry(substituted, entry);
+    const matchWholeWords = entry?.matchWholeWords ?? world_info_match_whole_words;
+
+    if (!matchWholeWords) {
+        return transformedHaystack.includes(transformedKey);
+    }
+
+    const keyWords = transformedKey.split(/\s+/);
+    if (keyWords.length > 1) {
+        return transformedHaystack.includes(transformedKey);
+    }
+
+    return new RegExp(`(?:^|\\W)(${escapeRegexLiteral(transformedKey)})(?:$|\\W)`).test(transformedHaystack);
+}
+
+function hasSecondaryActivationMatch(textToScan, entry) {
+    if (!entry?.selective || !Array.isArray(entry.keysecondary) || entry.keysecondary.length === 0) {
+        return true;
+    }
+
+    const selectiveLogic = entry.selectiveLogic ?? world_info_logic.AND_ANY;
+    let hasAnyMatch = false;
+    let hasAllMatch = true;
+
+    for (const key of entry.keysecondary) {
+        const matched = matchesWorldInfoKey(textToScan, key, entry);
+        if (matched) hasAnyMatch = true;
+        if (!matched) hasAllMatch = false;
+
+        if (selectiveLogic === world_info_logic.AND_ANY && matched) return true;
+        if (selectiveLogic === world_info_logic.NOT_ALL && !matched) return true;
+    }
+
+    if (selectiveLogic === world_info_logic.NOT_ANY && !hasAnyMatch) return true;
+    if (selectiveLogic === world_info_logic.AND_ALL && hasAllMatch) return true;
+    return false;
+}
+
+function getNaturalActivationReason(entry, textToScan = getRecentChatText()) {
+    if (!entry || entry.disable) {
+        return '';
+    }
+
+    if (entry.decorators?.includes?.('@@activate')) {
+        return '@@activate decorator';
+    }
+
+    if (entry.constant) {
+        return 'constant entry';
+    }
+
+    const primaryKeyMatch = Array.isArray(entry.key)
+        ? entry.key.find(key => matchesWorldInfoKey(textToScan, key, entry))
+        : null;
+    if (!primaryKeyMatch) {
+        return '';
+    }
+
+    return hasSecondaryActivationMatch(textToScan, entry)
+        ? `keyword match: ${primaryKeyMatch}`
+        : '';
+}
+
+function shouldSkipNaturalActivation(entry, textToScan) {
+    const settings = getSettings();
+    if (settings.dedupeNaturalActivation === false) {
+        return '';
+    }
+
+    return getNaturalActivationReason(entry, textToScan);
+}
 
 function getRetrievalStatusTimeoutMs() {
     const seconds = Number(getSettings().retrievalTimeoutSeconds ?? 8);
@@ -123,6 +237,7 @@ async function runPipelineRetrieval(setExtensionPrompt, extensionPromptTypes, ex
     const chatMessages = ctx?.chat ?? [];
 
     if (books.length === 0) {
+        clearRetrievalPrompt(setExtensionPrompt, PIPELINE_RETRIEVAL_KEY, extensionPromptTypes, extensionPromptRoles);
         console.log('[Pathfinder] No readable lorebooks with built trees for pipeline retrieval');
         logPathfinderRetrievalDetail({
             mode: 'pipeline',
@@ -136,6 +251,7 @@ async function runPipelineRetrieval(setExtensionPrompt, extensionPromptTypes, ex
     }
 
     if (chatMessages.length === 0) {
+        clearRetrievalPrompt(setExtensionPrompt, PIPELINE_RETRIEVAL_KEY, extensionPromptTypes, extensionPromptRoles);
         console.log('[Pathfinder] No chat messages for pipeline retrieval');
         logPathfinderRetrievalDetail({
             mode: 'pipeline',
@@ -155,6 +271,7 @@ async function runPipelineRetrieval(setExtensionPrompt, extensionPromptTypes, ex
     logPipelineComplete(pipelineId, result.selectedEntries?.length ?? 0, result.stageResults);
 
     if (!result.success) {
+        clearRetrievalPrompt(setExtensionPrompt, PIPELINE_RETRIEVAL_KEY, extensionPromptTypes, extensionPromptRoles);
         console.warn('[Pathfinder] Pipeline retrieval failed:', result.error);
         logPathfinderRetrievalDetail({
             mode: 'pipeline',
@@ -168,6 +285,7 @@ async function runPipelineRetrieval(setExtensionPrompt, extensionPromptTypes, ex
     }
 
     if (result.selectedEntries.length === 0) {
+        clearRetrievalPrompt(setExtensionPrompt, PIPELINE_RETRIEVAL_KEY, extensionPromptTypes, extensionPromptRoles);
         console.log('[Pathfinder] Pipeline returned no entries');
         logPathfinderRetrievalDetail({
             mode: 'pipeline',
@@ -182,6 +300,8 @@ async function runPipelineRetrieval(setExtensionPrompt, extensionPromptTypes, ex
 
     // Build content for injection - fetch actual entry content
     const entryContents = [];
+    const skippedNaturalEntries = [];
+    const textToScan = getRecentChatText();
 
     for (const entryName of result.selectedEntries) {
         for (const bookName of books) {
@@ -192,6 +312,17 @@ async function runPipelineRetrieval(setExtensionPrompt, extensionPromptTypes, ex
             for (const uid of uids) {
                 const entry = await getEntryContent(bookName, uid);
                 if (entry && entry.comment === entryName) {
+                    const naturalActivationReason = shouldSkipNaturalActivation(entry, textToScan);
+                    if (naturalActivationReason) {
+                        skippedNaturalEntries.push({
+                            name: entry.comment,
+                            bookName,
+                            uid,
+                            reason: naturalActivationReason,
+                        });
+                        break;
+                    }
+
                     entryContents.push({
                         name: entry.comment,
                         bookName,
@@ -229,6 +360,8 @@ async function runPipelineRetrieval(setExtensionPrompt, extensionPromptTypes, ex
                 pipelineId,
                 selectedEntryCount: entryContents.length,
                 candidateCount: result.selectedEntries?.length ?? 0,
+                skippedNaturalActivationCount: skippedNaturalEntries.length,
+                skippedNaturalEntries,
             },
         });
         setExtensionPrompt(
@@ -242,6 +375,7 @@ async function runPipelineRetrieval(setExtensionPrompt, extensionPromptTypes, ex
 
         console.log(`[Pathfinder] Pipeline injected ${entryContents.length} entries`);
     } else {
+        clearRetrievalPrompt(setExtensionPrompt, PIPELINE_RETRIEVAL_KEY, extensionPromptTypes, extensionPromptRoles);
         logPathfinderRetrievalDetail({
             mode: 'pipeline',
             books,
@@ -252,6 +386,8 @@ async function runPipelineRetrieval(setExtensionPrompt, extensionPromptTypes, ex
                 pipelineId,
                 selectedEntryCount: 0,
                 candidateCount: result.selectedEntries?.length ?? 0,
+                skippedNaturalActivationCount: skippedNaturalEntries.length,
+                skippedNaturalEntries,
             },
         });
     }

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tool-definitions.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tool-definitions.js
@@ -1,0 +1,21 @@
+import { getDefinition as getSearchDef } from './tools/search.js';
+import { getDefinition as getRememberDef } from './tools/remember.js';
+import { getDefinition as getUpdateDef } from './tools/update.js';
+import { getDefinition as getForgetDef } from './tools/forget.js';
+import { getDefinition as getSummarizeDef } from './tools/summarize.js';
+import { getDefinition as getReorganizeDef } from './tools/reorganize.js';
+import { getDefinition as getMergeSplitDef } from './tools/merge-split.js';
+import { getDefinition as getNotebookDef } from './tools/notebook.js';
+
+export function getPathfinderToolDefinitions() {
+    return [
+        getSearchDef(),
+        getRememberDef(),
+        getUpdateDef(),
+        getForgetDef(),
+        getSummarizeDef(),
+        getReorganizeDef(),
+        getMergeSplitDef(),
+        getNotebookDef(),
+    ];
+}

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tools/forget.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tools/forget.js
@@ -1,5 +1,5 @@
 import { forgetEntry } from '../entry-manager.js';
-import { getActiveTunnelVisionBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
+import { getDeletableBooks, getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
 import { registerToolAction, registerToolFormatter } from '../../tool-action-registry.js';
 import { logToolCallStarted, logToolCallCompleted, logToolCallError } from '../activity-feed.js';
 
@@ -17,10 +17,13 @@ async function forgetAction(args) {
         return 'Error: "uid" is required.';
     }
 
-    const targetBook = resolveTargetBook(bookName, getActiveTunnelVisionBooks());
+    const allowedBooks = hardDelete ? getDeletableBooks() : getWritableBooks();
+    const targetBook = resolveTargetBook(bookName, allowedBooks);
     if (!targetBook) {
-        logToolCallError(TOOL_NAMES.FORGET, 'No writable lorebooks');
-        return 'No Pathfinder-enabled lorebooks available.';
+        logToolCallError(TOOL_NAMES.FORGET, hardDelete ? 'No deletable lorebooks' : 'No writable lorebooks');
+        return hardDelete
+            ? 'No Pathfinder-enabled lorebooks allow deletion.'
+            : 'No Pathfinder-enabled lorebooks allow disabling entries.';
     }
 
     try {

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tools/merge-split.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tools/merge-split.js
@@ -1,5 +1,5 @@
 import { mergeEntries, splitEntry } from '../entry-manager.js';
-import { getActiveTunnelVisionBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
+import { getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
 import { registerToolAction, registerToolFormatter } from '../../tool-action-registry.js';
 import { logToolCallStarted, logToolCallCompleted, logToolCallError } from '../activity-feed.js';
 
@@ -16,7 +16,7 @@ async function mergeSplitAction(args) {
         return 'Error: "action" is required. Use "merge" or "split".';
     }
 
-    const writableBooks = getActiveTunnelVisionBooks();
+    const writableBooks = getWritableBooks();
     const targetBook = resolveTargetBook(bookName, writableBooks);
     if (!targetBook) {
         logToolCallError(TOOL_NAMES.MERGE_SPLIT, 'No writable lorebooks');

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tools/remember.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tools/remember.js
@@ -1,6 +1,6 @@
 import { getSettings } from '../tree-store.js';
 import { createEntry } from '../entry-manager.js';
-import { getActiveTunnelVisionBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
+import { getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
 import { registerToolAction, registerToolFormatter } from '../../tool-action-registry.js';
 import { logToolCallStarted, logToolCallCompleted, logToolCallError } from '../activity-feed.js';
 
@@ -34,7 +34,7 @@ async function rememberAction(args) {
         return 'Error: Both "title" and "content" are required.';
     }
 
-    const writableBooks = getActiveTunnelVisionBooks();
+    const writableBooks = getWritableBooks();
     const targetBook = resolveTargetBook(bookName, writableBooks);
 
     if (!targetBook) {

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tools/reorganize.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tools/reorganize.js
@@ -1,5 +1,5 @@
 import { moveEntry, createCategory } from '../entry-manager.js';
-import { getActiveTunnelVisionBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
+import { getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
 import { registerToolAction, registerToolFormatter } from '../../tool-action-registry.js';
 import { logToolCallStarted, logToolCallCompleted, logToolCallError } from '../activity-feed.js';
 
@@ -16,7 +16,7 @@ async function reorganizeAction(args) {
         return 'Error: "action" is required. Use "move" or "create_waypoint".';
     }
 
-    const writableBooks = getActiveTunnelVisionBooks();
+    const writableBooks = getWritableBooks();
     const targetBook = resolveTargetBook(bookName, writableBooks);
     if (!targetBook) {
         logToolCallError(TOOL_NAMES.REORGANIZE, 'No writable lorebooks');

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tools/summarize.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tools/summarize.js
@@ -6,13 +6,71 @@ import { logToolCallStarted, logToolCallCompleted, logToolCallError } from '../a
 import { setSummaryMemoryCreated } from '../summary-memory-store.js';
 
 const COMPACT_DESCRIPTION = 'Create a scene or event summary with significance level and optional narrative arc.';
+const GENERIC_SUMMARY_TITLE_PATTERN = /^(recent scene summary|scene summary|memory summary|summary|untitled summary)$/i;
+const MAX_DERIVED_TITLE_LENGTH = 64;
+const MAX_DERIVED_TITLE_WORDS = 9;
 
-export async function createSummaryMemoryEntry(args = {}) {
+function escapeRegExp(value) {
+    return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function normalizeTitle(value) {
+    return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+function trimDerivedTitle(value) {
+    const normalized = normalizeTitle(value);
+    if (normalized.length <= MAX_DERIVED_TITLE_LENGTH) {
+        return normalized;
+    }
+
+    const clipped = normalized.slice(0, MAX_DERIVED_TITLE_LENGTH);
+    return clipped.replace(/\s+\S*$/, '').trim() || clipped.trim();
+}
+
+function stripSummaryTitle(title, arc = '') {
+    let normalized = normalizeTitle(title).replace(/^\[Summary\]\s*/i, '');
+    const arcName = normalizeTitle(arc);
+    if (arcName) {
+        normalized = normalized.replace(new RegExp(`\\s+(?:\\u2014|-|:)\\s*${escapeRegExp(arcName)}$`, 'i'), '').trim();
+    }
+
+    return normalized;
+}
+
+function stripSummaryMetadata(content) {
+    return String(content || '').replace(/^Significance:\s*[^\n]*\n+/i, '').trim();
+}
+
+function deriveTitleFromContent(content) {
+    const body = stripSummaryMetadata(content);
+    const firstSentence = body.split(/[.!?]\s+|\n+/).find(part => part.trim()) || body;
+    const withoutSpeaker = firstSentence.replace(/^[\w .'-]{1,32}:\s+/, '').trim();
+    const words = withoutSpeaker
+        .replace(/[^\w\s'-]/g, ' ')
+        .split(/\s+/)
+        .filter(Boolean)
+        .slice(0, MAX_DERIVED_TITLE_WORDS);
+
+    return trimDerivedTitle(words.join(' '));
+}
+
+export function deriveSummaryLorebookTitle({ title = '', content = '', arc = '' } = {}) {
+    const existingTitle = stripSummaryTitle(title, arc);
+    if (existingTitle && !GENERIC_SUMMARY_TITLE_PATTERN.test(existingTitle)) {
+        return trimDerivedTitle(existingTitle);
+    }
+
+    return deriveTitleFromContent(content) || 'Summary note';
+}
+
+export async function createSummaryMemoryEntry(args = {}, options = {}) {
     const title = String(args.title || '').trim();
     const content = String(args.content || '').trim();
     const arc = String(args.arc || '').trim();
     const significance = String(args.significance || 'medium').trim();
     const bookName = String(args.book || '').trim();
+    const trackLatest = options.trackLatest !== false;
 
     logToolCallStarted(TOOL_NAMES.SUMMARIZE, { title, arc, bookName });
 
@@ -33,14 +91,16 @@ export async function createSummaryMemoryEntry(args = {}) {
 
     try {
         const result = await createEntry(targetBook, summaryTitle, formattedContent, ['summary', significance.toLowerCase()]);
-        setSummaryMemoryCreated({
-            title: summaryTitle,
-            content,
-            significance,
-            arc,
-            bookName: targetBook,
-            uid: result.uid,
-        });
+        if (trackLatest) {
+            setSummaryMemoryCreated({
+                title: summaryTitle,
+                content,
+                significance,
+                arc,
+                bookName: targetBook,
+                uid: result.uid,
+            });
+        }
 
         const tree = getTree(targetBook);
         if (tree && arc) {
@@ -78,6 +138,23 @@ export async function createSummaryMemoryEntry(args = {}) {
         logToolCallError(TOOL_NAMES.SUMMARIZE, err.message);
         throw err;
     }
+}
+
+export async function createSeparateSummaryMemoryEntry(args = {}) {
+    const content = String(args.content || '').trim();
+    if (!content) {
+        throw new Error('No summary text is available to save as a lorebook entry.');
+    }
+
+    return await createSummaryMemoryEntry({
+        ...args,
+        title: deriveSummaryLorebookTitle({
+            title: args.title,
+            content,
+            arc: args.arc,
+        }),
+        content,
+    }, { trackLatest: false });
 }
 
 async function summarizeAction(args) {

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tools/summarize.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tools/summarize.js
@@ -1,6 +1,6 @@
 import { getTree, createTreeNode, saveTree } from '../tree-store.js';
 import { createEntry } from '../entry-manager.js';
-import { getActiveTunnelVisionBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
+import { getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
 import { registerToolAction, registerToolFormatter } from '../../tool-action-registry.js';
 import { logToolCallStarted, logToolCallCompleted, logToolCallError } from '../activity-feed.js';
 import { setSummaryMemoryCreated } from '../summary-memory-store.js';
@@ -21,7 +21,7 @@ export async function createSummaryMemoryEntry(args = {}) {
         throw new Error('"title" and "content" are required.');
     }
 
-    const writableBooks = getActiveTunnelVisionBooks();
+    const writableBooks = getWritableBooks();
     const targetBook = resolveTargetBook(bookName, writableBooks);
     if (!targetBook) {
         logToolCallError(TOOL_NAMES.SUMMARIZE, 'No writable lorebooks');

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tools/update.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tools/update.js
@@ -1,5 +1,5 @@
 import { updateEntry } from '../entry-manager.js';
-import { getActiveTunnelVisionBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
+import { getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-tool-bridge.js';
 import { registerToolAction, registerToolFormatter } from '../../tool-action-registry.js';
 import { logToolCallStarted, logToolCallCompleted, logToolCallError } from '../activity-feed.js';
 
@@ -23,7 +23,7 @@ async function updateAction(args) {
         return 'Error: Provide at least "content" or "title" to update.';
     }
 
-    const targetBook = resolveTargetBook(bookName, getActiveTunnelVisionBooks());
+    const targetBook = resolveTargetBook(bookName, getWritableBooks());
     if (!targetBook) {
         logToolCallError(TOOL_NAMES.UPDATE, 'No writable lorebooks');
         return 'No Pathfinder-enabled lorebooks available for writing.';

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js
@@ -27,6 +27,9 @@ export const SETTING_DEFAULTS = {
     enabledLorebooks: [],
     includeContextualLorebooks: true,
     autoUseAttachedLorebook: false,
+    autoSyncLorebooksOnChatChange: true,
+    dedupeNaturalActivation: true,
+    toolStates: {},
     bookPermissions: {},
     confirmTools: {},
     // Pipeline settings
@@ -57,7 +60,7 @@ export function getSettings() {
 
 export function setSettings(newSettings) {
     const nextSettings = { ...SETTING_DEFAULTS, ...settings, ...(newSettings || {}) };
-    for (const key of ['bookPermissions', 'confirmTools', 'pipelinePrompts', 'pipelines']) {
+    for (const key of ['toolStates', 'bookPermissions', 'confirmTools', 'pipelinePrompts', 'pipelines']) {
         nextSettings[key] = {
             ...(SETTING_DEFAULTS[key] || {}),
             ...(settings?.[key] || {}),
@@ -225,6 +228,28 @@ export function setLorebookEnabled(bookName, enabled) {
     }
 }
 
+export function getToolStates() {
+    const s = getSettings();
+    if (!s.toolStates || typeof s.toolStates !== 'object') {
+        s.toolStates = {};
+    }
+    return s.toolStates;
+}
+
+export function isPathfinderToolEnabled(toolName, fallback = true) {
+    const states = getToolStates();
+    if (!Object.prototype.hasOwnProperty.call(states, toolName)) {
+        return fallback;
+    }
+
+    return states[toolName] !== false;
+}
+
+export function setPathfinderToolEnabled(toolName, enabled) {
+    const states = getToolStates();
+    states[toolName] = Boolean(enabled);
+}
+
 export function getBookDescription(bookName) {
     const tree = getTree(bookName);
     return tree?.description ?? '';
@@ -265,12 +290,34 @@ export function setBookPermission(bookName, permission, value) {
     s.bookPermissions[bookName][permission] = value;
 }
 
+function isPermissionAllowed(value) {
+    if (value === undefined || value === null) {
+        return true;
+    }
+
+    if (typeof value === 'boolean') {
+        return value;
+    }
+
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+
+    const normalized = String(value).trim().toLowerCase();
+    return !['none', 'false', 'off', 'deny', 'denied', 'no', '0', 'disabled'].includes(normalized);
+}
+
 export function canReadBook(bookName) {
     const perm = getBookPermission(bookName, 'read');
-    return perm !== 'none';
+    return isPermissionAllowed(perm);
 }
 
 export function canWriteBook(bookName) {
     const perm = getBookPermission(bookName, 'write');
-    return perm === 'readwrite';
+    return isPermissionAllowed(perm);
+}
+
+export function canDeleteBook(bookName) {
+    const perm = getBookPermission(bookName, 'delete');
+    return isPermissionAllowed(perm);
 }

--- a/public/scripts/st-context.js
+++ b/public/scripts/st-context.js
@@ -110,7 +110,7 @@ import { ToolManager } from './tool-calling.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { timestampToMoment, uuidv4, importFromExternalUrl } from './utils.js';
 import { addGlobalVariable, addLocalVariable, decrementGlobalVariable, decrementLocalVariable, deleteGlobalVariable, deleteLocalVariable, existsGlobalVariable, existsLocalVariable, getGlobalVariable, getLocalVariable, incrementGlobalVariable, incrementLocalVariable, setGlobalVariable, setLocalVariable } from './variables.js';
-import { convertCharacterBook, getWorldInfoPrompt, loadWorldInfo, reloadEditor, saveWorldInfo, updateWorldInfoList, world_info, world_names } from './world-info.js';
+import { convertCharacterBook, createWorldInfoEntry, getWorldInfoPrompt, loadWorldInfo, reloadEditor, saveWorldInfo, updateWorldInfoList, world_info, world_names } from './world-info.js';
 import { ChatCompletionService, TextCompletionService } from './custom-request.js';
 import { ConnectionManagerRequestService } from './extensions/shared.js';
 import { updateReasoningUI, parseReasoningFromString, getReasoningTemplateByName } from './reasoning.js';
@@ -292,7 +292,9 @@ export function getContext() {
                 has: existsGlobalVariable,
             },
         },
+        // SillyBunny: Pathfinder write tools need the lorebook entry factory in extension context.
         loadWorldInfo,
+        createWorldInfoEntry,
         saveWorldInfo,
         reloadWorldInfoEditor: reloadEditor,
         updateWorldInfoList,

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -127,7 +127,7 @@ describe('in-chat agent post-processing runner', () => {
         globalThis.toastr = {
             clear: jest.fn(),
             error: jest.fn(),
-            info: jest.fn(),
+            info: jest.fn(() => ({ toast: true })),
             success: jest.fn(),
             warning: jest.fn(),
         };
@@ -572,6 +572,48 @@ describe('in-chat agent post-processing runner', () => {
 
         expect(extensionPrompts.pathfinder_pipeline_retrieval).toEqual({ value: 'retrieved lore' });
         expect(extensionPrompts['inchat_agent_agent-pre-prompt']).toEqual({ value: 'Use the current scene style.' });
+    });
+
+    test('shows a processing toast while Pathfinder pipeline retrieval is running', async () => {
+        usePrePromptAgent();
+        enabledAgents.unshift({
+            id: 'agent-pathfinder',
+            name: 'Pathfinder',
+            category: 'tool',
+            sourceTemplateId: 'tpl-pathfinder',
+            phase: 'both',
+            prompt: '',
+            injection: { order: 0 },
+            settings: { pipelineEnabled: true, sidecarEnabled: false },
+            tools: [],
+            conditions: {
+                triggerKeywords: [],
+                triggerProbability: 100,
+                generationTypes: ['normal'],
+            },
+        });
+
+        let resolveRetrieval;
+        const retrievalDone = new Promise(resolve => {
+            resolveRetrieval = resolve;
+        });
+        runSidecarRetrieval.mockImplementation(async () => {
+            await retrievalDone;
+        });
+
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+
+        const generationPromise = eventSource.emit(eventTypes.GENERATION_AFTER_COMMANDS, 'normal', {}, false);
+        await Promise.resolve();
+
+        expect(globalThis.toastr.info).toHaveBeenCalledWith('Pathfinder is processing lore for this reply...', 'Please wait', { timeOut: 0, extendedTimeOut: 0 });
+        expect(globalThis.toastr.clear).not.toHaveBeenCalled();
+
+        resolveRetrieval();
+        await generationPromise;
+
+        expect(globalThis.toastr.clear).toHaveBeenCalledWith({ toast: true });
     });
 
     test('runs pre-generation intercept agents on text prompts without injecting their prompt', async () => {

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -213,6 +213,7 @@ describe('in-chat agent post-processing runner', () => {
             getEnabledToolAgents: jest.fn(() => []),
             getGlobalSettings: jest.fn(() => globalSettings),
             getPromptTransformMode: jest.fn(agent => agent?.postProcess?.promptTransformMode === 'append' ? 'append' : 'rewrite'),
+            saveAgent: jest.fn(async () => {}),
             isToolAgent: jest.fn(() => false),
             normalizePreProcessMaxTokens: jest.fn(value => Number.isFinite(Number(value)) ? Math.max(16, Math.min(16000, Number(value))) : 8192),
             normalizePromptTransformMaxTokens: jest.fn(value => Number.isFinite(Number(value)) ? Math.max(16, Math.min(16000, Number(value))) : 8192),
@@ -225,10 +226,19 @@ describe('in-chat agent post-processing runner', () => {
         }));
 
         await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js', () => ({
-            getAllEntryUids: jest.fn(() => []),
             getSettings: jest.fn(() => ({ pipelinePrompts: {}, pipelines: [] })),
-            getTree: jest.fn(() => null),
             setSettings: jest.fn(),
+        }));
+
+        await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/tool-definitions.js', () => ({
+            getPathfinderToolDefinitions: jest.fn(() => [
+                { name: 'Pathfinder_Search', displayName: 'Search', description: 'Search', parameters: {}, actionKey: 'pathfinder.search' },
+                { name: 'Pathfinder_Summarize', displayName: 'Summarize', description: 'Summarize', parameters: {}, actionKey: 'pathfinder.summarize' },
+            ]),
+        }));
+
+        await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/pathfinder-tool-bridge.js', () => ({
+            getContextualLorebooks: jest.fn(() => []),
         }));
 
         await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/sidecar-retrieval.js', () => ({

--- a/tests/pathfinder-diagnostics.test.js
+++ b/tests/pathfinder-diagnostics.test.js
@@ -16,6 +16,9 @@ let mockRuntimeAgent;
 let mockSyncToolAgentRegistrations;
 
 await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js', () => ({
+    canDeleteBook: jest.fn(() => true),
+    canReadBook: jest.fn(() => true),
+    canWriteBook: jest.fn(() => true),
     getSettings: jest.fn(() => mockSettings),
     getTree: jest.fn(bookName => mockTrees[bookName] ?? null),
     getAllEntryUids: jest.fn(tree => tree.uids ?? []),
@@ -33,6 +36,7 @@ await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agen
 
 await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-runner.js', () => ({
     getPathfinderRuntimeAgent: jest.fn(() => mockRuntimeAgent),
+    getToolRecursionState: jest.fn(() => ({ depth: 0, limit: 5, registeredToolNames: TOOL_NAMES })),
     syncToolAgentRegistrations: jest.fn(() => mockSyncToolAgentRegistrations()),
 }));
 
@@ -45,6 +49,9 @@ describe('Pathfinder diagnostics', () => {
             includeContextualLorebooks: true,
             pipelineEnabled: false,
             sidecarEnabled: true,
+            toolStates: Object.fromEntries(TOOL_NAMES.map(name => [name, true])),
+            autoSyncLorebooksOnChatChange: true,
+            dedupeNaturalActivation: true,
         };
         mockTrees = {
             'Manual Book': { uids: ['uid-1', 'uid-2'] },
@@ -78,7 +85,7 @@ describe('Pathfinder diagnostics', () => {
         expect(mockSyncToolAgentRegistrations).toHaveBeenCalledTimes(1);
         expect(results['Tool Registration']).toEqual({
             ok: true,
-            message: 'All 3 enabled Pathfinder tool(s) registered and active',
+            message: 'All 3 enabled Pathfinder tool(s) registered and active. Registered: Pathfinder_Search, Pathfinder_Summarize, Pathfinder_Remember. Enabled: Pathfinder_Search, Pathfinder_Summarize, Pathfinder_Remember. Recursion: 0/5.',
         });
     });
 
@@ -101,6 +108,7 @@ describe('Pathfinder diagnostics', () => {
                 { name: 'Pathfinder_Remember', enabled: false },
             ],
         };
+        mockSettings.toolStates = {};
         globalThis.window.SillyTavern.getContext = () => ({
             ToolManager: {
                 tools: new Map([
@@ -116,7 +124,25 @@ describe('Pathfinder diagnostics', () => {
 
         expect(results['Tool Registration']).toEqual({
             ok: true,
-            message: 'All 1 enabled Pathfinder tool(s) registered and active',
+            message: 'All 1 enabled Pathfinder tool(s) registered and active. Registered: Pathfinder_Search, Pathfinder_Summarize, Pathfinder_Remember. Enabled: Pathfinder_Summarize. Recursion: 0/5.',
+        });
+    });
+
+    test('prefers canonical toolStates over stale agent tool arrays', async () => {
+        mockRuntimeAgent = {
+            tools: TOOL_NAMES.map(name => ({ name, enabled: true })),
+        };
+        mockSettings.toolStates = {
+            Pathfinder_Search: false,
+            Pathfinder_Summarize: true,
+            Pathfinder_Remember: false,
+        };
+
+        const results = await runDiagnostics();
+
+        expect(results['Tool Registration']).toEqual({
+            ok: true,
+            message: 'All 1 enabled Pathfinder tool(s) registered and active. Registered: Pathfinder_Search, Pathfinder_Summarize, Pathfinder_Remember. Enabled: Pathfinder_Summarize. Recursion: 0/5.',
         });
     });
 });

--- a/tests/pathfinder-settings-utils.test.js
+++ b/tests/pathfinder-settings-utils.test.js
@@ -4,7 +4,16 @@ await jest.unstable_mockModule('../public/scripts/extensions.js', () => ({
     getContext: jest.fn(() => null),
 }));
 
-const { normalizeAutoSummaryInterval } = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js');
+const {
+    canDeleteBook,
+    canReadBook,
+    canWriteBook,
+    isPathfinderToolEnabled,
+    normalizeAutoSummaryInterval,
+    setBookPermission,
+    setPathfinderToolEnabled,
+    setSettings,
+} = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js');
 
 describe('Pathfinder settings utilities', () => {
     test('allows auto summary intervals below 20 down to the simple lower bound', () => {
@@ -12,5 +21,31 @@ describe('Pathfinder settings utilities', () => {
         expect(normalizeAutoSummaryInterval(5)).toBe(5);
         expect(normalizeAutoSummaryInterval(19)).toBe(19);
         expect(normalizeAutoSummaryInterval(1)).toBe(2);
+    });
+
+    test('persists canonical Pathfinder tool states independently of agent tool arrays', () => {
+        setSettings({ toolStates: {} });
+
+        expect(isPathfinderToolEnabled('Pathfinder_Search')).toBe(true);
+        setPathfinderToolEnabled('Pathfinder_Search', false);
+        expect(isPathfinderToolEnabled('Pathfinder_Search')).toBe(false);
+        setPathfinderToolEnabled('Pathfinder_Search', true);
+        expect(isPathfinderToolEnabled('Pathfinder_Search')).toBe(true);
+    });
+
+    test('interprets per-book permissions with backward compatible deny values', () => {
+        setSettings({ bookPermissions: {} });
+
+        expect(canReadBook('Book')).toBe(true);
+        expect(canWriteBook('Book')).toBe(true);
+        expect(canDeleteBook('Book')).toBe(true);
+
+        setBookPermission('Book', 'read', 'none');
+        setBookPermission('Book', 'write', false);
+        setBookPermission('Book', 'delete', 'disabled');
+
+        expect(canReadBook('Book')).toBe(false);
+        expect(canWriteBook('Book')).toBe(false);
+        expect(canDeleteBook('Book')).toBe(false);
     });
 });

--- a/tests/pathfinder-summary-tool.test.js
+++ b/tests/pathfinder-summary-tool.test.js
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+let mockWritableBooks;
+let mockCreatedEntries;
+let mockSummaryState;
+
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js', () => ({
+    createTreeNode: jest.fn((name, description, entries = [], children = []) => ({ name, description, entries, children })),
+    getTree: jest.fn(() => null),
+    saveTree: jest.fn(),
+}));
+
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/entry-manager.js', () => ({
+    createEntry: jest.fn(async (bookName, title, content, keys = []) => {
+        const entry = {
+            uid: mockCreatedEntries.length + 1,
+            bookName,
+            title,
+            content,
+            keys,
+        };
+        mockCreatedEntries.push(entry);
+        return { uid: entry.uid, title, bookName };
+    }),
+}));
+
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/pathfinder-tool-bridge.js', () => ({
+    TOOL_NAMES: { SUMMARIZE: 'Pathfinder_Summarize' },
+    getWritableBooks: jest.fn(() => mockWritableBooks),
+    resolveTargetBook: jest.fn((requestedBook, writableBooks) => {
+        if (requestedBook && writableBooks.includes(requestedBook)) {
+            return requestedBook;
+        }
+
+        return writableBooks[0] ?? null;
+    }),
+}));
+
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/tool-action-registry.js', () => ({
+    registerToolAction: jest.fn(),
+    registerToolFormatter: jest.fn(),
+}));
+
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/activity-feed.js', () => ({
+    logToolCallStarted: jest.fn(),
+    logToolCallCompleted: jest.fn(),
+    logToolCallError: jest.fn(),
+}));
+
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/summary-memory-store.js', () => ({
+    setSummaryMemoryCreated: jest.fn(payload => {
+        mockSummaryState = payload;
+    }),
+}));
+
+const {
+    createSeparateSummaryMemoryEntry,
+    createSummaryMemoryEntry,
+    deriveSummaryLorebookTitle,
+} = await import('../public/scripts/extensions/in-chat-agents/pathfinder/tools/summarize.js');
+
+describe('Pathfinder summary lorebook entries', () => {
+    beforeEach(() => {
+        mockWritableBooks = ['Memory Book'];
+        mockCreatedEntries = [];
+        mockSummaryState = null;
+    });
+
+    test('derives a specific title when the tracked summary title is generic', () => {
+        expect(deriveSummaryLorebookTitle({
+            title: '[Summary] Recent scene summary',
+            content: 'Significance: high\n\nMira discovered the hidden observatory beneath the old chapel. The party still needs the moon key.',
+        })).toBe('Mira discovered the hidden observatory beneath the old chapel');
+    });
+
+    test('creates a separate summary entry without replacing the tracked latest summary', async () => {
+        const tracked = await createSummaryMemoryEntry({
+            title: 'First tracked summary',
+            content: 'The original tracked summary remains selected.',
+            significance: 'medium',
+        });
+
+        expect(mockSummaryState.title).toBe('[Summary] First tracked summary');
+
+        const archived = await createSeparateSummaryMemoryEntry({
+            title: '[Summary] Recent scene summary',
+            content: 'Rin promised to return the stolen map before dawn. The guard captain suspects her.',
+            significance: 'high',
+        });
+
+        expect(archived.uid).not.toBe(tracked.uid);
+        expect(mockCreatedEntries).toHaveLength(2);
+        expect(mockCreatedEntries[1].title).toBe('[Summary] Rin promised to return the stolen map before dawn');
+        expect(mockCreatedEntries[1].content).toContain('Significance: high');
+        expect(mockSummaryState.title).toBe('[Summary] First tracked summary');
+    });
+});

--- a/tests/pathfinder-tool-bridge.test.js
+++ b/tests/pathfinder-tool-bridge.test.js
@@ -9,6 +9,7 @@ await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/path
     isLorebookEnabled: jest.fn(bookName => mockSettings.enabledLorebooks.includes(bookName)),
     canReadBook: jest.fn(() => true),
     canWriteBook: jest.fn(() => true),
+    canDeleteBook: jest.fn(() => true),
 }));
 
 const {


### PR DESCRIPTION
## Summary
- Move Pathfinder settings into the Extensions drawer and keep the agent gear focused on that embedded panel.
- Persist Pathfinder tool toggles through canonical `toolStates`, repair missing tool definitions, and register enabled tools from canonical definitions.
- Add per-lorebook read/write/delete permissions, richer diagnostics, chat-context lorebook auto-sync, and natural World Info activation de-dupe for retrieval injection.

## Verification
- `npm run test:unit --prefix tests -- tests/pathfinder-settings-utils.test.js tests/pathfinder-tool-bridge.test.js tests/pathfinder-diagnostics.test.js tests/in-chat-agents-runner.test.js`
- `npm run lint`
- `npm run test:unit --prefix tests`