### PR TITLE
fix: keep tablet shell edge-to-edge

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -389,7 +389,8 @@
 }
 
 @media screen and (min-width: 769px) and (max-width: 1180px) {
-    #sheld {
+    /* SillyBunny: keep tablet full-screen shells edge-to-edge without overriding MovingUI resizing. */
+    body:not(.movingUI) #sheld {
         width: 100vw !important;
         width: 100dvw !important;
         max-width: 100dvw !important;


### PR DESCRIPTION
## Summary
- Keep the tablet-width `#sheld` full-screen reset active only outside MovingUI mode.
- Preserve MovingUI resizing while fixing the Android/Brave tablet full-screen left-shift case.

## Verification
- npm run lint