### PR TITLE
Fix OpenRouter quantizations on profile requests

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -190,6 +190,12 @@ function getOpenRouterPlugins(request) {
     return plugins;
 }
 
+export function shouldIncludeOpenRouterQuantizations(requestBody) {
+    return Array.isArray(requestBody.quantizations)
+        && requestBody.quantizations.length > 0
+        && !Object.hasOwn(requestBody, 'secret_id');
+}
+
 function hasCustomReasoningParamConfig(requestBody) {
     return requestBody.chat_completion_source === CHAT_COMPLETION_SOURCES.CUSTOM
         && typeof requestBody.custom_reasoning_param_name === 'string'
@@ -2694,7 +2700,8 @@ router.post('/generate', async function (request, response) {
                 };
             }
 
-            if (Array.isArray(request.body.quantizations) && request.body.quantizations.length > 0) {
+            // Connection Manager profile requests use secret_id and may target models that reject quantizations.
+            if (shouldIncludeOpenRouterQuantizations(request.body)) {
                 bodyParams['provider'] ??= {};
                 bodyParams['provider']['quantizations'] = request.body.quantizations;
             }

--- a/tests/openrouter-quantizations.test.js
+++ b/tests/openrouter-quantizations.test.js
@@ -1,0 +1,40 @@
+import { beforeAll, describe, expect, test } from '@jest/globals';
+import { fileURLToPath } from 'node:url';
+
+import { setConfigFilePath } from '../src/util.js';
+
+setConfigFilePath(fileURLToPath(new URL('../default/config.yaml', import.meta.url)));
+
+describe('OpenRouter quantization parameters', () => {
+    let shouldIncludeOpenRouterQuantizations;
+
+    beforeAll(async () => {
+        ({ shouldIncludeOpenRouterQuantizations } = await import('../src/endpoints/backends/chat-completions.js'));
+    });
+
+    test('includes quantizations for main chat requests', () => {
+        expect(shouldIncludeOpenRouterQuantizations({
+            quantizations: ['int4'],
+        })).toBe(true);
+    });
+
+    test('omits quantizations for Connection Manager profile requests', () => {
+        expect(shouldIncludeOpenRouterQuantizations({
+            secret_id: 'profile-secret',
+            quantizations: ['int4'],
+        })).toBe(false);
+
+        expect(shouldIncludeOpenRouterQuantizations({
+            secret_id: '',
+            quantizations: ['int4'],
+        })).toBe(false);
+    });
+
+    test('omits quantizations when none are selected', () => {
+        expect(shouldIncludeOpenRouterQuantizations({
+            quantizations: [],
+        })).toBe(false);
+
+        expect(shouldIncludeOpenRouterQuantizations({})).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- skip forwarding OpenRouter quantizations when a Connection Manager profile request includes secret_id
- keep quantizations enabled for main chat requests
- add regression coverage for main chat, profile request, and empty quantization cases

## Tests
- npm run test:unit -- openrouter-quantizations.test.js openai-responses.test.js
- ./node_modules/.bin/eslint src/endpoints/backends/chat-completions.js
- ./node_modules/.bin/eslint openai-responses.test.js openrouter-quantizations.test.js