### PR TITLE
fix(mobile): keep controls within mobile bounds

### DIFF
--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -3759,7 +3759,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
         --sb-bottom-chat-mobile-gap: clamp(2px, calc(4px * var(--sb-bottom-bar-scale)), 6px);
         --sb-bottom-chat-mobile-padding-block: clamp(3px, calc(4px * var(--sb-bottom-bar-scale)), 6px);
         --sb-bottom-chat-mobile-padding-inline: clamp(5px, calc(6px * var(--sb-bottom-bar-scale)), 9px);
-        --sb-bottom-chat-mobile-button-size: clamp(44px, calc(44px * var(--sb-bottom-bar-scale)), 52px);
+        --sb-bottom-chat-mobile-button-size: var(--bottomFormBlockSize, clamp(44px, calc(44px * var(--sb-bottom-bar-scale)), 52px));
         --sb-bottom-chat-mobile-select-height: clamp(44px, calc(44px * var(--sb-bottom-bar-scale)), 52px);
         --sb-bottom-chat-mobile-persona-size: clamp(44px, calc(44px * var(--sb-bottom-bar-scale)), 52px);
         --sb-bottom-chat-mobile-radius: clamp(12px, calc(14px * var(--sb-bottom-bar-scale)), 18px);
@@ -3904,7 +3904,6 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
         --sb-bottom-chat-mobile-gap: clamp(2px, calc(2px * var(--sb-bottom-bar-scale)), 4px);
         --sb-bottom-chat-mobile-padding-block: clamp(3px, calc(3px * var(--sb-bottom-bar-scale)), 5px);
         --sb-bottom-chat-mobile-padding-inline: clamp(4px, calc(5px * var(--sb-bottom-bar-scale)), 7px);
-        --sb-bottom-chat-mobile-button-size: clamp(44px, calc(44px * var(--sb-bottom-bar-scale)), 50px);
         --sb-bottom-chat-mobile-select-height: clamp(44px, calc(44px * var(--sb-bottom-bar-scale)), 50px);
         --sb-bottom-chat-mobile-persona-size: clamp(44px, calc(44px * var(--sb-bottom-bar-scale)), 50px);
         --sb-bottom-chat-mobile-radius: clamp(11px, calc(13px * var(--sb-bottom-bar-scale)), 16px);

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -2840,8 +2840,8 @@ input[type='range']::-moz-range-thumb {
     grid-column: 2;
     justify-self: end;
     width: 100% !important;
-    min-width: 0;
-    max-width: none;
+    min-width: 0 !important;
+    max-width: 100%;
 }
 
 #openai_settings .oneline-dropdown > :is(.toggle-description, strong.toggle-description) {
@@ -2936,7 +2936,7 @@ input[type='range']::-moz-range-thumb {
     #openai_api .oneline-dropdown,
     #openai_settings .oneline-dropdown,
     #range_block_openai .oneline-dropdown {
-        grid-template-columns: 1fr;
+        grid-template-columns: minmax(0, 1fr);
         align-items: stretch;
         gap: 8px;
     }


### PR DESCRIPTION
## Summary
- Prevent OpenAI inline dropdown controls from retaining fit-content minimum widths on mobile.
- Reuse the composer mobile button size for bottom chat bar action buttons so top and bottom rows match.

## Verification
- git diff --check
- npm run check:frontend-budgets
