### PR TITLE
feat: add native Prompt Inspector extension

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -40,6 +40,7 @@ This update consolidates the v1.5.4 staging work since v1.5.3: preset and connec
 
 ### Chat Completion Tabs
 - Added the default Chat Completion Tabs extension for provider-specific chat completion controls.
+- Added the default Prompt Inspector extension for inspecting and editing chat completion and text completion prompts before they are sent.
 - Preserved tab content and scroll positions while switching, disabling, or scrolling through chat completion tabs.
 - Omitted disabled `top_k` controls and sampler-owned chat completion controls from places where they should not be saved or shown.
 - Honored connection profile secret IDs for custom chat completions so profile-backed secrets remain linked correctly.

--- a/public/scripts/extensions/prompt-inspector/index.js
+++ b/public/scripts/extensions/prompt-inspector/index.js
@@ -1,0 +1,200 @@
+import { eventSource, event_types, main_api, stopGeneration } from '../../../script.js';
+import { yaml } from '../../../lib.js';
+import { renderExtensionTemplateAsync } from '../../extensions.js';
+import { POPUP_RESULT, POPUP_TYPE, Popup } from '../../popup.js';
+import { t } from '../../i18n.js';
+
+const path = 'prompt-inspector';
+
+if (!('GENERATE_AFTER_COMBINE_PROMPTS' in event_types) || !('CHAT_COMPLETION_PROMPT_READY' in event_types)) {
+    toastr.error('Required event types not found. Update SillyBunny to the latest version.');
+    throw new Error('Events not found.');
+}
+
+function isChatCompletion() {
+    return main_api === 'openai';
+}
+
+function addLaunchButton() {
+    const enabledText = t`Stop Inspecting`;
+    const disabledText = t`Inspect Prompts`;
+    const enabledIcon = 'fa-solid fa-bug-slash';
+    const disabledIcon = 'fa-solid fa-bug';
+
+    const getIcon = () => inspectEnabled ? enabledIcon : disabledIcon;
+    const getText = () => inspectEnabled ? enabledText : disabledText;
+
+    const launchButton = document.createElement('div');
+    launchButton.id = 'inspectNextPromptButton';
+    launchButton.classList.add('list-group-item', 'flex-container', 'flexGap5', 'interactable');
+    launchButton.tabIndex = 0;
+    launchButton.title = t`Toggle prompt inspection`;
+    const icon = document.createElement('i');
+    icon.className = getIcon();
+    launchButton.appendChild(icon);
+    const textSpan = document.createElement('span');
+    textSpan.textContent = getText();
+    launchButton.appendChild(textSpan);
+
+    const extensionsMenu = document.getElementById('prompt_inspector_wand_container') ?? document.getElementById('extensionsMenu');
+
+    if (!extensionsMenu) {
+        throw new Error('Could not find the extensions menu');
+    }
+
+    extensionsMenu.classList.add('interactable');
+    extensionsMenu.tabIndex = 0;
+
+    extensionsMenu.appendChild(launchButton);
+    launchButton.addEventListener('click', () => {
+        toggleInspectNext();
+        textSpan.textContent = getText();
+        icon.className = getIcon();
+    });
+}
+
+let inspectEnabled = localStorage.getItem('promptInspectorEnabled') === 'true' || false;
+let inspectFormat = localStorage.getItem('promptInspectorFormat') || 'json';
+
+function toggleInspectNext() {
+    inspectEnabled = !inspectEnabled;
+    toastr.info(`Prompt inspection is now ${inspectEnabled ? 'enabled' : 'disabled'}`);
+    localStorage.setItem('promptInspectorEnabled', String(inspectEnabled));
+}
+
+eventSource.on(event_types.CHAT_COMPLETION_PROMPT_READY, async (data) => {
+    if (!inspectEnabled) {
+        return;
+    }
+
+    if (data.dryRun) {
+        console.debug('Prompt Inspector: Skipping dry run prompt');
+        return;
+    }
+
+    if (!isChatCompletion()) {
+        console.debug('Prompt Inspector: Not a chat completion prompt');
+        return;
+    }
+
+    const promptJson = JSON.stringify(data.chat, null, 4);
+    const result = await showPromptInspector(promptJson);
+
+    if (result === promptJson) {
+        console.debug('Prompt Inspector: No changes');
+        return;
+    }
+
+    try {
+        const chat = JSON.parse(result);
+
+        // Chat is passed by reference, so we can modify it directly
+        if (Array.isArray(chat) && Array.isArray(data.chat)) {
+            data.chat.splice(0, data.chat.length, ...chat);
+        }
+
+        console.debug('Prompt Inspector: Prompt updated');
+    } catch (e) {
+        console.error('Prompt Inspector: Invalid JSON');
+        toastr.error('Invalid JSON');
+    }
+});
+
+eventSource.on(event_types.GENERATE_AFTER_COMBINE_PROMPTS, async (data) => {
+    if (!inspectEnabled) {
+        return;
+    }
+
+    if (data.dryRun) {
+        console.debug('Prompt Inspector: Skipping dry run prompt');
+        return;
+    }
+
+    if (isChatCompletion()) {
+        console.debug('Prompt Inspector: Skipping chat completion prompt');
+        return;
+    }
+
+    const result = await showPromptInspector(data.prompt);
+
+    if (result === data.prompt) {
+        console.debug('Prompt Inspector: No changes');
+        return;
+    }
+
+    data.prompt = result;
+    console.debug('Prompt Inspector: Prompt updated');
+});
+
+function jsonToYaml(json) {
+    try {
+        const obj = JSON.parse(json);
+        return yaml.stringify(obj, { lineWidth: 0 });
+    } catch (e) {
+        console.error('Prompt Inspector: Failed to convert JSON to YAML', e);
+        toastr.error('Failed to convert JSON to YAML');
+        throw e;
+    }
+}
+
+function yamlToJson(yamlText) {
+    try {
+        const obj = yaml.parse(yamlText);
+        return JSON.stringify(obj, null, 4);
+    } catch (e) {
+        console.error('Prompt Inspector: Failed to convert YAML to JSON', e);
+        toastr.error('Failed to convert YAML to JSON');
+        throw e;
+    }
+}
+
+/**
+ * Shows a prompt inspector popup.
+ * @param {string} input Initial prompt JSON
+ * @returns {Promise<string>} Updated prompt JSON
+ */
+async function showPromptInspector(input) {
+    const template = $(await renderExtensionTemplateAsync(path, 'template'));
+    const prompt = template.find('#inspectPrompt');
+    prompt.val(isChatCompletion() && inspectFormat === 'yaml' ? jsonToYaml(input) : input);
+
+    const formatSelect = template.find('#inspectPromptFormat');
+    formatSelect.val(inspectFormat);
+    formatSelect.toggle(isChatCompletion());
+    formatSelect.on('change', () => {
+        inspectFormat = formatSelect.val();
+        localStorage.setItem('promptInspectorFormat', inspectFormat);
+
+        const currentValue = prompt.val();
+        prompt.val(inspectFormat === 'yaml' ? jsonToYaml(currentValue) : yamlToJson(currentValue));
+    });
+
+    /** @type {import('../../popup.js').CustomPopupButton} */
+    const customButton = {
+        text: 'Cancel generation',
+        result: POPUP_RESULT.CANCELLED,
+        appendAtEnd: true,
+        action: async () => {
+            await stopGeneration();
+            await popup.complete(POPUP_RESULT.CANCELLED);
+        },
+    };
+    const popup = new Popup(template, POPUP_TYPE.CONFIRM, '', { wide: true, large: true, okButton: 'Save changes', cancelButton: 'Discard changes', customButtons: [customButton] });
+    const result = await popup.show();
+
+    // If the user cancels, return the original input
+    if (!result) {
+        return input;
+    }
+
+    const output = prompt.val();
+    if (isChatCompletion() && inspectFormat === 'yaml') {
+        return String(yamlToJson(output));
+    }
+
+    return String(output);
+}
+
+export function init() {
+    addLaunchButton();
+}

--- a/public/scripts/extensions/prompt-inspector/manifest.json
+++ b/public/scripts/extensions/prompt-inspector/manifest.json
@@ -1,0 +1,14 @@
+{
+    "display_name": "Prompt Inspector",
+    "loading_order": 5,
+    "requires": [],
+    "optional": [],
+    "js": "index.js",
+    "css": "style.css",
+    "author": "Cohee1207",
+    "version": "1.1.0",
+    "homePage": "https://github.com/SillyTavern/Extension-PromptInspector",
+    "hooks": {
+        "activate": "init"
+    }
+}

--- a/public/scripts/extensions/prompt-inspector/style.css
+++ b/public/scripts/extensions/prompt-inspector/style.css
@@ -1,0 +1,22 @@
+#inspectPromptHeader {
+    position: relative;
+}
+
+#inspectPromptFormat {
+    position: absolute;
+    top: 0;
+    right: 0;
+    max-width: 5em;
+}
+
+@media screen and (max-width: 1000px) {
+    #inspectPromptHeader {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+
+    #inspectPromptFormat {
+        position: unset;
+    }
+}

--- a/public/scripts/extensions/prompt-inspector/style.css
+++ b/public/scripts/extensions/prompt-inspector/style.css
@@ -6,7 +6,8 @@
     position: absolute;
     top: 0;
     right: 0;
-    max-width: 5em;
+    width: auto;
+    min-width: 8em;
 }
 
 @media screen and (max-width: 1000px) {

--- a/public/scripts/extensions/prompt-inspector/template.html
+++ b/public/scripts/extensions/prompt-inspector/template.html
@@ -1,0 +1,10 @@
+<div class="flex-container flexFlowColumn height100p">
+    <div id="inspectPromptHeader">
+        <h3 data-i18n="View and Edit the prompt">View and Edit the prompt</h3>
+        <select id="inspectPromptFormat" class="text_pole">
+            <option value="json" data-i18n="JSON">JSON</option>
+            <option value="yaml" data-i18n="YAML">YAML</option>
+        </select>
+    </div>
+    <textarea id="inspectPrompt" class="flex1 monospace textarea_compact"></textarea>
+</div>


### PR DESCRIPTION
## Summary
- Add Prompt Inspector as a native system extension under public/scripts/extensions/prompt-inspector.
- Port upstream prompt editing for chat completion and text completion prompts, including YAML formatting for chat payloads.
- Add a changelog entry for the bundled extension.

## Verification
- npm ci --ignore-scripts
- npm run lint
- bun run start, checked /api/extensions/discover lists prompt-inspector as system and asset serves
- npm run start:node, checked discovery and asset serving