### PR TITLE
fix: abort upstream streams on client cancel

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -22,6 +22,7 @@ import {
 } from '../../constants.js';
 import {
     forwardFetchResponse,
+    abortOnResponseClose,
     getConfigValue,
     tryParse,
     uuidv4,
@@ -283,10 +284,7 @@ async function sendClaudeRequest(request, response) {
 
     try {
         const controller = new AbortController();
-        request.socket.removeAllListeners('close');
-        request.socket.on('close', function () {
-            controller.abort();
-        });
+        abortOnResponseClose(response, controller);
         const additionalHeaders = {};
         const betaHeaders = ['output-128k-2025-02-19', 'context-1m-2025-08-07'];
         const useTools = Array.isArray(request.body.tools) && request.body.tools.length > 0;
@@ -690,10 +688,7 @@ async function sendMakerSuiteRequest(request, response) {
 
     try {
         const controller = new AbortController();
-        request.socket.removeAllListeners('close');
-        request.socket.on('close', function () {
-            controller.abort();
-        });
+        abortOnResponseClose(response, controller);
 
         const apiVersion = getConfigValue('gemini.apiVersion', 'v1beta');
         const responseType = (stream ? 'streamGenerateContent' : 'generateContent');
@@ -827,10 +822,7 @@ async function sendAI21Request(request, response) {
 
     const bodyParams = {};
     const controller = new AbortController();
-    request.socket.removeAllListeners('close');
-    request.socket.on('close', function () {
-        controller.abort();
-    });
+    abortOnResponseClose(response, controller);
     // Hack to support JSON schema
     if (request.body.json_schema) {
         bodyParams.response_format = {
@@ -909,10 +901,7 @@ async function sendMistralAIRequest(request, response) {
     try {
         const messages = convertMistralMessages(request.body.messages, getPromptNames(request));
         const controller = new AbortController();
-        request.socket.removeAllListeners('close');
-        request.socket.on('close', function () {
-            controller.abort();
-        });
+        abortOnResponseClose(response, controller);
 
         const requestBody = {
             'model': request.body.model,
@@ -990,10 +979,7 @@ async function sendMistralAIRequest(request, response) {
 async function sendCohereRequest(request, response) {
     const apiKey = readSecret(request.user.directories, SECRET_KEYS.COHERE);
     const controller = new AbortController();
-    request.socket.removeAllListeners('close');
-    request.socket.on('close', function () {
-        controller.abort();
-    });
+    abortOnResponseClose(response, controller);
 
     if (!apiKey) {
         console.warn('Cohere API key is missing.');
@@ -1097,10 +1083,7 @@ async function sendDeepSeekRequest(request, response) {
     }
 
     const controller = new AbortController();
-    request.socket.removeAllListeners('close');
-    request.socket.on('close', function () {
-        controller.abort();
-    });
+    abortOnResponseClose(response, controller);
 
     try {
         let bodyParams = {};
@@ -1214,10 +1197,7 @@ async function sendXaiRequest(request, response) {
     }
 
     const controller = new AbortController();
-    request.socket.removeAllListeners('close');
-    request.socket.on('close', function () {
-        controller.abort();
-    });
+    abortOnResponseClose(response, controller);
 
     try {
         let bodyParams = {};
@@ -1322,10 +1302,7 @@ async function sendAimlapiRequest(request, response) {
     }
 
     const controller = new AbortController();
-    request.socket.removeAllListeners('close');
-    request.socket.on('close', function () {
-        controller.abort();
-    });
+    abortOnResponseClose(response, controller);
 
     try {
         let bodyParams = {};
@@ -1427,10 +1404,7 @@ async function sendElectronHubRequest(request, response) {
     }
 
     const controller = new AbortController();
-    request.socket.removeAllListeners('close');
-    request.socket.on('close', function () {
-        controller.abort();
-    });
+    abortOnResponseClose(response, controller);
 
     try {
         let bodyParams = {};
@@ -1539,10 +1513,7 @@ async function sendChutesRequest(request, response) {
     }
 
     const controller = new AbortController();
-    request.socket.removeAllListeners('close');
-    request.socket.on('close', function () {
-        controller.abort();
-    });
+    abortOnResponseClose(response, controller);
 
     try {
         let bodyParams = {};
@@ -1641,10 +1612,7 @@ async function sendMinimaxRequest(request, response) {
     }
 
     const controller = new AbortController();
-    request.socket.removeAllListeners('close');
-    request.socket.on('close', function () {
-        controller.abort();
-    });
+    abortOnResponseClose(response, controller);
 
     try {
         // MiniMax does not allow consecutive messages with the same role.
@@ -1760,8 +1728,7 @@ async function sendAzureOpenAIRequest(request, response) {
         : undefined;
 
     const controller = new AbortController();
-    request.socket.removeAllListeners('close');
-    request.socket.on('close', () => controller.abort());
+    abortOnResponseClose(response, controller);
 
     const config = {
         method: 'POST',
@@ -2515,10 +2482,7 @@ async function sendOpenAIResponsesRequest(request, response) {
     }
 
     const controller = new AbortController();
-    request.socket.removeAllListeners('close');
-    request.socket.on('close', function () {
-        controller.abort();
-    });
+    abortOnResponseClose(response, controller);
 
     try {
         const { input, instructions } = convertMessagesToResponsesFormat(request.body.messages);
@@ -2974,10 +2938,7 @@ router.post('/generate', async function (request, response) {
             `${apiUrl}/chat/completions`;
 
         const controller = new AbortController();
-        request.socket.removeAllListeners('close');
-        request.socket.on('close', function () {
-            controller.abort();
-        });
+        abortOnResponseClose(response, controller);
 
         if (!isTextCompletion && Array.isArray(request.body.tools) && request.body.tools.length > 0) {
             bodyParams['tools'] = request.body.tools;

--- a/src/endpoints/backends/kobold.js
+++ b/src/endpoints/backends/kobold.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import express from 'express';
 import fetch from 'node-fetch';
 
-import { forwardFetchResponse, delay, summarizeLlmPayloadForLog } from '../../util.js';
+import { forwardFetchResponse, abortOnResponseClose, delay, summarizeLlmPayloadForLog } from '../../util.js';
 import { getOverrideHeaders, setAdditionalHeaders, setAdditionalHeadersByType } from '../../additional-headers.js';
 import { TEXTGEN_TYPES } from '../../constants.js';
 
@@ -17,8 +17,12 @@ router.post('/generate', async function (request, response_generate) {
 
     const request_prompt = request.body.prompt;
     const controller = new AbortController();
-    request.socket.removeAllListeners('close');
-    request.socket.on('close', async function () {
+    abortOnResponseClose(response_generate, controller);
+    response_generate.on('close', async function () {
+        if (response_generate.writableEnded) {
+            return;
+        }
+
         if (request.body.can_abort && !response_generate.writableEnded) {
             try {
                 console.info('Aborting Kobold generation...');
@@ -34,7 +38,6 @@ router.post('/generate', async function (request, response_generate) {
                 console.error(error);
             }
         }
-        controller.abort();
     });
 
     let this_settings = {

--- a/src/endpoints/backends/text-completions.js
+++ b/src/endpoints/backends/text-completions.js
@@ -13,7 +13,7 @@ import {
     FEATHERLESS_KEYS,
     OPENAI_KEYS,
 } from '../../constants.js';
-import { forwardFetchResponse, trimV1, getConfigValue, summarizeLlmPayloadForLog } from '../../util.js';
+import { forwardFetchResponse, abortOnResponseClose, trimV1, getConfigValue, summarizeLlmPayloadForLog } from '../../util.js';
 import { setAdditionalHeaders } from '../../additional-headers.js';
 import { createHash } from 'node:crypto';
 
@@ -51,7 +51,11 @@ async function parseOllamaStream(jsonStream, request, response) {
             }
         });
 
-        request.socket.on('close', function () {
+        response.on('close', function () {
+            if (response.writableEnded) {
+                return;
+            }
+
             if (jsonStream.body instanceof Readable) jsonStream.body.destroy();
             response.end();
         });
@@ -282,13 +286,15 @@ router.post('/generate', async function (request, response) {
         console.debug('Text completion request:', summarizeLlmPayloadForLog(request.body));
 
         const controller = new AbortController();
-        request.socket.removeAllListeners('close');
-        request.socket.on('close', async function () {
+        abortOnResponseClose(response, controller);
+        response.on('close', async function () {
+            if (response.writableEnded) {
+                return;
+            }
+
             if (request.body.api_type === TEXTGEN_TYPES.KOBOLDCPP && !response.writableEnded) {
                 await abortKoboldCppRequest(request, trimV1(baseUrl));
             }
-
-            controller.abort();
         });
 
         let url = trimV1(baseUrl);

--- a/src/util.js
+++ b/src/util.js
@@ -729,7 +729,11 @@ export async function forwardFetchResponse(from, to) {
     if (from.body && to.socket) {
         from.body.pipe(to);
 
-        to.socket.on('close', function () {
+        to.on('close', function () {
+            if (to.writableEnded) {
+                return;
+            }
+
             if (from.body instanceof Readable) from.body.destroy(); // Close the remote stream
 
             to.end(); // End the Express response
@@ -742,6 +746,19 @@ export async function forwardFetchResponse(from, to) {
     } else {
         to.end();
     }
+}
+
+/**
+ * Aborts an upstream request if the client closes the Express response early.
+ * @param {import('express').Response} response The Express response to observe.
+ * @param {AbortController} controller Abort controller for the upstream request.
+ */
+export function abortOnResponseClose(response, controller) {
+    response.on('close', () => {
+        if (!response.writableEnded) {
+            controller.abort();
+        }
+    });
 }
 
 /**

--- a/tests/util.test.js
+++ b/tests/util.test.js
@@ -3,7 +3,7 @@ import { once } from 'node:events';
 import { PassThrough } from 'node:stream';
 import { Response } from 'node-fetch';
 import { CHAT_COMPLETION_SOURCES } from '../src/constants';
-import { flattenSchema, forwardFetchResponse } from '../src/util';
+import { abortOnResponseClose, flattenSchema, forwardFetchResponse } from '../src/util';
 
 function createMockExpressResponse() {
     const response = new PassThrough();
@@ -132,6 +132,18 @@ describe('flattenSchema', () => {
 });
 
 describe('forwardFetchResponse', () => {
+    test('should destroy upstream streaming bodies when the client response closes early', async () => {
+        const upstreamBody = new PassThrough();
+        const destroySpy = jest.spyOn(upstreamBody, 'destroy');
+        const response = createMockExpressResponse();
+        response.socket = {};
+
+        await forwardFetchResponse(new Response(upstreamBody), response);
+        response.emit('close');
+
+        expect(destroySpy).toHaveBeenCalled();
+    });
+
     test('should log JSON error bodies and return the original body for non-2xx streaming responses', async () => {
         const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
         const body = JSON.stringify({ error: { message: 'Forbidden by upstream policy' }, detail: 'policy_denied' });
@@ -162,5 +174,28 @@ describe('forwardFetchResponse', () => {
         expect(await bodyPromise).toBe(body);
         expect(response.statusCode).toBe(502);
         expect(warnSpy).toHaveBeenCalledWith(`Streaming request failed with status 502 Bad Gateway: ${body}`);
+    });
+});
+
+describe('abortOnResponseClose', () => {
+    test('should abort the upstream controller when the client response closes early', () => {
+        const response = createMockExpressResponse();
+        const controller = new AbortController();
+
+        abortOnResponseClose(response, controller);
+        response.emit('close');
+
+        expect(controller.signal.aborted).toBe(true);
+    });
+
+    test('should not abort the upstream controller after a normal response end', () => {
+        const response = createMockExpressResponse();
+        const controller = new AbortController();
+
+        abortOnResponseClose(response, controller);
+        response.end();
+        response.emit('close');
+
+        expect(controller.signal.aborted).toBe(false);
     });
 });


### PR DESCRIPTION
## Summary
- Replace socket-level streaming abort hooks with response-close abort handling so client cancels abort upstream fetches reliably.
- Stop removing all socket close listeners from shared keep-alive sockets.
- Destroy forwarded upstream stream bodies when the Express response closes early.

## Tests
- npm run test:unit --prefix tests -- tests/util.test.js
- npm run test:unit --prefix tests -- tests/openai-responses.test.js
- npm run lint
- npm run lint --prefix tests