### PR TITLE
fix(ui): remove presets lock icon

### DIFF
--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -37,8 +37,7 @@
         flex-basis: 100%;
     }
 
-    #rm_button_panel_pin_div,
-    #lm_button_panel_pin_div {
+    #rm_button_panel_pin_div {
         display: none;
     }
 

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1692,7 +1692,7 @@ body.sb-shell-resizing * {
     flex-direction: column;
     align-items: flex-start;
     gap: var(--sb-shell-space-xs);
-    padding: var(--sb-shell-space-lg) var(--sb-shell-panel-padding-inline) var(--sb-shell-space-xl);
+    padding: var(--sb-shell-space-md) var(--sb-shell-panel-padding-inline) var(--sb-shell-space-xl);
     border-bottom: 1px solid color-mix(in srgb, var(--sb-shell-border) 80%, transparent);
     background: transparent;
     text-align: left;

--- a/public/index.html
+++ b/public/index.html
@@ -40,13 +40,13 @@
     <link rel="apple-touch-icon" sizes="114x114" href="img/apple-icon-114x114.png" />
     <link rel="apple-touch-icon" sizes="144x144" href="img/apple-icon-144x144.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="img/apple-icon-180x180.png" />
-    <link rel="stylesheet" type="text/css" href="style.css?v=20260507a">
+    <link rel="stylesheet" type="text/css" href="style.css?v=20260516d">
     <link rel="stylesheet" type="text/css" href="css/st-tailwind.css">
     <link rel="stylesheet" type="text/css" href="css/toggle-dependent.css">
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css">
-    <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260516c" media="(max-width: 768px)">
+    <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260516d" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260516b">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260516c">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260516d">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260516c" media="(max-width: 1000px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
@@ -75,13 +75,6 @@
             </div>
             <div id="left-nav-panel" class="drawer-content fillLeft closedDrawer">
                 <div id="left-nav-panelheader" class="fa-solid fa-grip drag-grabber"></div>
-                <div id="lm_button_panel_pin_div" title="Locked = AI Configuration panel will stay open" data-i18n="[title]AI Configuration panel will stay open">
-                    <input type="checkbox" id="lm_button_panel_pin">
-                    <label for="lm_button_panel_pin">
-                        <div class="unchecked fa-solid fa-unlock right_menu_button"></div>
-                        <div class="checked fa-solid fa-lock right_menu_button"></div>
-                    </label>
-                </div>
                 <div id="labModeWarning" class="redWarningBG textAlignCenter displayNone" data-i18n="MAD LAB MODE ON">MAD LAB MODE ON</div>
                 <div class="scrollableInner">
                     <div class="flex-container flexNoGap" id="ai_response_configuration">

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -103,13 +103,10 @@ function parseMovingUIPixel(value, fallback = 0) {
 }
 
 var RPanelPin = document.getElementById('rm_button_panel_pin');
-var LPanelPin = document.getElementById('lm_button_panel_pin');
 var WIPanelPin = document.getElementById('WI_panel_pin');
 
 var RightNavPanel = document.getElementById('right-nav-panel');
 var RightNavDrawerIcon = document.getElementById('rightNavDrawerIcon');
-var LeftNavPanel = document.getElementById('left-nav-panel');
-var LeftNavDrawerIcon = document.getElementById('leftNavDrawerIcon');
 var WorldInfo = document.getElementById('WorldInfo');
 var WIDrawerIcon = document.getElementById('WIDrawerIcon');
 
@@ -491,16 +488,6 @@ function OpenNavPanels() {
             $('#rightNavDrawerIcon').trigger('click');
         }
 
-        //auto-open L nav if locked and previously open
-        if (accountStorage.getItem('LNavLockOn') == 'true' && accountStorage.getItem('LNavOpened') == 'true') {
-            console.debug('RA -- opening left shell');
-            if (window.SillyBunnyShell?.openTab) {
-                window.SillyBunnyShell.openTab('left');
-            } else {
-                $('#leftNavDrawerIcon').trigger('click');
-            }
-        }
-
         //auto-open WI if locked and previously open
         if (accountStorage.getItem('WINavLockOn') == 'true' && accountStorage.getItem('WINavOpened') == 'true') {
             console.debug('RA -- clicking WI to open');
@@ -802,24 +789,6 @@ export function initRossMods() {
             }
         }
     });
-    $(LPanelPin).on('click', function () {
-        accountStorage.setItem('LNavLockOn', $(LPanelPin).prop('checked'));
-        if ($(LPanelPin).prop('checked') == true) {
-            //console.log('adding pin class to Left nav');
-            $(LeftNavPanel).addClass('pinnedOpen');
-            $(LeftNavDrawerIcon).addClass('drawerPinnedOpen');
-        } else {
-            //console.log('removing pin class from Left nav');
-            $(LeftNavPanel).removeClass('pinnedOpen');
-            $(LeftNavDrawerIcon).removeClass('drawerPinnedOpen');
-
-            if ($(LeftNavPanel).hasClass('openDrawer') && $('.openDrawer').length > 1) {
-                const toggle = $('#ai-config-button>.drawer-toggle');
-                doNavbarIconClick.call(toggle);
-            }
-        }
-    });
-
     $(WIPanelPin).on('click', async function () {
         accountStorage.setItem('WINavLockOn', $(WIPanelPin).prop('checked'));
         if ($(WIPanelPin).prop('checked') == true) {
@@ -852,20 +821,7 @@ export function initRossMods() {
             $(RightNavPanel).addClass('pinnedOpen');
             $(RightNavDrawerIcon).addClass('drawerPinnedOpen');
         }
-        // read the state of left Nav Lock and apply to leftnav classlist
-        $(LPanelPin).prop('checked', accountStorage.getItem('LNavLockOn') === 'true');
-        if (accountStorage.getItem('LNavLockOn') == 'true') {
-            //console.log('setting pin class via local var');
-            $(LeftNavPanel).addClass('pinnedOpen');
-            $(LeftNavDrawerIcon).addClass('drawerPinnedOpen');
-        }
-        if ($(LPanelPin).prop('checked')) {
-            console.debug('setting pin class via checkbox state');
-            $(LeftNavPanel).addClass('pinnedOpen');
-            $(LeftNavDrawerIcon).addClass('drawerPinnedOpen');
-        }
-
-        // read the state of left Nav Lock and apply to leftnav classlist
+        // read the state of WI Lock and apply to WI classlist
         $(WIPanelPin).prop('checked', accountStorage.getItem('WINavLockOn') === 'true');
         if (accountStorage.getItem('WINavLockOn') == 'true') {
             //console.log('setting pin class via local var');
@@ -888,14 +844,7 @@ export function initRossMods() {
         } else { accountStorage.setItem('NavOpened', 'false'); }
     });
 
-    //save state of Left nav being open or closed
-    $('#leftNavDrawerIcon').on('click', function () {
-        if (!$('#leftNavDrawerIcon').hasClass('openIcon')) {
-            accountStorage.setItem('LNavOpened', 'true');
-        } else { accountStorage.setItem('LNavOpened', 'false'); }
-    });
-
-    //save state of Left nav being open or closed
+    //save state of WI being open or closed
     $('#WorldInfo').on('click', function () {
         if (!$('#WorldInfo').hasClass('openIcon')) {
             accountStorage.setItem('WINavOpened', 'true');
@@ -1334,8 +1283,8 @@ export function initRossMods() {
                 }
             }
 
-            if ($('#left-nav-panel').is(':visible') &&
-                $(LPanelPin).prop('checked') === false) {
+            // SillyBunny removes the legacy left-panel pin, so Escape always closes this shell.
+            if ($('#left-nav-panel').is(':visible')) {
                 $('#leftNavDrawerIcon').trigger('click');
                 return;
             }

--- a/public/scripts/util/AccountStorage.js
+++ b/public/scripts/util/AccountStorage.js
@@ -13,8 +13,6 @@ const MIGRATABLE_KEYS = [
     /^FeatherlessModels_PerPage$/,
     /^GroupMembers_PerPage$/,
     /^GroupCandidates_PerPage$/,
-    /^LNavLockOn$/,
-    /^LNavOpened$/,
     /^mediaWarningShown:/,
     /^NavLockOn$/,
     /^NavOpened$/,

--- a/public/style.css
+++ b/public/style.css
@@ -2943,7 +2943,6 @@ input[type="file"] {
 
 #rm_button_characters,
 #rm_button_panel_pin_div,
-#lm_button_panel_pin_div,
 #WI_button_panel_pin_div {
     font-size: 24px;
     display: inline;
@@ -2951,7 +2950,6 @@ input[type="file"] {
 }
 
 #rm_button_panel_pin_div,
-#lm_button_panel_pin_div,
 #WI_button_panel_pin_div {
     opacity: 0.5;
     transition: var(--animation-duration-2x);
@@ -2959,49 +2957,37 @@ input[type="file"] {
 
 #rm_button_panel_pin_div:hover,
 #rm_button_panel_pin_div:has(:focus-visible),
-#lm_button_panel_pin_div:hover,
-#lm_button_panel_pin_div:has(:focus-visible),
 #WI_button_panel_pin_div:hover,
 #WI_button_panel_pin_div:has(:focus-visible) {
     opacity: 1;
 }
 
-#lm_button_panel_pin_div {
-    text-align: start;
-}
-
 #rm_button_panel_pin,
-#lm_button_panel_pin,
 #WI_panel_pin {
     display: none;
 }
 
 #rm_button_panel_pin:checked+label,
-#lm_button_panel_pin:checked+label,
 #WI_panel_pin:checked+label {
     display: inline;
 }
 
 #rm_button_panel_pin:checked+label .checked,
-#lm_button_panel_pin:checked+label .checked,
 #WI_panel_pin:checked+label .checked {
     display: inline;
 }
 
 #rm_button_panel_pin:checked+label .unchecked,
-#lm_button_panel_pin:checked+label .unchecked,
 #WI_panel_pin:checked+label .unchecked {
     display: none;
 }
 
 #rm_button_panel_pin:not(:checked)+label .checked,
-#lm_button_panel_pin:not(:checked)+label .checked,
 #WI_panel_pin:not(:checked)+label .checked {
     display: none;
 }
 
 #rm_button_panel_pin:not(:checked)+label .unchecked,
-#lm_button_panel_pin:not(:checked)+label .unchecked,
 #WI_panel_pin:not(:checked)+label .unchecked {
     display: inline;
 }


### PR DESCRIPTION
## Summary
- Remove the legacy left-panel pin control that appeared as a standalone lock icon in the Presets workspace.
- Drop the now-unused left-nav pin/open persistence hooks while preserving the right nav and World Info pins.
- Tighten the desktop shell header top padding and bump affected CSS cache keys so the titlebar sits closer to the top after update.

## Verification
- `npm run lint`
- `npm run test:unit --prefix tests`
- `npm run check:frontend-budgets` fails on the existing `staging` baseline: blocking stylesheet bytes are 742 KiB against the 730 KiB budget; this branch slightly reduces the measured stylesheet bytes compared with `origin/staging`.