### PR TITLE
fix(chat): stop chat scroll jumps on macOS browsers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ This update consolidates the v1.5.4 staging work since v1.5.3: preset and connec
 
 ### Chat Loading And Search
 - Re-applied chat scroll anchoring across staging and main so scrolling upward no longer skips earlier messages.
+- Disabled native chat scroll anchoring on macOS browsers so it no longer fights SillyBunny's scroll preservation and jumps messages while scrolling.
 - Existing chats now force-scroll to the latest message on initial load across desktop and mobile, even when the normal auto-scroll preference is disabled.
 - Streaming and other non-forced chat scrolling still respect the user's auto-scroll preference and mobile manual-scroll suppression.
 - Bottom chat navigation now includes go-to-top and go-to-bottom controls for the active chat.

--- a/public/scripts/browser-fixes.js
+++ b/public/scripts/browser-fixes.js
@@ -2,6 +2,14 @@ import { getParsedUA, isMobile } from './RossAscends-mods.js';
 
 const isFirefox = () => /firefox/i.test(navigator.userAgent);
 
+function addMacOSPatch() {
+    const userAgent = getParsedUA();
+
+    if (userAgent?.os?.name === 'macOS') {
+        document.body.classList.add('is-macos');
+    }
+}
+
 function sanitizeInlineQuotationOnCopy() {
     // STRG+C, STRG+V on firefox leads to duplicate double quotes when inline quotation elements are copied.
     // To work around this, take the selection and transform <q> to <span> before calling toString().
@@ -237,6 +245,7 @@ function applyBrowserFixes() {
         window.addEventListener('sb-mobile-viewport-reset', scheduleViewportReset);
     }
 
+    addMacOSPatch();
     addSafariPatch();
     addFirefoxPatch();
     addChromePatch();

--- a/public/style.css
+++ b/public/style.css
@@ -935,6 +935,11 @@ body .panelControlBar {
     flex-grow: 1;
 }
 
+/* macOS browser scroll anchoring fights chat scroll preservation during message loads. */
+body.is-macos #chat {
+    overflow-anchor: none;
+}
+
 #form_sheld {
     white-space: nowrap;
     width: 100%;


### PR DESCRIPTION
## Summary
- Adds a generic `is-macos` body class from the parsed browser OS so Safari, Chrome, and Chromium variants on macOS can share platform-specific fixes.
- Disables native CSS scroll anchoring for `#chat` only on macOS browsers.
- Records the chat scroll stability fix in the changelog.

## Root cause
macOS browser-native scroll anchoring can race SillyBunny's JavaScript chat scroll preservation when older messages load or layout settles, causing visible message jumps while scrolling.

## Change
The chat scroller now uses `overflow-anchor: none` under `body.is-macos`, leaving the current non-macOS anchoring behavior unchanged.

## Risk / Rollback
Risk is limited to macOS chat scrolling because the CSS selector is gated by the new body class. Rollback is to remove the `body.is-macos #chat` override and the matching body class helper.

## Verification
- `npm ci --ignore-scripts`
- `npm run lint`
- Not manually verified in macOS Safari/Chrome from this Linux workspace.