### PR TITLE
fix: refresh topbar tokens after hiding messages

### DIFF
--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -166,6 +166,7 @@ export async function hideChatMessageRange(start, end, unhide, nameFitler = null
     refreshSwipeButtons();
 
     await saveChatConditional();
+    await eventSource.emit(event_types.MESSAGE_UPDATED, start);
 }
 
 /**

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -2674,7 +2674,6 @@ function bindMessageActionExtensionEvents() {
     context.eventSource.on(context.event_types.SETTINGS_UPDATED, () => syncMessageActionExtensionVisibility());
     context.eventSource.on(context.event_types.USER_MESSAGE_RENDERED, data => syncMessageActionExtensionVisibility(data?.element || data));
     context.eventSource.on(context.event_types.CHARACTER_MESSAGE_RENDERED, data => syncMessageActionExtensionVisibility(data?.element || data));
-    context.eventSource.on(context.event_types.MESSAGE_UPDATED, () => scheduleTopbarContextRefresh(0));
 }
 
 function getChatScriptModule() {
@@ -3116,6 +3115,7 @@ function bindTopBarBrand() {
         eventTypes.GROUP_CHAT_CREATED,
         eventTypes.MESSAGE_EDITED,
         eventTypes.MESSAGE_DELETED,
+        eventTypes.MESSAGE_UPDATED,
         eventTypes.CHARACTER_EDITED,
         eventTypes.CHARACTER_RENAMED,
         eventTypes.CHARACTER_DELETED,

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -2674,6 +2674,7 @@ function bindMessageActionExtensionEvents() {
     context.eventSource.on(context.event_types.SETTINGS_UPDATED, () => syncMessageActionExtensionVisibility());
     context.eventSource.on(context.event_types.USER_MESSAGE_RENDERED, data => syncMessageActionExtensionVisibility(data?.element || data));
     context.eventSource.on(context.event_types.CHARACTER_MESSAGE_RENDERED, data => syncMessageActionExtensionVisibility(data?.element || data));
+    context.eventSource.on(context.event_types.MESSAGE_UPDATED, () => scheduleTopbarContextRefresh(0));
 }
 
 function getChatScriptModule() {


### PR DESCRIPTION
## Summary
- emit MESSAGE_UPDATED after hide/unhide operations complete and save
- refresh topbar context tokens immediately when MESSAGE_UPDATED fires

## Validation
- npx eslint public/scripts/chats.js public/scripts/sillybunny-tabs.js
- git diff --check