### PR TITLE
fix: enable Prose Polisher for impersonation catalog

### DIFF
--- a/public/scripts/extensions/in-chat-agents/templates/index.json
+++ b/public/scripts/extensions/in-chat-agents/templates/index.json
@@ -588,7 +588,8 @@
         "normal",
         "continue",
         "impersonate"
-      ]
+      ],
+      "runOnImpersonate": true
     }
   },
   {

--- a/tests/in-chat-agents-templates.test.js
+++ b/tests/in-chat-agents-templates.test.js
@@ -7,6 +7,16 @@ function readTemplate(filename) {
     return JSON.parse(fs.readFileSync(new URL(filename, templateDir), 'utf8'));
 }
 
+function findCatalogTemplate(catalog, templateId) {
+    const template = catalog.find(template => template.id === templateId);
+
+    if (!template) {
+        throw new Error(`Missing catalog template: ${templateId}`);
+    }
+
+    return template;
+}
+
 describe('in-chat agent bundled templates', () => {
     test('keeps source files synced with the template browser catalog', () => {
         const catalog = readTemplate('index.json');
@@ -41,5 +51,18 @@ describe('in-chat agent bundled templates', () => {
             maxTokens: 4096,
         }));
         expect(template.conditions.generationTypes).toEqual(['normal', 'continue', 'impersonate']);
+    });
+
+    test('keeps Prose Polisher enabled for impersonation prompt rewrites in the catalog', () => {
+        const catalog = readTemplate('index.json');
+        const template = findCatalogTemplate(catalog, 'tpl-prose-polisher');
+
+        expect(template.postProcess).toEqual(expect.objectContaining({
+            promptTransformEnabled: true,
+            promptTransformMode: 'rewrite',
+        }));
+        expect(template.conditions).toEqual(expect.objectContaining({
+            runOnImpersonate: true,
+        }));
     });
 });


### PR DESCRIPTION
## What?
Adds the missing `conditions.runOnImpersonate: true` flag to the bundled template catalog entry for Prose Polisher. Also adds a focused regression assertion for the catalog entry so the impersonation prompt-transform settings stay present.

## Why?
The standalone `prose-polisher.json` template already opts into impersonation, but the runtime-loaded template browser catalog was missing the same flag. That meant importing/loading Prose Polisher from the catalog could lose the impersonation behavior even though the template source file was correct.

## How?
Kept the fix narrow: updated only the Prose Polisher object in `public/scripts/extensions/in-chat-agents/templates/index.json`, then extended the existing in-chat agent template test file with a catalog lookup assertion for `promptTransformEnabled`, `promptTransformMode: rewrite`, and `runOnImpersonate`.

## Testing?
- `npm ci --ignore-scripts`
- `npm ci --ignore-scripts --prefix tests`
- `npm run test:unit --prefix tests -- tests/in-chat-agents-templates.test.js`
- `npx eslint tests/in-chat-agents-templates.test.js`
- CI `✅ Check ESLint on PR`: passed
- CI `✅ Run Unit Tests on PR`: passed
- CI `✅ Check Frontend Budgets`: failed on existing blocking stylesheet budget (`742.2 KiB` > `730.0 KiB` in CI). This PR only changes a template JSON file and a test file, so the budget failure appears unrelated to this fix.

## Screenshots (optional)
No screenshots; this is a non-visual bundled template/test fix.

## Anything Else?
The existing source/catalog sync coverage still intentionally checks the same three templates it covered before. This PR adds a targeted Prose Polisher regression instead of broadening template mirror coverage beyond the requested fix.