### PR TITLE
fix(quick-replies): dedupe and force-update bundled Memory Sharding preset

### DIFF
--- a/public/scripts/extensions/quick-reply/index.js
+++ b/public/scripts/extensions/quick-reply/index.js
@@ -33,6 +33,8 @@ const defaultSettings = {
 
 /** @type {Boolean}*/
 let isReady = false;
+/** @type {Boolean}*/
+let initStarted = false;
 /** @type {Function[]}*/
 let executeQueue = [];
 /** @type {string}*/
@@ -168,6 +170,12 @@ const handleCharChange = () => {
 };
 
 export async function init() {
+    if (initStarted) {
+        debug('init() already started; skipping duplicate call');
+        return;
+    }
+    initStarted = true;
+
     await loadSets();
     await loadSettings();
     log('settings: ', settings);

--- a/public/scripts/extensions/quick-reply/index.js
+++ b/public/scripts/extensions/quick-reply/index.js
@@ -33,8 +33,8 @@ const defaultSettings = {
 
 /** @type {Boolean}*/
 let isReady = false;
-/** @type {Boolean}*/
-let initStarted = false;
+// SillyBunny divergence: shared in-flight init promise; resets on rejection.
+let initPromise = null;
 /** @type {Function[]}*/
 let executeQueue = [];
 /** @type {string}*/
@@ -169,13 +169,7 @@ const handleCharChange = () => {
     settings.charConfig = charConfig;
 };
 
-export async function init() {
-    if (initStarted) {
-        debug('init() already started; skipping duplicate call');
-        return;
-    }
-    initStarted = true;
-
+async function doInit() {
     await loadSets();
     await loadSettings();
     log('settings: ', settings);
@@ -230,6 +224,18 @@ export async function init() {
     eventSource.on(event_types.APP_READY, async () => await finalizeInit());
 
     globalThis.quickReplyApi = quickReplyApi;
+}
+
+export function init() {
+    if (initPromise) {
+        return initPromise;
+    }
+
+    initPromise = doInit().catch(err => {
+        initPromise = null;
+        throw err;
+    });
+    return initPromise;
 }
 
 const finalizeInit = async () => {

--- a/src/endpoints/content-manager.js
+++ b/src/endpoints/content-manager.js
@@ -81,6 +81,7 @@ const OBSOLETE_CONTENT_ITEMS = Object.freeze([
 ]);
 
 const MANAGED_BUNDLED_PRESETS = Object.freeze([
+    { filename: 'presets/quick-replies/Default.json', type: CONTENT_TYPES.QUICK_REPLIES },
     { filename: 'presets/quick-replies/Memory Sharding.json', type: CONTENT_TYPES.QUICK_REPLIES },
 ]);
 

--- a/src/endpoints/content-manager.js
+++ b/src/endpoints/content-manager.js
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import zlib from 'node:zlib';
 import { Buffer } from 'node:buffer';
+import { createHash } from 'node:crypto';
 
 import express from 'express';
 import fetch from 'node-fetch';
@@ -80,9 +81,15 @@ const OBSOLETE_CONTENT_ITEMS = Object.freeze([
     { filename: 'presets/sysprompt/Geechan - Universal Roleplay (NSFW Simplified) (V5.0).json', type: CONTENT_TYPES.SYSPROMPT },
 ]);
 
-const MANAGED_BUNDLED_PRESETS = Object.freeze([
-    { filename: 'presets/quick-replies/Default.json', type: CONTENT_TYPES.QUICK_REPLIES },
-    { filename: 'presets/quick-replies/Memory Sharding.json', type: CONTENT_TYPES.QUICK_REPLIES },
+// SillyBunny divergence: reconcile only the bundled Memory Sharding quick reply
+// during the existing default content pass. Hash-gating keeps user-authored or
+// edited files untouched, repeated runs stay idempotent, and staleHashes is a
+// migration ledger for future bundled prompt updates.
+const MANAGED_BUNDLED_QUICK_REPLIES = Object.freeze([
+    {
+        bundledPath: 'presets/quick-replies/Memory Sharding.json',
+        staleHashes: Object.freeze([]),
+    },
 ]);
 
 function isPresetContentType(type) {
@@ -435,96 +442,117 @@ function removeObsoleteContent(contentLog, directories) {
     }
 }
 
+function getSha256(buffer) {
+    return createHash('sha256').update(buffer).digest('hex');
+}
+
+function getJsonFilesRecursive(directory) {
+    const files = [];
+
+    try {
+        for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+            const entryPath = path.join(directory, entry.name);
+
+            if (entry.isDirectory()) {
+                files.push(...getJsonFilesRecursive(entryPath));
+                continue;
+            }
+
+            if (entry.isFile() && path.extname(entry.name).toLowerCase() === '.json') {
+                files.push(entryPath);
+            }
+        }
+    } catch (error) {
+        console.warn(`Failed to scan quick replies directory ${directory}`, error);
+    }
+
+    return files;
+}
+
 /**
- * Syncs managed bundled presets when users already have a copy installed.
+ * Reconciles managed bundled quick replies without touching user-modified files.
  * @param {import('../users.js').UserDirectoryList} directories User directories
  */
-function syncManagedBundledPresets(directories) {
-    try {
-        for (const contentItem of MANAGED_BUNDLED_PRESETS) {
-            const bundledPath = path.join(contentDirectory, contentItem.filename);
+export function reconcileManagedBundledQuickReplies(directories) {
+    const quickRepliesDirectory = getUserTargetByType(CONTENT_TYPES.QUICK_REPLIES, directories);
 
-            if (!fs.existsSync(bundledPath)) {
-                continue;
-            }
+    if (!quickRepliesDirectory || !fs.existsSync(quickRepliesDirectory)) {
+        return;
+    }
 
-            let bundledRawContent;
-            let bundledContent;
+    for (const managedQuickReply of MANAGED_BUNDLED_QUICK_REPLIES) {
+        const bundledPath = path.join(contentDirectory, managedQuickReply.bundledPath);
+        let bundledContent;
 
+        try {
+            bundledContent = fs.readFileSync(bundledPath);
+        } catch (error) {
+            console.warn(`Failed to read bundled quick reply ${managedQuickReply.bundledPath}`, error);
+            continue;
+        }
+
+        const currentHash = getSha256(bundledContent);
+        const staleHashes = new Set(managedQuickReply.staleHashes);
+        const currentMatches = [];
+        const staleMatches = [];
+
+        for (const filePath of getJsonFilesRecursive(quickRepliesDirectory)) {
             try {
-                bundledRawContent = fs.readFileSync(bundledPath, 'utf8');
-                bundledContent = JSON.parse(bundledRawContent);
-            } catch {
-                continue;
+                const fileHash = getSha256(fs.readFileSync(filePath));
+
+                if (fileHash === currentHash) {
+                    currentMatches.push(filePath);
+                } else if (staleHashes.has(fileHash)) {
+                    staleMatches.push(filePath);
+                }
+            } catch (error) {
+                console.warn(`Failed to inspect quick reply file ${filePath}`, error);
             }
+        }
 
-            const bundledName = typeof bundledContent.name === 'string' ? bundledContent.name.trim() : '';
+        if (currentMatches.length === 0 && staleMatches.length === 0) {
+            continue;
+        }
 
-            if (!bundledName) {
-                continue;
+        for (const filePath of staleMatches) {
+            try {
+                fs.rmSync(filePath, { force: true });
+                console.info(`Stale bundled quick reply removed from ${filePath}`);
+            } catch (error) {
+                console.warn(`Failed to remove stale bundled quick reply ${filePath}`, error);
             }
+        }
 
-            const contentTarget = getUserTargetByType(contentItem.type, directories);
+        const bundledName = path.parse(managedQuickReply.bundledPath).name;
+        const canonicalPath = path.join(quickRepliesDirectory, `${sanitize(bundledName)}.json`);
 
-            if (!contentTarget || !fs.existsSync(contentTarget)) {
-                continue;
-            }
+        if (currentMatches.length >= 2) {
+            const keepPath = currentMatches.includes(canonicalPath) ? canonicalPath : currentMatches[0];
 
-            /** @type {{ path: string, content: string }[]} */
-            const matches = [];
-            const pendingDirectories = [contentTarget];
-
-            while (pendingDirectories.length > 0) {
-                const currentDirectory = pendingDirectories.pop();
-
-                if (!currentDirectory) {
+            for (const filePath of currentMatches) {
+                if (filePath === keepPath) {
                     continue;
                 }
 
-                for (const entry of fs.readdirSync(currentDirectory, { withFileTypes: true })) {
-                    const entryPath = path.join(currentDirectory, entry.name);
-
-                    if (entry.isDirectory()) {
-                        pendingDirectories.push(entryPath);
-                        continue;
-                    }
-
-                    if (!entry.isFile() || path.extname(entry.name).toLowerCase() !== '.json') {
-                        continue;
-                    }
-
-                    try {
-                        const userRawContent = fs.readFileSync(entryPath, 'utf8');
-                        const userContent = JSON.parse(userRawContent);
-                        const userName = typeof userContent.name === 'string' ? userContent.name.trim() : '';
-
-                        if (userName === bundledName) {
-                            matches.push({ path: entryPath, content: userRawContent });
-                        }
-                    } catch {
-                        // Ignore unreadable or invalid JSON quick reply files.
-                    }
+                try {
+                    fs.rmSync(filePath, { force: true });
+                    console.info(`Duplicate bundled quick reply removed from ${filePath}`);
+                } catch (error) {
+                    console.warn(`Failed to remove duplicate bundled quick reply ${filePath}`, error);
                 }
             }
-
-            if (matches.length === 0) {
-                continue;
-            }
-
-            if (matches.length === 1 && matches[0].content === bundledRawContent) {
-                continue;
-            }
-
-            for (const match of matches) {
-                fs.rmSync(match.path, { recursive: true, force: true });
-            }
-
-            const targetPath = path.join(contentTarget, `${sanitize(bundledName)}.json`);
-            writeFileAtomicSync(targetPath, bundledRawContent, 'utf8');
-            setPermissionsSync(targetPath);
         }
-    } catch (err) {
-        console.warn('Managed preset sync failed', err);
+
+        if (currentMatches.length === 0 && staleMatches.length > 0) {
+            try {
+                fs.mkdirSync(path.dirname(canonicalPath), { recursive: true });
+                writeFileAtomicSync(canonicalPath, bundledContent);
+                setPermissionsSync(canonicalPath);
+                console.info(`Bundled quick reply restored to ${canonicalPath}`);
+            } catch (error) {
+                console.warn(`Failed to restore bundled quick reply ${canonicalPath}`, error);
+            }
+        }
     }
 }
 
@@ -544,7 +572,7 @@ async function seedContentForUser(contentIndex, directories, forceCategories) {
     const contentLog = getContentLog(contentLogPath);
     removeObsoleteContent(contentLog, directories);
     writeFileAtomicSync(contentLogPath, contentLog.join('\n'));
-    syncManagedBundledPresets(directories);
+    reconcileManagedBundledQuickReplies(directories);
     const filteredContentIndex = contentIndex.filter(contentItem => {
         if (!isPresetContentType(contentItem.type)) {
             return true;

--- a/src/endpoints/content-manager.js
+++ b/src/endpoints/content-manager.js
@@ -80,6 +80,10 @@ const OBSOLETE_CONTENT_ITEMS = Object.freeze([
     { filename: 'presets/sysprompt/Geechan - Universal Roleplay (NSFW Simplified) (V5.0).json', type: CONTENT_TYPES.SYSPROMPT },
 ]);
 
+const MANAGED_BUNDLED_PRESETS = Object.freeze([
+    { filename: 'presets/quick-replies/Memory Sharding.json', type: CONTENT_TYPES.QUICK_REPLIES },
+]);
+
 function isPresetContentType(type) {
     return PRESET_CONTENT_TYPES.includes(type);
 }
@@ -431,6 +435,99 @@ function removeObsoleteContent(contentLog, directories) {
 }
 
 /**
+ * Syncs managed bundled presets when users already have a copy installed.
+ * @param {import('../users.js').UserDirectoryList} directories User directories
+ */
+function syncManagedBundledPresets(directories) {
+    try {
+        for (const contentItem of MANAGED_BUNDLED_PRESETS) {
+            const bundledPath = path.join(contentDirectory, contentItem.filename);
+
+            if (!fs.existsSync(bundledPath)) {
+                continue;
+            }
+
+            let bundledRawContent;
+            let bundledContent;
+
+            try {
+                bundledRawContent = fs.readFileSync(bundledPath, 'utf8');
+                bundledContent = JSON.parse(bundledRawContent);
+            } catch {
+                continue;
+            }
+
+            const bundledName = typeof bundledContent.name === 'string' ? bundledContent.name.trim() : '';
+
+            if (!bundledName) {
+                continue;
+            }
+
+            const contentTarget = getUserTargetByType(contentItem.type, directories);
+
+            if (!contentTarget || !fs.existsSync(contentTarget)) {
+                continue;
+            }
+
+            /** @type {{ path: string, content: string }[]} */
+            const matches = [];
+            const pendingDirectories = [contentTarget];
+
+            while (pendingDirectories.length > 0) {
+                const currentDirectory = pendingDirectories.pop();
+
+                if (!currentDirectory) {
+                    continue;
+                }
+
+                for (const entry of fs.readdirSync(currentDirectory, { withFileTypes: true })) {
+                    const entryPath = path.join(currentDirectory, entry.name);
+
+                    if (entry.isDirectory()) {
+                        pendingDirectories.push(entryPath);
+                        continue;
+                    }
+
+                    if (!entry.isFile() || path.extname(entry.name).toLowerCase() !== '.json') {
+                        continue;
+                    }
+
+                    try {
+                        const userRawContent = fs.readFileSync(entryPath, 'utf8');
+                        const userContent = JSON.parse(userRawContent);
+                        const userName = typeof userContent.name === 'string' ? userContent.name.trim() : '';
+
+                        if (userName === bundledName) {
+                            matches.push({ path: entryPath, content: userRawContent });
+                        }
+                    } catch {
+                        // Ignore unreadable or invalid JSON quick reply files.
+                    }
+                }
+            }
+
+            if (matches.length === 0) {
+                continue;
+            }
+
+            if (matches.length === 1 && matches[0].content === bundledRawContent) {
+                continue;
+            }
+
+            for (const match of matches) {
+                fs.rmSync(match.path, { recursive: true, force: true });
+            }
+
+            const targetPath = path.join(contentTarget, `${sanitize(bundledName)}.json`);
+            writeFileAtomicSync(targetPath, bundledRawContent, 'utf8');
+            setPermissionsSync(targetPath);
+        }
+    } catch (err) {
+        console.warn('Managed preset sync failed', err);
+    }
+}
+
+/**
  * Seeds content for a user.
  * @param {ContentItem[]} contentIndex Content index
  * @param {import('../users.js').UserDirectoryList} directories User directories
@@ -446,6 +543,7 @@ async function seedContentForUser(contentIndex, directories, forceCategories) {
     const contentLog = getContentLog(contentLogPath);
     removeObsoleteContent(contentLog, directories);
     writeFileAtomicSync(contentLogPath, contentLog.join('\n'));
+    syncManagedBundledPresets(directories);
     const filteredContentIndex = contentIndex.filter(contentItem => {
         if (!isPresetContentType(contentItem.type)) {
             return true;


### PR DESCRIPTION
## Summary
- Add a managed bundled preset sync for the Memory Sharding Quick Reply set during startup content seeding.
- Replace stale or duplicate installed copies with the current bundled preset, keeping a single canonical file.
- Respect user deletion by doing nothing when no installed copy exists.

## Verification
- Ran targeted scratch startup checks for duplicate cleanup, stale single-copy replacement, idempotency, and deletion-respect behavior.
- Ran targeted ESLint on src/endpoints/content-manager.js.
- Confirmed package.json has no npm test script.