### PR TITLE
fix(cache): preserve local prompt cache lanes

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -3909,10 +3909,11 @@ export function getStoppingStrings(isImpersonate, isContinue, api = main_api) {
  * @prop {object} [jsonSchema] JSON schema to use for the structured generation. Usually requires a special instruction.
  * @prop {boolean} [removeReasoning] Parses and removes the reasoning block according to reasoning format preferences
  * @prop {boolean} [trimToSentence] Whether to trim the response to the last complete sentence
+ * @prop {'main'|'auxiliary'|'none'} [cacheScope] Prompt cache lane for local backends.
  * @param {GenerateQuietPromptParams} params Parameters for the quiet prompt generation
  * @returns {Promise<string>} Generated text. If using structured output, will contain a serialized JSON object.
  */
-export async function generateQuietPrompt({ quietPrompt = '', quietToLoud = false, skipWIAN = false, quietImage = null, quietName = null, responseLength = null, forceChId = null, jsonSchema = null, removeReasoning = true, trimToSentence = false } = {}) {
+export async function generateQuietPrompt({ quietPrompt = '', quietToLoud = false, skipWIAN = false, quietImage = null, quietName = null, responseLength = null, forceChId = null, jsonSchema = null, removeReasoning = true, trimToSentence = false, cacheScope = 'auxiliary' } = {}) {
     if (arguments.length > 0 && typeof arguments[0] !== 'object') {
         console.trace('generateQuietPrompt called with positional arguments. Please use an object instead.');
         [quietPrompt, quietToLoud, skipWIAN, quietImage, quietName, responseLength, forceChId, jsonSchema] = arguments;
@@ -3931,6 +3932,7 @@ export async function generateQuietPrompt({ quietPrompt = '', quietToLoud = fals
             quietName: quietName ?? null,
             force_chid: forceChId ?? null,
             jsonSchema: jsonSchema ?? null,
+            cacheScope,
         };
         if (responseLengthCustomized) {
             TempResponseLength.save(main_api, responseLength);
@@ -4893,6 +4895,7 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
  * @prop {string} [prefill] An optional prefill for the prompt.
  * @prop {JsonSchema} [jsonSchema] JSON schema to use for the structured generation. Usually requires a special instruction.
  * @prop {AbortSignal} [signal] Optional signal to abort the request.
+ * @prop {'main'|'auxiliary'|'none'} [cacheScope] Prompt cache lane for local backends.
  */
 
 /**
@@ -4901,7 +4904,7 @@ export function createRawPrompt(prompt, api, instructOverride, quietToLoud, syst
  * @param {GenerateRawParams} params Parameters for generating a message
  * @returns {Promise<object | string>} Raw API response data, or a JSON string extracted from the response when `jsonSchema` is provided.
  */
-export async function generateRawData({ prompt = '', api = null, instructOverride = false, quietToLoud = false, systemPrompt = '', responseLength = null, prefill = '', jsonSchema = null, signal = null } = {}) {
+export async function generateRawData({ prompt = '', api = null, instructOverride = false, quietToLoud = false, systemPrompt = '', responseLength = null, prefill = '', jsonSchema = null, signal = null, cacheScope = 'auxiliary' } = {}) {
     if (!api) {
         api = main_api;
     }
@@ -4973,7 +4976,7 @@ export async function generateRawData({ prompt = '', api = null, instructOverrid
                 break;
             }
             case 'textgenerationwebui':
-                generateData = await getTextGenGenerationData(prompt, amount_gen, false, false, null, 'quiet');
+                generateData = await getTextGenGenerationData(prompt, amount_gen, false, false, null, 'quiet', { cacheScope });
                 TempResponseLength.restore(api);
                 break;
             case 'openai': {
@@ -4987,7 +4990,7 @@ export async function generateRawData({ prompt = '', api = null, instructOverrid
         if (api === 'koboldhorde') {
             data = await generateHorde(prompt.toString(), generateData, abortController.signal, false);
         } else if (api === 'openai') {
-            data = await sendOpenAIRequest('quiet', generateData, abortController.signal, { jsonSchema });
+            data = await sendOpenAIRequest('quiet', generateData, abortController.signal, { jsonSchema, cacheScope });
         } else {
             const generateUrl = getGenerateUrl(api);
             const response = await fetch(generateUrl, {
@@ -5035,13 +5038,13 @@ export async function generateRawData({ prompt = '', api = null, instructOverrid
  * @param {GenerateRawParams} params Parameters for generating a message
  * @returns {Promise<string>} Generated output: a cleaned-up message string when `jsonSchema` is not provided, or an extracted JSON string conforming to `jsonSchema` when it is.
  */
-export async function generateRaw({ prompt = '', api = null, instructOverride = false, quietToLoud = false, systemPrompt = '', responseLength = null, trimNames = true, prefill = '', jsonSchema = null, signal = null } = {}) {
+export async function generateRaw({ prompt = '', api = null, instructOverride = false, quietToLoud = false, systemPrompt = '', responseLength = null, trimNames = true, prefill = '', jsonSchema = null, signal = null, cacheScope = 'auxiliary' } = {}) {
     if (arguments.length > 0 && typeof arguments[0] !== 'object') {
         console.trace('generateRaw called with positional arguments. Please use an object instead.');
         [prompt, api, instructOverride, quietToLoud, systemPrompt, responseLength, trimNames, prefill, jsonSchema] = arguments;
     }
 
-    const data = await generateRawData({ prompt, api, instructOverride, quietToLoud, systemPrompt, responseLength, prefill, jsonSchema, signal });
+    const data = await generateRawData({ prompt, api, instructOverride, quietToLoud, systemPrompt, responseLength, prefill, jsonSchema, signal, cacheScope });
 
     // JSON string (matching the provided schema) will already be extracted.
     if (jsonSchema) {
@@ -5194,6 +5197,7 @@ function removeLastMessage() {
  * @property {number} [depth] Recursion depth for the generation. Used to prevent infinite loops in tool calls.
  * @property {JsonSchema} [jsonSchema] JSON schema to use for the structured generation. Usually requires a special instruction.
  * @property {boolean} [suppressUserMessage] Whether the visible user message was already rendered by a caller.
+ * @property {'main'|'auxiliary'|'none'} [cacheScope] Prompt cache lane for local backends.
  */
 
 /**
@@ -5238,7 +5242,7 @@ function consumePendingUserMessageExtra(message) {
     pendingUserMessageExtra = null;
 }
 
-export async function Generate(type, { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, quietName, jsonSchema = null, depth = 0, suppressUserMessage = false } = {}, dryRun = false) {
+export async function Generate(type, { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, quietName, jsonSchema = null, depth = 0, suppressUserMessage = false, cacheScope = null } = {}, dryRun = false) {
     console.log('Generate entered');
     setGenerationProgress(0);
     generation_started = new Date();
@@ -5247,7 +5251,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     await unshallowCharacter(this_chid);
 
     // Occurs every time, even if the generation is aborted due to slash commands execution
-    await eventSource.emit(event_types.GENERATION_STARTED, type, { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage }, dryRun);
+    await eventSource.emit(event_types.GENERATION_STARTED, type, { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, cacheScope }, dryRun);
 
     // Don't recreate abort controller if signal is passed
     if (!(abortController && signal)) {
@@ -5257,6 +5261,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     // OpenAI doesn't need instruct mode. Use OAI main prompt instead.
     const isInstruct = power_user.instruct.enabled && main_api !== 'openai';
     const isImpersonate = type == 'impersonate';
+    const resolvedCacheScope = cacheScope ?? (type === 'quiet' ? 'auxiliary' : 'main');
     const shouldConsumeUserInput = type !== 'regenerate' && type !== 'swipe' && type !== 'quiet' && !isImpersonate && !dryRun && !depth && !suppressUserMessage;
 
     if (!(dryRun || depth || type == 'regenerate' || type == 'swipe' || type == 'quiet')) {
@@ -5270,7 +5275,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     }
 
     // Occurs only if the generation is not aborted due to slash commands execution
-    await eventSource.emit(event_types.GENERATION_AFTER_COMMANDS, type, { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage }, dryRun);
+    await eventSource.emit(event_types.GENERATION_AFTER_COMMANDS, type, { automatic_trigger, force_name2, quiet_prompt, quietToLoud, skipWIAN, force_chid, signal, quietImage, cacheScope: resolvedCacheScope }, dryRun);
 
     if (main_api == 'kobold' && kai_settings.streaming_kobold && !kai_flags.can_use_streaming) {
         toastr.error(t`Streaming is enabled, but the version of Kobold used does not support token streaming.`, undefined, { timeOut: 10000, preventDuplicates: true });
@@ -5293,7 +5298,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     if (selected_group && !is_group_generating) {
         if (!dryRun) {
             // Returns the promise that generateGroupWrapper returns; resolves when generation is done
-            return generateGroupWrapper(false, type, { quiet_prompt, force_chid, signal: abortController.signal, quietImage, jsonSchema });
+            return generateGroupWrapper(false, type, { quiet_prompt, force_chid, signal: abortController.signal, quietImage, jsonSchema, cacheScope: resolvedCacheScope });
         }
 
         const characterIndexMap = new Map(characters.map((char, index) => [char.avatar, index]));
@@ -6248,7 +6253,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             break;
         case 'textgenerationwebui': {
             const cfgValues = useCfgPrompt ? { guidanceScale: cfgGuidanceScale, negativePrompt: await getCombinedPrompt(true) } : null;
-            generate_data = await getTextGenGenerationData(finalPrompt, maxLength, isImpersonate, isContinue, cfgValues, type);
+            generate_data = await getTextGenGenerationData(finalPrompt, maxLength, isImpersonate, isContinue, cfgValues, type, { cacheScope: resolvedCacheScope });
             break;
         }
         case 'novel': {
@@ -6276,7 +6281,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
                 messages: oaiMessages,
                 messageExamples: oaiMessageExamples,
             }, dryRun);
-            generate_data = { prompt: prompt };
+            generate_data = { prompt: prompt, cacheScope: resolvedCacheScope };
 
             // TODO: move these side-effects somewhere else, so this switch-case solely sets generate_data
             // counts will return false if the user has not enabled the token breakdown feature
@@ -6366,7 +6371,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
                 activeStreamingProcessor.firstMessageText = '';
             }
 
-            activeStreamingProcessor.generator = await sendStreamingRequest(type, generate_data, { jsonSchema });
+            activeStreamingProcessor.generator = await sendStreamingRequest(type, generate_data, { jsonSchema, cacheScope: generate_data.cacheScope });
 
             hideSwipeButtons();
             let getMessage = await activeStreamingProcessor.generate();
@@ -6428,7 +6433,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             clearStreamingProcessorIfCurrent(activeStreamingProcessor);
             return;
         } else {
-            return await sendGenerationRequest(type, generate_data, { jsonSchema });
+            return await sendGenerationRequest(type, generate_data, { jsonSchema, cacheScope: generate_data.cacheScope });
         }
     }
 
@@ -7095,6 +7100,7 @@ function setInContextMessages(msgInContextCount, type) {
 /**
  * @typedef {object} AdditionalRequestOptions
  * @property {JsonSchema} [jsonSchema]
+ * @property {'main'|'auxiliary'|'none'} [cacheScope]
  */
 
 /**

--- a/public/scripts/local-url-utils.js
+++ b/public/scripts/local-url-utils.js
@@ -1,0 +1,48 @@
+const LOCAL_HOSTNAMES = new Set([
+    'localhost',
+    '127.0.0.1',
+    '::1',
+]);
+
+const PRIVATE_IPV4_PATTERNS = [
+    /^10\./,
+    /^192\.168\./,
+    /^172\.(1[6-9]|2\d|3[0-1])\./,
+];
+
+const FALLBACK_LOCAL_URL_PATTERN = /(^|[^\w:])(?:localhost|\[::1\]|::1|127\.0\.0\.1|10\.\d+\.\d+\.\d+|192\.168\.\d+\.\d+|172\.(?:1[6-9]|2\d|3[0-1])\.\d+\.\d+)([^\w.]|$)/i;
+
+function normalizeUrlHostname(hostname) {
+    const host = String(hostname ?? '').trim().toLowerCase();
+
+    if (host.startsWith('[') && host.endsWith(']')) {
+        return host.slice(1, -1);
+    }
+
+    return host;
+}
+
+function isPrivateIpv4Hostname(hostname) {
+    return PRIVATE_IPV4_PATTERNS.some(pattern => pattern.test(hostname));
+}
+
+/**
+ * Checks whether an API server URL points at a likely local backend.
+ * @param {string} serverUrl API server URL
+ * @param {string} [baseUrl] Optional base URL for resolving browser-relative URLs
+ * @returns {boolean} True if the URL points at a likely local backend
+ */
+export function isLikelyLocalServerUrl(serverUrl, baseUrl = undefined) {
+    if (typeof serverUrl !== 'string' || !serverUrl.trim()) {
+        return false;
+    }
+
+    try {
+        const url = baseUrl === undefined ? new URL(serverUrl) : new URL(serverUrl, baseUrl);
+        const host = normalizeUrlHostname(url.hostname);
+
+        return LOCAL_HOSTNAMES.has(host) || host.endsWith('.local') || isPrivateIpv4Hostname(host);
+    } catch {
+        return FALLBACK_LOCAL_URL_PATTERN.test(serverUrl);
+    }
+}

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -4350,7 +4350,7 @@ function getVerbosity(settings = null) {
  * @param {import('../script.js').AdditionalRequestOptions} options Additional request options
  * @returns {Promise<object>} Final generation parameters object appropriate for the chat completion source
  */
-export async function createGenerationParameters(settings, model, type, messages, { jsonSchema = null } = {}) {
+export async function createGenerationParameters(settings, model, type, messages, { jsonSchema = null, cacheScope = null } = {}) {
     // HACK: Filter out null and non-object messages
     if (!Array.isArray(messages)) {
         throw new Error('messages must be an array');
@@ -4476,6 +4476,7 @@ export async function createGenerationParameters(settings, model, type, messages
         'request_image_aspect_ratio': String(settings.request_image_aspect_ratio),
         'custom_prompt_post_processing': settings.custom_prompt_post_processing,
         'verbosity': getVerbosity(settings),
+        'cacheScope': cacheScope ?? (type === 'quiet' ? 'auxiliary' : 'main'),
     };
 
     if (settings.chat_completion_source === chat_completion_sources.AZURE_OPENAI) {
@@ -4760,14 +4761,14 @@ export async function createGenerationParameters(settings, model, type, messages
  * @returns {Promise<unknown>}
  * @throws {Error}
  */
-async function sendOpenAIRequest(type, messages, signal, { jsonSchema = null } = {}) {
+async function sendOpenAIRequest(type, messages, signal, { jsonSchema = null, cacheScope = null } = {}) {
     // Provide default abort signal
     if (!signal) {
         signal = new AbortController().signal;
     }
 
     const model = getChatCompletionModel(oai_settings);
-    const { generate_data, stream, canMultiSwipe } = await createGenerationParameters(oai_settings, model, type, messages, { jsonSchema });
+    const { generate_data, stream, canMultiSwipe } = await createGenerationParameters(oai_settings, model, type, messages, { jsonSchema, cacheScope });
     await eventSource.emit(event_types.CHAT_COMPLETION_SETTINGS_READY, generate_data);
 
     const generate_url = '/api/backends/chat-completions/generate';

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -141,6 +141,30 @@ export const SERVER_INPUTS = {
 };
 
 const KOBOLDCPP_ORDER = [6, 0, 1, 3, 4, 2, 5];
+
+function isLikelyLocalServerUrl(serverUrl) {
+    if (typeof serverUrl !== 'string' || !serverUrl.trim()) {
+        return false;
+    }
+
+    try {
+        const url = new URL(serverUrl, window.location.href);
+        const host = String(url.hostname ?? '').toLowerCase();
+        return [
+            'localhost',
+            '127.0.0.1',
+            '::1',
+        ].includes(host) || host.endsWith('.local') || /^10\./.test(host) || /^192\.168\./.test(host) || /^172\.(1[6-9]|2\d|3[0-1])\./.test(host);
+    } catch {
+        return /(^|[^\w])localhost([^\w]|$)/i.test(serverUrl) || /127\.0\.0\.1|\b10\.\d+\.\d+\.\d+\b|\b192\.168\.\d+\.\d+\b|\b172\.(1[6-9]|2\d|3[0-1])\.\d+\.\d+\b/.test(serverUrl);
+    }
+}
+
+function shouldUseLocalPromptCache(settings) {
+    const serverUrl = getTextGenServer(settings?.type);
+    return isLikelyLocalServerUrl(serverUrl);
+}
+
 export const textgenerationwebui_settings = {
     temp: 0.7,
     temperature_last: true,
@@ -1586,13 +1610,14 @@ export function replaceMacrosInList(str) {
  * @param {string} type Request type (impersonate, quiet, continue, etc)
  * @returns {object} Final generation parameters object appropriate for the text completion source
  */
-export function createTextGenGenerationData(settings, model, finalPrompt = null, maxTokens = null, isImpersonate = false, isContinue = false, cfgValues = null, type = 'quiet') {
+export function createTextGenGenerationData(settings, model, finalPrompt = null, maxTokens = null, isImpersonate = false, isContinue = false, cfgValues = null, type = 'quiet', generationOptions = {}) {
     settings = settings ?? textgenerationwebui_settings;
     model = model ?? getTextGenModel(settings);
 
     const canMultiSwipe = !isContinue && !isImpersonate && type !== 'quiet';
     const dynatemp = isDynamicTemperatureSupported(settings);
     const { banned_tokens, banned_strings } = getCustomTokenBans(settings);
+    const cacheScope = String(generationOptions?.cacheScope ?? 'auxiliary');
     const jsonSchema = isObject(settings.json_schema)
         ? settings.json_schema_allow_empty
             ? settings.json_schema
@@ -1820,12 +1845,19 @@ export function createTextGenGenerationData(settings, model, finalPrompt = null,
             'logit_bias': logitBiasArray,
             // Conflicts with ooba's grammar_string
             'grammar': settings.grammar_string,
-            'cache_prompt': true,
             'dry_sequence_breakers': sequenceBreakers,
         };
         params = Object.assign(params, llamaCppParams);
         if (!Array.isArray(sequenceBreakers) || sequenceBreakers.length === 0) {
             delete params.dry_sequence_breakers;
+        }
+    }
+
+    if (shouldUseLocalPromptCache(settings)) {
+        if (cacheScope === 'main') {
+            params.cache_prompt = true;
+        } else {
+            delete params.cache_prompt;
         }
     }
 
@@ -2052,9 +2084,9 @@ function groupTextGenSettingsIntoDrawers() {
     $settingsBlock.data('sb-grouped', true);
 }
 
-export async function getTextGenGenerationData(finalPrompt, maxTokens, isImpersonate, isContinue, cfgValues, type) {
+export async function getTextGenGenerationData(finalPrompt, maxTokens, isImpersonate, isContinue, cfgValues, type, generationOptions = {}) {
     const model = getTextGenModel(textgenerationwebui_settings);
-    const params = createTextGenGenerationData(textgenerationwebui_settings, model, finalPrompt, maxTokens, isImpersonate, isContinue, cfgValues, type);
+    const params = createTextGenGenerationData(textgenerationwebui_settings, model, finalPrompt, maxTokens, isImpersonate, isContinue, cfgValues, type, generationOptions);
     await eventSource.emit(event_types.TEXT_COMPLETION_SETTINGS_READY, params);
     return params;
 }

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -23,6 +23,7 @@ import { power_user, registerDebugFunction } from './power-user.js';
 import { getActiveManualApiSamplers, loadApiSelectedSamplers, isSamplerManualPriorityEnabled } from './samplerSelect.js';
 import { SECRET_KEYS, writeSecret } from './secrets.js';
 import { getEventSourceStream } from './sse-stream.js';
+import { isLikelyLocalServerUrl } from './local-url-utils.js';
 import { getCurrentDreamGenModelTokenizer, getCurrentOpenRouterModelTokenizer, loadAphroditeModels, loadDreamGenModels, loadFeatherlessModels, loadGenericModels, loadInfermaticAIModels, loadLlamaCppModels, loadMancerModels, loadOllamaModels, loadOpenRouterModels, loadTabbyModels, loadTogetherAIModels, loadVllmModels, updateOpenRouterProvidersWarning } from './textgen-models.js';
 import { ENCODE_TOKENIZERS, TEXTGEN_TOKENIZERS, TOKENIZER_SUPPORTED_KEY, getTextTokens, getTokenizerBestMatch, tokenizers } from './tokenizers.js';
 import { AbortReason } from './util/AbortReason.js';
@@ -142,27 +143,9 @@ export const SERVER_INPUTS = {
 
 const KOBOLDCPP_ORDER = [6, 0, 1, 3, 4, 2, 5];
 
-function isLikelyLocalServerUrl(serverUrl) {
-    if (typeof serverUrl !== 'string' || !serverUrl.trim()) {
-        return false;
-    }
-
-    try {
-        const url = new URL(serverUrl, window.location.href);
-        const host = String(url.hostname ?? '').toLowerCase();
-        return [
-            'localhost',
-            '127.0.0.1',
-            '::1',
-        ].includes(host) || host.endsWith('.local') || /^10\./.test(host) || /^192\.168\./.test(host) || /^172\.(1[6-9]|2\d|3[0-1])\./.test(host);
-    } catch {
-        return /(^|[^\w])localhost([^\w]|$)/i.test(serverUrl) || /127\.0\.0\.1|\b10\.\d+\.\d+\.\d+\b|\b192\.168\.\d+\.\d+\b|\b172\.(1[6-9]|2\d|3[0-1])\.\d+\.\d+\b/.test(serverUrl);
-    }
-}
-
 function shouldUseLocalPromptCache(settings) {
     const serverUrl = getTextGenServer(settings?.type);
-    return isLikelyLocalServerUrl(serverUrl);
+    return isLikelyLocalServerUrl(serverUrl, window.location.href);
 }
 
 export const textgenerationwebui_settings = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -338,6 +338,7 @@ export const OLLAMA_KEYS = [
     'seed',
     'repeat_last_n',
     'min_p',
+    'cache_prompt',
 ];
 
 // https://platform.openai.com/docs/api-reference/completions
@@ -429,6 +430,7 @@ export const VLLM_KEYS = [
     'skip_special_tokens',
     'spaces_between_special_tokens',
     'truncate_prompt_tokens',
+    'cache_prompt',
 
     'include_stop_str_in_output',
     'response_format',

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -3,6 +3,7 @@ import process from 'node:process';
 import express from 'express';
 import fetch from 'node-fetch';
 import urlJoin from 'url-join';
+import { isLikelyLocalServerUrl } from '../../../public/scripts/local-url-utils.js';
 
 import {
     AIMLAPI_HEADERS,
@@ -246,24 +247,6 @@ function applyCustomReasoningParameters(bodyParams, requestBody) {
         case 'thinking_object':
             bodyParams[paramName] = { type: isEnabled ? enabledValue : disabledValue };
             break;
-    }
-}
-
-function isLikelyLocalServerUrl(serverUrl) {
-    if (typeof serverUrl !== 'string' || !serverUrl.trim()) {
-        return false;
-    }
-
-    try {
-        const url = new URL(serverUrl);
-        const host = String(url.hostname ?? '').toLowerCase();
-        return [
-            'localhost',
-            '127.0.0.1',
-            '::1',
-        ].includes(host) || host.endsWith('.local') || /^10\./.test(host) || /^192\.168\./.test(host) || /^172\.(1[6-9]|2\d|3[0-1])\./.test(host);
-    } catch {
-        return /(^|[^\w])localhost([^\w]|$)/i.test(serverUrl) || /127\.0\.0\.1|\b10\.\d+\.\d+\.\d+\b|\b192\.168\.\d+\.\d+\b|\b172\.(1[6-9]|2\d|3[0-1])\.\d+\.\d+\b/.test(serverUrl);
     }
 }
 

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -249,6 +249,46 @@ function applyCustomReasoningParameters(bodyParams, requestBody) {
     }
 }
 
+function isLikelyLocalServerUrl(serverUrl) {
+    if (typeof serverUrl !== 'string' || !serverUrl.trim()) {
+        return false;
+    }
+
+    try {
+        const url = new URL(serverUrl);
+        const host = String(url.hostname ?? '').toLowerCase();
+        return [
+            'localhost',
+            '127.0.0.1',
+            '::1',
+        ].includes(host) || host.endsWith('.local') || /^10\./.test(host) || /^192\.168\./.test(host) || /^172\.(1[6-9]|2\d|3[0-1])\./.test(host);
+    } catch {
+        return /(^|[^\w])localhost([^\w]|$)/i.test(serverUrl) || /127\.0\.0\.1|\b10\.\d+\.\d+\.\d+\b|\b192\.168\.\d+\.\d+\b|\b172\.(1[6-9]|2\d|3[0-1])\.\d+\.\d+\b/.test(serverUrl);
+    }
+}
+
+function getOpenAiCompatibleServerUrl(requestBody) {
+    return requestBody.chat_completion_source === CHAT_COMPLETION_SOURCES.CUSTOM ? requestBody.custom_url : '';
+}
+
+function applyLocalPromptCacheScope(bodyParams, requestBody) {
+    if (requestBody.chat_completion_source !== CHAT_COMPLETION_SOURCES.CUSTOM) {
+        return;
+    }
+
+    const serverUrl = getOpenAiCompatibleServerUrl(requestBody);
+    if (!isLikelyLocalServerUrl(serverUrl)) {
+        return;
+    }
+
+    // SillyBunny: isolate helper generations so local prompt caches keep the main chat lane hot.
+    if (String(requestBody.cacheScope ?? 'auxiliary') === 'main') {
+        bodyParams.cache_prompt = true;
+    } else {
+        delete bodyParams.cache_prompt;
+    }
+}
+
 /**
  * Hacky way to use JSON schema only if json_object format is supported.
  * @param {object} bodyParams Additional body parameters
@@ -2957,6 +2997,8 @@ router.post('/generate', async function (request, response) {
                 bodyParams['verbosity'] = request.body.verbosity;
             }
         }
+
+        applyLocalPromptCacheScope(bodyParams, request.body);
 
         if (!apiKey && !request.body.reverse_proxy && request.body.chat_completion_source !== CHAT_COMPLETION_SOURCES.CUSTOM) {
             console.warn('OpenAI API key is missing.');

--- a/tests/local-url-utils.test.js
+++ b/tests/local-url-utils.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { isLikelyLocalServerUrl } from '../public/scripts/local-url-utils.js';
+
+describe('isLikelyLocalServerUrl', () => {
+    const localServerUrls = [
+        ['http://localhost:5000/v1'],
+        ['http://127.0.0.1:5000/v1'],
+        ['http://[::1]:5000/v1'],
+        ['http://10.0.0.2:5000/v1'],
+        ['http://192.168.1.20:5000/v1'],
+        ['http://172.20.0.2:5000/v1'],
+        ['http://sillybunny.local:5000/v1'],
+    ];
+
+    for (const [serverUrl] of localServerUrls) {
+        test(`treats ${serverUrl} as local`, () => {
+            expect(isLikelyLocalServerUrl(serverUrl)).toBe(true);
+        });
+    }
+
+    test('resolves browser-relative URLs against the supplied local base URL', () => {
+        expect(isLikelyLocalServerUrl('/v1', 'http://[::1]:5000')).toBe(true);
+    });
+
+    const remoteServerUrls = [
+        ['https://api.openai.com/v1'],
+        ['http://example.com/v1'],
+        ['http://172.15.0.2:5000/v1'],
+        ['http://[2001:db8::1]:5000/v1'],
+    ];
+
+    for (const [serverUrl] of remoteServerUrls) {
+        test(`does not treat ${serverUrl} as local`, () => {
+            expect(isLikelyLocalServerUrl(serverUrl)).toBe(false);
+        });
+    }
+});


### PR DESCRIPTION
Currently, there are issues with prompt caching in local backends behaving erratically depending on context size. This may be due to some features we've implemented vs. upstream. This PR should hopefully address these errant issues by adding a `cacheScope` function to prevent extraneous features from causing prompt caching issues.

## Summary
- Add a shared `cacheScope` flow so helper generations do not disturb the main local prompt cache lane.
- Apply local cache gating to text-completions and Custom chat-completions backends only.

## Testing
Need to check if this affects any of the following functionality before merging:

- Quick Image Gen: public/scripts/extensions/quick-image-gen/index.js uses generateRawData, generateRaw, and generateQuietPrompt.
- Memory summarization: public/scripts/extensions/memory/index.js:708, public/scripts/extensions/memory/index.js:738.
- Expressions via LLM: public/scripts/extensions/expressions/index.js:1091, public/scripts/extensions/expressions/index.js:1094.
- Vectors summaries: public/scripts/extensions/vectors/index.js:357.
- Background/image/stable-diffusion prompt helpers can also use generateQuietPrompt.