### PR TITLE
feat: add Guided Correction to Guided Generations extension

### DIFF
--- a/public/scripts/extensions/guided-generations/index.js
+++ b/public/scripts/extensions/guided-generations/index.js
@@ -1,6 +1,7 @@
 import { saveSettingsDebounced } from '../../../script.js';
 import { extensionNames, extension_settings, renderExtensionTemplateAsync } from '../../extensions.js';
 import { extensionName, getPresetsForApiType, getProfileApiType, getProfileList } from './scripts/shared.js';
+import { guidedCorrection } from './scripts/guidedCorrection.js';
 import { guidedImpersonate } from './scripts/guidedImpersonate.js';
 import { guidedResponse } from './scripts/guidedResponse.js';
 import { guidedSwipe } from './scripts/guidedSwipe.js';
@@ -16,6 +17,7 @@ const oldExtensionName = 'third-party/GuidedGenerations-Extension';
 const defaultSettings = {
     showGuidedResponse: true,
     showGuidedSwipe: true,
+    showGuidedCorrection: true,
     showImpersonate1stPerson: true,
     showSimpleSendButton: true,
     integrateQrBar: true,
@@ -23,9 +25,11 @@ const defaultSettings = {
     debugMode: false,
     promptGuidedResponse: '[Take the following into special consideration for your next message: {{input}}]',
     promptGuidedSwipe: '[Take the following into special consideration for your next message: {{input}}]',
+    promptGuidedCorrection: '[Apply the following correction to your previous message: {{input}}]',
     promptImpersonate1st: 'Write in first Person perspective from {{user}}. {{input}}',
     depthPromptGuidedResponse: 0,
     depthPromptGuidedSwipe: 0,
+    depthPromptGuidedCorrection: 0,
     profileImpersonate1st: '',
     presetImpersonate1st: '',
     profileImpersonate1stApiType: '',
@@ -296,6 +300,7 @@ function updateExtensionButtons() {
         settings.showSimpleSendButton && createActionButton('gg_simple_send_button', 'Simple Send', 'fa-solid fa-paper-plane', simpleSend),
         settings.showImpersonate1stPerson && createActionButton('gg_impersonate_button', 'Guided Impersonate', 'fa-solid fa-user', guidedImpersonate),
         settings.showGuidedSwipe && createActionButton('gg_swipe_button', 'Guided Swipe', 'fa-solid fa-forward', guidedSwipe),
+        settings.showGuidedCorrection && createActionButton('gg_correction_button', 'Guided Correction', 'fa-solid fa-pen-to-square', guidedCorrection),
         settings.showGuidedResponse && createActionButton('gg_response_button', 'Guided Response', 'fa-solid fa-compass', guidedResponse),
     ].filter(Boolean);
 

--- a/public/scripts/extensions/guided-generations/manifest.json
+++ b/public/scripts/extensions/guided-generations/manifest.json
@@ -6,7 +6,7 @@
     "js": "index.js",
     "css": "style.css",
     "author": "Samueras (vendored by TLD)",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "homePage": "https://github.com/Samueras/GuidedGenerations-Extension",
     "manifest_version": 3,
     "hooks": {

--- a/public/scripts/extensions/guided-generations/scripts/guidedCorrection.js
+++ b/public/scripts/extensions/guided-generations/scripts/guidedCorrection.js
@@ -1,0 +1,240 @@
+import { Generate, eventSource, event_types, is_send_press } from '../../../../script.js';
+import { is_group_generating } from '../../../group-chats.js';
+import {
+    applyPromptTemplate,
+    debugLog,
+    extensionName,
+    extension_settings,
+    getContext,
+    getLastAiMessage,
+} from './shared.js';
+
+const correctionInjectionId = 'correction';
+
+async function executeSTScriptCommand(command) {
+    const context = getContext();
+    if (typeof context?.executeSlashCommandsWithOptions !== 'function') {
+        throw new Error('SillyTavern slash command execution is not available.');
+    }
+
+    await context.executeSlashCommandsWithOptions(command);
+}
+
+async function waitForInjection(id) {
+    for (let i = 0; i < 5; i++) {
+        if (getContext().chatMetadata?.script_injects?.[id]) {
+            return true;
+        }
+
+        await new Promise(resolve => setTimeout(resolve, 150));
+    }
+
+    return false;
+}
+
+function getTargetForceCharacterId(message) {
+    const context = getContext();
+    if (!context?.groupId || !Array.isArray(context.characters)) {
+        return undefined;
+    }
+
+    const avatar = message?.original_avatar;
+    if (avatar) {
+        const avatarIndex = context.characters.findIndex(character => character?.avatar === avatar);
+        if (avatarIndex !== -1) {
+            return avatarIndex;
+        }
+    }
+
+    const name = String(message?.name ?? '').trim();
+    if (!name) {
+        return undefined;
+    }
+
+    const nameIndex = context.characters.findIndex(character => character?.name === name);
+    return nameIndex !== -1 ? nameIndex : undefined;
+}
+
+async function isolateTargetMessage(context, targetIndex) {
+    const trailingMessages = context.chat.slice(targetIndex + 1);
+    if (trailingMessages.length === 0) {
+        return trailingMessages;
+    }
+
+    context.chat.length = targetIndex + 1;
+    await context.redisplayChat({ targetChat: context.chat, startIndex: targetIndex, fade: false });
+    return trailingMessages;
+}
+
+async function restoreTrailingMessages(context, targetIndex, trailingMessages) {
+    if (trailingMessages.length === 0) {
+        return;
+    }
+
+    context.chat.splice(targetIndex + 1, 0, ...trailingMessages);
+    await context.redisplayChat({ targetChat: context.chat, startIndex: targetIndex + 1, fade: false });
+    await context.saveChat();
+}
+
+async function restoreChatSnapshot(context, chatSnapshot, startIndex) {
+    context.chat.length = 0;
+    context.chat.push(...chatSnapshot);
+    await context.redisplayChat({ targetChat: context.chat, startIndex, fade: false });
+    await context.saveChat();
+}
+
+function cloneChatMessage(message) {
+    const clone = { ...message };
+
+    if (message?.extra && typeof message.extra === 'object') {
+        clone.extra = { ...message.extra };
+    }
+
+    if (Array.isArray(message?.swipes)) {
+        clone.swipes = [...message.swipes];
+    }
+
+    return clone;
+}
+
+function copyGeneratedMessageToTarget(targetMessage, generatedMessage) {
+    const preservedIdentity = {
+        name: targetMessage.name,
+        is_user: targetMessage.is_user,
+        is_system: targetMessage.is_system,
+        force_avatar: targetMessage.force_avatar,
+        original_avatar: targetMessage.original_avatar,
+        send_date: targetMessage.send_date,
+    };
+    const originalExtra = { ...(targetMessage.extra ?? {}) };
+    const generatedExtra = { ...(generatedMessage.extra ?? {}) };
+    const generatedSwipes = Array.isArray(generatedMessage.swipes) ? [...generatedMessage.swipes] : undefined;
+
+    for (const key of Object.keys(targetMessage)) {
+        delete targetMessage[key];
+    }
+
+    Object.assign(targetMessage, generatedMessage, preservedIdentity);
+    targetMessage.extra = { ...originalExtra, ...generatedExtra };
+
+    if (generatedSwipes) {
+        targetMessage.swipes = generatedSwipes;
+    }
+}
+
+async function applyAppendedGenerationToTarget(context, targetIndex, targetMessage) {
+    if (context.chat[targetIndex] !== targetMessage) {
+        return false;
+    }
+
+    const generatedIndex = context.chat.length - 1;
+    const generatedMessage = context.chat[generatedIndex];
+    if (generatedIndex <= targetIndex || !generatedMessage || generatedMessage.is_user || generatedMessage.is_system) {
+        return false;
+    }
+
+    copyGeneratedMessageToTarget(targetMessage, generatedMessage);
+    context.updateMessageBlock(targetIndex, targetMessage);
+    await eventSource.emit(event_types.MESSAGE_EDITED, targetIndex);
+    await eventSource.emit(event_types.MESSAGE_UPDATED, targetIndex);
+    await context.deleteMessage(generatedIndex, undefined, false);
+    await context.saveChat();
+    return true;
+}
+
+async function generateCorrection(target) {
+    const forceCharacterId = getTargetForceCharacterId(target.message);
+    const options = {};
+
+    if (forceCharacterId !== undefined) {
+        options.force_chid = forceCharacterId;
+    }
+
+    await Generate('regenerate', options);
+}
+
+async function guidedCorrection() {
+    if (is_send_press || is_group_generating) {
+        toastr.warning('Please wait for the current generation to complete.', 'Guided Correction');
+        return;
+    }
+
+    const textarea = document.getElementById('send_textarea');
+    if (!(textarea instanceof HTMLTextAreaElement)) {
+        console.error('[GuidedGenerations][Correction] Textarea #send_textarea not found.');
+        return;
+    }
+
+    const originalInput = textarea.value;
+    if (!originalInput.trim()) {
+        toastr.warning('Please enter a correction instruction.', 'Guided Correction');
+        return;
+    }
+
+    const target = getLastAiMessage();
+    if (!target) {
+        toastr.error('No AI message found to correct.', 'Guided Correction');
+        return;
+    }
+
+    const context = getContext();
+    const chatSnapshot = context.chat.map(cloneChatMessage);
+    let trailingMessages = [];
+    let didRestoreSnapshot = false;
+
+    try {
+        const settings = extension_settings[extensionName] ?? {};
+        const injectionRole = settings.injectionEndRole ?? 'system';
+        const depth = settings.depthPromptGuidedCorrection ?? 0;
+        const promptTemplate = settings.promptGuidedCorrection ?? '';
+        const filledPrompt = applyPromptTemplate(promptTemplate, originalInput);
+        const stscriptCommand = `/inject id=${correctionInjectionId} position=chat ephemeral=true scan=true depth=${depth} role=${injectionRole} ${filledPrompt} |`;
+
+        await executeSTScriptCommand(stscriptCommand);
+        debugLog('[Correction] Executed command:', stscriptCommand);
+
+        if (!await waitForInjection(correctionInjectionId)) {
+            toastr.error('Could not verify correction instruction injection.', 'Guided Correction');
+            return;
+        }
+
+        trailingMessages = await isolateTargetMessage(context, target.index);
+
+        await generateCorrection(target);
+        const targetWasUpdatedInPlace = await applyAppendedGenerationToTarget(context, target.index, target.message);
+        const regeneratedMessage = context.chat[target.index];
+        const targetWasRegenerated = Boolean(regeneratedMessage && regeneratedMessage !== target.message && !regeneratedMessage.is_user && !regeneratedMessage.is_system);
+
+        if (!targetWasRegenerated && !targetWasUpdatedInPlace) {
+            await restoreChatSnapshot(context, chatSnapshot, target.index);
+            didRestoreSnapshot = true;
+            toastr.error('Guided Correction did not produce a replacement message.', 'Guided Correction');
+            return;
+        }
+
+        await restoreTrailingMessages(context, target.index, trailingMessages);
+    } catch (error) {
+        console.error('[GuidedGenerations][Correction] Error during guided correction execution:', error);
+
+        if (!didRestoreSnapshot) {
+            try {
+                await restoreChatSnapshot(context, chatSnapshot, target.index);
+            } catch (restoreError) {
+                console.error('[GuidedGenerations][Correction] Could not restore chat after correction failure:', restoreError);
+            }
+        }
+
+        toastr.error(String(error?.message || error), 'Guided Correction');
+    } finally {
+        textarea.value = originalInput;
+        textarea.dispatchEvent(new Event('input', { bubbles: true }));
+
+        try {
+            await executeSTScriptCommand(`/flushinject ${correctionInjectionId}`);
+        } catch (error) {
+            console.warn('[GuidedGenerations][Correction] Could not flush guided correction injection:', error);
+        }
+    }
+}
+
+export { guidedCorrection };

--- a/public/scripts/extensions/guided-generations/scripts/shared.js
+++ b/public/scripts/extensions/guided-generations/scripts/shared.js
@@ -45,6 +45,24 @@ function isGroupChat() {
     return Boolean(context?.groupId && context?.groups);
 }
 
+function getLastAiMessage() {
+    const context = getContext();
+    const chat = context?.chat;
+
+    if (!Array.isArray(chat) || chat.length === 0) {
+        return null;
+    }
+
+    for (let i = chat.length - 1; i >= 0; i--) {
+        const message = chat[i];
+        if (message && !message.is_user && !message.is_system) {
+            return { message, index: i };
+        }
+    }
+
+    return null;
+}
+
 function applyPromptTemplate(template, input) {
     return String(template ?? '').split('{{input}}').join(input ?? '');
 }
@@ -57,6 +75,7 @@ export {
     extension_settings,
     getContext,
     getCurrentProfile,
+    getLastAiMessage,
     getLastImpersonateResult,
     getPresetsForApiType,
     getPreviousImpersonateInput,

--- a/public/scripts/extensions/guided-generations/settings.html
+++ b/public/scripts/extensions/guided-generations/settings.html
@@ -19,6 +19,10 @@
                     <span>Guided Swipe button</span>
                 </label>
                 <label class="checkbox_label">
+                    <input type="checkbox" id="gg_showGuidedCorrection" name="showGuidedCorrection" class="gg-setting-input">
+                    <span>Guided Correction button</span>
+                </label>
+                <label class="checkbox_label">
                     <input type="checkbox" id="gg_showImpersonate1stPerson" name="showImpersonate1stPerson" class="gg-setting-input">
                     <span>Guided Impersonate button</span>
                 </label>
@@ -60,6 +64,16 @@
                     <label for="gg_depthPromptGuidedSwipe">Depth</label>
                     <input id="gg_depthPromptGuidedSwipe" name="depthPromptGuidedSwipe" class="gg-setting-input text_pole" type="number" min="0" step="1">
                     <button type="button" class="menu_button gg-default-button" data-target="promptGuidedSwipe">Reset</button>
+                </div>
+            </div>
+
+            <div class="setting_item">
+                <label for="gg_promptGuidedCorrection">Guided Correction prompt</label>
+                <textarea id="gg_promptGuidedCorrection" name="promptGuidedCorrection" class="gg-setting-input text_pole gg-prompt-field" rows="3"></textarea>
+                <div class="flex-container flexGap5">
+                    <label for="gg_depthPromptGuidedCorrection">Depth</label>
+                    <input id="gg_depthPromptGuidedCorrection" name="depthPromptGuidedCorrection" class="gg-setting-input text_pole" type="number" min="0" step="1">
+                    <button type="button" class="menu_button gg-default-button" data-target="promptGuidedCorrection">Reset</button>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- Add Guided Correction generation flow with empty-input, no-AI-message, and in-progress guards.
- Wire the new fa-pen-to-square action button between Guided Swipe and Guided Response.
- Add settings for visibility, prompt customization, and depth, then bump the extension manifest to 1.7.1.

## Testing
- node --check public/scripts/extensions/guided-generations/scripts/guidedCorrection.js
- node --check public/scripts/extensions/guided-generations/scripts/shared.js
- node --check public/scripts/extensions/guided-generations/index.js
- node -e "JSON.parse(require('fs').readFileSync('public/scripts/extensions/guided-generations/manifest.json','utf8'))"
- ./node_modules/.bin/eslint public/scripts/extensions/guided-generations/index.js public/scripts/extensions/guided-generations/scripts/shared.js public/scripts/extensions/guided-generations/scripts/guidedCorrection.js
- git diff --check

Manual chat/generation scenarios from the implementation plan still need verification in a running client.