### PR TITLE
fix: prevent Reasoning Effort overflow on mobile

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -483,6 +483,40 @@
     #right-nav-panel.openDrawer {
         padding-bottom: env(keyboard-inset-height, 0px) !important;
     }
+
+    #left-nav-panel.openDrawer #openai_settings .reasoning-effort-wrapper,
+    #left-nav-panel.openDrawer #openai_settings .reasoning-effort-row {
+        box-sizing: border-box !important;
+        width: 100% !important;
+        min-width: 0 !important;
+        max-width: 100% !important;
+        overflow-x: hidden !important;
+    }
+
+    #left-nav-panel.openDrawer #openai_settings .reasoning-effort-row {
+        display: grid !important;
+        grid-template-columns: minmax(0, 1fr) !important;
+        align-items: stretch !important;
+        justify-items: stretch !important;
+    }
+
+    #left-nav-panel.openDrawer #openai_settings .reasoning-effort-row > label,
+    #left-nav-panel.openDrawer #openai_settings .reasoning-effort-row > #openai_reasoning_effort,
+    #left-nav-panel.openDrawer #openai_settings .reasoning-effort-row > :is(.toggle-description, strong.toggle-description) {
+        grid-column: 1 !important;
+        box-sizing: border-box !important;
+        width: 100% !important;
+        min-width: 0 !important;
+        max-width: 100% !important;
+        margin-left: 0 !important;
+        margin-right: 0 !important;
+    }
+
+    #left-nav-panel.openDrawer #openai_settings .reasoning-effort-row > :is(.toggle-description, strong.toggle-description) {
+        white-space: normal !important;
+        overflow-wrap: anywhere !important;
+        word-break: break-word;
+    }
 }
 
 @supports (-webkit-overflow-scrolling: touch) {

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -484,8 +484,8 @@
         padding-bottom: env(keyboard-inset-height, 0px) !important;
     }
 
-    #left-nav-panel.openDrawer #openai_settings .reasoning-effort-wrapper,
-    #left-nav-panel.openDrawer #openai_settings .reasoning-effort-row {
+    #left-nav-panel #openai_settings .reasoning-effort-wrapper,
+    #left-nav-panel #openai_settings .reasoning-effort-row {
         box-sizing: border-box !important;
         width: 100% !important;
         min-width: 0 !important;
@@ -493,18 +493,17 @@
         overflow-x: hidden !important;
     }
 
-    #left-nav-panel.openDrawer #openai_settings .reasoning-effort-row {
-        display: grid !important;
-        grid-template-columns: minmax(0, 1fr) !important;
+    #left-nav-panel #openai_settings .reasoning-effort-row {
+        display: flex !important;
+        flex-direction: column !important;
         align-items: stretch !important;
-        justify-items: stretch !important;
+        justify-content: flex-start !important;
     }
 
-    #left-nav-panel.openDrawer #openai_settings .reasoning-effort-row > label,
-    #left-nav-panel.openDrawer #openai_settings .reasoning-effort-row > #openai_reasoning_effort,
-    #left-nav-panel.openDrawer #openai_settings .reasoning-effort-row > :is(.toggle-description, strong.toggle-description) {
-        grid-column: 1 !important;
+    #left-nav-panel #openai_settings .reasoning-effort-row > label,
+    #left-nav-panel #openai_settings .reasoning-effort-row > #openai_reasoning_effort {
         box-sizing: border-box !important;
+        display: block !important;
         width: 100% !important;
         min-width: 0 !important;
         max-width: 100% !important;
@@ -512,9 +511,19 @@
         margin-right: 0 !important;
     }
 
-    #left-nav-panel.openDrawer #openai_settings .reasoning-effort-row > :is(.toggle-description, strong.toggle-description) {
+    #left-nav-panel #openai_settings .reasoning-effort-row > .toggle-description,
+    #left-nav-panel #openai_settings .reasoning-effort-row > strong.toggle-description {
+        box-sizing: border-box !important;
+        display: block !important;
+        width: 100% !important;
+        min-width: 0 !important;
+        max-width: 100% !important;
+        margin-left: 0 !important;
+        margin-right: 0 !important;
         white-space: normal !important;
+        overflow-wrap: break-word !important;
         overflow-wrap: anywhere !important;
+        word-wrap: break-word !important;
         word-break: break-word;
     }
 }

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -3042,11 +3042,18 @@ input[type='range']::-moz-range-thumb {
         min-width: 0;
     }
 
+    #openai_settings .reasoning-effort-wrapper,
     #openai_settings .reasoning-effort-row {
         box-sizing: border-box;
         inline-size: 100%;
+        min-inline-size: 0;
         max-inline-size: 100%;
         overflow-x: hidden;
+    }
+
+    #openai_settings .reasoning-effort-wrapper {
+        width: min(100%, 100vw) !important;
+        max-width: 100vw !important;
     }
 
     #openai_settings .reasoning-effort-row > label,

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -3042,6 +3042,18 @@ input[type='range']::-moz-range-thumb {
         min-width: 0;
     }
 
+    #openai_settings .oneline-dropdown:has(> #openai_reasoning_effort),
+    #openai_reasoning_effort,
+    #openai_reasoning_effort ~ .toggle-description {
+        min-width: 0;
+        max-width: 100%;
+    }
+
+    #openai_reasoning_effort ~ .toggle-description {
+        overflow-wrap: anywhere;
+        word-break: break-word;
+    }
+
     #openai_api-presets .flex-container.marginLeft5,
     #openai_api-presets .flex-container.gap3px {
         width: 100%;

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -3042,14 +3042,23 @@ input[type='range']::-moz-range-thumb {
         min-width: 0;
     }
 
-    #openai_settings .oneline-dropdown:has(> #openai_reasoning_effort),
-    #openai_reasoning_effort,
-    #openai_reasoning_effort ~ .toggle-description {
-        min-width: 0;
-        max-width: 100%;
+    #openai_settings .reasoning-effort-row {
+        box-sizing: border-box;
+        inline-size: 100%;
+        max-inline-size: 100%;
+        overflow-x: hidden;
     }
 
-    #openai_reasoning_effort ~ .toggle-description {
+    #openai_settings .reasoning-effort-row > label,
+    #openai_settings .reasoning-effort-row > #openai_reasoning_effort,
+    #openai_settings .reasoning-effort-row > .toggle-description {
+        box-sizing: border-box;
+        inline-size: 100% !important;
+        min-inline-size: 0 !important;
+        max-inline-size: 100% !important;
+    }
+
+    #openai_settings .reasoning-effort-row > .toggle-description {
         overflow-wrap: anywhere;
         word-break: break-word;
     }

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -3045,8 +3045,11 @@ input[type='range']::-moz-range-thumb {
     #openai_settings .reasoning-effort-wrapper,
     #openai_settings .reasoning-effort-row {
         box-sizing: border-box;
+        width: 100%;
         inline-size: 100%;
+        min-width: 0;
         min-inline-size: 0;
+        max-width: 100%;
         max-inline-size: 100%;
         overflow-x: hidden;
     }
@@ -3056,17 +3059,44 @@ input[type='range']::-moz-range-thumb {
         max-width: 100vw !important;
     }
 
+    #openai_settings .reasoning-effort-row {
+        display: flex !important;
+        flex-direction: column !important;
+        align-items: stretch !important;
+        justify-content: flex-start !important;
+    }
+
     #openai_settings .reasoning-effort-row > label,
     #openai_settings .reasoning-effort-row > #openai_reasoning_effort,
     #openai_settings .reasoning-effort-row > .toggle-description {
         box-sizing: border-box;
+        display: block;
+        width: 100% !important;
         inline-size: 100% !important;
+        min-width: 0 !important;
         min-inline-size: 0 !important;
+        max-width: 100% !important;
         max-inline-size: 100% !important;
+        margin-left: 0 !important;
+        margin-right: 0 !important;
     }
 
-    #openai_settings .reasoning-effort-row > .toggle-description {
+    #openai_settings .reasoning-effort-row > strong.toggle-description {
+        box-sizing: border-box;
+        display: block;
+        width: 100% !important;
+        min-width: 0 !important;
+        max-width: 100% !important;
+        margin-left: 0 !important;
+        margin-right: 0 !important;
+    }
+
+    #openai_settings .reasoning-effort-row > .toggle-description,
+    #openai_settings .reasoning-effort-row > strong.toggle-description {
+        white-space: normal !important;
+        overflow-wrap: break-word;
         overflow-wrap: anywhere;
+        word-wrap: break-word;
         word-break: break-word;
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -45,7 +45,7 @@
     <link rel="stylesheet" type="text/css" href="css/toggle-dependent.css">
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css">
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260516d" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260516b">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260516c">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260516d">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260516c" media="(max-width: 1000px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">

--- a/public/index.html
+++ b/public/index.html
@@ -47,7 +47,7 @@
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260516d" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260516d">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260516d">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260516c" media="(max-width: 1000px)">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260516d" media="(max-width: 1000px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
 </head>

--- a/public/index.html
+++ b/public/index.html
@@ -45,7 +45,7 @@
     <link rel="stylesheet" type="text/css" href="css/toggle-dependent.css">
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css">
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260516d" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260516c">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260516d">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260516d">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260516c" media="(max-width: 1000px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
@@ -2164,7 +2164,7 @@
                                             </select>
                                         </div>
                                     </div>
-                                    <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai,custom,claude,xai,makersuite,vertexai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes,nanogpt">
+                                    <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10 reasoning-effort-wrapper" data-source="openai,custom,claude,xai,makersuite,vertexai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes,nanogpt">
                                         <div class="flex-container oneline-dropdown reasoning-effort-row" title="Constrains effort on reasoning for reasoning models.&#10;Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response." data-i18n="[title]Constrains effort on reasoning for reasoning models.">
                                             <label for="openai_reasoning_effort">
                                                 <span data-i18n="Reasoning Effort">Reasoning Effort</span>

--- a/public/index.html
+++ b/public/index.html
@@ -45,9 +45,9 @@
     <link rel="stylesheet" type="text/css" href="css/toggle-dependent.css">
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css">
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260516d" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260516d">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260516e">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260516d">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260516d" media="(max-width: 1000px)">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260516e" media="(max-width: 1000px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
 </head>

--- a/public/index.html
+++ b/public/index.html
@@ -2165,7 +2165,7 @@
                                         </div>
                                     </div>
                                     <div class="flex-container flexFlowColumn wide100p textAlignCenter marginTop10" data-source="openai,custom,claude,xai,makersuite,vertexai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes,nanogpt">
-                                        <div class="flex-container oneline-dropdown" title="Constrains effort on reasoning for reasoning models.&#10;Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response." data-i18n="[title]Constrains effort on reasoning for reasoning models.">
+                                        <div class="flex-container oneline-dropdown reasoning-effort-row" title="Constrains effort on reasoning for reasoning models.&#10;Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response." data-i18n="[title]Constrains effort on reasoning for reasoning models.">
                                             <label for="openai_reasoning_effort">
                                                 <span data-i18n="Reasoning Effort">Reasoning Effort</span>
                                                 <a href="https://docs.sillytavern.app/usage/prompts/reasoning/#reasoning-effort" target="_blank" class="opacity50p fa-solid fa-circle-question"></a>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const SB_SW_CACHE_VERSION = 'sillybunny-cache-v20260513b';
+const SB_SW_CACHE_VERSION = 'sillybunny-cache-v20260516a';
 const SB_STATIC_CACHE = `${SB_SW_CACHE_VERSION}-static`;
 const SB_SHELL_CACHE = `${SB_SW_CACHE_VERSION}-shell`;
 const SB_FRONTEND_ASSET_PREFIX = '/frontend-assets/';

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const SB_SW_CACHE_VERSION = 'sillybunny-cache-v20260516a';
+const SB_SW_CACHE_VERSION = 'sillybunny-cache-v20260516b';
 const SB_STATIC_CACHE = `${SB_SW_CACHE_VERSION}-static`;
 const SB_SHELL_CACHE = `${SB_SW_CACHE_VERSION}-shell`;
 const SB_FRONTEND_ASSET_PREFIX = '/frontend-assets/';


### PR DESCRIPTION
## Summary
- Constrain the mobile-only Reasoning Effort dropdown row so it cannot exceed the settings drawer width.
- Force the Reasoning Effort help text to wrap on narrow screens without changing desktop styles.

## Verification
- Ran `npm run check:frontend-budgets` (fails on existing blocking stylesheet budget: 742.5 KiB > 730.0 KiB).
- Confirmed the CSS change is scoped inside the existing `@media screen and (max-width: 760px)` block.