### PR TITLE
fix(quick-image-gen): repair bundled dynamic imports

### DIFF
--- a/public/scripts/extensions/quick-image-gen/index.js
+++ b/public/scripts/extensions/quick-image-gen/index.js
@@ -13824,8 +13824,8 @@ jQuery(function () {
     // Non-blocking async initialization
     (async () => {
         try {
-            const extensionsModule = await import("../../../extensions.js");
-            const scriptModule = await import("../../../../script.js");
+            const extensionsModule = await import("../../extensions.js");
+            const scriptModule = await import("../../../script.js");
             extension_settings = extensionsModule.extension_settings;
             getContext = extensionsModule.getContext;
             saveSettingsDebounced = scriptModule.saveSettingsDebounced;
@@ -13836,7 +13836,7 @@ jQuery(function () {
             getRequestHeaders = scriptModule.getRequestHeaders;
 
             try {
-                const openAICompatModule = await import("../../../openai.js");
+                const openAICompatModule = await import("../../openai.js");
                 createGenerationParameters = openAICompatModule.createGenerationParameters;
                 getChatCompletionModel = openAICompatModule.getChatCompletionModel;
             } catch (e) {
@@ -13844,7 +13844,7 @@ jQuery(function () {
             }
 
             try {
-                const utilsModule = await import("../../../utils.js");
+                const utilsModule = await import("../../utils.js");
                 saveBase64AsFile = utilsModule.saveBase64AsFile;
                 getSanitizedFilename = utilsModule.getSanitizedFilename;
             } catch (e) {
@@ -13852,14 +13852,14 @@ jQuery(function () {
             }
 
             try {
-                const rossModule = await import("../../../RossAscends-mods.js");
+                const rossModule = await import("../../RossAscends-mods.js");
                 humanizedDateTime = rossModule.humanizedDateTime;
             } catch (e) {
                 console.warn("[ImageGen] Could not import RossAscends-mods:", e.message);
             }
 
             try {
-                const secretsModule = await import("../../../../scripts/secrets.js");
+                const secretsModule = await import("../../secrets.js");
                 secret_state = secretsModule.secret_state;
                 rotateSecret = secretsModule.rotateSecret;
             } catch (e) {

--- a/scripts/sync-quick-image-gen.sh
+++ b/scripts/sync-quick-image-gen.sh
@@ -116,6 +116,55 @@ mkdir -p "$WORK_DIR"
 cp "$SOURCE_DIR/index.js" "$WORK_DIR/index.js"
 cp "$SOURCE_DIR/style.css" "$WORK_DIR/style.css"
 
+node - "$WORK_DIR/index.js" "$TARGET_DIR" <<'NODE'
+const fs = require('fs');
+const path = require('path');
+
+const indexPath = process.argv[2];
+const bundledExtensionDir = process.argv[3];
+let source = fs.readFileSync(indexPath, 'utf8');
+
+const importRewrites = new Map([
+    ['await import("../../../extensions.js")', 'await import("../../extensions.js")'],
+    ['await import("../../../../script.js")', 'await import("../../../script.js")'],
+    ['await import("../../../openai.js")', 'await import("../../openai.js")'],
+    ['await import("../../../utils.js")', 'await import("../../utils.js")'],
+    ['await import("../../../RossAscends-mods.js")', 'await import("../../RossAscends-mods.js")'],
+    ['await import("../../../../scripts/secrets.js")', 'await import("../../secrets.js")'],
+]);
+
+for (const [upstreamImport, bundledImport] of importRewrites) {
+    if (!source.includes(upstreamImport)) {
+        console.error(`Upstream Quick Image Gen index.js is missing expected import: ${upstreamImport}`);
+        process.exit(1);
+    }
+
+    source = source.replaceAll(upstreamImport, bundledImport);
+}
+
+const remainingUpstreamImports = [...importRewrites.keys()].filter(importPath => source.includes(importPath));
+if (remainingUpstreamImports.length) {
+    console.error('Quick Image Gen index.js still contains upstream-depth imports after rewriting:');
+    for (const importPath of remainingUpstreamImports) {
+        console.error(`- ${importPath}`);
+    }
+    process.exit(1);
+}
+
+const dynamicImportPattern = /await\s+import\("([^"]+)"\)/g;
+for (const [, specifier] of source.matchAll(dynamicImportPattern)) {
+    if (!specifier.startsWith('.')) continue;
+
+    const resolvedPath = path.resolve(bundledExtensionDir, specifier);
+    if (!fs.existsSync(resolvedPath)) {
+        console.error(`Quick Image Gen dynamic import does not resolve in the bundled location: ${specifier}`);
+        process.exit(1);
+    }
+}
+
+fs.writeFileSync(indexPath, source);
+NODE
+
 node - "$SOURCE_DIR/manifest.json" "$WORK_DIR/manifest.json" <<'NODE'
 const fs = require('fs');
 


### PR DESCRIPTION
## Summary
- Restores Quick Image Gen dynamic import paths for the SillyBunny bundled extension location.
- Adds sync-script rewrite and validation so future upstream Quick Image Gen syncs keep resolving against the bundled directory.
- Leaves unrelated third-party extension manifest 404s out of scope.

## Details
Quick Image Gen upstream is installed one directory deeper than SillyBunny's bundled copy. The recent upstream sync copied the upstream import depth directly, causing browser module loads for core helper files to resolve to missing paths. When the dev server returns the HTML fallback for those missing module URLs, browsers block the load as `text/html` and QIG initialization fails.

This PR rewrites the six known upstream dynamic imports during sync and verifies that all relative dynamic imports resolve from `public/scripts/extensions/quick-image-gen/` before the generated files are compared or copied.

## Verification
- `bash scripts/sync-quick-image-gen.sh --check`
- `bun run lint`
- `npm run test:unit --prefix tests`
- `npm run check:frontend-budgets` currently fails because blocking stylesheet bytes are `730.5 KiB` against a `730.0 KiB` budget; this appears unrelated to this import-path-only change.