### PR TITLE
Fix mobile reasoning effort label wrapping

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -477,6 +477,14 @@
         -webkit-overflow-scrolling: touch !important;
     }
 
+    #left-nav-panel .toggle-description {
+        width: auto !important;
+        max-width: 100% !important;
+        white-space: normal !important;
+        word-wrap: break-word !important;
+        overflow-wrap: break-word !important;
+    }
+
     #left-nav-panel.openDrawer,
     #user-settings-block.openDrawer,
     .sb-shell-root.openDrawer,


### PR DESCRIPTION
## Summary
- allow left nav toggle descriptions to wrap on mobile
- prevent long reasoning effort labels from forcing the drawer layout wider

## Verification
- git diff --check