### PR TITLE
fix(ui): reorder reasoning effort options

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2176,8 +2176,8 @@
                                                 <option data-i18n="openai_reasoning_effort_low" value="low">Low</option>
                                                 <option data-i18n="openai_reasoning_effort_medium" value="medium">Medium</option>
                                                 <option data-i18n="openai_reasoning_effort_high" value="high">High</option>
-                                                <option data-i18n="openai_reasoning_effort_maximum" value="max">Maximum</option>
                                                 <option data-i18n="openai_reasoning_effort_xhigh" value="xhigh">Extra High</option>
+                                                <option data-i18n="openai_reasoning_effort_maximum" value="max">Maximum</option>
                                             </select>
                                             <div class="toggle-description justifyLeft marginBot5" data-source="openai,custom,xai,aimlapi,openrouter,pollinations,perplexity,cometapi,electronhub,azure_openai,chutes" data-i18n="OpenAI-style options: low, medium, high, xhigh. Minimum and maximum are adaptive aliases. None does not send an effort level.">
                                                 OpenAI-style options: low, medium, high, xhigh. Minimum and maximum are adaptive aliases. None does not send an effort level.


### PR DESCRIPTION
## Summary
- Move `Extra High` above `Maximum` in the OpenAI reasoning effort dropdown.
- Keep all option values and localization keys unchanged.

## Screenshot reference
- Matches the requested dropdown order from the provided screenshot: None / Minimum / Low / Medium / High / Extra High / Maximum.

## Test plan
- `npm run test:unit -- prompt-converters.test.js`
- Started local server on `http://127.0.0.1:54565/` and confirmed the served `#openai_reasoning_effort` option order is None / Minimum / Low / Medium / High / Extra High / Maximum.
