### PR TITLE
feat: customize mobile quick actions and tighten composer

### DIFF
--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -1573,6 +1573,18 @@
 
     #send_form {
         border-radius: 14px 14px 0 0;
+        gap: 0 !important;
+        row-gap: 0 !important;
+    }
+
+    #qr--bar {
+        margin-block: 0 !important;
+        padding-block: 0 !important;
+        min-height: 0 !important;
+    }
+
+    #qr--bar + #nonQRFormItems {
+        margin-block-start: 2px !important;
     }
 
     #nonQRFormItems {
@@ -1585,16 +1597,16 @@
         align-items: center !important;
         column-gap: 6px !important;
         row-gap: 2px !important;
-        min-height: calc(var(--sb-mobile-composer-input-height) + var(--bottomFormBlockSize) + 8px) !important;
-        padding: 3px 6px 4px !important;
+        min-height: calc(var(--sb-mobile-composer-input-height) + var(--bottomFormBlockSize) + 6px) !important;
+        padding: 0 6px 4px !important;
         box-sizing: border-box !important;
     }
 
     :root[data-sb-compact-mode='true'] #nonQRFormItems {
         column-gap: 5px !important;
         row-gap: 1px !important;
-        min-height: calc(var(--sb-mobile-composer-input-height) + var(--bottomFormBlockSize) + 6px) !important;
-        padding: 2px 6px 3px !important;
+        min-height: calc(var(--sb-mobile-composer-input-height) + var(--bottomFormBlockSize) + 4px) !important;
+        padding: 0 6px 3px !important;
     }
 
     #leftSendForm,

--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -1558,13 +1558,17 @@
     :root {
         --bottomFormBlockSize: clamp(34px, calc(var(--sb-mobile-touch-target, 44px) * var(--sb-bottom-bar-scale, 1)), 58px);
         --bottomFormIconSize: clamp(16px, calc(20px * var(--sb-bottom-bar-scale, 1)), 25px);
-        --sb-mobile-composer-input-height: 68px;
+        --sb-mobile-composer-input-height: 40px;
     }
 
     :root[data-sb-compact-mode='true'] {
         --bottomFormBlockSize: clamp(32px, calc(var(--sb-mobile-touch-target, 44px) * var(--sb-bottom-bar-scale, 1)), 54px);
         --bottomFormIconSize: clamp(15px, calc(18px * var(--sb-bottom-bar-scale, 1)), 23px);
-        --sb-mobile-composer-input-height: 60px;
+        --sb-mobile-composer-input-height: 36px;
+    }
+
+    #form_sheld {
+        padding-block-end: env(safe-area-inset-bottom, 0px) !important;
     }
 
     #send_form {
@@ -1580,17 +1584,17 @@
             "tools action" !important;
         align-items: center !important;
         column-gap: 6px !important;
-        row-gap: 6px !important;
-        min-height: calc(var(--sb-mobile-composer-input-height) + var(--bottomFormBlockSize) + 18px) !important;
-        padding: 4px 6px 6px !important;
+        row-gap: 2px !important;
+        min-height: calc(var(--sb-mobile-composer-input-height) + var(--bottomFormBlockSize) + 8px) !important;
+        padding: 3px 6px 4px !important;
         box-sizing: border-box !important;
     }
 
     :root[data-sb-compact-mode='true'] #nonQRFormItems {
         column-gap: 5px !important;
-        row-gap: 5px !important;
-        min-height: calc(var(--sb-mobile-composer-input-height) + var(--bottomFormBlockSize) + 15px) !important;
-        padding: 3px 6px 5px !important;
+        row-gap: 1px !important;
+        min-height: calc(var(--sb-mobile-composer-input-height) + var(--bottomFormBlockSize) + 6px) !important;
+        padding: 2px 6px 3px !important;
     }
 
     #leftSendForm,
@@ -1675,17 +1679,17 @@
         field-sizing: content !important;
         max-height: 42dvh !important;
         overflow-y: auto !important;
-        padding: 8px 10px !important;
+        padding: 5px 9px !important;
         font-size: 16px !important;
-        line-height: 1.25 !important;
+        line-height: 1.2 !important;
         align-self: stretch !important;
         box-sizing: border-box !important;
     }
 
     :root[data-sb-compact-mode='true'] #send_textarea {
         min-height: var(--sb-mobile-composer-input-height) !important;
-        padding: 7px 9px !important;
-        line-height: 1.22 !important;
+        padding: 4px 8px !important;
+        line-height: 1.18 !important;
     }
 
     #send_but::before,

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -3583,6 +3583,137 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     box-shadow: inset 0 0 0 2px var(--color-primary, var(--sb-accent));
 }
 
+.sb-mobile-quick-actions-group {
+    gap: 12px;
+}
+
+.sb-mobile-quick-action-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.sb-mobile-quick-action-heading {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+}
+
+.sb-mobile-quick-action-heading strong {
+    font-size: calc(var(--mainFontSize) * 0.82);
+}
+
+.sb-mobile-quick-action-search {
+    width: 100%;
+    min-height: 34px;
+    margin: 0;
+    box-sizing: border-box;
+}
+
+.sb-mobile-quick-action-results,
+.sb-mobile-quick-action-list {
+    display: grid;
+    gap: 8px;
+}
+
+.sb-mobile-quick-action-results:empty {
+    display: none;
+}
+
+.sb-mobile-quick-action-empty,
+.sb-mobile-quick-action-result,
+.sb-mobile-quick-action-current {
+    border-radius: 12px;
+    border: 1px solid color-mix(in srgb, var(--sb-shell-border) 72%, transparent);
+    background: color-mix(in srgb, var(--SmartThemeBodyColor) 3%, transparent);
+}
+
+.sb-mobile-quick-action-empty {
+    padding: 10px 12px;
+    font-size: calc(var(--mainFontSize) * 0.74);
+    line-height: 1.4;
+    opacity: 0.76;
+}
+
+.sb-mobile-quick-action-result,
+.sb-mobile-quick-action-current {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) max-content;
+    align-items: center;
+    gap: 10px;
+    min-height: 46px;
+    padding: 8px 10px;
+}
+
+.sb-mobile-quick-action-current {
+    background: color-mix(in srgb, var(--SmartThemeBodyColor) 5%, transparent);
+}
+
+.sb-mobile-quick-action-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    min-width: 0;
+}
+
+.sb-mobile-quick-action-copy strong,
+.sb-mobile-quick-action-copy small {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.sb-mobile-quick-action-copy strong {
+    font-size: calc(var(--mainFontSize) * 0.78);
+    line-height: 1.2;
+}
+
+.sb-mobile-quick-action-copy small {
+    font-size: calc(var(--mainFontSize) * 0.7);
+    line-height: 1.3;
+    opacity: 0.72;
+}
+
+.sb-mobile-quick-action-add,
+.sb-mobile-quick-action-remove,
+.sb-mobile-quick-action-reset {
+    min-height: 30px;
+    margin: 0;
+    white-space: nowrap;
+}
+
+.sb-mobile-quick-action-remove {
+    color: color-mix(in srgb, var(--color-danger, var(--sb-color-danger, #fb7185)) 82%, var(--SmartThemeBodyColor) 18%);
+}
+
+.sb-mobile-quick-action-search:focus-visible,
+.sb-mobile-quick-action-add:focus-visible,
+.sb-mobile-quick-action-remove:focus-visible,
+.sb-mobile-quick-action-reset:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--sb-focus-ring) 72%, transparent);
+}
+
+@media screen and (max-width: 768px) {
+    .sb-mobile-quick-action-header,
+    .sb-mobile-quick-action-result,
+    .sb-mobile-quick-action-current {
+        grid-template-columns: 1fr;
+    }
+
+    .sb-mobile-quick-action-header {
+        display: grid;
+    }
+
+    .sb-mobile-quick-action-reset,
+    .sb-mobile-quick-action-add,
+    .sb-mobile-quick-action-remove {
+        width: 100%;
+    }
+}
+
 /* Bottom chat management bar */
 #sb-bottom-chat-bar {
     display: flex;

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -3770,7 +3770,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
         align-items: center;
         justify-content: stretch;
         gap: var(--sb-bottom-chat-mobile-gap);
-        margin: 0 auto 6px;
+        margin: 0 auto;
         padding: var(--sb-bottom-chat-mobile-padding-block) var(--sb-bottom-chat-mobile-padding-inline);
         min-height: calc(var(--sb-bottom-chat-mobile-persona-size) + var(--sb-bottom-chat-mobile-padding-block) + var(--sb-bottom-chat-mobile-padding-block));
         border-radius: var(--sb-bottom-chat-mobile-radius);

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -19,7 +19,8 @@ const SB_STORAGE_KEYS = Object.freeze({
     bottomBarScale: 'sb-bottom-bar-scale',
     bottomChatSecondaryOpen: 'sb-bottom-chat-secondary-open',
     mobileButtonScale: 'sb-mobile-button-scale',
-    mobileQuickActions: 'sb-mobile-quick-actions',
+    mobileQuickActions: 'sb-mobile-quick-actions-v2',
+    mobileQuickActionsLegacy: 'sb-mobile-quick-actions',
     settingsDrawerAutoClose: 'sb-settings-drawer-auto-close',
     compactMode: 'sb-compact-mode',
     frontendIcon: 'sb-frontend-icon',
@@ -534,12 +535,12 @@ const SB_UNIVERSAL_SEARCH_RESULT_LIMIT = 10;
 const SB_MOBILE_QUICK_ACTION_LIMIT = 12;
 const SB_MOBILE_QUICK_ACTION_LABEL_MAX_LENGTH = 36;
 const SB_MOBILE_DEFAULT_QUICK_ACTIONS = Object.freeze([
-    { shell: 'left', tab: 'presets', icon: 'fa-sliders', label: 'Presets' },
-    { shell: 'left', tab: 'api', icon: 'fa-plug', label: 'API' },
-    { shell: 'left', tab: 'sampling', icon: 'fa-wave-square', label: 'Sampling' },
-    { shell: 'left', tab: 'advanced-formatting', icon: 'fa-text-height', label: 'Formatting' },
-    { shell: 'left', tab: 'world-info', icon: 'fa-book-atlas', label: 'World Info' },
-    { shell: 'left', tab: 'agents', icon: 'fa-robot', label: 'Agents' },
+    { type: 'tab', shellKey: 'left', tabId: 'presets', icon: 'fa-sliders', label: 'Presets' },
+    { type: 'tab', shellKey: 'left', tabId: 'api', icon: 'fa-plug', label: 'API' },
+    { type: 'tab', shellKey: 'left', tabId: 'sampling', icon: 'fa-wave-square', label: 'Sampling' },
+    { type: 'tab', shellKey: 'left', tabId: 'advanced-formatting', icon: 'fa-text-height', label: 'Formatting' },
+    { type: 'tab', shellKey: 'left', tabId: 'world-info', icon: 'fa-book-atlas', label: 'World Info' },
+    { type: 'tab', shellKey: 'left', tabId: 'agents', icon: 'fa-robot', label: 'Agents' },
 ]);
 
 const sbState = {
@@ -841,87 +842,70 @@ function normalizeTopbarOffset(value) {
     };
 }
 
+function getMobileQuickActionTabConfig(shellKey, tabId) {
+    const shellConfig = getShellConfig(shellKey);
+    if (!shellConfig || !tabId) {
+        return null;
+    }
+
+    return [
+        shellConfig.baseTab,
+        ...(Array.isArray(shellConfig.embeddedTabs) ? shellConfig.embeddedTabs : []),
+        ...(Array.isArray(shellConfig.customTabs) ? shellConfig.customTabs : []),
+    ].find(tab => tab?.id === tabId) || null;
+}
+
 function normalizeMobileQuickAction(value) {
     if (!value || typeof value !== 'object') {
         return null;
     }
 
-    const shellKey = normalizeText(value.shellKey);
-    const tabId = normalizeText(value.tabId);
+    const shellKey = normalizeText(value.shellKey || value.shell);
+    const tabId = normalizeText(value.tabId || value.tab);
     const shellConfig = getShellConfig(shellKey);
 
     if (!shellConfig || !tabId) {
         return null;
     }
 
+    const tabConfig = getMobileQuickActionTabConfig(shellKey, tabId);
+    const dedupeKey = clampText(value.dedupeKey, 160);
+    const type = dedupeKey ? 'custom' : 'tab';
     const displayText = clampText(value.displayText, 80);
     const sectionLabel = clampText(value.sectionLabel, 80);
-    const label = clampText(value.label || displayText || sectionLabel, SB_MOBILE_QUICK_ACTION_LABEL_MAX_LENGTH);
-    const dedupeKey = clampText(value.dedupeKey, 160);
+    const fallbackLabel = type === 'custom'
+        ? displayText || sectionLabel
+        : tabConfig?.label || tabId;
+    const label = clampText(value.label || fallbackLabel, SB_MOBILE_QUICK_ACTION_LABEL_MAX_LENGTH);
 
-    if (!label || !dedupeKey) {
+    if (!label) {
         return null;
     }
 
-    return {
+    const action = {
+        type,
         shellKey,
         tabId,
-        sectionLabel,
-        displayText,
-        dedupeKey,
+        icon: clampText(value.icon || (type === 'custom' ? 'fa-bolt' : tabConfig?.icon || 'fa-bars'), 60),
         label,
     };
-}
 
-function loadMobileQuickActions() {
-    const storedValue = safeGetItem(SB_STORAGE_KEYS.mobileQuickActions);
-    if (!storedValue) {
-        return [];
+    if (type === 'custom') {
+        action.sectionLabel = sectionLabel;
+        action.displayText = displayText || label;
+        action.dedupeKey = dedupeKey;
     }
 
-    try {
-        const parsedValue = JSON.parse(storedValue);
-        if (!Array.isArray(parsedValue)) {
-            return [];
-        }
-
-        return parsedValue
-            .map(normalizeMobileQuickAction)
-            .filter(Boolean)
-            .slice(0, SB_MOBILE_QUICK_ACTION_LIMIT);
-    } catch {
-        return [];
-    }
+    return action;
 }
 
-function saveMobileQuickActions() {
-    safeSetItem(SB_STORAGE_KEYS.mobileQuickActions, JSON.stringify(sbState.mobileQuickActions));
-}
-
-function getMobileQuickActionKey(action) {
-    return [
-        action.shellKey,
-        action.tabId,
-        action.dedupeKey,
-    ].filter(Boolean).join('::');
-}
-
-function createMobileQuickActionFromMatch(match) {
-    const normalizedMatch = normalizeMobileQuickAction({
-        shellKey: match?.shellKey,
-        tabId: match?.tabId,
-        sectionLabel: match?.sectionLabel,
-        displayText: match?.displayText,
-        dedupeKey: match?.dedupeKey,
-        label: match?.displayText || match?.sectionLabel,
-    });
-
-    return normalizedMatch;
-}
-
-function setMobileQuickActions(actions, { persist = true } = {}) {
+function normalizeMobileQuickActionList(actions) {
     const seen = new Set();
     const nextActions = [];
+
+    if (!Array.isArray(actions)) {
+        return nextActions;
+    }
 
     for (const action of actions) {
         const normalizedAction = normalizeMobileQuickAction(action);
@@ -942,13 +926,88 @@ function setMobileQuickActions(actions, { persist = true } = {}) {
         }
     }
 
-    sbState.mobileQuickActions = nextActions;
+    return nextActions;
+}
+
+function getDefaultMobileQuickActions() {
+    return normalizeMobileQuickActionList(SB_MOBILE_DEFAULT_QUICK_ACTIONS);
+}
+
+function parseMobileQuickActionStorage(storedValue) {
+    if (storedValue === null) {
+        return null;
+    }
+
+    try {
+        const parsedValue = JSON.parse(storedValue);
+        if (!Array.isArray(parsedValue)) {
+            return null;
+        }
+
+        return normalizeMobileQuickActionList(parsedValue);
+    } catch {
+        return null;
+    }
+}
+
+function loadMobileQuickActions() {
+    const storedActions = parseMobileQuickActionStorage(safeGetItem(SB_STORAGE_KEYS.mobileQuickActions));
+    if (storedActions) {
+        return storedActions;
+    }
+
+    const defaultActions = getDefaultMobileQuickActions();
+    const legacyActions = parseMobileQuickActionStorage(safeGetItem(SB_STORAGE_KEYS.mobileQuickActionsLegacy));
+    const nextActions = legacyActions
+        ? normalizeMobileQuickActionList([...defaultActions, ...legacyActions])
+        : defaultActions;
+
+    safeSetItem(SB_STORAGE_KEYS.mobileQuickActions, JSON.stringify(nextActions));
+    return nextActions;
+}
+
+function saveMobileQuickActions() {
+    safeSetItem(SB_STORAGE_KEYS.mobileQuickActions, JSON.stringify(sbState.mobileQuickActions));
+}
+
+function getMobileQuickActionKey(action) {
+    const normalizedAction = normalizeMobileQuickAction(action);
+    if (!normalizedAction) {
+        return '';
+    }
+
+    return [
+        normalizedAction.type,
+        normalizedAction.shellKey,
+        normalizedAction.tabId,
+        normalizedAction.dedupeKey,
+    ].filter(Boolean).join('::');
+}
+
+function createMobileQuickActionFromMatch(match) {
+    const normalizedMatch = normalizeMobileQuickAction({
+        type: 'custom',
+        shellKey: match?.shellKey,
+        tabId: match?.tabId,
+        icon: 'fa-bolt',
+        sectionLabel: match?.sectionLabel,
+        displayText: match?.displayText,
+        dedupeKey: match?.dedupeKey,
+        label: match?.displayText || match?.sectionLabel,
+    });
+
+    return normalizedMatch;
+}
+
+function setMobileQuickActions(actions, { persist = true } = {}) {
+    sbState.mobileQuickActions = normalizeMobileQuickActionList(actions);
 
     if (persist) {
         saveMobileQuickActions();
     }
 
     renderMobileQuickActionSettingsList();
+    refreshMobileQuickActionSearchResults();
     refreshMobileNavQuickActions();
 }
 
@@ -973,6 +1032,10 @@ function addMobileQuickActionFromMatch(match) {
 
 function removeMobileQuickAction(actionKey) {
     setMobileQuickActions(sbState.mobileQuickActions.filter(action => getMobileQuickActionKey(action) !== actionKey));
+}
+
+function resetMobileQuickActions() {
+    setMobileQuickActions(getDefaultMobileQuickActions());
 }
 
 function normalizeTopbarScale(value) {
@@ -2066,14 +2129,31 @@ function ensureShellReady(shellKey) {
     return Boolean(getShellState(shellKey));
 }
 
+function syncExistingMobileNavQuickActions(overlay) {
+    if (!(overlay instanceof HTMLElement)) {
+        return;
+    }
+
+    overlay.querySelectorAll('.sb-mobile-section-title').forEach(heading => heading.remove());
+
+    const list = overlay.querySelector('.sb-mobile-section-list');
+    if (list instanceof HTMLElement) {
+        sbState.mobileNav.quickActionContainer = list;
+        refreshMobileNavQuickActions();
+    }
+}
+
 function ensureMobileNavReady() {
     const existingOverlay = document.getElementById('sb-mobile-nav');
     if (existingOverlay instanceof HTMLElement) {
+        syncExistingMobileNavQuickActions(existingOverlay);
         return existingOverlay;
     }
 
     buildMobileNav();
-    return document.getElementById('sb-mobile-nav');
+    const overlay = document.getElementById('sb-mobile-nav');
+    syncExistingMobileNavQuickActions(overlay);
+    return overlay;
 }
 
 function getThemeOption(themeId) {
@@ -9265,9 +9345,48 @@ function createShortcutSettingsGroup() {
 }
 
 function getMobileQuickActionContextLabel(action) {
-    const shellLabel = getShellConfig(action.shellKey)?.title || action.shellKey;
-    const tabLabel = getShellState(action.shellKey)?.tabs.get(action.tabId)?.label || action.tabId;
-    return `${shellLabel} · ${tabLabel}`;
+    const normalizedAction = normalizeMobileQuickAction(action);
+    if (!normalizedAction) {
+        return '';
+    }
+
+    const shellLabel = getShellConfig(normalizedAction.shellKey)?.title || normalizedAction.shellKey;
+    const tabLabel = getShellState(normalizedAction.shellKey)?.tabs?.get(normalizedAction.tabId)?.label
+        || getMobileQuickActionTabConfig(normalizedAction.shellKey, normalizedAction.tabId)?.label
+        || normalizedAction.tabId;
+    const labels = [shellLabel, tabLabel];
+
+    if (normalizedAction.type === 'custom'
+        && normalizedAction.sectionLabel
+        && normalizeText(normalizedAction.sectionLabel) !== normalizeText(tabLabel)) {
+        labels.push(normalizedAction.sectionLabel);
+    }
+
+    return labels.join(' · ');
+}
+
+function updateMobileQuickActionSettingsStatus() {
+    const status = document.getElementById('sb-mobile-quick-action-status');
+    if (status instanceof HTMLElement) {
+        status.textContent = `${sbState.mobileQuickActions.length}/${SB_MOBILE_QUICK_ACTION_LIMIT} selected. This list replaces the Workspace drawer shortcuts.`;
+    }
+
+    const resetButton = document.getElementById('sb-mobile-quick-action-reset');
+    if (resetButton instanceof HTMLButtonElement) {
+        const currentKeys = sbState.mobileQuickActions.map(getMobileQuickActionKey);
+        const defaultKeys = getDefaultMobileQuickActions().map(getMobileQuickActionKey);
+        resetButton.disabled = currentKeys.length === defaultKeys.length
+            && currentKeys.every((key, index) => key === defaultKeys[index]);
+    }
+}
+
+function refreshMobileQuickActionSearchResults() {
+    const searchInput = document.getElementById('sb-mobile-quick-action-search');
+    const results = document.getElementById('sb-mobile-quick-action-results');
+
+    if (searchInput instanceof HTMLInputElement && results instanceof HTMLElement) {
+        renderMobileQuickActionResults(searchInput.value, results);
+    }
 }
 
 function renderMobileQuickActionResults(query, resultsElement) {
@@ -9305,6 +9424,7 @@ function renderMobileQuickActionResults(query, resultsElement) {
         const actionKey = getMobileQuickActionKey(action);
         const isAdded = currentKeys.has(actionKey);
         const isFull = sbState.mobileQuickActions.length >= SB_MOBILE_QUICK_ACTION_LIMIT;
+        const buttonText = isAdded ? 'Added' : isFull ? 'Full' : 'Add';
         const row = createElement('div', { className: 'sb-mobile-quick-action-result' });
         const copy = createElement('span', { className: 'sb-mobile-quick-action-copy' });
         const title = createElement('strong', { text: action.label });
@@ -9313,19 +9433,17 @@ function renderMobileQuickActionResults(query, resultsElement) {
         });
         const button = createElement('button', {
             className: 'menu_button sb-mobile-quick-action-add',
-            text: isAdded ? 'Added' : 'Add',
+            text: buttonText,
             attrs: {
                 type: 'button',
-                'aria-label': `Add ${action.label} to mobile Quick Actions`,
+                'aria-label': isAdded
+                    ? `${action.label} is already in mobile Quick Actions`
+                    : `Add ${action.label} to mobile Quick Actions`,
             },
         });
 
         button.disabled = isAdded || isFull;
-        button.addEventListener('click', () => {
-            if (addMobileQuickActionFromMatch(match)) {
-                renderMobileQuickActionResults(trimmedQuery, resultsElement);
-            }
-        });
+        button.addEventListener('click', () => addMobileQuickActionFromMatch(match));
 
         copy.append(title, detail);
         row.append(copy, button);
@@ -9334,6 +9452,8 @@ function renderMobileQuickActionResults(query, resultsElement) {
 }
 
 function renderMobileQuickActionSettingsList() {
+    updateMobileQuickActionSettingsStatus();
+
     const list = document.getElementById('sb-mobile-quick-action-list');
     if (!(list instanceof HTMLElement)) {
         return;
@@ -9344,7 +9464,7 @@ function renderMobileQuickActionSettingsList() {
     if (!sbState.mobileQuickActions.length) {
         list.appendChild(createElement('div', {
             className: 'sb-mobile-quick-action-empty',
-            text: 'No custom mobile Quick Actions yet.',
+            text: 'No mobile Quick Actions selected. Add one from search or reset to defaults.',
         }));
         return;
     }
@@ -9376,8 +9496,21 @@ function createMobileQuickActionSettingsGroup() {
     const group = createElement('section', {
         className: 'sb-theme-slider-group sb-mobile-quick-actions-group',
     });
-    const heading = createElement('div', { className: 'sb-theme-slider-label' });
-    heading.innerHTML = '<strong>Mobile Quick Actions</strong><br><small>Add shortcuts to any searchable setting or extension in the mobile Workspace panel.</small>';
+    const header = createElement('div', { className: 'sb-mobile-quick-action-header' });
+    const heading = createElement('div', { className: 'sb-mobile-quick-action-heading' });
+    const title = createElement('strong', { text: 'Mobile Quick Actions' });
+    const description = createElement('p', {
+        className: 'sb-theme-slider-caption',
+        text: 'Choose the shortcuts shown in the mobile Workspace drawer. Defaults can be removed or restored.',
+    });
+    const resetButton = createElement('button', {
+        id: 'sb-mobile-quick-action-reset',
+        className: 'menu_button sb-mobile-quick-action-reset',
+        text: 'Reset to defaults',
+        attrs: {
+            type: 'button',
+        },
+    });
 
     const searchInput = createElement('input', {
         id: 'sb-mobile-quick-action-search',
@@ -9398,16 +9531,21 @@ function createMobileQuickActionSettingsGroup() {
         className: 'sb-mobile-quick-action-list',
     });
     const status = createElement('p', {
+        id: 'sb-mobile-quick-action-status',
         className: 'sb-theme-slider-caption',
-        text: `Custom actions appear after the default Quick Actions. Limit ${SB_MOBILE_QUICK_ACTION_LIMIT}.`,
     });
+
+    heading.append(title, description);
+    header.append(heading, resetButton);
+
+    resetButton.addEventListener('click', resetMobileQuickActions);
 
     searchInput.addEventListener('input', event => {
         const input = event.currentTarget;
         renderMobileQuickActionResults(input instanceof HTMLInputElement ? input.value : '', results);
     });
 
-    group.append(heading, searchInput, results, list, status);
+    group.append(header, searchInput, results, list, status);
     renderMobileQuickActionResults('', results);
 
     window.requestAnimationFrame(renderMobileQuickActionSettingsList);
@@ -10870,6 +11008,11 @@ function bindWorldInfoRoute() {
 }
 
 function createMobileQuickActionButton(item) {
+    const action = normalizeMobileQuickAction(item);
+    if (!action) {
+        return null;
+    }
+
     const button = createElement('button', {
         className: 'sb-nav-item',
         attrs: {
@@ -10877,27 +11020,21 @@ function createMobileQuickActionButton(item) {
         },
     });
     const icon = createElement('i', {
-        className: `fa-solid ${item.icon || 'fa-bolt'}`,
+        className: `fa-solid ${action.icon || 'fa-bolt'}`,
         attrs: {
             'aria-hidden': 'true',
         },
     });
-    const label = createElement('span', { text: item.label });
+    const label = createElement('span', { text: action.label });
 
     button.append(icon, label);
     button.addEventListener('click', () => {
         closeMobileNav();
 
-        if (item.action === 'custom') {
-            activateMobileQuickAction(item);
-        } else if (item.action === 'home') {
-            void returnToLandingPage();
-        } else if (item.action === 'chat-tools') {
-            openMobileChatTools();
-        } else if (item.action === 'characters') {
-            toggleCharacterPanel();
+        if (action.type === 'custom') {
+            activateMobileQuickAction(action);
         } else {
-            toggleShellPanel(item.shell, item.tab);
+            toggleShellPanel(action.shellKey, action.tabId);
         }
     });
 
@@ -10914,16 +11051,11 @@ function refreshMobileNavQuickActions() {
     sbState.mobileNav.quickActionContainer = list;
     list.replaceChildren();
 
-    for (const item of SB_MOBILE_DEFAULT_QUICK_ACTIONS) {
-        list.appendChild(createMobileQuickActionButton(item));
-    }
-
     for (const action of sbState.mobileQuickActions) {
-        list.appendChild(createMobileQuickActionButton({
-            ...action,
-            action: 'custom',
-            icon: 'fa-bolt',
-        }));
+        const button = createMobileQuickActionButton(action);
+        if (button) {
+            list.appendChild(button);
+        }
     }
 }
 

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -19,6 +19,7 @@ const SB_STORAGE_KEYS = Object.freeze({
     bottomBarScale: 'sb-bottom-bar-scale',
     bottomChatSecondaryOpen: 'sb-bottom-chat-secondary-open',
     mobileButtonScale: 'sb-mobile-button-scale',
+    mobileQuickActions: 'sb-mobile-quick-actions',
     settingsDrawerAutoClose: 'sb-settings-drawer-auto-close',
     compactMode: 'sb-compact-mode',
     frontendIcon: 'sb-frontend-icon',
@@ -530,6 +531,16 @@ const SB_UNIVERSAL_SEARCH_IDLE_TITLE = 'Search all settings';
 const SB_UNIVERSAL_SEARCH_IDLE_HINT = 'Jump to any workspace or customization control from one place.';
 const SB_UNIVERSAL_SEARCH_EMPTY_HINT = 'Could not find query. Try a broader term or a different setting name.';
 const SB_UNIVERSAL_SEARCH_RESULT_LIMIT = 10;
+const SB_MOBILE_QUICK_ACTION_LIMIT = 12;
+const SB_MOBILE_QUICK_ACTION_LABEL_MAX_LENGTH = 36;
+const SB_MOBILE_DEFAULT_QUICK_ACTIONS = Object.freeze([
+    { shell: 'left', tab: 'presets', icon: 'fa-sliders', label: 'Presets' },
+    { shell: 'left', tab: 'api', icon: 'fa-plug', label: 'API' },
+    { shell: 'left', tab: 'sampling', icon: 'fa-wave-square', label: 'Sampling' },
+    { shell: 'left', tab: 'advanced-formatting', icon: 'fa-text-height', label: 'Formatting' },
+    { shell: 'left', tab: 'world-info', icon: 'fa-book-atlas', label: 'World Info' },
+    { shell: 'left', tab: 'agents', icon: 'fa-robot', label: 'Agents' },
+]);
 
 const sbState = {
     initialized: false,
@@ -594,7 +605,9 @@ const sbState = {
     },
     mobileNav: {
         lastOpenedAt: 0,
+        quickActionContainer: null,
     },
+    mobileQuickActions: [],
     chatbar: {
         desktop: null,
         sidebar: null,
@@ -828,6 +841,140 @@ function normalizeTopbarOffset(value) {
     };
 }
 
+function normalizeMobileQuickAction(value) {
+    if (!value || typeof value !== 'object') {
+        return null;
+    }
+
+    const shellKey = normalizeText(value.shellKey);
+    const tabId = normalizeText(value.tabId);
+    const shellConfig = getShellConfig(shellKey);
+
+    if (!shellConfig || !tabId) {
+        return null;
+    }
+
+    const displayText = clampText(value.displayText, 80);
+    const sectionLabel = clampText(value.sectionLabel, 80);
+    const label = clampText(value.label || displayText || sectionLabel, SB_MOBILE_QUICK_ACTION_LABEL_MAX_LENGTH);
+    const dedupeKey = clampText(value.dedupeKey, 160);
+
+    if (!label || !dedupeKey) {
+        return null;
+    }
+
+    return {
+        shellKey,
+        tabId,
+        sectionLabel,
+        displayText,
+        dedupeKey,
+        label,
+    };
+}
+
+function loadMobileQuickActions() {
+    const storedValue = safeGetItem(SB_STORAGE_KEYS.mobileQuickActions);
+    if (!storedValue) {
+        return [];
+    }
+
+    try {
+        const parsedValue = JSON.parse(storedValue);
+        if (!Array.isArray(parsedValue)) {
+            return [];
+        }
+
+        return parsedValue
+            .map(normalizeMobileQuickAction)
+            .filter(Boolean)
+            .slice(0, SB_MOBILE_QUICK_ACTION_LIMIT);
+    } catch {
+        return [];
+    }
+}
+
+function saveMobileQuickActions() {
+    safeSetItem(SB_STORAGE_KEYS.mobileQuickActions, JSON.stringify(sbState.mobileQuickActions));
+}
+
+function getMobileQuickActionKey(action) {
+    return [
+        action.shellKey,
+        action.tabId,
+        action.dedupeKey,
+    ].filter(Boolean).join('::');
+}
+
+function createMobileQuickActionFromMatch(match) {
+    const normalizedMatch = normalizeMobileQuickAction({
+        shellKey: match?.shellKey,
+        tabId: match?.tabId,
+        sectionLabel: match?.sectionLabel,
+        displayText: match?.displayText,
+        dedupeKey: match?.dedupeKey,
+        label: match?.displayText || match?.sectionLabel,
+    });
+
+    return normalizedMatch;
+}
+
+function setMobileQuickActions(actions, { persist = true } = {}) {
+    const seen = new Set();
+    const nextActions = [];
+
+    for (const action of actions) {
+        const normalizedAction = normalizeMobileQuickAction(action);
+        if (!normalizedAction) {
+            continue;
+        }
+
+        const key = getMobileQuickActionKey(normalizedAction);
+        if (seen.has(key)) {
+            continue;
+        }
+
+        seen.add(key);
+        nextActions.push(normalizedAction);
+
+        if (nextActions.length >= SB_MOBILE_QUICK_ACTION_LIMIT) {
+            break;
+        }
+    }
+
+    sbState.mobileQuickActions = nextActions;
+
+    if (persist) {
+        saveMobileQuickActions();
+    }
+
+    renderMobileQuickActionSettingsList();
+    refreshMobileNavQuickActions();
+}
+
+function addMobileQuickActionFromMatch(match) {
+    const action = createMobileQuickActionFromMatch(match);
+    if (!action) {
+        return false;
+    }
+
+    if (sbState.mobileQuickActions.length >= SB_MOBILE_QUICK_ACTION_LIMIT) {
+        return false;
+    }
+
+    const actionKey = getMobileQuickActionKey(action);
+    if (sbState.mobileQuickActions.some(existingAction => getMobileQuickActionKey(existingAction) === actionKey)) {
+        return false;
+    }
+
+    setMobileQuickActions([...sbState.mobileQuickActions, action]);
+    return true;
+}
+
+function removeMobileQuickAction(actionKey) {
+    setMobileQuickActions(sbState.mobileQuickActions.filter(action => getMobileQuickActionKey(action) !== actionKey));
+}
+
 function normalizeTopbarScale(value) {
     const numericValue = Number(value);
 
@@ -877,6 +1024,7 @@ function restorePersistedTopbarState() {
     sbState.chatbar.visible = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.chatbarVisible), sbState.chatbar.visible);
     sbState.chatbar.topbarOffset = normalizeTopbarOffset(safeGetItem(SB_STORAGE_KEYS.topbarOffset));
     sbState.compactMode = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.compactMode), sbState.compactMode);
+    sbState.mobileQuickActions = loadMobileQuickActions();
     sbState.characterDrawer.rightLocked = normalizeStoredBoolean(
         getPersistentStorageItem(SB_STORAGE_KEYS.characterDrawerRightLocked),
         sbState.characterDrawer.rightLocked,
@@ -9116,6 +9264,156 @@ function createShortcutSettingsGroup() {
     return group;
 }
 
+function getMobileQuickActionContextLabel(action) {
+    const shellLabel = getShellConfig(action.shellKey)?.title || action.shellKey;
+    const tabLabel = getShellState(action.shellKey)?.tabs.get(action.tabId)?.label || action.tabId;
+    return `${shellLabel} · ${tabLabel}`;
+}
+
+function renderMobileQuickActionResults(query, resultsElement) {
+    if (!(resultsElement instanceof HTMLElement)) {
+        return;
+    }
+
+    resultsElement.replaceChildren();
+
+    const trimmedQuery = String(query ?? '').trim();
+    if (trimmedQuery.length < 2) {
+        resultsElement.appendChild(createElement('div', {
+            className: 'sb-mobile-quick-action-empty',
+            text: 'Type at least 2 characters to find settings and extensions.',
+        }));
+        return;
+    }
+
+    const matches = getMobileQuickActionSearchMatches(trimmedQuery);
+    if (!matches.length) {
+        resultsElement.appendChild(createElement('div', {
+            className: 'sb-mobile-quick-action-empty',
+            text: `No matches for "${trimmedQuery}" yet.`,
+        }));
+        return;
+    }
+
+    const currentKeys = new Set(sbState.mobileQuickActions.map(getMobileQuickActionKey));
+    for (const match of matches) {
+        const action = createMobileQuickActionFromMatch(match);
+        if (!action) {
+            continue;
+        }
+
+        const actionKey = getMobileQuickActionKey(action);
+        const isAdded = currentKeys.has(actionKey);
+        const isFull = sbState.mobileQuickActions.length >= SB_MOBILE_QUICK_ACTION_LIMIT;
+        const row = createElement('div', { className: 'sb-mobile-quick-action-result' });
+        const copy = createElement('span', { className: 'sb-mobile-quick-action-copy' });
+        const title = createElement('strong', { text: action.label });
+        const detail = createElement('small', {
+            text: `${match.shellLabel} · ${match.tabLabel}${action.sectionLabel ? ` · ${action.sectionLabel}` : ''}`,
+        });
+        const button = createElement('button', {
+            className: 'menu_button sb-mobile-quick-action-add',
+            text: isAdded ? 'Added' : 'Add',
+            attrs: {
+                type: 'button',
+                'aria-label': `Add ${action.label} to mobile Quick Actions`,
+            },
+        });
+
+        button.disabled = isAdded || isFull;
+        button.addEventListener('click', () => {
+            if (addMobileQuickActionFromMatch(match)) {
+                renderMobileQuickActionResults(trimmedQuery, resultsElement);
+            }
+        });
+
+        copy.append(title, detail);
+        row.append(copy, button);
+        resultsElement.appendChild(row);
+    }
+}
+
+function renderMobileQuickActionSettingsList() {
+    const list = document.getElementById('sb-mobile-quick-action-list');
+    if (!(list instanceof HTMLElement)) {
+        return;
+    }
+
+    list.replaceChildren();
+
+    if (!sbState.mobileQuickActions.length) {
+        list.appendChild(createElement('div', {
+            className: 'sb-mobile-quick-action-empty',
+            text: 'No custom mobile Quick Actions yet.',
+        }));
+        return;
+    }
+
+    for (const action of sbState.mobileQuickActions) {
+        const actionKey = getMobileQuickActionKey(action);
+        const row = createElement('div', { className: 'sb-mobile-quick-action-current' });
+        const copy = createElement('span', { className: 'sb-mobile-quick-action-copy' });
+        const title = createElement('strong', { text: action.label });
+        const detail = createElement('small', { text: getMobileQuickActionContextLabel(action) });
+        const removeButton = createElement('button', {
+            className: 'menu_button sb-mobile-quick-action-remove',
+            text: 'Remove',
+            attrs: {
+                type: 'button',
+                'aria-label': `Remove ${action.label} from mobile Quick Actions`,
+            },
+        });
+
+        removeButton.addEventListener('click', () => removeMobileQuickAction(actionKey));
+
+        copy.append(title, detail);
+        row.append(copy, removeButton);
+        list.appendChild(row);
+    }
+}
+
+function createMobileQuickActionSettingsGroup() {
+    const group = createElement('section', {
+        className: 'sb-theme-slider-group sb-mobile-quick-actions-group',
+    });
+    const heading = createElement('div', { className: 'sb-theme-slider-label' });
+    heading.innerHTML = '<strong>Mobile Quick Actions</strong><br><small>Add shortcuts to any searchable setting or extension in the mobile Workspace panel.</small>';
+
+    const searchInput = createElement('input', {
+        id: 'sb-mobile-quick-action-search',
+        className: 'text_pole sb-mobile-quick-action-search',
+        attrs: {
+            type: 'search',
+            placeholder: 'Search settings or extensions...',
+            autocomplete: 'off',
+            'aria-label': 'Search settings and extensions to add as mobile Quick Actions',
+        },
+    });
+    const results = createElement('div', {
+        id: 'sb-mobile-quick-action-results',
+        className: 'sb-mobile-quick-action-results',
+    });
+    const list = createElement('div', {
+        id: 'sb-mobile-quick-action-list',
+        className: 'sb-mobile-quick-action-list',
+    });
+    const status = createElement('p', {
+        className: 'sb-theme-slider-caption',
+        text: `Custom actions appear after the default Quick Actions. Limit ${SB_MOBILE_QUICK_ACTION_LIMIT}.`,
+    });
+
+    searchInput.addEventListener('input', event => {
+        const input = event.currentTarget;
+        renderMobileQuickActionResults(input instanceof HTMLInputElement ? input.value : '', results);
+    });
+
+    group.append(heading, searchInput, results, list, status);
+    renderMobileQuickActionResults('', results);
+
+    window.requestAnimationFrame(renderMobileQuickActionSettingsList);
+    return group;
+}
+
 function createCompactModeSettingsGroup() {
     const group = createElement('section', {
         className: 'sb-theme-slider-group sb-compact-mode-group',
@@ -9352,6 +9650,7 @@ function injectThemePicker() {
     const compactModeSettingsGroup = createCompactModeSettingsGroup();
     const frontendIconSettingsGroup = createFrontendIconSettingsGroup();
     const shortcutSettingsGroup = createShortcutSettingsGroup();
+    const mobileQuickActionSettingsGroup = createMobileQuickActionSettingsGroup();
     header.append(title, description);
 
     for (const theme of SB_THEMES) {
@@ -9375,7 +9674,7 @@ function injectThemePicker() {
     getMessageStyleSelect()?.addEventListener('change', updateThemePickerUi);
     document.addEventListener('sb:chat-style-updated', updateThemePickerUi);
 
-    card.append(header, optionRow, frontendIconSettingsGroup, surfaceSliderGroup, bottomBarSliderGroup, mobileButtonSliderGroup, compactModeSettingsGroup, topbarLabelSettingsGroup, shortcutSettingsGroup);
+    card.append(header, optionRow, frontendIconSettingsGroup, surfaceSliderGroup, bottomBarSliderGroup, mobileButtonSliderGroup, compactModeSettingsGroup, topbarLabelSettingsGroup, shortcutSettingsGroup, mobileQuickActionSettingsGroup);
     themeBlock.prepend(card);
     updateThemePickerUi();
 }
@@ -9472,7 +9771,7 @@ function updateThemePickerUi() {
     }
 }
 
-function createSearchIndex(tabState) {
+function createSearchIndex(tabState, { includeThemeCard = false } = {}) {
     const searchRoot = tabState.searchRoot;
     if (!(searchRoot instanceof HTMLElement)) {
         return [];
@@ -9480,13 +9779,16 @@ function createSearchIndex(tabState) {
 
     const entries = [];
     const seen = new Set();
+    const excludedSelector = includeThemeCard
+        ? '.sb-search-result, .sb-legacy-search-hidden, .sb-mobile-quick-actions-group'
+        : '.sb-search-result, .sb-theme-card, .sb-legacy-search-hidden';
 
     for (const element of searchRoot.querySelectorAll(SB_SEARCH_TARGET_SELECTOR)) {
         if (!(element instanceof HTMLElement)) {
             continue;
         }
 
-        if (element.closest('.sb-search-result, .sb-theme-card, .sb-legacy-search-hidden')) {
+        if (element.closest(excludedSelector)) {
             continue;
         }
 
@@ -9656,6 +9958,102 @@ function collectGlobalSearchMatches(query) {
     return Array.from(matches.values())
         .sort((left, right) => right.score - left.score)
         .slice(0, SB_UNIVERSAL_SEARCH_RESULT_LIMIT);
+}
+
+function getTabSearchEntries(tabState, { includeThemeCard = false } = {}) {
+    const searchIndex = includeThemeCard ? createSearchIndex(tabState, { includeThemeCard }) : tabState.searchIndex;
+
+    if (!searchIndex) {
+        tabState.searchIndex = createSearchIndex(tabState);
+    }
+
+    return [
+        ...(searchIndex || tabState.searchIndex),
+        ...(tabState.id === 'persona' ? getPersonaSearchEntries(tabState) : []),
+    ];
+}
+
+function getMobileQuickActionSearchMatches(query) {
+    const normalizedQuery = normalizeText(query);
+
+    if (normalizedQuery.length < 2) {
+        return [];
+    }
+
+    const searchTerms = normalizedQuery.split(' ').filter(Boolean);
+    const matches = new Map();
+
+    for (const [shellKey, shellState] of Object.entries(sbState.shells)) {
+        const shellLabel = getShellConfig(shellKey)?.title || shellKey;
+
+        for (const tabState of shellState.tabs.values()) {
+            for (const entry of getTabSearchEntries(tabState, { includeThemeCard: true })) {
+                if (!searchTerms.every(term => entry.searchText.includes(term))) {
+                    continue;
+                }
+
+                const match = {
+                    ...entry,
+                    shellKey,
+                    shellLabel,
+                    score: Number(entry.searchText.startsWith(normalizedQuery)) * 10 - entry.displayText.length / 1000,
+                };
+                const matchKey = [
+                    shellKey,
+                    entry.dedupeKey,
+                ].filter(Boolean).join('::');
+                const existingMatch = matches.get(matchKey);
+
+                if (!existingMatch || match.score > existingMatch.score) {
+                    matches.set(matchKey, match);
+                }
+            }
+        }
+    }
+
+    return Array.from(matches.values())
+        .sort((left, right) => right.score - left.score)
+        .slice(0, SB_UNIVERSAL_SEARCH_RESULT_LIMIT);
+}
+
+function findMobileQuickActionMatch(action) {
+    const normalizedAction = normalizeMobileQuickAction(action);
+    if (!normalizedAction) {
+        return null;
+    }
+
+    const shellState = getShellState(normalizedAction.shellKey);
+    const tabState = shellState?.tabs.get(normalizedAction.tabId);
+    if (!tabState) {
+        return null;
+    }
+
+    const entries = getTabSearchEntries(tabState, { includeThemeCard: true });
+    const exactMatch = entries.find(entry => entry.dedupeKey === normalizedAction.dedupeKey);
+    const fallbackMatch = exactMatch || entries.find(entry => (
+        normalizeText(entry.sectionLabel) === normalizeText(normalizedAction.sectionLabel)
+        && normalizeText(entry.displayText) === normalizeText(normalizedAction.displayText)
+    ));
+
+    if (!fallbackMatch) {
+        return null;
+    }
+
+    return {
+        ...fallbackMatch,
+        shellKey: normalizedAction.shellKey,
+        shellLabel: getShellConfig(normalizedAction.shellKey)?.title || normalizedAction.shellKey,
+    };
+}
+
+function activateMobileQuickAction(action) {
+    const match = findMobileQuickActionMatch(action);
+    if (!match) {
+        openShell(action.shellKey, action.tabId);
+        return;
+    }
+
+    revealSearchMatch(action.shellKey, match);
 }
 
 function renderUniversalSearchResults(query) {
@@ -10471,6 +10869,64 @@ function bindWorldInfoRoute() {
     });
 }
 
+function createMobileQuickActionButton(item) {
+    const button = createElement('button', {
+        className: 'sb-nav-item',
+        attrs: {
+            type: 'button',
+        },
+    });
+    const icon = createElement('i', {
+        className: `fa-solid ${item.icon || 'fa-bolt'}`,
+        attrs: {
+            'aria-hidden': 'true',
+        },
+    });
+    const label = createElement('span', { text: item.label });
+
+    button.append(icon, label);
+    button.addEventListener('click', () => {
+        closeMobileNav();
+
+        if (item.action === 'custom') {
+            activateMobileQuickAction(item);
+        } else if (item.action === 'home') {
+            void returnToLandingPage();
+        } else if (item.action === 'chat-tools') {
+            openMobileChatTools();
+        } else if (item.action === 'characters') {
+            toggleCharacterPanel();
+        } else {
+            toggleShellPanel(item.shell, item.tab);
+        }
+    });
+
+    return button;
+}
+
+function refreshMobileNavQuickActions() {
+    const list = sbState.mobileNav.quickActionContainer
+        ?? document.querySelector('#sb-mobile-nav .sb-mobile-section-list');
+    if (!(list instanceof HTMLElement)) {
+        return;
+    }
+
+    sbState.mobileNav.quickActionContainer = list;
+    list.replaceChildren();
+
+    for (const item of SB_MOBILE_DEFAULT_QUICK_ACTIONS) {
+        list.appendChild(createMobileQuickActionButton(item));
+    }
+
+    for (const action of sbState.mobileQuickActions) {
+        list.appendChild(createMobileQuickActionButton({
+            ...action,
+            action: 'custom',
+            icon: 'fa-bolt',
+        }));
+    }
+}
+
 function buildMobileNav() {
     if (document.getElementById('sb-mobile-nav')) {
         return;
@@ -10492,55 +10948,12 @@ function buildMobileNav() {
         overlay.inert = true;
     }
 
-    const sections = [
-        {
-            label: 'Quick Actions',
-            items: [
-                { shell: 'left', tab: 'presets', icon: 'fa-sliders', label: 'Presets' },
-                { shell: 'left', tab: 'api', icon: 'fa-plug', label: 'API' },
-                { shell: 'left', tab: 'sampling', icon: 'fa-wave-square', label: 'Sampling' },
-                { shell: 'left', tab: 'advanced-formatting', icon: 'fa-text-height', label: 'Formatting' },
-                { shell: 'left', tab: 'world-info', icon: 'fa-book-atlas', label: 'World Info' },
-                { shell: 'left', tab: 'agents', icon: 'fa-robot', label: 'Agents' },
-            ],
-        },
-    ];
-
-    for (const section of sections) {
-        const sectionBlock = createElement('section', { className: 'sb-mobile-section' });
-        const heading = createElement('strong', { className: 'sb-mobile-section-title', text: section.label });
-        const list = createElement('div', { className: 'sb-mobile-section-list' });
-
-        for (const item of section.items) {
-            const button = createElement('button', {
-                className: 'sb-nav-item',
-                attrs: {
-                    type: 'button',
-                },
-            });
-
-            button.innerHTML = `<i class="fa-solid ${item.icon}" aria-hidden="true"></i><span>${item.label}</span>`;
-
-            button.addEventListener('click', () => {
-                closeMobileNav();
-
-                if (item.action === 'home') {
-                    void returnToLandingPage();
-                } else if (item.action === 'chat-tools') {
-                    openMobileChatTools();
-                } else if (item.action === 'characters') {
-                    toggleCharacterPanel();
-                } else {
-                    toggleShellPanel(item.shell, item.tab);
-                }
-            });
-
-            list.appendChild(button);
-        }
-
-        sectionBlock.append(heading, list);
-        content.appendChild(sectionBlock);
-    }
+    const sectionBlock = createElement('section', { className: 'sb-mobile-section' });
+    const list = createElement('div', { className: 'sb-mobile-section-list' });
+    sectionBlock.appendChild(list);
+    content.appendChild(sectionBlock);
+    sbState.mobileNav.quickActionContainer = list;
+    refreshMobileNavQuickActions();
 
     const header = createElement('div', { className: 'sb-mobile-panel-header' });
     const closeButton = createElement('button', {
@@ -10664,6 +11077,7 @@ function setMobileNavOpenState(isOpen) {
     queueMobileModalStateSync();
 
     if (shouldOpen) {
+        refreshMobileNavQuickActions();
         window.requestAnimationFrame(() => {
             overlay.querySelector('#sb-mobile-nav-title')?.focus?.({ preventScroll: true });
         });


### PR DESCRIPTION
## Summary
- Tighten the mobile composer by reducing the message input height, compressing internal row spacing, and removing the artificial bottom padding while preserving real safe-area insets.
- Remove the duplicate lower Quick Actions label from the mobile Workspace panel.
- Add a Customize > Settings control for adding custom mobile Quick Actions from searchable settings/extensions while keeping the default actions.

## Verification
- npm run lint
- npm run check:frontend-budgets
- npm run test:unit --prefix tests