### PR TITLE
fix(mobile): center sampling sliders and add scroll guards

### DIFF
--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -2297,6 +2297,20 @@ input[type='range']::-moz-range-thumb {
     font-size: 0.86rem;
 }
 
+/* Mobile/touch: keep slider thumbs away from card edges and let vertical drags scroll. */
+@media (pointer: coarse) {
+    .sb-sampling-control-card input[type='range'].neo-range-slider {
+        display: block;
+        max-width: min(420px, calc(100% - 48px));
+        margin-inline: auto;
+        touch-action: pan-y;
+    }
+
+    .sb-sampling-grid {
+        row-gap: 14px;
+    }
+}
+
 .sb-presets-advanced-formatting {
     margin-top: 12px;
 }


### PR DESCRIPTION
## Summary
- Center and constrain Sampling range sliders on touch devices so the thumb is no longer flush with the card/viewport edge.
- Add `touch-action: pan-y` to Sampling sliders under `(pointer: coarse)` so vertical drags scroll the panel instead of accidentally changing sampler values.
- Slightly increase Sampling grid row spacing on touch devices for more scroll-safe breathing room.

## Verification
- `npm run lint`

## Risk
- CSS-only, touch-device media-query scoped change; desktop slider layout is unchanged.