### PR TITLE
fix(presets): add connection field guardrails

### DIFF
--- a/public/scripts/openai-preset-utils.js
+++ b/public/scripts/openai-preset-utils.js
@@ -33,3 +33,13 @@ export function getChatCompletionConnectionPresetKeys(settingsMap) {
         .filter(([, [, , , isConnection]]) => isConnection)
         .map(([presetKey]) => presetKey);
 }
+
+/**
+ * Returns whether OpenAI preset saves should include provider/model/API fields.
+ *
+ * @param {Record<string, any>} settings Live OpenAI settings
+ * @returns {boolean} True when linked preset mode is enabled
+ */
+export function shouldIncludeConnectionFieldsInPreset(settings) {
+    return Boolean(settings?.bind_preset_to_connection);
+}

--- a/public/scripts/openai-preset-utils.js
+++ b/public/scripts/openai-preset-utils.js
@@ -1,0 +1,35 @@
+/**
+ * Builds a Chat Completion preset body from live settings and the OpenAI settings map.
+ * The default preserves legacy behavior by including connection fields.
+ *
+ * @param {Record<string, any>} settings Live OpenAI settings
+ * @param {Record<string, [string, string, boolean, boolean]>} settingsMap OpenAI preset setting map
+ * @param {object} [options] Build options
+ * @param {boolean} [options.includeConnection=true] Whether to include provider/model/API fields
+ * @returns {Record<string, any>} Preset body
+ */
+export function buildChatCompletionPreset(settings, settingsMap, { includeConnection = true } = {}) {
+    const presetBody = {};
+
+    for (const [presetKey, [, settingsKey, , isConnection]] of Object.entries(settingsMap ?? {})) {
+        if (isConnection && !includeConnection) {
+            continue;
+        }
+
+        presetBody[presetKey] = settings?.[settingsKey];
+    }
+
+    return structuredClone(presetBody);
+}
+
+/**
+ * Lists preset keys that represent provider/model/API connection state.
+ *
+ * @param {Record<string, [string, string, boolean, boolean]>} settingsMap OpenAI preset setting map
+ * @returns {string[]} Preset keys that should be treated as connection fields
+ */
+export function getChatCompletionConnectionPresetKeys(settingsMap) {
+    return Object.entries(settingsMap ?? {})
+        .filter(([, [, , , isConnection]]) => isConnection)
+        .map(([presetKey]) => presetKey);
+}

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -83,6 +83,7 @@ import { COMETAPI_IGNORE_PATTERNS, IGNORE_SYMBOL, MEDIA_DISPLAY, MEDIA_TYPE } fr
 import { syncOpenRouterProvidersForModel, updateOpenRouterProvidersWarning } from './textgen-models.js';
 import { hasTextOrArrayPayload, shouldRetainContextAtDepth, stripHtmlTagsFromContext, stripOocBlocksFromContext } from './ooc-blocks.js';
 import { checkPostInterceptChatBudget } from './openai-prompt-budget.js';
+import { buildChatCompletionPreset } from './openai-preset-utils.js';
 
 export {
     openai_messages_count,
@@ -6235,11 +6236,7 @@ async function getStatusOpen() {
  * @returns {Object} The preset body object
  */
 export function getChatCompletionPreset(settings = oai_settings) {
-    const presetBody = {};
-    for (const [presetKey, [, settingsKey]] of Object.entries(settingsToUpdate)) {
-        presetBody[presetKey] = settings[settingsKey];
-    }
-    return structuredClone(presetBody);
+    return buildChatCompletionPreset(settings, settingsToUpdate);
 }
 
 function normalizeLogitBiasEntry(entry) {

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -83,7 +83,7 @@ import { COMETAPI_IGNORE_PATTERNS, IGNORE_SYMBOL, MEDIA_DISPLAY, MEDIA_TYPE } fr
 import { syncOpenRouterProvidersForModel, updateOpenRouterProvidersWarning } from './textgen-models.js';
 import { hasTextOrArrayPayload, shouldRetainContextAtDepth, stripHtmlTagsFromContext, stripOocBlocksFromContext } from './ooc-blocks.js';
 import { checkPostInterceptChatBudget } from './openai-prompt-budget.js';
-import { buildChatCompletionPreset } from './openai-preset-utils.js';
+import { buildChatCompletionPreset, shouldIncludeConnectionFieldsInPreset } from './openai-preset-utils.js';
 
 export {
     openai_messages_count,
@@ -6324,7 +6324,9 @@ function refreshLogitBiasPresetOptions() {
  * @returns {Promise<void>}
  */
 async function saveOpenAIPreset(name, settings, triggerUi = true) {
-    const presetBody = getChatCompletionPreset(settings);
+    const presetBody = buildChatCompletionPreset(settings, settingsToUpdate, {
+        includeConnection: shouldIncludeConnectionFieldsInPreset(settings),
+    });
     const savePresetSettings = await fetch('/api/presets/save', {
         method: 'POST',
         headers: getRequestHeaders(),

--- a/tests/openai-preset-utils.test.js
+++ b/tests/openai-preset-utils.test.js
@@ -1,0 +1,56 @@
+import { describe, expect, test } from '@jest/globals';
+import { buildChatCompletionPreset, getChatCompletionConnectionPresetKeys } from '../public/scripts/openai-preset-utils.js';
+
+const settingsMap = {
+    chat_completion_source: ['#chat_completion_source', 'chat_completion_source', false, true],
+    temperature: ['#temp_openai', 'temp_openai', false, false],
+    openai_model: ['#model_openai_select', 'openai_model', false, true],
+    assistant_prefill: ['#claude_assistant_prefill', 'assistant_prefill', false, false],
+    custom_url: ['#custom_api_url_text', 'custom_url', false, true],
+    prompts: ['', 'prompts', false, false],
+};
+
+const settings = {
+    chat_completion_source: 'custom',
+    temp_openai: 0.72,
+    openai_model: 'mimo-model',
+    assistant_prefill: '',
+    custom_url: 'http://127.0.0.1:8080/v1',
+    prompts: [{ identifier: 'main', content: 'Prompt after edit' }],
+};
+
+describe('Chat Completion preset utilities', () => {
+    test('preserves legacy preset behavior by including connection fields by default', () => {
+        expect(buildChatCompletionPreset(settings, settingsMap)).toEqual({
+            chat_completion_source: 'custom',
+            temperature: 0.72,
+            openai_model: 'mimo-model',
+            assistant_prefill: '',
+            custom_url: 'http://127.0.0.1:8080/v1',
+            prompts: [{ identifier: 'main', content: 'Prompt after edit' }],
+        });
+    });
+
+    test('can build a generation preset without provider/model connection fields', () => {
+        expect(buildChatCompletionPreset(settings, settingsMap, { includeConnection: false })).toEqual({
+            temperature: 0.72,
+            assistant_prefill: '',
+            prompts: [{ identifier: 'main', content: 'Prompt after edit' }],
+        });
+    });
+
+    test('keeps explicit empty generation values when excluding connection fields', () => {
+        const preset = buildChatCompletionPreset(settings, settingsMap, { includeConnection: false });
+
+        expect(Object.hasOwn(preset, 'assistant_prefill')).toBe(true);
+        expect(preset.assistant_prefill).toBe('');
+    });
+
+    test('lists connection preset keys using preset field names', () => {
+        expect(getChatCompletionConnectionPresetKeys(settingsMap)).toEqual([
+            'chat_completion_source',
+            'openai_model',
+            'custom_url',
+        ]);
+    });
+});

--- a/tests/openai-preset-utils.test.js
+++ b/tests/openai-preset-utils.test.js
@@ -1,5 +1,9 @@
 import { describe, expect, test } from '@jest/globals';
-import { buildChatCompletionPreset, getChatCompletionConnectionPresetKeys } from '../public/scripts/openai-preset-utils.js';
+import {
+    buildChatCompletionPreset,
+    getChatCompletionConnectionPresetKeys,
+    shouldIncludeConnectionFieldsInPreset,
+} from '../public/scripts/openai-preset-utils.js';
 
 const settingsMap = {
     chat_completion_source: ['#chat_completion_source', 'chat_completion_source', false, true],
@@ -52,5 +56,34 @@ describe('Chat Completion preset utilities', () => {
             'openai_model',
             'custom_url',
         ]);
+    });
+
+    test('excludes connection fields for normal preset saves', () => {
+        const includeConnection = shouldIncludeConnectionFieldsInPreset({
+            ...settings,
+            bind_preset_to_connection: false,
+        });
+
+        expect(buildChatCompletionPreset(settings, settingsMap, { includeConnection })).toEqual({
+            temperature: 0.72,
+            assistant_prefill: '',
+            prompts: [{ identifier: 'main', content: 'Prompt after edit' }],
+        });
+    });
+
+    test('includes connection fields for explicitly linked preset saves', () => {
+        const includeConnection = shouldIncludeConnectionFieldsInPreset({
+            ...settings,
+            bind_preset_to_connection: true,
+        });
+
+        expect(buildChatCompletionPreset(settings, settingsMap, { includeConnection })).toEqual({
+            chat_completion_source: 'custom',
+            temperature: 0.72,
+            openai_model: 'mimo-model',
+            assistant_prefill: '',
+            custom_url: 'http://127.0.0.1:8080/v1',
+            prompts: [{ identifier: 'main', content: 'Prompt after edit' }],
+        });
     });
 });


### PR DESCRIPTION
## Summary
- Extract Chat Completion preset body construction into a pure helper.
- Keep normal OpenAI preset saves from including provider/model/API connection fields.
- Preserve linked preset behavior as an explicit opt-in via `Keep API/model linked to preset`.
- Add regression coverage for excluding connection fields while preserving explicit empty generation values.
## Why
Users reported that linked API/preset behavior can contaminate connection profiles and make provider/model settings unreliable. This keeps normal presets focused on generation/prompt settings, while still allowing advanced linked presets to intentionally save provider/model/API state.
## Notes
- `getChatCompletionPreset()` keeps its legacy default behavior for compatibility.
- `saveOpenAIPreset()` now uses the new helper policy so connection fields are only saved when linked preset mode is enabled.