### PR TITLE
Fix Docker startup regressions

### DIFF
--- a/default/config.yaml
+++ b/default/config.yaml
@@ -64,6 +64,8 @@ enableForwardedWhitelist: true
 whitelist:
   - ::1
   - 127.0.0.1
+  - 172.16.0.0/12
+  - 192.168.0.0/16
 # Automatically whitelist Docker host and gateway IPs
 whitelistDockerHosts: true
 # Toggle basic authentication for endpoints

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,6 +8,9 @@ services:
       - NODE_ENV=production
       - FORCE_COLOR=1
       - SILLYTAVERN_HEARTBEATINTERVAL=30
+      # Match container-created files to your host user and group by default.
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
     ports:
       - "4444:4444"
     volumes:

--- a/public/scripts/welcome-screen.js
+++ b/public/scripts/welcome-screen.js
@@ -205,6 +205,8 @@ const WELCOME_BUNDLED_ASSISTANTS = Object.freeze([
     Object.freeze({
         id: 'guide',
         avatarStorageKey: assistantAvatarKey,
+        identityStorageKey: 'bundledAssistantGuideAvatar',
+        deletedStorageKey: 'bundledAssistantGuideDeleted',
         defaultAvatar: 'default_SillyBunnyGuide.png',
         fileName: 'default_SillyBunnyGuide',
         portrait: 'img/sillybunny-guide-assistant-portrait.png',
@@ -233,6 +235,8 @@ const WELCOME_BUNDLED_ASSISTANTS = Object.freeze([
     Object.freeze({
         id: 'nahida',
         avatarStorageKey: bundledAssistantNahidaAvatarKey,
+        identityStorageKey: 'bundledAssistantNahidaIdentityAvatar',
+        deletedStorageKey: 'bundledAssistantNahidaDeleted',
         defaultAvatar: 'default_AssistantNahida.png',
         fileName: 'default_AssistantNahida',
         cardAsset: 'img/assistant-nahida-portrait.png',
@@ -459,6 +463,66 @@ function getBundledAssistantConfig(assistantId = DEFAULT_BUNDLED_ASSISTANT_ID) {
     return WELCOME_BUNDLED_ASSISTANTS.find(item => item.id === assistantId) ?? WELCOME_BUNDLED_ASSISTANTS[0];
 }
 
+function isBundledAssistantMarkedDeleted(config) {
+    return accountStorage.getItem(config.deletedStorageKey) === 'true';
+}
+
+function clearBundledAssistantDeleted(config) {
+    accountStorage.removeItem(config.deletedStorageKey);
+}
+
+function markBundledAssistantDeleted(config, deletedAvatar) {
+    accountStorage.setItem(config.deletedStorageKey, 'true');
+    const storedAvatar = accountStorage.getItem(config.avatarStorageKey);
+    if (!storedAvatar || storedAvatar === deletedAvatar) {
+        accountStorage.removeItem(config.avatarStorageKey);
+    }
+    const identityAvatar = accountStorage.getItem(config.identityStorageKey);
+    if (!identityAvatar || identityAvatar === deletedAvatar) {
+        accountStorage.removeItem(config.identityStorageKey);
+    }
+}
+
+function getBundledAssistantIdentityAvatar(config) {
+    return accountStorage.getItem(config.identityStorageKey) || config.defaultAvatar;
+}
+
+function setBundledAssistantIdentityAvatar(config, avatar) {
+    if (!avatar || avatar === config.defaultAvatar) {
+        accountStorage.removeItem(config.identityStorageKey);
+    } else {
+        accountStorage.setItem(config.identityStorageKey, avatar);
+    }
+
+    clearBundledAssistantDeleted(config);
+}
+
+function hasBundledAssistantFingerprint(config, character) {
+    const creator = typeof character?.creator === 'string' ? character.creator.toLowerCase() : '';
+    const creatorNotes = typeof character?.creator_notes === 'string' ? character.creator_notes.toLowerCase() : '';
+    const name = typeof character?.name === 'string' ? character.name.toLowerCase() : '';
+    const tags = Array.isArray(character?.tags) ? character.tags.map(tag => String(tag).toLowerCase()) : [];
+
+    return creatorNotes.includes('bundled')
+        || creatorNotes.includes(config.title.toLowerCase())
+        || (creator === String(config.creator).toLowerCase() && name === String(config.characterName).toLowerCase())
+        || (creator === String(config.creator).toLowerCase() && name === config.title.toLowerCase())
+        || tags.includes('bundled');
+}
+
+function isBundledAssistantCharacter(config, character) {
+    const avatar = typeof character?.avatar === 'string' ? character.avatar : '';
+    if (!avatar) {
+        return false;
+    }
+
+    const identityAvatar = getBundledAssistantIdentityAvatar(config);
+    const storedAvatar = accountStorage.getItem(config.avatarStorageKey);
+    return avatar === config.defaultAvatar
+        || avatar === identityAvatar
+        || (avatar === storedAvatar && hasBundledAssistantFingerprint(config, character));
+}
+
 function setBundledAssistantStoredAvatar(config, avatar) {
     if (!avatar || avatar === config.defaultAvatar) {
         accountStorage.removeItem(config.avatarStorageKey);
@@ -515,13 +579,17 @@ function findBundledAssistantCharacterId(config, avatar = getBundledAssistantAva
  * @param {object} [options]
  * @param {boolean} [options.tryCreate=true] Whether a missing assistant should be created automatically.
  * @param {boolean} [options.created=false] Whether the current resolution came from a fresh create flow.
+ * @param {boolean} [options.forceCreate=false] Whether to create even if the bundled assistant was deleted.
  * @returns {Promise<{avatar: string, characterId: number, created: boolean} | null>}
  */
-async function ensureBundledAssistantCharacter(config, { tryCreate = true, created = false } = {}) {
+async function ensureBundledAssistantCharacter(config, { tryCreate = true, created = false, forceCreate = false } = {}) {
     const avatar = getBundledAssistantAvatar(config);
     const characterId = findBundledAssistantCharacterId(config, avatar);
 
     if (characterId !== -1) {
+        if (avatar === config.defaultAvatar || avatar === getBundledAssistantIdentityAvatar(config)) {
+            clearBundledAssistantDeleted(config);
+        }
         return { avatar, characterId, created };
     }
 
@@ -530,10 +598,15 @@ async function ensureBundledAssistantCharacter(config, { tryCreate = true, creat
         return null;
     }
 
+    if (isBundledAssistantMarkedDeleted(config) && !forceCreate) {
+        console.info(`Bundled assistant "${config.id}" was deleted by the user. Skipping automatic recreation.`);
+        return null;
+    }
+
     try {
         console.log(`Character not found for avatar ID: ${avatar}. Creating new bundled assistant.`, config.id);
         await createBundledAssistant(config);
-        return ensureBundledAssistantCharacter(config, { tryCreate: false, created: true });
+        return ensureBundledAssistantCharacter(config, { tryCreate: false, created: true, forceCreate });
     } catch (error) {
         console.error(`Error creating bundled assistant "${config.id}":`, error);
         toastr.error(t`Failed to create ${config.characterName}. See console for details.`);
@@ -2013,7 +2086,7 @@ async function getRecentChats() {
 export async function openPermanentAssistantChat({ tryCreate = true, created = false } = {}) {
     try {
         const assistantConfig = getBundledAssistantConfig(DEFAULT_BUNDLED_ASSISTANT_ID);
-        const assistant = await ensureBundledAssistantCharacter(assistantConfig, { tryCreate, created });
+        const assistant = await ensureBundledAssistantCharacter(assistantConfig, { tryCreate, created, forceCreate: tryCreate });
         if (!assistant) {
             return;
         }
@@ -2077,6 +2150,7 @@ async function createBundledAssistant(config) {
 
         const resolvedAvatar = characters[createdCharacterId]?.avatar;
         setBundledAssistantStoredAvatar(config, resolvedAvatar || '');
+        setBundledAssistantIdentityAvatar(config, resolvedAvatar || config.defaultAvatar);
         return;
     }
 
@@ -2120,11 +2194,12 @@ async function createBundledAssistant(config) {
 
     const resolvedAvatar = characters[createdCharacterId]?.avatar;
     setBundledAssistantStoredAvatar(config, resolvedAvatar || '');
+    setBundledAssistantIdentityAvatar(config, resolvedAvatar || config.defaultAvatar);
 }
 
 async function openBundledAssistantCard(assistantId = DEFAULT_BUNDLED_ASSISTANT_ID) {
     const assistantConfig = getBundledAssistantConfig(assistantId);
-    const assistant = await ensureBundledAssistantCharacter(assistantConfig);
+    const assistant = await ensureBundledAssistantCharacter(assistantConfig, { forceCreate: true });
     if (!assistant) {
         return;
     }
@@ -2197,8 +2272,22 @@ export function initWelcomeScreen() {
     eventSource.on(event_types.CHARACTER_RENAMED, (oldAvatar, newAvatar) => {
         for (const assistant of WELCOME_BUNDLED_ASSISTANTS) {
             const storedAvatar = accountStorage.getItem(assistant.avatarStorageKey);
+            const identityAvatar = getBundledAssistantIdentityAvatar(assistant);
+            if (identityAvatar === oldAvatar || assistant.defaultAvatar === oldAvatar) {
+                setBundledAssistantIdentityAvatar(assistant, newAvatar);
+            }
+
             if (storedAvatar === oldAvatar || (!storedAvatar && assistant.defaultAvatar === oldAvatar)) {
                 setBundledAssistantStoredAvatar(assistant, newAvatar);
+            }
+        }
+    });
+
+    eventSource.on(event_types.CHARACTER_DELETED, (event) => {
+        const deletedCharacter = event?.character;
+        for (const assistant of WELCOME_BUNDLED_ASSISTANTS) {
+            if (isBundledAssistantCharacter(assistant, deletedCharacter)) {
+                markBundledAssistantDeleted(assistant, deletedCharacter?.avatar || '');
             }
         }
     });

--- a/src/users.js
+++ b/src/users.js
@@ -615,7 +615,7 @@ export function getCookieSessionName() {
     // Get server hostname and hash it to generate a session suffix
     const hostname = os.hostname() || 'localhost';
     const suffix = crypto.createHash('sha256').update(hostname).digest('hex').slice(0, 8);
-    return `session-${suffix}`;
+    return `session-sillybunny-${suffix}`;
 }
 
 export function getSessionCookieAge() {


### PR DESCRIPTION
## Summary
- Prevent bundled assistant cards from being recreated on startup after the user deletes them
- Namespace SillyBunny session cookies to avoid collisions with SillyTavern on the same host
- Add default PUID/PGID compose environment values for host-friendly file ownership
- Add common Docker/private network CIDRs to the tracked default whitelist template

## Verification
- bunx eslint public/scripts/welcome-screen.js src/users.js
- node --check public/scripts/welcome-screen.js
- node --check src/users.js
- bun YAML parse check for default/config.yaml and docker/docker-compose.yml
- git diff --check

Note: docker is not installed in this environment, so I could not run docker compose config.