### PR TITLE
fix(agents): prevent duplicate Prose Polisher after template prompt update

### DIFF
--- a/public/scripts/extensions/in-chat-agents/agent-store.js
+++ b/public/scripts/extensions/in-chat-agents/agent-store.js
@@ -533,6 +533,18 @@ function choosePathfinderAgentToKeep(agents) {
     return [...agents].sort((a, b) => getPathfinderKeepRank(a) - getPathfinderKeepRank(b))[0] ?? null;
 }
 
+function chooseSameTemplateAgentToKeep(agents, template) {
+    const templatePrompt = template ? String(template?.prompt ?? '').trim() : null;
+    if (templatePrompt !== null) {
+        const currentTemplatePromptAgent = agents.find(agent => String(agent?.prompt ?? '').trim() === templatePrompt);
+        if (currentTemplatePromptAgent) {
+            return currentTemplatePromptAgent;
+        }
+    }
+
+    return agents.find(agent => agent?.enabled) ?? agents[0] ?? null;
+}
+
 export function getRedundantBundledAgentDuplicateIds(agentList = [], templateList = []) {
     const groupedAgents = new Map();
 
@@ -581,6 +593,34 @@ export function getRedundantBundledAgentDuplicateIds(agentList = [], templateLis
 
         for (const agent of unsourced) {
             if (agent?.id && !agent.phaseLocked) {
+                redundantIds.add(agent.id);
+            }
+        }
+    }
+
+    const agentsByTemplateId = new Map();
+    for (const agent of agentList) {
+        const sourceTemplateId = String(agent?.sourceTemplateId ?? '').trim();
+        if (!sourceTemplateId) {
+            continue;
+        }
+
+        if (!agentsByTemplateId.has(sourceTemplateId)) {
+            agentsByTemplateId.set(sourceTemplateId, []);
+        }
+
+        agentsByTemplateId.get(sourceTemplateId).push(agent);
+    }
+
+    for (const grouped of agentsByTemplateId.values()) {
+        if (grouped.length < 2) {
+            continue;
+        }
+
+        const template = findTemplateForAgentSnapshot(grouped[0], templateList);
+        const keepAgent = chooseSameTemplateAgentToKeep(grouped, template);
+        for (const agent of grouped) {
+            if (agent?.id && agent.id !== keepAgent?.id && !agent.phaseLocked) {
                 redundantIds.add(agent.id);
             }
         }

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -479,17 +479,36 @@ function hasIdenticalAgent(agent, existingAgents = getAgents()) {
     );
 }
 
-async function confirmDuplicateAgentAddition(agent) {
-    if (!hasIdenticalAgent(agent)) {
+async function confirmDuplicateAgentAddition(agent, existingAgents = getAgents()) {
+    if (hasIdenticalAgent(agent, existingAgents)) {
+        const result = await new Popup(
+            'An identical agent is already active. Add anyway?',
+            POPUP_TYPE.CONFIRM,
+            'Duplicate agent',
+            {
+                okButton: 'Add Agent',
+                cancelButton: 'Cancel',
+            },
+        ).show();
+
+        return result === POPUP_RESULT.AFFIRMATIVE;
+    }
+
+    const sourceTemplateId = String(agent?.sourceTemplateId ?? '').trim();
+    const hasSameTemplateAgent = sourceTemplateId && existingAgents.some(existingAgent =>
+        String(existingAgent?.sourceTemplateId ?? '').trim() === sourceTemplateId,
+    );
+    if (!hasSameTemplateAgent) {
         return true;
     }
 
+    const agentName = String(agent?.name ?? 'this template').trim() || 'this template';
     const result = await new Popup(
-        'An identical agent is already active. Add anyway?',
+        `You already have a "${escapeHtml(agentName)}" agent installed. Add another copy?`,
         POPUP_TYPE.CONFIRM,
         'Duplicate agent',
         {
-            okButton: 'Add Agent',
+            okButton: 'Add Another',
             cancelButton: 'Cancel',
         },
     ).show();
@@ -2191,22 +2210,28 @@ async function openTemplateBrowser() {
     tplSection.append('<p class="ica--template-section-desc">Bundled trackers and helpers live here. Click any card to install it into your agent list.</p>');
 
     const grid = $('<div class="ica--template-grid"></div>');
+    const existingAgents = getAgents();
 
     for (const tpl of templates) {
         const catInfo = AGENT_CATEGORIES[tpl.category] || AGENT_CATEGORIES.custom;
         const regexCount = getTemplateRegexCount(tpl);
+        const alreadyAdded = hasMatchingAgentSnapshot(buildAgentFromTemplate(tpl), existingAgents);
         const trackerBadge = tpl.category === 'tracker'
             ? '<span class="ica--card-pill"><i class="fa-solid fa-chart-line fa-xs"></i> Bundled tracker</span>'
             : '';
+        const addedBadge = alreadyAdded
+            ? '<span class="ica--card-pill"><i class="fa-solid fa-check fa-xs"></i> Added</span>'
+            : '';
         const card = $(`
-            <div class="ica--template-card" data-id="${tpl.id}">
+            <div class="ica--template-card${alreadyAdded ? ' ica--template-card--added' : ''}" data-id="${tpl.id}">
                 <div class="ica--template-card-header">
                     <span class="ica--template-card-name">${escapeHtml(tpl.name)}</span>
                     <span class="ica--template-card-category"><i class="fa-solid ${catInfo.icon}"></i> ${catInfo.label}</span>
                 </div>
                 <div class="ica--template-card-description">${escapeHtml(tpl.description)}</div>
-                ${(trackerBadge || regexCount > 0) ? `
+                ${(trackerBadge || regexCount > 0 || addedBadge) ? `
                     <div class="ica--template-card-badges">
+                        ${addedBadge}
                         ${trackerBadge}
                         ${regexCount > 0 ? `<span class="ica--card-pill"><i class="fa-solid fa-wand-magic-sparkles fa-xs"></i> ${buildRegexTemplateLabel(regexCount)}</span>` : ''}
                     </div>

--- a/public/scripts/extensions/in-chat-agents/style.css
+++ b/public/scripts/extensions/in-chat-agents/style.css
@@ -1045,6 +1045,15 @@
     border-color: var(--SmartThemeQuoteColor, #8b8);
 }
 
+.ica--template-card--added {
+    filter: saturate(0.72);
+    opacity: 0.74;
+}
+
+.ica--template-card--added:hover {
+    opacity: 0.9;
+}
+
 .ica--template-card-header {
     display: flex;
     justify-content: space-between;

--- a/tests/in-chat-agents-store.test.js
+++ b/tests/in-chat-agents-store.test.js
@@ -247,6 +247,61 @@ describe('in-chat agent scoped enabled state', () => {
         expect(store.getRedundantBundledAgentDuplicateIds(agents, templates)).toEqual(['duplicate-pathfinder']);
     });
 
+    test('removes same-template duplicates while keeping the current template prompt', async () => {
+        const store = await importStore();
+        const templates = [{
+            id: 'tpl-prose-polisher',
+            name: 'Prose Polisher',
+            prompt: 'new bundled wording',
+            category: 'content',
+        }];
+        const agents = [
+            {
+                id: 'old-prose-polisher',
+                name: 'Prose Polisher',
+                prompt: 'old bundled wording',
+                sourceTemplateId: 'tpl-prose-polisher',
+                enabled: true,
+            },
+            {
+                id: 'current-prose-polisher',
+                name: 'Prose Polisher',
+                prompt: 'new bundled wording',
+                sourceTemplateId: 'tpl-prose-polisher',
+                enabled: false,
+            },
+        ];
+
+        expect(store.getRedundantBundledAgentDuplicateIds(agents, templates)).toEqual(['old-prose-polisher']);
+    });
+
+    test('does not mark phase-locked same-template duplicates redundant', async () => {
+        const store = await importStore();
+        const templates = [{
+            id: 'tpl-prose-polisher',
+            name: 'Prose Polisher',
+            prompt: 'new bundled wording',
+            category: 'content',
+        }];
+        const agents = [
+            {
+                id: 'old-locked-prose-polisher',
+                name: 'Prose Polisher',
+                prompt: 'old bundled wording',
+                sourceTemplateId: 'tpl-prose-polisher',
+                phaseLocked: true,
+            },
+            {
+                id: 'current-prose-polisher',
+                name: 'Prose Polisher',
+                prompt: 'new bundled wording',
+                sourceTemplateId: 'tpl-prose-polisher',
+            },
+        ];
+
+        expect(store.getRedundantBundledAgentDuplicateIds(agents, templates)).toEqual([]);
+    });
+
     test('matches bundled template snapshots after template prompt wording changes', async () => {
         const store = await importStore();
         const templates = [{


### PR DESCRIPTION
## Summary
- Prompt before adding another copy of a template-backed agent when the template id is already installed.
- Heal existing same-template duplicate agents on extension load, preferring the current bundled template prompt and preserving phase-locked agents.
- Show an Added pill and dimmed state for already-installed templates in the Templates browser.

## Verification
- npm run test:unit -- in-chat-agents-store.test.js in-chat-agents-templates.test.js
- npx eslint public/scripts/extensions/in-chat-agents/agent-store.js public/scripts/extensions/in-chat-agents/index.js
- ./node_modules/.bin/eslint in-chat-agents-store.test.js (from tests/)
- git diff --check