### PR TITLE
fix: detect and warn on stripped card scripts (#94)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ Date: 2026-05-13
 
 This update consolidates the v1.5.4 staging work since v1.5.3: preset and connection profile save reliability, full-chat navigation and search, mobile bottom-bar and drawer polish, chat completion tabs, pre-generation agent interceptors, iOS streaming stabilization, context-depth controls, character-menu rework, runtime update hardening, and release documentation automation.
 
+### Character Cards
+- fix(cards): warn when card HTML contains stripped `<script>`/`<iframe>` blocks (#94).
+
 ### Presets And Connection Profiles
 - Connection profile changes now serialize in order, abort superseded applications cleanly, and save only after the latest selected profile finishes applying.
 - OpenAI preset changes now expose an awaitable completion path and ignore stale async preset applications, keeping linked provider/model settings from being overwritten by older selections.

--- a/public/index.html
+++ b/public/index.html
@@ -5752,6 +5752,11 @@
                                     <input id="forbid_external_media" type="checkbox" />
                                     <small data-i18n="Forbid External Media">Forbid External Media</small>
                                 </label>
+                                <label class="checkbox_label" for="allow_card_scripts" title="Run sandboxed scripts embedded in character cards. Off by default. Coming soon - PR3 will enable this control." data-i18n="[title]Run sandboxed scripts embedded in character cards. Off by default. Coming soon">
+                                    <input id="allow_card_scripts" type="checkbox" disabled />
+                                    <small data-i18n="Allow Card Scripts (sandboxed)">Allow Card Scripts (sandboxed)</small>
+                                    <small class="opacity50p" data-i18n="Coming soon">Coming soon</small>
+                                </label>
                                 <label class="checkbox_label" for="allow_name2_display">
                                     <input id="allow_name2_display" type="checkbox" />
                                     <small data-i18n="Allow {{char}}: in bot messages">Show {{char}}: in responses</small>

--- a/public/script.js
+++ b/public/script.js
@@ -305,6 +305,15 @@ import { compressRequest, setRequestCompressionConfig } from './scripts/request-
 import { canJumpToSwipeForMessage, canOpenSwipePickerForMessage, initSwipePicker } from './scripts/swipe-picker.js';
 import { bindIOSFastTapSendButton, isIOSWebKitPlatform } from './scripts/mobile-send-button.js';
 import { getStreamingUpdateInterval } from './scripts/mobile-streaming.js';
+import {
+    CARD_SCRIPT_MARKER_TAG,
+    buildCardScriptToastKey,
+    forgetAllCardScripts,
+    getCardScriptSnapshot,
+    hasCardScriptToastBeenShown,
+    markCardScriptHtml,
+    markCardScriptToastShown,
+} from './scripts/card-script-detection.js';
 
 const DEFERRED_STARTUP_STYLESHEETS = Object.freeze([
     { href: 'css/bright.min.css', id: 'deferred-highlight-theme-css' },
@@ -918,6 +927,8 @@ async function firstLoadInit() {
         initLibraryShims();
         addShowdownPatch(showdown);
         addDOMPurifyHooks();
+        // SillyBunny: card script detection - see #94.
+        eventSource.on(event_types.CHAT_CHANGED, forgetAllCardScripts);
         reloadMarkdownProcessor();
         applyBrowserFixes();
         await getClientVersion();
@@ -2329,6 +2340,7 @@ export function messageFormatting(mes, ch_name, isSystem, isUser, messageId, san
         return '';
     }
 
+    const originalMessageHtml = mes;
     const oocBlocks = [];
 
     const resolvedMessageId = messageId !== null && messageId !== undefined && messageId !== ''
@@ -2499,15 +2511,54 @@ export function messageFormatting(mes, ch_name, isSystem, isUser, messageId, san
         RETURN_DOM_FRAGMENT: false,
         RETURN_TRUSTED_TYPE: false,
         MESSAGE_SANITIZE: true,
-        ADD_TAGS: ['custom-style'],
+        ADD_TAGS: ['custom-style', CARD_SCRIPT_MARKER_TAG],
         ...sanitizerOverrides,
     };
     mes = restoreOocBlocksForDisplay(mes, oocBlocks);
+    // SillyBunny: card script detection - see #94.
+    mes = markCardScriptHtml(mes, messageId, originalMessageHtml);
     mes = encodeStyleTags(mes);
     mes = DOMPurify.sanitize(mes, config);
     mes = decodeStyleTags(mes, { prefix: '.mes_text ' });
 
     return mes;
+}
+
+function notifyCardScriptStripped(messageElement, messageId) {
+    const normalizedMessageId = Number(messageId);
+
+    if (!Number.isInteger(normalizedMessageId) || normalizedMessageId < 0) {
+        return;
+    }
+
+    const $messageElement = messageElement?.jquery ? messageElement : $(messageElement);
+
+    if ($messageElement.length === 0) {
+        return;
+    }
+
+    const marker = $messageElement.find(CARD_SCRIPT_MARKER_TAG).filter((_, markerElement) => {
+        return Number(markerElement.dataset.msgId) === normalizedMessageId;
+    }).first();
+
+    if (marker.length === 0) {
+        return;
+    }
+
+    const snapshot = getCardScriptSnapshot(normalizedMessageId);
+
+    if (!snapshot) {
+        return;
+    }
+
+    const toastKey = buildCardScriptToastKey(getCurrentChatId(), normalizedMessageId, snapshot.hash);
+
+    if (hasCardScriptToastBeenShown(toastKey)) {
+        return;
+    }
+
+    markCardScriptToastShown(toastKey);
+    toastr.warning(t`This message contains card scripts. SillyBunny does not run them by default.`, t`Card scripts blocked`, { timeOut: 6000, preventDuplicates: true });
 }
 
 /**
@@ -2657,6 +2708,7 @@ function applyMessageBlockUpdate(messageId, message, { rerenderMessage = true } 
     if (rerenderMessage) {
         const text = message?.extra?.display_text ?? message.mes;
         messageElement.find('.mes_text').html(messageFormatting(text, message.name, message.is_system, message.is_user, messageId, {}, false));
+        notifyCardScriptStripped(messageElement, messageId);
     }
     updateMessageMetaBadges(messageElement, message);
 
@@ -3380,6 +3432,7 @@ export function updateMessageElement(mes, { messageId = chat.length - 1, message
 
     appendMediaToMessage(mes, messageElement, adjustMediaScroll);
     messageElement.find('.mes_text').html(messageHTML);
+    notifyCardScriptStripped(messageElement, messageId);
     addCopyToCodeBlocks(messageElement);
 
     // Set the swipes counter for all non-user messages.
@@ -9923,6 +9976,7 @@ function messageEditAuto(div) {
         {},
         false,
     ));
+    notifyCardScriptStripped(mesBlock.closest('.mes'), this_edit_mes_id);
     mesBlock.find('.mes_bias').empty();
     mesBlock.find('.mes_bias').append(messageFormatting(bias, '', false, false, -1, {}, false));
     saveChatDebounced();
@@ -10038,6 +10092,7 @@ async function messageEditCancel(messageId = this_edit_mes_id) {
             {},
             false,
         ));
+    notifyCardScriptStripped(thisMesDiv, messageId);
     appendMediaToMessage(chat[messageId], thisMesDiv);
     addCopyToCodeBlocks(thisMesDiv);
 
@@ -10134,6 +10189,7 @@ async function messageEditDone(div) {
             false,
         ),
     );
+    notifyCardScriptStripped(div.closest('.mes'), this_edit_mes_id);
     mesBlock.find('.mes_bias').empty();
     mesBlock.find('.mes_bias').append(messageFormatting(bias, '', false, false, -1, {}, false));
     appendMediaToMessage(mes, div.closest('.mes'));

--- a/public/scripts/card-script-detection.js
+++ b/public/scripts/card-script-detection.js
@@ -7,6 +7,10 @@ const cardScriptSnapshots = new Map();
 const shownCardScriptToastKeys = new Set();
 
 function normalizeMessageId(messageId) {
+    if (messageId === null || messageId === undefined || messageId === '') {
+        return null;
+    }
+
     const normalized = Number(messageId);
     return Number.isInteger(normalized) && normalized >= 0 ? normalized : null;
 }

--- a/public/scripts/card-script-detection.js
+++ b/public/scripts/card-script-detection.js
@@ -1,0 +1,99 @@
+const CARD_SCRIPT_TAG_PATTERN = /<\s*(?:script|iframe)(?:\s|>)/i;
+
+export const CARD_SCRIPT_MARKER_TAG = 'custom-card-script-marker';
+export const MAX_STASHED_CARD_SCRIPTS = 200;
+
+const cardScriptSnapshots = new Map();
+const shownCardScriptToastKeys = new Set();
+
+function normalizeMessageId(messageId) {
+    const normalized = Number(messageId);
+    return Number.isInteger(normalized) && normalized >= 0 ? normalized : null;
+}
+
+export function containsEmbeddedCardScript(html) {
+    return CARD_SCRIPT_TAG_PATTERN.test(String(html ?? ''));
+}
+
+export function hashCardScriptHtml(html) {
+    const value = String(html ?? '');
+    let hash = 2166136261;
+
+    for (let index = 0; index < value.length; index++) {
+        hash ^= value.charCodeAt(index);
+        hash = Math.imul(hash, 16777619);
+    }
+
+    return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+export function rememberCardScript(messageId, html) {
+    const normalizedMessageId = normalizeMessageId(messageId);
+    const htmlString = String(html ?? '');
+
+    if (normalizedMessageId === null || !containsEmbeddedCardScript(htmlString)) {
+        return null;
+    }
+
+    const hash = hashCardScriptHtml(htmlString);
+    const existingSnapshot = cardScriptSnapshots.get(normalizedMessageId);
+
+    if (existingSnapshot?.hash === hash && existingSnapshot.html === htmlString) {
+        cardScriptSnapshots.delete(normalizedMessageId);
+        cardScriptSnapshots.set(normalizedMessageId, existingSnapshot);
+        return existingSnapshot;
+    }
+
+    const snapshot = { html: htmlString, hash };
+    cardScriptSnapshots.delete(normalizedMessageId);
+    cardScriptSnapshots.set(normalizedMessageId, snapshot);
+
+    while (cardScriptSnapshots.size > MAX_STASHED_CARD_SCRIPTS) {
+        const oldestKey = cardScriptSnapshots.keys().next().value;
+        cardScriptSnapshots.delete(oldestKey);
+    }
+
+    return snapshot;
+}
+
+export function markCardScriptHtml(html, messageId, originalHtml = html) {
+    const htmlString = String(html ?? '');
+    const sourceHtml = containsEmbeddedCardScript(originalHtml) ? originalHtml : htmlString;
+    const snapshot = rememberCardScript(messageId, sourceHtml);
+
+    if (!snapshot) {
+        return htmlString;
+    }
+
+    return `${htmlString}<${CARD_SCRIPT_MARKER_TAG} data-msg-id="${Number(messageId)}"></${CARD_SCRIPT_MARKER_TAG}>`;
+}
+
+export function getCardScriptSnapshot(messageId) {
+    const normalizedMessageId = normalizeMessageId(messageId);
+    return normalizedMessageId === null ? null : cardScriptSnapshots.get(normalizedMessageId) ?? null;
+}
+
+export function buildCardScriptToastKey(chatId, messageId, hash) {
+    return `${chatId ?? ''}:${messageId}:${hash}`;
+}
+
+export function hasCardScriptToastBeenShown(toastKey) {
+    return shownCardScriptToastKeys.has(toastKey);
+}
+
+export function markCardScriptToastShown(toastKey) {
+    shownCardScriptToastKeys.add(toastKey);
+}
+
+export function getStoredCardScriptCount() {
+    return cardScriptSnapshots.size;
+}
+
+export function getShownCardScriptToastCount() {
+    return shownCardScriptToastKeys.size;
+}
+
+export function forgetAllCardScripts() {
+    cardScriptSnapshots.clear();
+    shownCardScriptToastKeys.clear();
+}

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -473,6 +473,7 @@ export const power_user = {
     auto_connect: false,
     auto_load_chat: false,
     forbid_external_media: true,
+    allow_card_scripts: false,
     external_media_allowed_overrides: [],
     external_media_forbidden_overrides: [],
     pin_styles: true,
@@ -1935,6 +1936,7 @@ export async function loadPowerUserSettings(settings, data) {
     $('#auto-connect-checkbox').prop('checked', power_user.auto_connect);
     $('#auto-load-chat-checkbox').prop('checked', power_user.auto_load_chat);
     $('#forbid_external_media').prop('checked', power_user.forbid_external_media);
+    $('#allow_card_scripts').prop('checked', !!power_user.allow_card_scripts);
     $('#pin_styles').prop('checked', power_user.pin_styles);
     $('#click_to_edit').prop('checked', power_user.click_to_edit);
     $('#media_display').val(power_user.media_display);
@@ -4259,6 +4261,11 @@ jQuery(async () => {
         power_user.forbid_external_media = !!$(this).prop('checked');
         saveSettingsDebounced();
         reloadCurrentChat();
+    });
+
+    $('#allow_card_scripts').on('input', function () {
+        power_user.allow_card_scripts = !!$(this).prop('checked');
+        saveSettingsDebounced();
     });
 
     $('#pin_styles').on('input', function () {

--- a/tests/card-script-detection.test.js
+++ b/tests/card-script-detection.test.js
@@ -1,0 +1,131 @@
+import { describe, test, expect, beforeEach } from '@jest/globals';
+import {
+    CARD_SCRIPT_MARKER_TAG,
+    MAX_STASHED_CARD_SCRIPTS,
+    buildCardScriptToastKey,
+    containsEmbeddedCardScript,
+    forgetAllCardScripts,
+    getCardScriptSnapshot,
+    getShownCardScriptToastCount,
+    getStoredCardScriptCount,
+    hasCardScriptToastBeenShown,
+    hashCardScriptHtml,
+    markCardScriptHtml,
+    markCardScriptToastShown,
+    rememberCardScript,
+} from '../public/scripts/card-script-detection.js';
+
+beforeEach(() => {
+    forgetAllCardScripts();
+});
+
+describe('card script detection', () => {
+    test('detects script tags and appends a marker', () => {
+        const html = '<p>Hello</p><script>alert(1)</script>';
+        const markedHtml = markCardScriptHtml(html, 7);
+
+        expect(containsEmbeddedCardScript(html)).toBe(true);
+        expect(markedHtml).toContain(`<${CARD_SCRIPT_MARKER_TAG} data-msg-id="7"></${CARD_SCRIPT_MARKER_TAG}>`);
+        expect(getCardScriptSnapshot(7)).toMatchObject({
+            html,
+            hash: hashCardScriptHtml(html),
+        });
+    });
+
+    test('detects iframe tags and appends a marker', () => {
+        const html = '<iframe src="https://example.com"></iframe>';
+        const markedHtml = markCardScriptHtml(html, 8);
+
+        expect(containsEmbeddedCardScript(html)).toBe(true);
+        expect(markedHtml).toContain(`<${CARD_SCRIPT_MARKER_TAG} data-msg-id="8"></${CARD_SCRIPT_MARKER_TAG}>`);
+        expect(getCardScriptSnapshot(8)).toMatchObject({ html });
+    });
+
+    test('detects uppercase tags and whitespace before attributes', () => {
+        expect(containsEmbeddedCardScript('<SCRIPT type="text/javascript"></SCRIPT>')).toBe(true);
+        expect(containsEmbeddedCardScript('<  iframe src="https://example.com"></iframe>')).toBe(true);
+    });
+
+    test('does not detect lookalike tag names', () => {
+        expect(containsEmbeddedCardScript('<scripts>alert(1)</scripts>')).toBe(false);
+    });
+
+    test('does not stash or mark plain text', () => {
+        const html = '<p>No runnable card script here.</p>';
+
+        expect(markCardScriptHtml(html, 9)).toBe(html);
+        expect(getCardScriptSnapshot(9)).toBeNull();
+        expect(getStoredCardScriptCount()).toBe(0);
+    });
+
+    test('documents the accepted false positive for script text in code blocks', () => {
+        const markdown = '```html\n<script>alert(1)</script>\n```';
+        const markedHtml = markCardScriptHtml('<pre><code>&lt;script&gt;alert(1)&lt;/script&gt;</code></pre>', 10, markdown);
+
+        expect(containsEmbeddedCardScript(markdown)).toBe(true);
+        expect(markedHtml).toContain(`<${CARD_SCRIPT_MARKER_TAG} data-msg-id="10"></${CARD_SCRIPT_MARKER_TAG}>`);
+        expect(getCardScriptSnapshot(10)).toMatchObject({ html: markdown });
+    });
+
+    test('dedupes the same message id and content', () => {
+        const html = '<script>console.log("same")</script>';
+        const firstSnapshot = rememberCardScript(11, html);
+        const secondSnapshot = rememberCardScript(11, html);
+
+        expect(secondSnapshot).toBe(firstSnapshot);
+        expect(getStoredCardScriptCount()).toBe(1);
+    });
+
+    test('evicts the oldest snapshots beyond the LRU limit', () => {
+        for (let index = 0; index <= MAX_STASHED_CARD_SCRIPTS; index++) {
+            markCardScriptHtml(`<script>${index}</script>`, index);
+        }
+
+        expect(getStoredCardScriptCount()).toBe(MAX_STASHED_CARD_SCRIPTS);
+        expect(getCardScriptSnapshot(0)).toBeNull();
+        expect(getCardScriptSnapshot(1)).toMatchObject({ html: '<script>1</script>' });
+    });
+
+    test('refreshes a reused message id so recent snapshots are retained', () => {
+        const html = '<script>still-recent</script>';
+        markCardScriptHtml(html, 0);
+
+        for (let index = 1; index < MAX_STASHED_CARD_SCRIPTS; index++) {
+            markCardScriptHtml(`<script>${index}</script>`, index);
+        }
+
+        rememberCardScript(0, html);
+        markCardScriptHtml('<script>new-oldest</script>', MAX_STASHED_CARD_SCRIPTS);
+
+        expect(getStoredCardScriptCount()).toBe(MAX_STASHED_CARD_SCRIPTS);
+        expect(getCardScriptSnapshot(0)).toMatchObject({ html });
+        expect(getCardScriptSnapshot(1)).toBeNull();
+    });
+
+    test('clears stored snapshots and toast keys', () => {
+        const html = '<script>alert(1)</script>';
+        const snapshot = rememberCardScript(12, html);
+        const toastKey = buildCardScriptToastKey('chat-a', 12, snapshot.hash);
+        markCardScriptToastShown(toastKey);
+
+        forgetAllCardScripts();
+
+        expect(getStoredCardScriptCount()).toBe(0);
+        expect(getShownCardScriptToastCount()).toBe(0);
+        expect(getCardScriptSnapshot(12)).toBeNull();
+        expect(hasCardScriptToastBeenShown(toastKey)).toBe(false);
+    });
+
+    test('includes chat id, message id, and hash in toast keys so cross-chat messages re-toast', () => {
+        const hash = hashCardScriptHtml('<script>alert(1)</script>');
+        const firstChatKey = buildCardScriptToastKey('chat-a', 13, hash);
+        const secondChatKey = buildCardScriptToastKey('chat-b', 13, hash);
+
+        markCardScriptToastShown(firstChatKey);
+
+        expect(firstChatKey).toBe(`chat-a:13:${hash}`);
+        expect(secondChatKey).toBe(`chat-b:13:${hash}`);
+        expect(hasCardScriptToastBeenShown(firstChatKey)).toBe(true);
+        expect(hasCardScriptToastBeenShown(secondChatKey)).toBe(false);
+    });
+});

--- a/tests/card-script-detection.test.js
+++ b/tests/card-script-detection.test.js
@@ -58,6 +58,17 @@ describe('card script detection', () => {
         expect(getStoredCardScriptCount()).toBe(0);
     });
 
+    test('does not stash or mark nullish or empty message ids as message zero', () => {
+        const html = '<script>alert(1)</script>';
+
+        expect(markCardScriptHtml(html, null)).toBe(html);
+        expect(markCardScriptHtml(html, undefined)).toBe(html);
+        expect(markCardScriptHtml(html, '')).toBe(html);
+
+        expect(getCardScriptSnapshot(0)).toBeNull();
+        expect(getStoredCardScriptCount()).toBe(0);
+    });
+
     test('documents the accepted false positive for script text in code blocks', () => {
         const markdown = '```html\n<script>alert(1)</script>\n```';
         const markedHtml = markCardScriptHtml('<pre><code>&lt;script&gt;alert(1)&lt;/script&gt;</code></pre>', 10, markdown);


### PR DESCRIPTION
## Summary
- Detects chat message HTML that includes embedded `<script>` or `<iframe>` tags before DOMPurify strips them, keeps a small LRU snapshot, and shows a once-per-chat/message/content warning.
- Adds an off-by-default `allow_card_scripts` settings scaffold with a disabled UI checkbox for the later sandbox runner work.
- Records the compatibility warning in the changelog and adds pure Jest coverage for detection, marker insertion, dedupe, LRU eviction, clearing, toast keys, and the accepted code-block false positive.

## Context
- Resolves #94 for PR1 scope by warning users when card scripts are blocked instead of silently disappearing.
- `triggerSlash` is a third-party JS-Slash-Runner/TavernHelper-style global, not a stock SillyTavern upstream global.
- Stock upstream and SillyBunny both strip message `<script>` and `<iframe>` blocks through DOMPurify by default; this PR does not change that security behavior.

## Not In This PR
- Does not run embedded scripts.
- Does not expose `triggerSlash`, TavernHelper, `getContext`, or any parent-page bridge to card HTML.
- Does not enable the new checkbox; it is a disabled placeholder for the planned PR3 sandbox runner.
- Does not change creator-notes or character-description rendering.

## Follow-Up Stack
- PR2: pure sandbox security modules (`wrapper.js`, `allowlist.js`, `rate-limiter.js`) with unit tests and no runtime wiring.
- PR3: runtime bridge, per-message run button, sandbox iframe lifecycle, policy select, e2e coverage, and security-invariant docs.

## Verification
- `npm ci --ignore-scripts`
- `npm ci --ignore-scripts --prefix tests`
- `npm run lint`
- `npm run test:unit --prefix tests -- card-script-detection`
- `npm run check:frontend-budgets` fails on current `staging` and on this branch with the same pre-existing blocking stylesheet budget issue: `742.5 KiB` used vs `730.0 KiB` budget.

## Manual Test Recipe
- Add or edit a chat message containing `<script>triggerSlash('/echo blocked')</script>`.
- Confirm the rendered message does not execute the script.
- Confirm a warning toast appears: "This message contains card scripts. SillyBunny does not run them by default."
- Re-render the same message in the same chat and confirm the toast is deduped; switch chats and confirm the same content can warn again.

## Known Risk
- Detection runs before markdown/code-block interpretation, so literal `<script>` text inside fenced code blocks is intentionally treated as a false positive in PR1.