### PR TITLE
feat: add prompt manager preview

### DIFF
--- a/public/css/promptmanager.css
+++ b/public/css/promptmanager.css
@@ -168,7 +168,8 @@
 #completion_prompt_manager_popup #completion_prompt_manager_popup_edit,
 #completion_prompt_manager_popup #completion_prompt_manager_popup_chathistory_edit,
 #completion_prompt_manager_popup #completion_prompt_manager_popup_dialogueexamples_edit,
-#completion_prompt_manager_popup #completion_prompt_manager_popup_inspect {
+#completion_prompt_manager_popup #completion_prompt_manager_popup_inspect,
+#completion_prompt_manager_popup #completion_prompt_manager_popup_preview {
     display: none;
     padding: 0.5em;
     height: 100%;
@@ -822,7 +823,8 @@
     }
 
     #completion_prompt_manager .completion_prompt_manager_editor_host #completion_prompt_manager_popup_edit,
-    #completion_prompt_manager .completion_prompt_manager_editor_host #completion_prompt_manager_popup_inspect {
+    #completion_prompt_manager .completion_prompt_manager_editor_host #completion_prompt_manager_popup_inspect,
+    #completion_prompt_manager .completion_prompt_manager_editor_host #completion_prompt_manager_popup_preview {
         display: flex;
         flex-direction: column;
         justify-content: flex-start;

--- a/public/css/promptmanager.css
+++ b/public/css/promptmanager.css
@@ -228,6 +228,80 @@
     padding: 0.5em;
 }
 
+#completion_prompt_manager_popup .completion_prompt_manager_popup_tabs {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-bottom: 1em;
+    padding: 0 0.5em 0.5em;
+    border-bottom: 1px solid var(--SmartThemeBorderColor);
+}
+
+#completion_prompt_manager_popup .completion_prompt_manager_tab_button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 36px;
+    padding: 8px 16px;
+    border: 1px solid transparent;
+    border-radius: 9999px;
+    background: transparent;
+    color: var(--SmartThemeEmColor);
+    font-size: calc(var(--mainFontSize) * 0.9);
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 200ms ease;
+}
+
+#completion_prompt_manager_popup .completion_prompt_manager_tab_button:hover {
+    background-color: color-mix(in srgb, var(--SmartThemeBlurTintColor) 84%, var(--SmartThemeBodyColor) 16%);
+    color: var(--SmartThemeBodyColor);
+}
+
+#completion_prompt_manager_popup .completion_prompt_manager_tab_button.active {
+    border-color: var(--SmartThemeBorderColor);
+    background-color: var(--SmartThemeBlurTintColor);
+    color: var(--SmartThemeBodyColor);
+}
+
+#completion_prompt_manager_popup .completion_prompt_manager_preview_content {
+    margin-top: 1em;
+    padding: 1em;
+    border: 1px solid var(--SmartThemeBorderColor);
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 20%, transparent);
+}
+
+#completion_prompt_manager_popup .completion_prompt_manager_preview_meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1em;
+    margin-bottom: 0.75em;
+    padding-bottom: 0.75em;
+    border-bottom: 1px solid var(--SmartThemeBorderColor);
+    font-size: calc(var(--mainFontSize) * 0.9);
+}
+
+#completion_prompt_manager_popup .completion_prompt_manager_preview_role,
+#completion_prompt_manager_popup .completion_prompt_manager_preview_tokens {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+}
+
+#completion_prompt_manager_popup .completion_prompt_manager_preview_text {
+    min-height: 100px;
+    max-height: 400px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: var(--SmartThemeBodyColor);
+    font-family: var(--monoFontFamily, 'Courier New', monospace);
+    font-size: calc(var(--mainFontSize) * 0.95);
+    line-height: 1.5;
+}
+
 .completion_prompt_manager_popup_entry_form_control {
     margin-top: 1em;
 }
@@ -538,6 +612,21 @@
 
     #completion_prompt_manager .completion_prompt_manager_header_tokens {
         padding-top: 0;
+    }
+
+    #completion_prompt_manager_popup .completion_prompt_manager_popup_tabs {
+        padding: 0.5em;
+    }
+
+    #completion_prompt_manager_popup .completion_prompt_manager_tab_button {
+        min-height: var(--sb-mobile-touch-target, 44px);
+        flex: 1 1 0;
+    }
+
+    #completion_prompt_manager_popup .completion_prompt_manager_preview_meta {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 0.5em;
     }
 
     #completion_prompt_manager #completion_prompt_manager_list li {

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -1603,7 +1603,8 @@ body.bubblechat .mes[is_user='true'] .mes_block {
     }
 
     #completion_prompt_manager_popup #completion_prompt_manager_popup_edit,
-    #completion_prompt_manager_popup #completion_prompt_manager_popup_inspect {
+    #completion_prompt_manager_popup #completion_prompt_manager_popup_inspect,
+    #completion_prompt_manager_popup #completion_prompt_manager_popup_preview {
         gap: 10px;
         padding: 0;
         min-width: 0;

--- a/public/index.html
+++ b/public/index.html
@@ -7850,6 +7850,14 @@
                     </form>
                 </div>
             </div>
+            <div id="completion_prompt_manager_popup_tabs" class="completion_prompt_manager_popup_tabs" style="display: none;">
+                <button type="button" class="completion_prompt_manager_tab_button active" data-tab="edit">
+                    <span data-i18n="prompt_manager_edit">Edit</span>
+                </button>
+                <button type="button" class="completion_prompt_manager_tab_button" data-tab="preview">
+                    <span data-i18n="prompt_manager_preview">Preview</span>
+                </button>
+            </div>
             <div id="completion_prompt_manager_popup_edit">
                 <h3 data-i18n="prompt_manager_edit">Edit</h3>
                 <div class="completion_prompt_manager_popup_entry">
@@ -7947,6 +7955,35 @@
                             <a id="completion_prompt_manager_popup_entry_form_save" title="Save" data-i18n="[title]save" class="fa-solid fa-save menu_button" data-pm-prompt=""></a>
                         </div>
                     </form>
+                </div>
+            </div>
+            <div id="completion_prompt_manager_popup_preview" style="display: none;">
+                <h3 data-i18n="prompt_manager_preview">Preview</h3>
+                <div class="completion_prompt_manager_popup_entry">
+                    <div class="completion_prompt_manager_popup_entry_form">
+                        <div class="completion_prompt_manager_popup_entry_form_control">
+                            <div class="completion_prompt_manager_popup_header">
+                                <label>
+                                    <span data-i18n="prompt_manager_rendered_prompt">Rendered Prompt</span>
+                                </label>
+                                <a id="completion_prompt_manager_popup_preview_close_button" title="close" data-i18n="[title]close" class="fa-solid fa-close menu_button"></a>
+                            </div>
+                            <div class="text_muted" data-i18n="Preview this prompt with macros substituted before saving changes.">Preview this prompt with macros substituted before saving changes.</div>
+                            <div class="completion_prompt_manager_preview_content">
+                                <div class="completion_prompt_manager_preview_meta">
+                                    <span class="completion_prompt_manager_preview_role">
+                                        <strong data-i18n="Role">Role</strong>
+                                        <span id="completion_prompt_manager_preview_role_value">system</span>
+                                    </span>
+                                    <span class="completion_prompt_manager_preview_tokens" title="Token counts may be inaccurate and provided just for reference." data-i18n="[title]Token counts may be inaccurate and provided just for reference.">
+                                        <strong data-i18n="Tokens">Tokens</strong>
+                                        <span id="completion_prompt_manager_preview_token_count">0</span>
+                                    </span>
+                                </div>
+                                <div id="completion_prompt_manager_preview_text" class="completion_prompt_manager_preview_text"></div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -379,8 +379,12 @@ class PromptManager {
         // Currently selected prompt shown in the editor pane.
         this.selectedPromptId = null;
 
-        // Active editor pane area (`edit` / `inspect`) when visible.
+        // Active editor pane area (`edit` / `inspect` / `preview`) when visible.
         this.activePopupArea = '';
+
+        // Prompt preview update state.
+        this.previewUpdateDebounced = null;
+        this.previewTokenCountRequest = 0;
 
         // Original popup position before the desktop editor host moves it inline.
         this.popupOriginalParent = null;
@@ -411,6 +415,9 @@ class PromptManager {
 
         /** Prompt row click */
         this.handlePromptRowClick = () => { };
+
+        /** Prompt editor tab click */
+        this.handlePromptEditorTabClick = () => { };
 
         /** Detach prompt button click */
         this.handleDetach = () => { };
@@ -697,6 +704,14 @@ class PromptManager {
                 event.preventDefault();
                 event.stopPropagation();
             }
+        };
+
+        this.handlePromptEditorTabClick = (event) => {
+            const tabName = event.currentTarget?.dataset?.tab;
+            if (!['edit', 'preview'].includes(tabName)) return;
+
+            event.preventDefault();
+            this.showPopup(tabName);
         };
 
         // Open edit form and load selected prompt
@@ -1084,6 +1099,11 @@ class PromptManager {
         // Clear forms on closing the popup
         document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_close').addEventListener('click', closeAndClearPopup);
         document.getElementById(this.configuration.prefix + 'prompt_manager_popup_close_button').addEventListener('click', closeAndClearPopup);
+        document.getElementById(this.configuration.prefix + 'prompt_manager_popup_preview_close_button').addEventListener('click', closeAndClearPopup);
+        document.querySelectorAll('.' + this.configuration.prefix + 'prompt_manager_tab_button').forEach(button => {
+            button.addEventListener('click', this.handlePromptEditorTabClick);
+        });
+        this.setupPreviewListeners();
         closeAndClearPopup();
 
         // Re-render prompt manager on openai preset change
@@ -1750,6 +1770,61 @@ class PromptManager {
         });
     }
 
+    syncPreviewTabState(activeArea) {
+        document.querySelectorAll('.' + this.configuration.prefix + 'prompt_manager_tab_button').forEach(button => {
+            button.classList.toggle('active', button.dataset.tab === activeArea);
+        });
+    }
+
+    setupPreviewListeners() {
+        this.previewUpdateDebounced = debounce(() => this.updatePromptPreview(), 300);
+
+        [
+            'prompt_manager_popup_entry_form_name',
+            'prompt_manager_popup_entry_form_role',
+            'prompt_manager_popup_entry_form_prompt',
+        ].forEach(idSuffix => {
+            const field = document.getElementById(this.configuration.prefix + idSuffix);
+            field?.addEventListener('input', this.previewUpdateDebounced);
+            field?.addEventListener('change', this.previewUpdateDebounced);
+        });
+    }
+
+    async updatePromptPreview() {
+        if (this.activePopupArea !== 'preview') return;
+
+        const roleField = /** @type {HTMLSelectElement} */(document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_role'));
+        const promptField = /** @type {HTMLTextAreaElement} */(document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_prompt'));
+        const roleValue = document.getElementById(this.configuration.prefix + 'prompt_manager_preview_role_value');
+        const tokenCount = document.getElementById(this.configuration.prefix + 'prompt_manager_preview_token_count');
+        const previewText = document.getElementById(this.configuration.prefix + 'prompt_manager_preview_text');
+
+        if (!roleField || !promptField || !roleValue || !tokenCount || !previewText) return;
+
+        const previewRequest = ++this.previewTokenCountRequest;
+        const preparedPrompt = this.preparePrompt({
+            role: roleField.value || 'system',
+            content: promptField.value || '',
+        });
+        const previewContent = preparedPrompt.content || '';
+
+        roleValue.textContent = preparedPrompt.role || 'system';
+        previewText.textContent = previewContent || t`(Empty prompt)`;
+        tokenCount.textContent = t`Calculating...`;
+
+        try {
+            const message = await Message.fromPromptAsync(preparedPrompt);
+            if (previewRequest === this.previewTokenCountRequest) {
+                tokenCount.textContent = String(message.getTokens());
+            }
+        } catch (error) {
+            if (previewRequest === this.previewTokenCountRequest) {
+                tokenCount.textContent = '?';
+            }
+            this.log('Prompt preview token counting failed: ' + error.message);
+        }
+    }
+
     /**
      * Clears all input fields in the edit form.
      */
@@ -2277,6 +2352,18 @@ class PromptManager {
             return;
         }
 
+        ['edit', 'inspect', 'preview'].forEach(areaName => {
+            const element = document.getElementById(this.configuration.prefix + 'prompt_manager_popup_' + areaName);
+            if (element instanceof HTMLElement) {
+                element.style.display = 'none';
+            }
+        });
+
+        const tabsElement = document.getElementById(this.configuration.prefix + 'prompt_manager_popup_tabs');
+        if (tabsElement instanceof HTMLElement) {
+            tabsElement.style.display = ['edit', 'preview'].includes(area) ? 'flex' : 'none';
+        }
+
         areaElement.style.display = 'flex';
 
         if (this.isDesktopSplitLayout()) {
@@ -2290,11 +2377,17 @@ class PromptManager {
 
         this.syncEditorPaneState();
         this.syncListSelection();
+        this.syncPreviewTabState(area);
+
+        if (area === 'preview') {
+            this.updatePromptPreview();
+        }
 
         window.setTimeout(() => {
             const focusTarget = area === 'edit'
                 ? document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_prompt')
-                : document.getElementById(this.configuration.prefix + 'prompt_manager_popup_close_button');
+                : document.getElementById(this.configuration.prefix + 'prompt_manager_popup_' + area + '_close_button')
+                    || document.getElementById(this.configuration.prefix + 'prompt_manager_popup_close_button');
 
             if (focusTarget instanceof HTMLElement) {
                 focusTarget.focus({ preventScroll: true });


### PR DESCRIPTION
## Summary
- Add Edit/Preview tabs to the prompt manager editor popup.
- Render a live prompt preview with macro substitution before saving.
- Show preview role and async token count with mobile-friendly styling.

## Tests
- npm run lint -- --quiet public/scripts/PromptManager.js
- node --check public/scripts/PromptManager.js
- npm run check:frontend-budgets (fails: existing blocking stylesheet bytes 742.2 KiB exceed 730.0 KiB budget)