### PR TITLE
fix(mobile): enlarge composer textarea and balance spacing

### DIFF
--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -1558,13 +1558,13 @@
     :root {
         --bottomFormBlockSize: clamp(34px, calc(var(--sb-mobile-touch-target, 44px) * var(--sb-bottom-bar-scale, 1)), 58px);
         --bottomFormIconSize: clamp(16px, calc(20px * var(--sb-bottom-bar-scale, 1)), 25px);
-        --sb-mobile-composer-input-height: 46px;
+        --sb-mobile-composer-input-height: 84px;
     }
 
     :root[data-sb-compact-mode='true'] {
         --bottomFormBlockSize: clamp(32px, calc(var(--sb-mobile-touch-target, 44px) * var(--sb-bottom-bar-scale, 1)), 54px);
         --bottomFormIconSize: clamp(15px, calc(18px * var(--sb-bottom-bar-scale, 1)), 23px);
-        --sb-mobile-composer-input-height: 42px;
+        --sb-mobile-composer-input-height: 72px;
     }
 
     #send_form {
@@ -1580,17 +1580,17 @@
             "tools action" !important;
         align-items: center !important;
         column-gap: 6px !important;
-        row-gap: 5px !important;
-        min-height: calc(var(--sb-mobile-composer-input-height) + var(--bottomFormBlockSize) + 14px) !important;
-        padding: 5px 6px !important;
+        row-gap: 6px !important;
+        min-height: calc(var(--sb-mobile-composer-input-height) + var(--bottomFormBlockSize) + 18px) !important;
+        padding: 6px 6px !important;
         box-sizing: border-box !important;
     }
 
     :root[data-sb-compact-mode='true'] #nonQRFormItems {
         column-gap: 5px !important;
-        row-gap: 4px !important;
-        min-height: calc(var(--sb-mobile-composer-input-height) + var(--bottomFormBlockSize) + 12px) !important;
-        padding: 4px 6px !important;
+        row-gap: 5px !important;
+        min-height: calc(var(--sb-mobile-composer-input-height) + var(--bottomFormBlockSize) + 15px) !important;
+        padding: 5px 6px !important;
     }
 
     #leftSendForm,

--- a/public/scripts/extensions/input-history/style.css
+++ b/public/scripts/extensions/input-history/style.css
@@ -9,7 +9,7 @@
   order: 0;
   width: 100%;
   box-sizing: border-box;
-  padding: 0 8px 6px;
+  padding: 0 8px 0;
 }
 .stih--buttons .stih--button {
   flex: 0 0 var(--bottomFormBlockSize);
@@ -123,7 +123,7 @@ html > body .stih--history .stih--hidden {
   }
 
   .stih--buttons.stih--standalone {
-    padding: 0 6px 5px;
+    padding: 0 6px 0;
   }
 
   .stih--buttons .stih--arrows {


### PR DESCRIPTION
## Summary
- Enlarges the mobile composer textarea resting height to give the message box more room.
- Balances the vertical gap above and below the textarea by aligning the input-history standalone row spacing with the mobile composer grid gap.

## Verification
- Ran `git diff --check`.
- CSS-only change; mobile visual verification should confirm phone-width composer spacing with input history enabled and disabled, including compact mode.