### PR TITLE
feat(ui): rework send message box

### DIFF
--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -1556,7 +1556,7 @@
         --bottomFormIconSize: clamp(14px, calc(17px * var(--sb-bottom-bar-scale, 1)), 21px);
         --sb-composer-action-size: clamp(22px, calc(var(--bottomFormBlockSize) * 0.56), 28px);
         --sb-composer-action-icon-size: clamp(11px, calc(var(--bottomFormIconSize, 20px) * 0.62), 14px);
-        --sb-mobile-composer-input-height: 44px;
+        --sb-mobile-composer-input-height: clamp(34px, calc(44px * var(--sb-bottom-bar-scale, 1)), 58px);
     }
 
     :root[data-sb-compact-mode='true'] {
@@ -1564,7 +1564,7 @@
         --bottomFormIconSize: clamp(13px, calc(15px * var(--sb-bottom-bar-scale, 1)), 19px);
         --sb-composer-action-size: clamp(20px, calc(var(--bottomFormBlockSize) * 0.54), 25px);
         --sb-composer-action-icon-size: clamp(10px, calc(var(--bottomFormIconSize, 18px) * 0.58), 12px);
-        --sb-mobile-composer-input-height: 36px;
+        --sb-mobile-composer-input-height: clamp(30px, calc(36px * var(--sb-bottom-bar-scale, 1)), 50px);
     }
 
     #form_sheld {
@@ -1658,7 +1658,7 @@
         overflow: visible !important;
     }
 
-    #rightSendForm > div:not(#send_but):not(#mes_stop):not(#extensionsMenuButton):not(.stscript_btn) {
+    #rightSendForm > div:not(#send_but):not(#mes_stop):not(#qig-input-btn):not(.stscript_btn) {
         display: none !important;
     }
 

--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -591,17 +591,17 @@
 
     /* Input area mobile optimization */
     #send_textarea {
-        min-height: calc(var(--bottomFormBlockSize) * 1.1);
-        padding: var(--input-padding-y) var(--input-padding-x);
+        min-height: var(--sb-mobile-composer-input-height, 44px);
+        padding: 5px 7px;
     }
 
     #send_form .mes_stop {
-        width: var(--bottomFormBlockSize);
-        min-width: var(--bottomFormBlockSize);
-        height: var(--bottomFormBlockSize);
-        min-height: var(--bottomFormBlockSize);
-        flex: 0 0 var(--bottomFormBlockSize);
-        font-size: var(--bottomFormIconSize);
+        width: var(--sb-composer-action-size, var(--bottomFormBlockSize));
+        min-width: var(--sb-composer-action-size, var(--bottomFormBlockSize));
+        height: var(--sb-composer-action-size, var(--bottomFormBlockSize));
+        min-height: var(--sb-composer-action-size, var(--bottomFormBlockSize));
+        flex: 0 0 var(--sb-composer-action-size, var(--bottomFormBlockSize));
+        font-size: var(--sb-composer-action-icon-size, var(--bottomFormIconSize));
         padding: 0;
         align-self: center;
         display: inline-flex;
@@ -611,13 +611,13 @@
 
     #send_form.sb-generating-controls #mes_stop {
         display: flex !important;
-        width: var(--bottomFormBlockSize) !important;
-        min-width: var(--bottomFormBlockSize) !important;
-        max-width: var(--bottomFormBlockSize) !important;
-        height: var(--bottomFormBlockSize) !important;
-        min-height: var(--bottomFormBlockSize) !important;
-        max-height: var(--bottomFormBlockSize) !important;
-        flex: 0 0 var(--bottomFormBlockSize) !important;
+        width: var(--sb-composer-action-size, var(--bottomFormBlockSize)) !important;
+        min-width: var(--sb-composer-action-size, var(--bottomFormBlockSize)) !important;
+        max-width: var(--sb-composer-action-size, var(--bottomFormBlockSize)) !important;
+        height: var(--sb-composer-action-size, var(--bottomFormBlockSize)) !important;
+        min-height: var(--sb-composer-action-size, var(--bottomFormBlockSize)) !important;
+        max-height: var(--sb-composer-action-size, var(--bottomFormBlockSize)) !important;
+        flex: 0 0 var(--sb-composer-action-size, var(--bottomFormBlockSize)) !important;
     }
 
     /* Hide stop button when not generating */
@@ -636,7 +636,7 @@
     #rightSendForm {
         width: auto !important;
         min-width: max-content;
-        min-height: var(--bottomFormBlockSize);
+        min-height: var(--sb-composer-action-size, var(--bottomFormBlockSize));
         flex-wrap: nowrap !important;
         align-items: center;
     }
@@ -647,9 +647,9 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        min-width: var(--sb-mobile-touch-target, 44px);
-        min-height: var(--sb-mobile-touch-target, 44px);
-        font-size: calc(var(--mainFontSize) * 1.1);
+        min-width: var(--sb-composer-action-size, var(--sb-mobile-touch-target, 44px));
+        min-height: var(--sb-composer-action-size, var(--sb-mobile-touch-target, 44px));
+        font-size: var(--sb-composer-action-icon-size, calc(var(--mainFontSize) * 1.1));
     }
 
     /* Ensure consistent hamburger button sizing */
@@ -994,10 +994,6 @@
         overflow-x: hidden
     }
 
-    .mes_buttons {
-        font-size: calc(var(--mainFontSize)*1.2);
-    }
-
     .mes .ch_name {
         flex-wrap: wrap;
         align-items: flex-start;
@@ -1015,7 +1011,7 @@
         flex-wrap: wrap;
         justify-content: flex-start;
         align-items: center;
-        row-gap: 6px;
+        row-gap: 4px;
         overflow: visible;
     }
 
@@ -1532,18 +1528,18 @@
 
     /* Input area optimization for small phones */
     #send_textarea {
-        min-height: calc(var(--bottomFormBlockSize) * 1.1);
-        padding: 8px;
+        min-height: var(--sb-mobile-composer-input-height, 44px);
+        padding: 5px 7px;
         font-size: calc(var(--mainFontSize) * 1.05);
     }
 
     #send_form .mes_stop {
-        width: var(--bottomFormBlockSize);
-        min-width: var(--bottomFormBlockSize);
-        height: var(--bottomFormBlockSize);
-        min-height: var(--bottomFormBlockSize);
-        flex: 0 0 var(--bottomFormBlockSize);
-        font-size: var(--bottomFormIconSize);
+        width: var(--sb-composer-action-size, var(--bottomFormBlockSize));
+        min-width: var(--sb-composer-action-size, var(--bottomFormBlockSize));
+        height: var(--sb-composer-action-size, var(--bottomFormBlockSize));
+        min-height: var(--sb-composer-action-size, var(--bottomFormBlockSize));
+        flex: 0 0 var(--sb-composer-action-size, var(--bottomFormBlockSize));
+        font-size: var(--sb-composer-action-icon-size, var(--bottomFormIconSize));
     }
 }
 
@@ -1556,41 +1552,49 @@
 /* Final mobile chat-bar guardrails: keep controls compact and square. */
 @media screen and (max-width: 768px) {
     :root {
-        --bottomFormBlockSize: clamp(34px, calc(var(--sb-mobile-touch-target, 44px) * var(--sb-bottom-bar-scale, 1)), 58px);
-        --bottomFormIconSize: clamp(16px, calc(20px * var(--sb-bottom-bar-scale, 1)), 25px);
-        --sb-mobile-composer-input-height: 68px;
+        --bottomFormBlockSize: clamp(30px, calc(var(--sb-mobile-touch-target, 44px) * 0.92 * var(--sb-bottom-bar-scale, 1)), 50px);
+        --bottomFormIconSize: clamp(14px, calc(17px * var(--sb-bottom-bar-scale, 1)), 21px);
+        --sb-composer-action-size: clamp(22px, calc(var(--bottomFormBlockSize) * 0.56), 28px);
+        --sb-composer-action-icon-size: clamp(11px, calc(var(--bottomFormIconSize, 20px) * 0.62), 14px);
+        --sb-mobile-composer-input-height: 44px;
     }
 
     :root[data-sb-compact-mode='true'] {
-        --bottomFormBlockSize: clamp(32px, calc(var(--sb-mobile-touch-target, 44px) * var(--sb-bottom-bar-scale, 1)), 54px);
-        --bottomFormIconSize: clamp(15px, calc(18px * var(--sb-bottom-bar-scale, 1)), 23px);
-        --sb-mobile-composer-input-height: 60px;
+        --bottomFormBlockSize: clamp(26px, calc(var(--sb-mobile-touch-target, 44px) * 0.82 * var(--sb-bottom-bar-scale, 1)), 44px);
+        --bottomFormIconSize: clamp(13px, calc(15px * var(--sb-bottom-bar-scale, 1)), 19px);
+        --sb-composer-action-size: clamp(20px, calc(var(--bottomFormBlockSize) * 0.54), 25px);
+        --sb-composer-action-icon-size: clamp(10px, calc(var(--bottomFormIconSize, 18px) * 0.58), 12px);
+        --sb-mobile-composer-input-height: 36px;
     }
 
     #send_form {
         border-radius: 14px 14px 0 0;
+        overflow: visible !important;
     }
 
     #nonQRFormItems {
         display: grid !important;
-        grid-template-columns: minmax(0, 1fr) max-content !important;
-        grid-template-rows: minmax(var(--sb-mobile-composer-input-height), auto) var(--bottomFormBlockSize) !important;
+        grid-template-columns:
+            minmax(var(--sb-composer-action-size), min(34vw, calc(var(--sb-composer-action-size) * 4 + 9px)))
+            minmax(0, 1fr)
+            var(--sb-composer-action-size) !important;
+        grid-template-rows: minmax(var(--sb-mobile-composer-input-height), auto) !important;
         grid-template-areas:
-            "input input"
-            "tools action" !important;
+            "tools input action" !important;
         align-items: center !important;
-        column-gap: 6px !important;
-        row-gap: 6px !important;
-        min-height: calc(var(--sb-mobile-composer-input-height) + var(--bottomFormBlockSize) + 18px) !important;
-        padding: 4px 6px 6px !important;
+        column-gap: 4px !important;
+        row-gap: 0 !important;
+        min-height: calc(var(--sb-mobile-composer-input-height) + 5px) !important;
+        padding: 2px 4px 3px !important;
         box-sizing: border-box !important;
+        overflow: visible !important;
     }
 
     :root[data-sb-compact-mode='true'] #nonQRFormItems {
-        column-gap: 5px !important;
-        row-gap: 5px !important;
-        min-height: calc(var(--sb-mobile-composer-input-height) + var(--bottomFormBlockSize) + 15px) !important;
-        padding: 3px 6px 5px !important;
+        column-gap: 3px !important;
+        row-gap: 0 !important;
+        min-height: calc(var(--sb-mobile-composer-input-height) + 5px) !important;
+        padding: 2px 4px 3px !important;
     }
 
     #leftSendForm,
@@ -1604,19 +1608,20 @@
     #leftSendForm {
         grid-area: tools !important;
         width: 100% !important;
-        min-height: var(--bottomFormBlockSize) !important;
-        height: var(--bottomFormBlockSize) !important;
+        max-width: 100% !important;
+        min-height: var(--sb-composer-action-size) !important;
+        height: var(--sb-composer-action-size) !important;
         justify-content: flex-start !important;
-        gap: 4px !important;
+        gap: 3px !important;
         overflow-x: auto !important;
         overflow-y: hidden !important;
         scrollbar-width: none !important;
     }
 
     :root[data-sb-compact-mode='true'] #leftSendForm {
-        min-height: var(--bottomFormBlockSize) !important;
-        height: var(--bottomFormBlockSize) !important;
-        gap: 3px !important;
+        min-height: var(--sb-composer-action-size) !important;
+        height: var(--sb-composer-action-size) !important;
+        gap: 2px !important;
     }
 
     #leftSendForm::-webkit-scrollbar {
@@ -1625,14 +1630,20 @@
 
     #rightSendForm {
         grid-area: action !important;
-        width: auto !important;
-        min-width: var(--bottomFormBlockSize) !important;
-        height: var(--bottomFormBlockSize) !important;
-        min-height: var(--bottomFormBlockSize) !important;
+        width: var(--sb-composer-action-size) !important;
+        min-width: var(--sb-composer-action-size) !important;
+        max-width: var(--sb-composer-action-size) !important;
+        height: var(--sb-composer-action-size) !important;
+        min-height: var(--sb-composer-action-size) !important;
         align-items: center !important;
         justify-content: center !important;
         align-self: center !important;
-        gap: 4px !important;
+        gap: 0 !important;
+        overflow: visible !important;
+    }
+
+    #rightSendForm > div:not(#send_but):not(#mes_stop):not(.stscript_btn) {
+        display: none !important;
     }
 
     #leftSendForm > div,
@@ -1640,21 +1651,21 @@
     #send_but,
     #send_form .mes_stop,
     #send_form.sb-generating-controls #mes_stop {
-        width: var(--bottomFormBlockSize) !important;
-        min-width: var(--bottomFormBlockSize) !important;
-        max-width: var(--bottomFormBlockSize) !important;
-        height: var(--bottomFormBlockSize) !important;
-        min-height: var(--bottomFormBlockSize) !important;
-        max-height: var(--bottomFormBlockSize) !important;
-        flex: 0 0 var(--bottomFormBlockSize) !important;
+        width: var(--sb-composer-action-size) !important;
+        min-width: var(--sb-composer-action-size) !important;
+        max-width: var(--sb-composer-action-size) !important;
+        height: var(--sb-composer-action-size) !important;
+        min-height: var(--sb-composer-action-size) !important;
+        max-height: var(--sb-composer-action-size) !important;
+        flex: 0 0 var(--sb-composer-action-size) !important;
         padding: 0 !important;
         margin: 0 !important;
         align-items: center !important;
         justify-content: center !important;
         box-sizing: border-box !important;
-        border-radius: 10px !important;
+        border-radius: 8px !important;
         line-height: 1 !important;
-        font-size: var(--bottomFormIconSize) !important;
+        font-size: var(--sb-composer-action-icon-size) !important;
     }
 
     :root[data-sb-compact-mode='true'] #leftSendForm > div,
@@ -1662,30 +1673,32 @@
     :root[data-sb-compact-mode='true'] #send_but,
     :root[data-sb-compact-mode='true'] #send_form .mes_stop,
     :root[data-sb-compact-mode='true'] #send_form.sb-generating-controls #mes_stop {
-        border-radius: 9px !important;
-        font-size: var(--bottomFormIconSize) !important;
+        border-radius: 7px !important;
+        font-size: var(--sb-composer-action-icon-size) !important;
     }
 
     #send_textarea {
         grid-area: input !important;
         flex: 1 1 100% !important;
         width: 100% !important;
+        max-width: 100% !important;
         min-width: 0 !important;
         min-height: var(--sb-mobile-composer-input-height) !important;
         field-sizing: content !important;
         max-height: 42dvh !important;
         overflow-y: auto !important;
-        padding: 8px 10px !important;
+        padding: 5px 7px !important;
         font-size: 16px !important;
-        line-height: 1.25 !important;
+        line-height: 1.18 !important;
         align-self: stretch !important;
+        justify-self: stretch !important;
         box-sizing: border-box !important;
     }
 
     :root[data-sb-compact-mode='true'] #send_textarea {
         min-height: var(--sb-mobile-composer-input-height) !important;
-        padding: 7px 9px !important;
-        line-height: 1.22 !important;
+        padding: 4px 6px !important;
+        line-height: 1.12 !important;
     }
 
     #send_but::before,
@@ -1696,13 +1709,13 @@
         display: inline-flex !important;
         align-items: center !important;
         justify-content: center !important;
-        font-size: var(--bottomFormIconSize) !important;
+        font-size: var(--sb-composer-action-icon-size) !important;
         line-height: 1 !important;
     }
 
     :root[data-sb-compact-mode='true'] #send_but::before,
     :root[data-sb-compact-mode='true'] #mes_stop > i {
-        font-size: var(--bottomFormIconSize) !important;
+        font-size: var(--sb-composer-action-icon-size) !important;
     }
 
     #send_form:not(.sb-generating-controls) #mes_stop {
@@ -1720,9 +1733,9 @@
         align-self: center !important;
         align-items: center !important;
         justify-content: center !important;
-        height: var(--bottomFormBlockSize) !important;
-        min-height: var(--bottomFormBlockSize) !important;
-        max-height: var(--bottomFormBlockSize) !important;
+        height: var(--sb-composer-action-size) !important;
+        min-height: var(--sb-composer-action-size) !important;
+        max-height: var(--sb-composer-action-size) !important;
         margin-block: 0 !important;
     }
 

--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -1591,9 +1591,9 @@
     #nonQRFormItems {
         display: grid !important;
         grid-template-columns:
-            minmax(var(--sb-composer-action-size), min(34vw, calc(var(--sb-composer-action-size) * 4 + 9px)))
+            minmax(calc(var(--sb-composer-action-size) * 2 + 3px), min(30vw, calc(var(--sb-composer-action-size) * 2 + 3px)))
             minmax(0, 1fr)
-            var(--sb-composer-action-size) !important;
+            minmax(calc(var(--sb-composer-action-size) * 2 + 3px), calc(var(--sb-composer-action-size) + var(--sb-composer-send-width, calc(var(--sb-composer-action-size) * 1.45)) + 3px)) !important;
         grid-template-rows: minmax(var(--sb-mobile-composer-input-height), auto) !important;
         grid-template-areas:
             "tools input action" !important;
@@ -1646,19 +1646,19 @@
 
     #rightSendForm {
         grid-area: action !important;
-        width: var(--sb-composer-action-size) !important;
-        min-width: var(--sb-composer-action-size) !important;
-        max-width: var(--sb-composer-action-size) !important;
+        width: 100% !important;
+        min-width: calc(var(--sb-composer-action-size) * 2 + 3px) !important;
+        max-width: 100% !important;
         height: var(--sb-composer-action-size) !important;
         min-height: var(--sb-composer-action-size) !important;
         align-items: center !important;
-        justify-content: center !important;
+        justify-content: flex-end !important;
         align-self: center !important;
-        gap: 0 !important;
+        gap: 3px !important;
         overflow: visible !important;
     }
 
-    #rightSendForm > div:not(#send_but):not(#mes_stop):not(.stscript_btn) {
+    #rightSendForm > div:not(#send_but):not(#mes_stop):not(#extensionsMenuButton):not(.stscript_btn) {
         display: none !important;
     }
 

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -34,6 +34,113 @@
         font-size: 14px;
     }
 
+    #nonQRFormItems {
+        --sb-mobile-composer-input-height: 42px;
+        --sb-composer-action-size: 26px;
+        --sb-composer-send-width: calc(var(--sb-composer-action-size) * 1.45);
+        --sb-composer-action-icon-size: 13px;
+        --sb-composer-side-rail-width: min(24vw, calc(var(--sb-composer-action-size) * 3 + 9px));
+        display: grid !important;
+        grid-template-columns: var(--sb-composer-side-rail-width) minmax(0, 1fr) var(--sb-composer-side-rail-width) !important;
+        grid-template-rows: var(--sb-mobile-composer-input-height) !important;
+        grid-template-areas: 'tools input action' !important;
+        align-items: center !important;
+        gap: 0 4px !important;
+        min-height: calc(var(--sb-mobile-composer-input-height) + 4px) !important;
+        padding: 2px 4px !important;
+        box-sizing: border-box !important;
+        overflow: visible !important;
+    }
+
+    :root[data-sb-compact-mode='true'] #nonQRFormItems {
+        --sb-mobile-composer-input-height: 34px;
+        --sb-composer-action-size: 22px;
+        --sb-composer-send-width: calc(var(--sb-composer-action-size) * 1.42);
+        --sb-composer-action-icon-size: 11px;
+        --sb-composer-side-rail-width: min(22vw, calc(var(--sb-composer-action-size) * 3 + 6px));
+        gap: 0 3px !important;
+    }
+
+    #leftSendForm {
+        grid-area: tools !important;
+        width: 100% !important;
+        min-width: 0 !important;
+        max-width: 100% !important;
+        height: var(--sb-composer-action-size) !important;
+        min-height: var(--sb-composer-action-size) !important;
+        overflow-x: auto !important;
+        overflow-y: hidden !important;
+        scrollbar-width: none !important;
+        gap: 3px !important;
+    }
+
+    #rightSendForm {
+        grid-area: action !important;
+        width: 100% !important;
+        min-width: 0 !important;
+        max-width: 100% !important;
+        height: var(--sb-composer-action-size) !important;
+        min-height: var(--sb-composer-action-size) !important;
+        overflow: visible !important;
+        justify-content: flex-end !important;
+        gap: 0 !important;
+    }
+
+    #rightSendForm > div:not(#send_but):not(#mes_stop):not(.stscript_btn) {
+        display: none !important;
+    }
+
+    #leftSendForm > div,
+    #rightSendForm > div:not(.stscript_btn),
+    #send_but,
+    #send_form .mes_stop,
+    #send_form.sb-generating-controls #mes_stop {
+        width: var(--sb-composer-action-size) !important;
+        min-width: var(--sb-composer-action-size) !important;
+        max-width: var(--sb-composer-action-size) !important;
+        height: var(--sb-composer-action-size) !important;
+        min-height: var(--sb-composer-action-size) !important;
+        max-height: var(--sb-composer-action-size) !important;
+        flex: 0 0 var(--sb-composer-action-size) !important;
+        padding: 0 !important;
+        margin: 0 !important;
+        box-sizing: border-box !important;
+        font-size: var(--sb-composer-action-icon-size) !important;
+        line-height: 1 !important;
+    }
+
+    #send_textarea {
+        grid-area: input !important;
+        width: 100% !important;
+        min-width: 0 !important;
+        max-width: 100% !important;
+        height: var(--sb-mobile-composer-input-height) !important;
+        min-height: var(--sb-mobile-composer-input-height) !important;
+        max-height: var(--sb-mobile-composer-input-height) !important;
+        resize: none !important;
+        overflow-y: auto !important;
+        box-sizing: border-box !important;
+        padding: 5px 7px !important;
+        line-height: 1.18 !important;
+        align-self: stretch !important;
+        justify-self: stretch !important;
+    }
+
+    #send_but {
+        width: var(--sb-composer-send-width) !important;
+        min-width: var(--sb-composer-send-width) !important;
+        max-width: var(--sb-composer-send-width) !important;
+        flex: 0 0 var(--sb-composer-send-width) !important;
+    }
+
+    #send_form .mes_stop,
+    #send_form.sb-generating-controls #mes_stop {
+        width: var(--sb-composer-send-width) !important;
+        min-width: var(--sb-composer-send-width) !important;
+        max-width: var(--sb-composer-send-width) !important;
+        flex: 0 0 var(--sb-composer-send-width) !important;
+    }
+
     body.sb-mobile-modal-open {
         overflow: hidden !important;
     }

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -39,9 +39,10 @@
         --sb-composer-action-size: 26px;
         --sb-composer-send-width: calc(var(--sb-composer-action-size) * 1.45);
         --sb-composer-action-icon-size: 13px;
-        --sb-composer-side-rail-width: min(24vw, calc(var(--sb-composer-action-size) * 3 + 9px));
+        --sb-composer-left-rail-width: min(28vw, calc(var(--sb-composer-action-size) * 2 + 3px));
+        --sb-composer-right-rail-width: calc(var(--sb-composer-action-size) + var(--sb-composer-send-width) + 3px);
         display: grid !important;
-        grid-template-columns: var(--sb-composer-side-rail-width) minmax(0, 1fr) var(--sb-composer-side-rail-width) !important;
+        grid-template-columns: var(--sb-composer-left-rail-width) minmax(0, 1fr) var(--sb-composer-right-rail-width) !important;
         grid-template-rows: var(--sb-mobile-composer-input-height) !important;
         grid-template-areas: 'tools input action' !important;
         align-items: center !important;
@@ -57,7 +58,8 @@
         --sb-composer-action-size: 22px;
         --sb-composer-send-width: calc(var(--sb-composer-action-size) * 1.42);
         --sb-composer-action-icon-size: 11px;
-        --sb-composer-side-rail-width: min(22vw, calc(var(--sb-composer-action-size) * 3 + 6px));
+        --sb-composer-left-rail-width: min(26vw, calc(var(--sb-composer-action-size) * 2 + 2px));
+        --sb-composer-right-rail-width: calc(var(--sb-composer-action-size) + var(--sb-composer-send-width) + 2px);
         gap: 0 3px !important;
     }
 
@@ -83,10 +85,10 @@
         min-height: var(--sb-composer-action-size) !important;
         overflow: visible !important;
         justify-content: flex-end !important;
-        gap: 0 !important;
+        gap: 3px !important;
     }
 
-    #rightSendForm > div:not(#send_but):not(#mes_stop):not(.stscript_btn) {
+    #rightSendForm > div:not(#send_but):not(#mes_stop):not(#extensionsMenuButton):not(.stscript_btn) {
         display: none !important;
     }
 

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -35,15 +35,15 @@
     }
 
     #nonQRFormItems {
-        --sb-mobile-composer-input-height: 42px;
-        --sb-composer-action-size: 26px;
+        --sb-mobile-composer-input-height: clamp(34px, calc(42px * var(--sb-bottom-bar-scale, 1)), 56px);
+        --sb-composer-action-size: clamp(20px, calc(26px * var(--sb-bottom-bar-scale, 1)), 36px);
         --sb-composer-send-width: calc(var(--sb-composer-action-size) * 1.45);
-        --sb-composer-action-icon-size: 13px;
+        --sb-composer-action-icon-size: clamp(10px, calc(13px * var(--sb-bottom-bar-scale, 1)), 18px);
         --sb-composer-left-rail-width: min(28vw, calc(var(--sb-composer-action-size) * 2 + 3px));
         --sb-composer-right-rail-width: calc(var(--sb-composer-action-size) + var(--sb-composer-send-width) + 3px);
         display: grid !important;
         grid-template-columns: var(--sb-composer-left-rail-width) minmax(0, 1fr) var(--sb-composer-right-rail-width) !important;
-        grid-template-rows: var(--sb-mobile-composer-input-height) !important;
+        grid-template-rows: minmax(var(--sb-mobile-composer-input-height), auto) !important;
         grid-template-areas: 'tools input action' !important;
         align-items: center !important;
         gap: 0 4px !important;
@@ -54,10 +54,10 @@
     }
 
     :root[data-sb-compact-mode='true'] #nonQRFormItems {
-        --sb-mobile-composer-input-height: 34px;
-        --sb-composer-action-size: 22px;
+        --sb-mobile-composer-input-height: clamp(30px, calc(34px * var(--sb-bottom-bar-scale, 1)), 48px);
+        --sb-composer-action-size: clamp(18px, calc(22px * var(--sb-bottom-bar-scale, 1)), 32px);
         --sb-composer-send-width: calc(var(--sb-composer-action-size) * 1.42);
-        --sb-composer-action-icon-size: 11px;
+        --sb-composer-action-icon-size: clamp(9px, calc(11px * var(--sb-bottom-bar-scale, 1)), 16px);
         --sb-composer-left-rail-width: min(26vw, calc(var(--sb-composer-action-size) * 2 + 2px));
         --sb-composer-right-rail-width: calc(var(--sb-composer-action-size) + var(--sb-composer-send-width) + 2px);
         gap: 0 3px !important;
@@ -88,7 +88,7 @@
         gap: 3px !important;
     }
 
-    #rightSendForm > div:not(#send_but):not(#mes_stop):not(#extensionsMenuButton):not(.stscript_btn) {
+    #rightSendForm > div:not(#send_but):not(#mes_stop):not(#qig-input-btn):not(.stscript_btn) {
         display: none !important;
     }
 
@@ -116,9 +116,9 @@
         width: 100% !important;
         min-width: 0 !important;
         max-width: 100% !important;
-        height: var(--sb-mobile-composer-input-height) !important;
         min-height: var(--sb-mobile-composer-input-height) !important;
-        max-height: var(--sb-mobile-composer-input-height) !important;
+        max-height: 42dvh !important;
+        field-sizing: content !important;
         resize: none !important;
         overflow-y: auto !important;
         box-sizing: border-box !important;

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -3960,12 +3960,12 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     #sb-bottom-chat-bar {
         --sb-bottom-chat-mobile-gutter: max(14px, env(safe-area-inset-left, 0px), env(safe-area-inset-right, 0px));
         --sb-bottom-chat-mobile-width: calc(100% - (var(--sb-bottom-chat-mobile-gutter) * 2));
-        --sb-bottom-chat-mobile-gap: clamp(1px, calc(3px * var(--sb-bottom-bar-scale)), 5px);
-        --sb-bottom-chat-mobile-padding-block: clamp(2px, calc(3px * var(--sb-bottom-bar-scale)), 5px);
+        --sb-bottom-chat-mobile-gap: clamp(1px, calc(2px * var(--sb-bottom-bar-scale)), 4px);
+        --sb-bottom-chat-mobile-padding-block: clamp(1px, calc(2px * var(--sb-bottom-bar-scale)), 3px);
         --sb-bottom-chat-mobile-padding-inline: clamp(4px, calc(5px * var(--sb-bottom-bar-scale)), 7px);
-        --sb-bottom-chat-mobile-button-size: var(--bottomFormBlockSize, clamp(44px, calc(44px * var(--sb-bottom-bar-scale)), 52px));
-        --sb-bottom-chat-mobile-select-height: clamp(var(--sb-bottom-chat-min-touch), calc(34px * var(--sb-bottom-bar-scale)), 42px);
-        --sb-bottom-chat-mobile-persona-size: clamp(var(--sb-bottom-chat-min-touch), calc(34px * var(--sb-bottom-bar-scale)), 42px);
+        --sb-bottom-chat-mobile-button-size: clamp(28px, calc(30px * var(--sb-bottom-bar-scale)), 34px);
+        --sb-bottom-chat-mobile-select-height: clamp(28px, calc(30px * var(--sb-bottom-bar-scale)), 34px);
+        --sb-bottom-chat-mobile-persona-size: clamp(28px, calc(30px * var(--sb-bottom-bar-scale)), 34px);
         --sb-bottom-chat-mobile-radius: clamp(9px, calc(11px * var(--sb-bottom-bar-scale)), 14px);
         width: min(var(--sb-bottom-chat-mobile-width), calc(100% - (var(--sb-bottom-chat-mobile-gutter) * 2)));
         max-width: calc(100% - (var(--sb-bottom-chat-mobile-gutter) * 2));
@@ -4105,11 +4105,12 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     #sb-bottom-chat-bar {
         --sb-bottom-chat-mobile-gutter: max(4px, env(safe-area-inset-left, 0px), env(safe-area-inset-right, 0px));
         --sb-bottom-chat-mobile-width: calc(100% - (var(--sb-bottom-chat-mobile-gutter) * 2));
-        --sb-bottom-chat-mobile-gap: clamp(1px, calc(2px * var(--sb-bottom-bar-scale)), 3px);
-        --sb-bottom-chat-mobile-padding-block: clamp(2px, calc(2px * var(--sb-bottom-bar-scale)), 4px);
+        --sb-bottom-chat-mobile-gap: clamp(1px, calc(1.5px * var(--sb-bottom-bar-scale)), 3px);
+        --sb-bottom-chat-mobile-padding-block: clamp(1px, calc(1.5px * var(--sb-bottom-bar-scale)), 2px);
         --sb-bottom-chat-mobile-padding-inline: clamp(3px, calc(4px * var(--sb-bottom-bar-scale)), 6px);
-        --sb-bottom-chat-mobile-select-height: clamp(var(--sb-bottom-chat-min-touch), calc(32px * var(--sb-bottom-bar-scale)), 40px);
-        --sb-bottom-chat-mobile-persona-size: clamp(var(--sb-bottom-chat-min-touch), calc(32px * var(--sb-bottom-bar-scale)), 40px);
+        --sb-bottom-chat-mobile-button-size: clamp(26px, calc(28px * var(--sb-bottom-bar-scale)), 32px);
+        --sb-bottom-chat-mobile-select-height: clamp(26px, calc(28px * var(--sb-bottom-bar-scale)), 32px);
+        --sb-bottom-chat-mobile-persona-size: clamp(26px, calc(28px * var(--sb-bottom-bar-scale)), 32px);
         --sb-bottom-chat-mobile-radius: clamp(8px, calc(10px * var(--sb-bottom-bar-scale)), 13px);
     }
 

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -3788,6 +3788,15 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     border-radius: var(--sb-radius-button, 14px) !important;
 }
 
+@media screen and (min-width: 1001px) {
+    #send_form #qig-input-btn {
+        padding: 0 !important;
+        box-sizing: border-box !important;
+        font-size: var(--sb-composer-action-icon-size, 15px) !important;
+        line-height: 1 !important;
+    }
+}
+
 #sb-bottom-chat-bar {
     display: flex;
     align-items: center;

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -8,6 +8,7 @@
     --sb-topbar-scale-mobile: 1;
     --sb-mobile-button-scale: 1;
     --sb-bottom-bar-scale: 1;
+    --sb-bottom-chat-min-touch: 32px;
     --sb-topbar-scale-active: var(--sb-topbar-scale-desktop);
     --sb-chatbar-scale-active: calc(var(--sb-topbar-scale-active) * var(--sb-bottom-bar-scale));
     --sb-topbar-primary-height-base: var(--topBarBlockSize);
@@ -147,6 +148,7 @@
 
 :root[data-sb-compact-mode='true'] {
     --sb-density-scale: 0.88;
+    --sb-bottom-chat-min-touch: 28px;
     --sb-topbar-primary-height-base: 34px;
     --sb-topbar-padding-x-base: 7px;
     --sb-topbar-stack-gap-base: 3px;
@@ -3587,18 +3589,86 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 }
 
 /* Bottom chat management bar */
+#nonQRFormItems {
+    display: grid !important;
+    grid-template-columns: var(--sb-composer-side-rail-width, min(16%, 132px)) minmax(0, 1fr) var(--sb-composer-side-rail-width, min(16%, 132px)) !important;
+    grid-template-areas: 'tools input action' !important;
+    align-items: center !important;
+    gap: 0 4px !important;
+    min-width: 0 !important;
+    overflow: visible !important;
+    box-sizing: border-box !important;
+}
+
+#leftSendForm {
+    grid-area: tools !important;
+    width: 100% !important;
+    min-width: 0 !important;
+    max-width: 100% !important;
+    overflow-x: auto !important;
+    overflow-y: hidden !important;
+    scrollbar-width: none !important;
+}
+
+#leftSendForm::-webkit-scrollbar {
+    display: none !important;
+}
+
+#send_textarea {
+    grid-area: input !important;
+    width: 100% !important;
+    min-width: 0 !important;
+    max-width: 100% !important;
+    resize: none !important;
+    box-sizing: border-box !important;
+    justify-self: stretch !important;
+}
+
+#rightSendForm {
+    grid-area: action !important;
+    width: 100% !important;
+    min-width: 0 !important;
+    max-width: 100% !important;
+    overflow: visible !important;
+    justify-self: end !important;
+    justify-content: flex-end !important;
+}
+
+#send_but {
+    width: var(--sb-composer-send-width, calc(var(--sb-composer-action-size, 30px) * 1.45)) !important;
+    min-width: var(--sb-composer-send-width, calc(var(--sb-composer-action-size, 30px) * 1.45)) !important;
+    max-width: var(--sb-composer-send-width, calc(var(--sb-composer-action-size, 30px) * 1.45)) !important;
+    height: var(--sb-composer-action-size, 30px) !important;
+    min-height: var(--sb-composer-action-size, 30px) !important;
+    max-height: var(--sb-composer-action-size, 30px) !important;
+    flex: 0 0 var(--sb-composer-send-width, calc(var(--sb-composer-action-size, 30px) * 1.45)) !important;
+    border-radius: var(--sb-radius-button, 14px) !important;
+}
+
+#send_form .mes_stop,
+#send_form.sb-generating-controls #mes_stop {
+    width: var(--sb-composer-send-width, calc(var(--sb-composer-action-size, 30px) * 1.45)) !important;
+    min-width: var(--sb-composer-send-width, calc(var(--sb-composer-action-size, 30px) * 1.45)) !important;
+    max-width: var(--sb-composer-send-width, calc(var(--sb-composer-action-size, 30px) * 1.45)) !important;
+    height: var(--sb-composer-action-size, 30px) !important;
+    min-height: var(--sb-composer-action-size, 30px) !important;
+    max-height: var(--sb-composer-action-size, 30px) !important;
+    flex: 0 0 var(--sb-composer-send-width, calc(var(--sb-composer-action-size, 30px) * 1.45)) !important;
+    border-radius: var(--sb-radius-button, 14px) !important;
+}
+
 #sb-bottom-chat-bar {
     display: flex;
     align-items: center;
-    gap: calc(8px * var(--sb-bottom-bar-scale));
+    gap: calc(4px * var(--sb-bottom-bar-scale));
     box-sizing: border-box;
     margin-block-end: var(--sb-chat-composer-gap, 8px);
-    padding: calc(6px * var(--sb-bottom-bar-scale)) calc(12px * var(--sb-bottom-bar-scale));
+    padding: calc(3px * var(--sb-bottom-bar-scale)) calc(8px * var(--sb-bottom-bar-scale));
     border: 1px solid color-mix(in srgb, var(--SmartThemeBorderColor) 72%, transparent);
-    border-radius: var(--sb-radius-xl, 22px);
+    border-radius: var(--sb-radius-md, 14px);
     background: var(--sb-composer-surface-bg, var(--sb-chat-surface-bg, color-mix(in srgb, var(--SmartThemeBlurTintColor) 92%, var(--SmartThemeChatTintColor) 8%)));
     box-shadow: 0 10px 26px color-mix(in srgb, var(--SmartThemeShadowColor) 12%, transparent);
-    min-height: max(44px, calc(34px * var(--sb-bottom-bar-scale)));
+    min-height: max(var(--sb-bottom-chat-min-touch), calc(26px * var(--sb-bottom-bar-scale)));
     overflow: hidden;
 }
 
@@ -3609,10 +3679,10 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 #sb-bottom-chat-select {
     flex: 0 1 clamp(120px, 22vw, 260px);
     min-width: 0;
-    height: max(44px, calc(28px * var(--sb-bottom-bar-scale)));
-    min-height: max(44px, calc(28px * var(--sb-bottom-bar-scale)));
+    height: max(var(--sb-bottom-chat-min-touch), calc(23px * var(--sb-bottom-bar-scale)));
+    min-height: max(var(--sb-bottom-chat-min-touch), calc(23px * var(--sb-bottom-bar-scale)));
     margin: 0;
-    padding: 0 calc(12px * var(--sb-bottom-bar-scale));
+    padding: 0 calc(9px * var(--sb-bottom-bar-scale));
     box-sizing: border-box;
     font: inherit;
     font-size: calc(var(--mainFontSize) * 0.85 * var(--sb-bottom-bar-scale));
@@ -3620,7 +3690,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     color: var(--SmartThemeBodyColor);
     background: color-mix(in srgb, var(--SmartThemeBodyColor) 4%, var(--sb-composer-surface-base, var(--SmartThemeBlurTintColor)));
     border: 1px solid color-mix(in srgb, var(--SmartThemeBorderColor) 40%, transparent);
-    border-radius: calc(14px * var(--sb-bottom-bar-scale));
+    border-radius: calc(10px * var(--sb-bottom-bar-scale));
     appearance: none;
     cursor: pointer;
     overflow: hidden;
@@ -3634,18 +3704,18 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     isolation: isolate;
     display: flex;
     align-items: center;
-    gap: calc(7px * var(--sb-bottom-bar-scale));
+    gap: calc(4px * var(--sb-bottom-bar-scale));
     flex: 1 1 180px;
     min-width: 110px;
-    height: max(44px, calc(28px * var(--sb-bottom-bar-scale)));
-    min-height: max(44px, calc(28px * var(--sb-bottom-bar-scale)));
+    height: max(var(--sb-bottom-chat-min-touch), calc(23px * var(--sb-bottom-bar-scale)));
+    min-height: max(var(--sb-bottom-chat-min-touch), calc(23px * var(--sb-bottom-bar-scale)));
     margin: 0;
-    padding: 0 calc(10px * var(--sb-bottom-bar-scale));
+    padding: 0 calc(8px * var(--sb-bottom-bar-scale));
     box-sizing: border-box;
     color: var(--SmartThemeBodyColor);
     background: color-mix(in srgb, var(--SmartThemeBodyColor) 4%, var(--sb-composer-surface-base, var(--SmartThemeBlurTintColor)));
     border: 1px solid color-mix(in srgb, var(--SmartThemeBorderColor) 40%, transparent);
-    border-radius: calc(14px * var(--sb-bottom-bar-scale));
+    border-radius: calc(10px * var(--sb-bottom-bar-scale));
     overflow: hidden;
 }
 
@@ -3659,7 +3729,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     flex: 1 1 auto;
     min-width: 0;
     width: 100%;
-    height: calc(20px * var(--sb-bottom-bar-scale)) !important;
+    height: calc(17px * var(--sb-bottom-bar-scale)) !important;
     min-height: 0 !important;
     margin: 0;
     padding: 0 !important;
@@ -3721,10 +3791,10 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-width: max(44px, calc(28px * var(--sb-bottom-bar-scale)));
-    min-height: max(44px, calc(28px * var(--sb-bottom-bar-scale)));
+    min-width: max(var(--sb-bottom-chat-min-touch), calc(23px * var(--sb-bottom-bar-scale)));
+    min-height: max(var(--sb-bottom-chat-min-touch), calc(23px * var(--sb-bottom-bar-scale)));
     margin: 0;
-    padding: calc(4px * var(--sb-bottom-bar-scale)) calc(8px * var(--sb-bottom-bar-scale));
+    padding: calc(2px * var(--sb-bottom-bar-scale)) calc(6px * var(--sb-bottom-bar-scale));
     box-sizing: border-box;
     border-radius: calc(8px * var(--sb-bottom-bar-scale));
     font-size: calc(var(--mainFontSize) * 0.9 * var(--sb-bottom-bar-scale));
@@ -3759,13 +3829,13 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     #sb-bottom-chat-bar {
         --sb-bottom-chat-mobile-gutter: max(14px, env(safe-area-inset-left, 0px), env(safe-area-inset-right, 0px));
         --sb-bottom-chat-mobile-width: calc(100% - (var(--sb-bottom-chat-mobile-gutter) * 2));
-        --sb-bottom-chat-mobile-gap: clamp(2px, calc(4px * var(--sb-bottom-bar-scale)), 6px);
-        --sb-bottom-chat-mobile-padding-block: clamp(3px, calc(4px * var(--sb-bottom-bar-scale)), 6px);
-        --sb-bottom-chat-mobile-padding-inline: clamp(5px, calc(6px * var(--sb-bottom-bar-scale)), 9px);
+        --sb-bottom-chat-mobile-gap: clamp(1px, calc(3px * var(--sb-bottom-bar-scale)), 5px);
+        --sb-bottom-chat-mobile-padding-block: clamp(2px, calc(3px * var(--sb-bottom-bar-scale)), 5px);
+        --sb-bottom-chat-mobile-padding-inline: clamp(4px, calc(5px * var(--sb-bottom-bar-scale)), 7px);
         --sb-bottom-chat-mobile-button-size: var(--bottomFormBlockSize, clamp(44px, calc(44px * var(--sb-bottom-bar-scale)), 52px));
-        --sb-bottom-chat-mobile-select-height: clamp(44px, calc(44px * var(--sb-bottom-bar-scale)), 52px);
-        --sb-bottom-chat-mobile-persona-size: clamp(44px, calc(44px * var(--sb-bottom-bar-scale)), 52px);
-        --sb-bottom-chat-mobile-radius: clamp(12px, calc(14px * var(--sb-bottom-bar-scale)), 18px);
+        --sb-bottom-chat-mobile-select-height: clamp(var(--sb-bottom-chat-min-touch), calc(34px * var(--sb-bottom-bar-scale)), 42px);
+        --sb-bottom-chat-mobile-persona-size: clamp(var(--sb-bottom-chat-min-touch), calc(34px * var(--sb-bottom-bar-scale)), 42px);
+        --sb-bottom-chat-mobile-radius: clamp(9px, calc(11px * var(--sb-bottom-bar-scale)), 14px);
         width: min(var(--sb-bottom-chat-mobile-width), calc(100% - (var(--sb-bottom-chat-mobile-gutter) * 2)));
         max-width: calc(100% - (var(--sb-bottom-chat-mobile-gutter) * 2));
         display: grid;
@@ -3904,12 +3974,12 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     #sb-bottom-chat-bar {
         --sb-bottom-chat-mobile-gutter: max(4px, env(safe-area-inset-left, 0px), env(safe-area-inset-right, 0px));
         --sb-bottom-chat-mobile-width: calc(100% - (var(--sb-bottom-chat-mobile-gutter) * 2));
-        --sb-bottom-chat-mobile-gap: clamp(2px, calc(2px * var(--sb-bottom-bar-scale)), 4px);
-        --sb-bottom-chat-mobile-padding-block: clamp(3px, calc(3px * var(--sb-bottom-bar-scale)), 5px);
-        --sb-bottom-chat-mobile-padding-inline: clamp(4px, calc(5px * var(--sb-bottom-bar-scale)), 7px);
-        --sb-bottom-chat-mobile-select-height: clamp(44px, calc(44px * var(--sb-bottom-bar-scale)), 50px);
-        --sb-bottom-chat-mobile-persona-size: clamp(44px, calc(44px * var(--sb-bottom-bar-scale)), 50px);
-        --sb-bottom-chat-mobile-radius: clamp(11px, calc(13px * var(--sb-bottom-bar-scale)), 16px);
+        --sb-bottom-chat-mobile-gap: clamp(1px, calc(2px * var(--sb-bottom-bar-scale)), 3px);
+        --sb-bottom-chat-mobile-padding-block: clamp(2px, calc(2px * var(--sb-bottom-bar-scale)), 4px);
+        --sb-bottom-chat-mobile-padding-inline: clamp(3px, calc(4px * var(--sb-bottom-bar-scale)), 6px);
+        --sb-bottom-chat-mobile-select-height: clamp(var(--sb-bottom-chat-min-touch), calc(32px * var(--sb-bottom-bar-scale)), 40px);
+        --sb-bottom-chat-mobile-persona-size: clamp(var(--sb-bottom-chat-min-touch), calc(32px * var(--sb-bottom-bar-scale)), 40px);
+        --sb-bottom-chat-mobile-radius: clamp(8px, calc(10px * var(--sb-bottom-bar-scale)), 13px);
     }
 
     #sb-bottom-chat-select {

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -1473,10 +1473,10 @@ body.bubblechat .mes[is_user='true']::before {
 
 .mes[is_user='true'] .mes_block {
     box-sizing: border-box;
-    border: 1px solid color-mix(in srgb, var(--color-primary, var(--sb-accent)) 24%, transparent);
+    border: 1px solid color-mix(in srgb, var(--SmartThemeBodyColor) 14%, transparent);
     border-radius: var(--sb-radius-md);
     padding: 10px 12px;
-    background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 4%, transparent);
+    background: color-mix(in srgb, var(--SmartThemeBodyColor) 3%, transparent);
 }
 
 body.flatchat .mes[is_user='true'] .mes_block,

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -45,7 +45,11 @@
     --sb-row-gap: 10px;
     --sb-section-gap: 14px;
     --sb-settings-card-padding: var(--spacing-md) 14px;
-    --sb-message-icon-size: 1.75rem;
+    --sb-message-icon-size: clamp(24px, calc(var(--bottomFormBlockSize, 36px) * 0.78), 30px);
+    --sb-composer-action-size: clamp(24px, calc(var(--bottomFormBlockSize, 36px) * 0.72), 30px);
+    --sb-composer-send-width: calc(var(--sb-composer-action-size) * 1.45);
+    --sb-composer-action-icon-size: clamp(12px, calc(var(--bottomFormIconSize, 20px) * 0.62), 15px);
+    --sb-composer-side-rail-width: min(16%, calc(var(--sb-composer-action-size) * 4 + 12px));
     --sb-message-meta-line-height: 1.18;
     --sb-chat-composer-gap: var(--spacing-sm);
     --sb-chat-composer-edge-gap: var(--spacing-sm);
@@ -150,6 +154,11 @@
     --sb-chat-composer-edge-gap: 6px;
     --sb-icon-control-size: 1.85rem;
     --sb-inline-drawer-icon-size: 1.85rem;
+    --sb-message-icon-size: clamp(20px, calc(var(--bottomFormBlockSize, 34px) * 0.68), 26px);
+    --sb-composer-action-size: clamp(20px, calc(var(--bottomFormBlockSize, 34px) * 0.62), 26px);
+    --sb-composer-send-width: calc(var(--sb-composer-action-size) * 1.42);
+    --sb-composer-action-icon-size: clamp(11px, calc(var(--bottomFormIconSize, 18px) * 0.58), 13px);
+    --sb-composer-side-rail-width: min(14%, calc(var(--sb-composer-action-size) * 4 + 10px));
 }
 
 @media (pointer: coarse), screen and (max-width: 760px) {
@@ -632,7 +641,7 @@ h3:not(.popup h3):not(#chat h3) {
     box-sizing: border-box;
     line-height: 1;
     text-align: center;
-    overflow: hidden;
+    overflow: visible;
 }
 
 .menu_button:is(.fa, .fa-solid, .fa-regular, .fa-brands):empty::before,
@@ -791,8 +800,8 @@ select.text_pole:where(:not([multiple]):not([size]):not(.select2-hidden-accessib
     position: relative;
     isolation: isolate;
     box-sizing: border-box;
-    padding: 8px;
-    border-radius: var(--sb-radius-xl);
+    padding: 4px;
+    border-radius: 16px;
     border-color: color-mix(in srgb, var(--sb-shell-border) 92%, transparent);
     box-shadow: 0 -10px 40px color-mix(in srgb, var(--SmartThemeShadowColor) 14%, transparent);
     background:
@@ -816,15 +825,45 @@ select.text_pole:where(:not([multiple]):not([size]):not(.select2-hidden-accessib
 
 #nonQRFormItems {
     align-items: center;
-    gap: 6px;
-    padding: 6px 8px;
+    gap: 4px;
+    padding: 4px 6px;
     font-size: calc(var(--bottomFormIconSize) * 0.76);
+    min-width: 0;
+    overflow: visible;
+    border: 1px solid color-mix(in srgb, var(--sb-shell-border) 88%, var(--SmartThemeBodyColor) 12%);
+    border-radius: 999px;
+    background: linear-gradient(
+        180deg,
+        color-mix(in srgb, var(--SmartThemeBodyColor) 8%, var(--sb-composer-surface-base, transparent)),
+        color-mix(in srgb, var(--SmartThemeBodyColor) 3%, var(--sb-composer-surface-base, transparent))
+    );
+    box-shadow:
+        inset 0 1px 0 color-mix(in srgb, var(--SmartThemeBodyColor) 14%, transparent),
+        0 6px 14px color-mix(in srgb, var(--SmartThemeShadowColor) 14%, transparent);
 }
 
 #leftSendForm,
 #rightSendForm {
     gap: 6px;
     align-items: center;
+    flex: 0 0 auto;
+    min-width: 0;
+}
+
+#leftSendForm {
+    max-width: min(35%, calc(var(--sb-composer-action-size) * 6 + 30px));
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+}
+
+#leftSendForm::-webkit-scrollbar {
+    display: none;
+}
+
+#rightSendForm {
+    max-width: max-content;
+    overflow: visible;
 }
 
 #leftSendForm > div,
@@ -834,16 +873,16 @@ select.text_pole:where(:not([multiple]):not([size]):not(.select2-hidden-accessib
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: var(--bottomFormBlockSize);
-    min-width: var(--bottomFormBlockSize);
-    height: var(--bottomFormBlockSize);
+    width: var(--sb-composer-action-size);
+    min-width: var(--sb-composer-action-size);
+    height: var(--sb-composer-action-size);
     margin: 0;
     padding: 0;
     border-radius: var(--sb-radius-button);
     background: color-mix(in srgb, var(--SmartThemeBodyColor) 6%, transparent);
     border: 1px solid color-mix(in srgb, var(--sb-shell-border) 82%, transparent);
     box-shadow: 0 10px 18px color-mix(in srgb, var(--SmartThemeShadowColor) 10%, transparent);
-    font-size: calc(var(--bottomFormIconSize) * 0.75);
+    font-size: var(--sb-composer-action-icon-size);
 }
 
 #send_form .mes_stop {
@@ -1053,42 +1092,45 @@ select.text_pole:where(:not([multiple]):not([size]):not(.select2-hidden-accessib
 }
 
 #send_textarea {
-    min-height: 68px;
+    min-width: 0;
+    width: auto;
+    flex: 1 1 0;
+    min-height: 46px;
     height: auto;
     field-sizing: content;
     max-height: min(50vh, 28rem);
     overflow-y: auto;
-    padding: var(--input-padding-y, 14px) var(--input-padding-x, 16px);
-    line-height: 1.56;
-    border-radius: var(--sb-radius-md);
+    padding: 6px 8px;
+    line-height: 1.28;
+    border-radius: 10px;
     background: var(--sb-composer-input-bg);
     color: var(--SmartThemeBodyColor);
     caret-color: var(--color-primary, var(--sb-accent));
-    font-size: calc(var(--mainFontSize) * 0.98);
+    font-size: calc(var(--mainFontSize) * 0.9);
     transition: border-color var(--sb-transition-fast), box-shadow var(--sb-transition-fast), background-color var(--sb-transition-fast);
 }
 
 :root[data-sb-compact-mode='true'] #send_form {
-    padding: 6px;
-    border-radius: 20px;
+    padding: 3px;
+    border-radius: 12px;
 }
 
 :root[data-sb-compact-mode='true'] #nonQRFormItems {
-    gap: 5px;
-    padding: 4px 6px;
+    gap: 3px;
+    padding: 3px 5px;
 }
 
 :root[data-sb-compact-mode='true'] #leftSendForm,
 :root[data-sb-compact-mode='true'] #rightSendForm {
-    gap: 5px;
+    gap: 3px;
 }
 
 :root[data-sb-compact-mode='true'] #send_textarea {
-    min-height: 56px;
-    padding: 10px 12px;
-    line-height: 1.45;
-    border-radius: 12px;
-    font-size: calc(var(--mainFontSize) * 0.94);
+    min-height: 38px;
+    padding: 5px 7px;
+    line-height: 1.18;
+    border-radius: 8px;
+    font-size: calc(var(--mainFontSize) * 0.86);
 }
 
 #send_textarea::placeholder {
@@ -1114,7 +1156,40 @@ select.text_pole:where(:not([multiple]):not([size]):not(.select2-hidden-accessib
 }
 
 #send_but {
-    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-primary, var(--sb-accent)) 30%, transparent);
+    width: var(--sb-composer-send-width) !important;
+    min-width: var(--sb-composer-send-width) !important;
+    max-width: var(--sb-composer-send-width) !important;
+    height: var(--sb-composer-action-size) !important;
+    min-height: var(--sb-composer-action-size) !important;
+    max-height: var(--sb-composer-action-size) !important;
+    flex: 0 0 var(--sb-composer-send-width) !important;
+    border-radius: var(--sb-radius-button) !important;
+    background: var(--color-primary, var(--sb-accent, var(--SmartThemeQuoteColor))) !important;
+    border: 1px solid transparent !important;
+    box-shadow:
+        inset 0 0 0 1px color-mix(in srgb, var(--color-primary, var(--sb-accent)) 30%, transparent),
+        0 10px 18px color-mix(in srgb, var(--SmartThemeShadowColor) 10%, transparent);
+    color: var(--sb-on-solid-accent, var(--sb-on-accent, var(--color-background, var(--SmartThemeBlurTintColor)))) !important;
+    font-size: var(--sb-composer-action-icon-size) !important;
+}
+
+#send_form .mes_stop,
+#send_form.sb-generating-controls #mes_stop {
+    width: var(--sb-composer-send-width) !important;
+    min-width: var(--sb-composer-send-width) !important;
+    max-width: var(--sb-composer-send-width) !important;
+    height: var(--sb-composer-action-size) !important;
+    min-height: var(--sb-composer-action-size) !important;
+    max-height: var(--sb-composer-action-size) !important;
+    flex: 0 0 var(--sb-composer-send-width) !important;
+    border-radius: var(--sb-radius-button) !important;
+    background: var(--color-primary, var(--sb-accent, var(--SmartThemeQuoteColor))) !important;
+    border: 1px solid transparent !important;
+    box-shadow:
+        inset 0 0 0 1px color-mix(in srgb, var(--color-primary, var(--sb-accent)) 30%, transparent),
+        0 10px 18px color-mix(in srgb, var(--SmartThemeShadowColor) 10%, transparent);
+    color: var(--sb-on-solid-accent, var(--sb-on-accent, var(--color-background, var(--SmartThemeBlurTintColor)))) !important;
+    font-size: var(--sb-composer-action-icon-size) !important;
 }
 
 /*
@@ -1167,33 +1242,33 @@ select.text_pole:where(:not([multiple]):not([size]):not(.select2-hidden-accessib
     #leftSendForm > div,
     #rightSendForm > div:not(.mes_stop),
     #options_button {
-        width: var(--bottomFormBlockSize) !important;
-        min-width: var(--bottomFormBlockSize) !important;
-        height: var(--bottomFormBlockSize) !important;
-        min-height: var(--bottomFormBlockSize) !important;
-        max-width: var(--bottomFormBlockSize) !important;
-        max-height: var(--bottomFormBlockSize) !important;
+        width: var(--sb-composer-action-size) !important;
+        min-width: var(--sb-composer-action-size) !important;
+        height: var(--sb-composer-action-size) !important;
+        min-height: var(--sb-composer-action-size) !important;
+        max-width: var(--sb-composer-action-size) !important;
+        max-height: var(--sb-composer-action-size) !important;
     }
 
     /* Override any optional theme-specific sizing. */
     #leftSendForm > *,
     #rightSendForm > *:not(.mes_stop),
     #form_sheld #options_button {
-        width: var(--bottomFormBlockSize) !important;
-        min-width: var(--bottomFormBlockSize) !important;
-        height: var(--bottomFormBlockSize) !important;
-        min-height: var(--bottomFormBlockSize) !important;
-        max-width: var(--bottomFormBlockSize) !important;
-        max-height: var(--bottomFormBlockSize) !important;
+        width: var(--sb-composer-action-size) !important;
+        min-width: var(--sb-composer-action-size) !important;
+        height: var(--sb-composer-action-size) !important;
+        min-height: var(--sb-composer-action-size) !important;
+        max-width: var(--sb-composer-action-size) !important;
+        max-height: var(--sb-composer-action-size) !important;
     }
 
     #send_form .mes_stop {
-        width: var(--bottomFormBlockSize);
-        min-width: var(--bottomFormBlockSize);
-        max-width: var(--bottomFormBlockSize);
-        height: var(--bottomFormBlockSize);
-        min-height: var(--bottomFormBlockSize);
-        max-height: var(--bottomFormBlockSize);
+        width: var(--sb-composer-action-size);
+        min-width: var(--sb-composer-action-size);
+        max-width: var(--sb-composer-action-size);
+        height: var(--sb-composer-action-size);
+        min-height: var(--sb-composer-action-size);
+        max-height: var(--sb-composer-action-size);
     }
 
     #send_textarea {
@@ -1282,7 +1357,7 @@ select.text_pole:where(:not([multiple]):not([size]):not(.select2-hidden-accessib
 #chat .mes .mes_buttons,
 #chat .mes .extraMesButtons {
     align-items: center;
-    gap: 4px;
+    gap: 3px;
     min-block-size: var(--sb-message-icon-size);
     padding: 0;
 }
@@ -1300,10 +1375,19 @@ select.text_pole:where(:not([multiple]):not([size]):not(.select2-hidden-accessib
     justify-content: center;
     flex: 0 0 var(--sb-message-icon-size);
     padding: 0;
-    border-radius: 8px;
+    border-radius: 7px;
     box-sizing: border-box;
     line-height: var(--sb-message-icon-size);
     text-align: center;
+    font-size: calc(var(--sb-message-icon-size) * 0.52);
+}
+
+#chat .mes .mes_button:is(.fa, .fa-solid, .fa-regular, .fa-brands),
+#chat .mes .extraMesButtons > div:is(.fa, .fa-solid, .fa-regular, .fa-brands),
+#chat .mes .mes_button > :is(.fa, .fa-solid, .fa-regular, .fa-brands, i, svg),
+#chat .mes .extraMesButtons > div > :is(.fa, .fa-solid, .fa-regular, .fa-brands, i, svg) {
+    font-size: calc(var(--sb-message-icon-size) * 0.52);
+    line-height: 1;
 }
 
 #chat .mes[is_system="true"] .mes_hide,
@@ -1333,6 +1417,7 @@ select.text_pole:where(:not([multiple]):not([size]):not(.select2-hidden-accessib
     aspect-ratio: 1 / 1;
     line-height: 1 !important;
     overflow: hidden;
+    font-size: calc(var(--sb-message-icon-size) * 0.52) !important;
 }
 
 #chat .mes .mes_view_agent_changes[style*="display: none"],
@@ -1421,12 +1506,13 @@ body.bubblechat .mes[is_user='true'] .mes_block {
         --sb-icon-control-size: 2.5rem;
         --sb-control-min-height: var(--sb-mobile-touch-target);
         --sb-control-icon-physical-size: max(var(--sb-icon-control-size), var(--sb-control-min-height));
-        --sb-message-icon-size: 2rem;
+        --sb-message-icon-size: clamp(28px, calc(var(--bottomFormBlockSize, 44px) * 0.62), 34px);
     }
 
     :root[data-sb-compact-mode='true'] {
         --sb-control-min-height: var(--sb-mobile-touch-target);
         --sb-control-icon-physical-size: max(var(--sb-icon-control-size), var(--sb-control-min-height));
+        --sb-message-icon-size: clamp(24px, calc(var(--bottomFormBlockSize, 36px) * 0.62), 30px);
     }
 
     #form_sheld {
@@ -1507,7 +1593,7 @@ body.bubblechat .mes[is_user='true'] .mes_block {
     #chat .mes .mes_button,
     #chat .mes .extraMesButtons > div,
     #chat .mes :is(.swipe_left, .swipe_right) {
-        border-radius: 9px;
+        border-radius: 8px;
     }
 
     #completion_prompt_manager_popup {
@@ -4914,15 +5000,20 @@ input[type='range']::-moz-range-thumb {
     #rightSendForm > div:not(.mes_stop),
     #send_form .mes_stop,
     #options_button {
-        width: var(--bottomFormBlockSize);
-        min-width: var(--bottomFormBlockSize);
-        height: var(--bottomFormBlockSize);
-        min-height: var(--bottomFormBlockSize);
-        max-height: var(--bottomFormBlockSize);
+        width: var(--sb-composer-action-size);
+        min-width: var(--sb-composer-action-size);
+        height: var(--sb-composer-action-size);
+        min-height: var(--sb-composer-action-size);
+        max-height: var(--sb-composer-action-size);
     }
 
     #send_textarea {
-        min-height: 74px;
-        padding: var(--input-padding-y) var(--input-padding-x);
+        min-height: 46px;
+        padding: 6px 8px;
+    }
+
+    :root[data-sb-compact-mode='true'] #send_textarea {
+        min-height: 38px;
+        padding: 5px 7px;
     }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -45,7 +45,7 @@
     <link rel="stylesheet" type="text/css" href="css/toggle-dependent.css">
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css">
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260516c" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260516a">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260516b">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260516c">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260516c" media="(max-width: 1000px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
     </style>
     <link rel="preload" as="style" href="style.css">
     <link rel="modulepreload" href="script.js">
-    <link rel="modulepreload" href="scripts/sillybunny-tabs.js?v=20260516b">
+    <link rel="modulepreload" href="scripts/sillybunny-tabs.js?v=20260516c">
     <link rel="preload" as="font" type="font/woff2" href="webfonts/Figtree/Figtree-Regular.woff2?v=20260422b" crossorigin>
     <link rel="manifest" crossorigin="use-credentials" href="manifest.json">
     <link href="webfonts/Figtree/stylesheet.css?v=20260422b" rel="stylesheet">
@@ -44,10 +44,10 @@
     <link rel="stylesheet" type="text/css" href="css/st-tailwind.css">
     <link rel="stylesheet" type="text/css" href="css/toggle-dependent.css">
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css">
-    <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260516b" media="(max-width: 768px)">
+    <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260516c" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260516a">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260516b">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260516b" media="(max-width: 1000px)">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260516c" media="(max-width: 1000px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
 </head>
@@ -8809,7 +8809,7 @@
     <script type="module" src="scripts/i18n.js"></script>
     <script type="module" src="scripts/performance-loader.js"></script>
     <script type="module" src="script.js"></script>
-    <script type="module" src="scripts/sillybunny-tabs.js?v=20260516b"></script>
+    <script type="module" src="scripts/sillybunny-tabs.js?v=20260516c"></script>
     <script>
         window.addEventListener('load', (event) => {
             const documentHeight = () => {

--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,7 @@
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css">
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260516c" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260516a">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260516b">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260516c">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260516c" media="(max-width: 1000px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
     </style>
     <link rel="preload" as="style" href="style.css">
     <link rel="modulepreload" href="script.js">
-    <link rel="modulepreload" href="scripts/sillybunny-tabs.js?v=20260513a">
+    <link rel="modulepreload" href="scripts/sillybunny-tabs.js?v=20260516b">
     <link rel="preload" as="font" type="font/woff2" href="webfonts/Figtree/Figtree-Regular.woff2?v=20260422b" crossorigin>
     <link rel="manifest" crossorigin="use-credentials" href="manifest.json">
     <link href="webfonts/Figtree/stylesheet.css?v=20260422b" rel="stylesheet">
@@ -44,10 +44,10 @@
     <link rel="stylesheet" type="text/css" href="css/st-tailwind.css">
     <link rel="stylesheet" type="text/css" href="css/toggle-dependent.css">
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css">
-    <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260516a" media="(max-width: 768px)">
+    <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260516b" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260516a">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260516a">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260516a" media="(max-width: 1000px)">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260516b">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260516b" media="(max-width: 1000px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
 </head>
@@ -8809,7 +8809,7 @@
     <script type="module" src="scripts/i18n.js"></script>
     <script type="module" src="scripts/performance-loader.js"></script>
     <script type="module" src="script.js"></script>
-    <script type="module" src="scripts/sillybunny-tabs.js?v=20260513a"></script>
+    <script type="module" src="scripts/sillybunny-tabs.js?v=20260516b"></script>
     <script>
         window.addEventListener('load', (event) => {
             const documentHeight = () => {

--- a/public/index.html
+++ b/public/index.html
@@ -44,10 +44,10 @@
     <link rel="stylesheet" type="text/css" href="css/st-tailwind.css">
     <link rel="stylesheet" type="text/css" href="css/toggle-dependent.css">
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css">
-    <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260505a" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260513a">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260513b">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260513b" media="(max-width: 1000px)">
+    <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260516a" media="(max-width: 768px)">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260516a">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260516a">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260516a" media="(max-width: 1000px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
 </head>

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -90,6 +90,8 @@ let sbInlineDrawerPersistenceObserver = null;
 let sbInlineDrawerPersistenceQueued = false;
 let sbChatScriptModulePromise = null;
 let sbMainScriptModulePromise = null;
+let sbComposerControlsObserver = null;
+let sbComposerControlsSyncQueued = false;
 let sbStorageFlushTimer = 0;
 let sbStorageFlushEventsBound = false;
 let sbMessageActionEventsBound = false;
@@ -1190,6 +1192,107 @@ function setMobileButtonScale(value, { persist = true } = {}) {
     updateThemePickerUi();
 }
 
+function moveElementBefore(element, parent, referenceNode) {
+    if (!(element instanceof HTMLElement) || !(parent instanceof HTMLElement)) {
+        return;
+    }
+
+    if (referenceNode instanceof Node) {
+        if (element.parentElement === parent && element.nextElementSibling === referenceNode) {
+            return;
+        }
+
+        parent.insertBefore(element, referenceNode);
+        return;
+    }
+
+    if (element.parentElement === parent && element.nextSibling === null) {
+        return;
+    }
+
+    parent.appendChild(element);
+}
+
+function moveElementToStart(element, parent) {
+    if (!(element instanceof HTMLElement) || !(parent instanceof HTMLElement)) {
+        return;
+    }
+
+    if (element.parentElement === parent && element.previousElementSibling === null) {
+        return;
+    }
+
+    parent.insertBefore(element, parent.firstChild);
+}
+
+function moveElementAfter(element, referenceElement, parent) {
+    if (!(element instanceof HTMLElement)
+        || !(referenceElement instanceof HTMLElement)
+        || !(parent instanceof HTMLElement)) {
+        return;
+    }
+
+    if (element.parentElement === parent && element.previousElementSibling === referenceElement) {
+        return;
+    }
+
+    parent.insertBefore(element, referenceElement.nextSibling);
+}
+
+function placeComposerControls() {
+    const leftForm = document.getElementById('leftSendForm');
+    const rightForm = document.getElementById('rightSendForm');
+
+    if (!(leftForm instanceof HTMLElement) || !(rightForm instanceof HTMLElement)) {
+        return;
+    }
+
+    const paletteButton = document.getElementById('qig-input-btn');
+    const optionsButton = document.getElementById('options_button');
+    const wandButton = document.getElementById('extensionsMenuButton');
+    const sendButton = document.getElementById('send_but');
+
+    moveElementToStart(paletteButton, leftForm);
+
+    if (paletteButton instanceof HTMLElement && paletteButton.parentElement === leftForm) {
+        moveElementAfter(optionsButton, paletteButton, leftForm);
+    } else {
+        moveElementToStart(optionsButton, leftForm);
+    }
+
+    moveElementBefore(wandButton, rightForm, sendButton);
+}
+
+function queueComposerControlPlacement() {
+    if (sbComposerControlsSyncQueued) {
+        return;
+    }
+
+    sbComposerControlsSyncQueued = true;
+    window.requestAnimationFrame(() => {
+        sbComposerControlsSyncQueued = false;
+        placeComposerControls();
+    });
+}
+
+function bindComposerControlPlacement() {
+    const leftForm = document.getElementById('leftSendForm');
+    const rightForm = document.getElementById('rightSendForm');
+
+    if (!(leftForm instanceof HTMLElement) || !(rightForm instanceof HTMLElement)) {
+        return;
+    }
+
+    if (!(sbComposerControlsObserver instanceof MutationObserver)) {
+        sbComposerControlsObserver = new MutationObserver(() => queueComposerControlPlacement());
+    }
+
+    sbComposerControlsObserver.disconnect();
+    sbComposerControlsObserver.observe(leftForm, { childList: true });
+    sbComposerControlsObserver.observe(rightForm, { childList: true });
+    queueComposerControlPlacement();
+}
+
 function setCompactMode(enabled, { persist = true } = {}) {
     const nextEnabled = Boolean(enabled);
     sbState.compactMode = nextEnabled;
@@ -1201,6 +1304,7 @@ function setCompactMode(enabled, { persist = true } = {}) {
         safeSetItem(SB_STORAGE_KEYS.compactMode, String(nextEnabled));
     }
 
+    queueComposerControlPlacement();
     updateThemePickerUi();
 }
 
@@ -12254,6 +12358,7 @@ function initAll() {
     setTopbarScale('mobile', sbState.topbarScale.mobile, { persist: false });
     setBottomBarScale(sbState.bottomBarScale, { persist: false });
     setMobileButtonScale(sbState.mobileButtonScale, { persist: false });
+    bindComposerControlPlacement();
     initChatAvatarVariables();
     syncDesktopShellSizing();
     buildTopBar();

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -1252,15 +1252,15 @@ function placeComposerControls() {
     const wandButton = document.getElementById('extensionsMenuButton');
     const sendButton = document.getElementById('send_but');
 
-    moveElementToStart(paletteButton, leftForm);
+    moveElementToStart(optionsButton, leftForm);
 
-    if (paletteButton instanceof HTMLElement && paletteButton.parentElement === leftForm) {
-        moveElementAfter(optionsButton, paletteButton, leftForm);
+    if (optionsButton instanceof HTMLElement && optionsButton.parentElement === leftForm) {
+        moveElementAfter(wandButton, optionsButton, leftForm);
     } else {
-        moveElementToStart(optionsButton, leftForm);
+        moveElementToStart(wandButton, leftForm);
     }
 
-    moveElementBefore(wandButton, rightForm, sendButton);
+    moveElementBefore(paletteButton, rightForm, sendButton);
 }
 
 function queueComposerControlPlacement() {


### PR DESCRIPTION
This PR overhauls the UI for the send message box to better align with the rest of the shell, and to reduce unnecessary space usage. Untested for mobile.

- Vertical height is now much more compact, scaling for both compact mode and regular mode.
- Extensions, more, and send buttons have shrunk to remove oversized UI elements.
- Send reply window reduced in size to a more reasonable height.
- Better delineation between the main send message box and the GG guided controls. 