### PR TITLE
feat: categorise templates browser, retire Pathfinder agent

### DIFF
--- a/public/scripts/extensions/in-chat-agents/agent-store.js
+++ b/public/scripts/extensions/in-chat-agents/agent-store.js
@@ -649,6 +649,19 @@ export const AGENT_CATEGORIES = {
     custom: { label: 'Custom', icon: 'fa-puzzle-piece' },
 };
 
+/**
+ * Modal-only template subgroup labels.
+ */
+export const AGENT_SUBCATEGORIES = {
+    world: { category: 'tracker', label: 'World & Scene', icon: 'fa-map' },
+    characters: { category: 'tracker', label: 'Character State', icon: 'fa-users' },
+    progress: { category: 'tracker', label: 'Player Progress', icon: 'fa-trophy' },
+    'player-choices': { category: 'tracker', label: 'Player Choices', icon: 'fa-list-check' },
+    'prose-quality': { category: 'content', label: 'Prose Quality', icon: 'fa-feather' },
+    pov: { category: 'content', label: 'Point of View', icon: 'fa-user-pen' },
+    behaviour: { category: 'content', label: 'Behaviour & Tone', icon: 'fa-masks-theater' },
+};
+
 function escapeRegexLiteral(value) {
     return String(value ?? '').replaceAll('/', '\\/');
 }
@@ -792,13 +805,16 @@ export function normalizeToolDef(raw = {}) {
  */
 export function normalizeAgent(rawAgent = {}) {
     const defaults = createDefaultAgent();
+    const rawAgentWithoutModalMetadata = { ...rawAgent };
+    delete rawAgentWithoutModalMetadata.subcategory;
+
     const rawPreProcess = rawAgent.preProcess && typeof rawAgent.preProcess === 'object' ? rawAgent.preProcess : {};
     const rawPostProcess = rawAgent.postProcess && typeof rawAgent.postProcess === 'object' ? rawAgent.postProcess : {};
     const conditions = rawAgent.conditions && typeof rawAgent.conditions === 'object' ? rawAgent.conditions : {};
 
     return {
         ...defaults,
-        ...rawAgent,
+        ...rawAgentWithoutModalMetadata,
         id: typeof rawAgent.id === 'string' && rawAgent.id.trim() ? rawAgent.id.trim() : defaults.id,
         name: typeof rawAgent.name === 'string' ? rawAgent.name : defaults.name,
         description: typeof rawAgent.description === 'string' ? rawAgent.description : defaults.description,

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -3517,6 +3517,9 @@ async function refinePromptWithAI(currentPrompt, category, phase, connectionProf
             setGlobalSettings(savedState.globalSettings);
         }
         restoreAutoSeededTemplateIds(savedState);
+        if (savedState.dismissedTemplatesCallout === true) {
+            $('.ica--templates-callout').hide();
+        }
     }
 
     const initResults = await Promise.allSettled([
@@ -3656,6 +3659,16 @@ async function refinePromptWithAI(currentPrompt, category, phase, connectionProf
     $('#ica--exportAll').on('click', handleExportAll);
     $('#ica--templates').on('click', openTemplateBrowser);
     $('#ica--templatesCallout').on('click', openTemplateBrowser);
+    $('#ica--templatesCalloutDismiss').on('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        $('.ica--templates-callout').hide();
+        extension_settings.inChatAgents = {
+            ...(extension_settings.inChatAgents ?? {}),
+            dismissedTemplatesCallout: true,
+        };
+        saveSettingsDebounced();
+    });
     $('#ica--cancelGeneration').on('click', () => {
         cancelAgentGeneration();
         updateCancelGenerationButton();

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -18,6 +18,7 @@ import {
     exportAllAgents,
     exportAgent,
     AGENT_CATEGORIES,
+    AGENT_SUBCATEGORIES,
     DEFAULT_AGENT_MAX_TOKENS,
     getGlobalSettings,
     initializeScopedAgentEnableState,
@@ -73,6 +74,7 @@ const MODULE_NAME = 'in-chat-agents';
 const PATHFINDER_EXTENSIONS_HOST_ID = 'extension_settings_in_chat_agents_pathfinder';
 
 let collapsedCategories = new Set();
+let templateBrowserSearchValue = '';
 
 /** Built-in templates loaded from JSON files. */
 let templates = [];
@@ -81,7 +83,6 @@ let autoSeededTemplateIds = new Set();
 
 const DEFAULT_BUNDLED_TEMPLATE_IDS = new Set([
     'tpl-prose-polisher',
-    'tpl-pathfinder',
 ]);
 
 /** Whether the agent list is in multi-select mode. */
@@ -95,12 +96,14 @@ const REMOVED_BUNDLED_TEMPLATE_IDS = new Set([
     'tpl-anti-slop-regex',
     'tpl-director-core',
     'tpl-nsfw-mode',
+    'tpl-pathfinder',
 ]);
 
 const REMOVED_BUNDLED_AGENT_NAMES = new Set([
     'anti-slop regex',
     'director core',
     'nsfw mode',
+    'pathfinder',
 ]);
 
 const REMOVED_BUNDLED_GROUP_IDS = new Set([
@@ -213,6 +216,42 @@ function findTemplateById(templateId) {
 
 function findTemplateForAgent(agent) {
     return findTemplateForAgentSnapshot(agent, templates);
+}
+
+function findSourceTemplateForAgent(agent) {
+    const sourceTemplateId = String(agent?.sourceTemplateId ?? '').trim();
+    return sourceTemplateId ? findTemplateById(sourceTemplateId) : null;
+}
+
+function getAgentOrderValue(agent) {
+    const order = Number(agent?.injection?.order ?? 0);
+    return Number.isFinite(order) ? order : 0;
+}
+
+function getAgentVersionValue(agent) {
+    const version = Number(agent?.version ?? 1);
+    return Number.isFinite(version) ? version : 1;
+}
+
+function getTemplateVersionValue(template) {
+    const version = Number(template?.version ?? 1);
+    return Number.isFinite(version) ? version : 1;
+}
+
+function buildAgentOrderPill(agent) {
+    return `<span class="ica--card-pill ica--card-pill--order" title="Lower numbers run earlier when Append Agents Execution is set to Sequential."><i class="fa-solid fa-sort-numeric-down fa-xs"></i> Order ${escapeHtml(getAgentOrderValue(agent))}</span>`;
+}
+
+function buildAgentVersionPill(agent) {
+    const sourceTemplate = findSourceTemplateForAgent(agent);
+    const agentVersion = getAgentVersionValue(agent);
+    const templateVersion = getTemplateVersionValue(sourceTemplate);
+
+    if (sourceTemplate && templateVersion > agentVersion) {
+        return `<button type="button" class="ica--card-pill ica--card-pill--version ica--card-pill--version-update" title="A newer template is available.">v${escapeHtml(agentVersion)} &rarr; v${escapeHtml(templateVersion)}</button>`;
+    }
+
+    return `<span class="ica--card-pill ica--card-pill--version">v${escapeHtml(agentVersion)}</span>`;
 }
 
 function getBundledRegexScriptsForTemplate(templateId) {
@@ -329,6 +368,73 @@ function getTemplateRegexCount(template) {
     return Array.isArray(template?.regexScripts) ? template.regexScripts.length : 0;
 }
 
+const TEMPLATE_BROWSER_CATEGORY_LABELS = {
+    tracker: 'Trackers',
+    randomizer: 'Randomizers',
+    content: 'Content',
+    tool: 'Tools',
+};
+
+function getTemplateBrowserCategoryOrder(templateList = templates) {
+    return Object.keys(AGENT_CATEGORIES)
+        .filter(category => category !== 'custom')
+        .filter(category => templateList.some(template => template.category === category));
+}
+
+function getTemplateCategoryLabel(category) {
+    return TEMPLATE_BROWSER_CATEGORY_LABELS[category] ?? AGENT_CATEGORIES[category]?.label ?? 'Custom';
+}
+
+function getTemplateSubcategoryInfo(subcategory) {
+    const normalizedSubcategory = String(subcategory ?? '').trim();
+    return normalizedSubcategory ? AGENT_SUBCATEGORIES[normalizedSubcategory] ?? null : null;
+}
+
+function getTemplateSubcategoryLabel(template) {
+    const subcategoryInfo = getTemplateSubcategoryInfo(template?.subcategory);
+    return subcategoryInfo?.label ?? String(template?.subcategory ?? '').trim();
+}
+
+function getTemplateSubcategoriesForCategory(category) {
+    return Object.entries(AGENT_SUBCATEGORIES)
+        .filter(([, subcategory]) => subcategory.category === category);
+}
+
+function sortTemplatesByName(templateList = []) {
+    return [...templateList].sort((a, b) => String(a?.name ?? '').localeCompare(String(b?.name ?? '')));
+}
+
+function getTemplateSearchHaystack(template) {
+    const categoryLabel = getTemplateCategoryLabel(template?.category);
+    const subcategoryLabel = getTemplateSubcategoryLabel(template);
+    const tags = Array.isArray(template?.tags) ? template.tags.join(' ') : '';
+
+    return [
+        template?.name,
+        template?.description,
+        tags,
+        categoryLabel,
+        subcategoryLabel,
+    ].join(' ').toLowerCase();
+}
+
+function filterTemplates(templateList = templates, { searchTerm = '', category = '' } = {}) {
+    const normalizedSearchTerm = String(searchTerm ?? '').trim().toLowerCase();
+    const normalizedCategory = String(category ?? '').trim();
+
+    return templateList.filter(template => {
+        if (normalizedCategory && template.category !== normalizedCategory) {
+            return false;
+        }
+
+        if (!normalizedSearchTerm) {
+            return true;
+        }
+
+        return getTemplateSearchHaystack(template).includes(normalizedSearchTerm);
+    });
+}
+
 function describeRegexPlacements(regexScript) {
     return (regexScript.placement || [])
         .map(placement => REGEX_PLACEMENT_LABELS[placement] || `Placement ${placement}`)
@@ -419,13 +525,52 @@ async function previewPreGenerationPrompt(agent, promptOverride = null) {
 }
 
 function buildAgentFromTemplate(template) {
-    return {
+    const agent = {
         ...createDefaultAgent(),
         ...structuredClone(mergeTemplateDefaults(template)),
         id: uuidv4(),
         sourceTemplateId: template.id,
         enabled: false,
     };
+    delete agent.subcategory;
+    return agent;
+}
+
+function buildUpdatedAgentFromTemplate(agent, template) {
+    const updatedAgent = buildAgentFromTemplate(template);
+    updatedAgent.id = agent.id;
+    updatedAgent.enabled = Boolean(agent.enabled);
+    updatedAgent.favorite = Boolean(agent.favorite);
+    updatedAgent.connectionProfile = typeof agent.connectionProfile === 'string' ? agent.connectionProfile : '';
+    updatedAgent.modelOverride = typeof agent.modelOverride === 'string' ? agent.modelOverride : '';
+    updatedAgent.injection = {
+        ...updatedAgent.injection,
+        order: getAgentOrderValue(agent),
+    };
+    updatedAgent.phaseLocked = false;
+    return updatedAgent;
+}
+
+async function updateAgentFromSourceTemplate(agent) {
+    const template = findSourceTemplateForAgent(agent);
+    if (!template) {
+        return;
+    }
+
+    const agentVersion = getAgentVersionValue(agent);
+    const templateVersion = getTemplateVersionValue(template);
+    const result = await new Popup(
+        `Update "${escapeHtml(agent.name || template.name)}" from template v${escapeHtml(agentVersion)} to v${escapeHtml(templateVersion)}? Enabled state, quick toggle pin, order, and profile overrides will be kept.`,
+        POPUP_TYPE.CONFIRM,
+    ).show();
+
+    if (result !== POPUP_RESULT.AFFIRMATIVE) {
+        return;
+    }
+
+    await saveAgent(buildUpdatedAgentFromTemplate(agent, template));
+    renderAgentList();
+    toastr.success(`Updated "${template.name}" to v${templateVersion}.`);
 }
 
 function buildAgentFromSnapshot(snapshot) {
@@ -1314,6 +1459,7 @@ function renderAgentList() {
                 const enabledClass = agentEnabled ? 'is-enabled' : '';
                 const categoryLabel = AGENT_CATEGORIES[agent.category]?.label ?? 'Custom';
                 const phaseLabel = AGENT_PHASE_LABELS[agent.phase] || agent.phase;
+                const orderLabel = `Order ${getAgentOrderValue(agent)}`;
                 const canApplyToLastReply = !isPathfinderAgent(agent);
                 const quickItem = $(`
                     <div class="ica--quick-chip ${enabledClass}">
@@ -1323,7 +1469,7 @@ function renderAgentList() {
                             </span>
                             <span class="ica--quick-chip-copy">
                                 <span class="ica--quick-chip-name">${escapeHtml(agent.name || 'Untitled Agent')}</span>
-                                <span class="ica--quick-chip-meta">${escapeHtml(categoryLabel)} • ${escapeHtml(phaseLabel)}</span>
+                                <span class="ica--quick-chip-meta">${escapeHtml(categoryLabel)} • ${escapeHtml(phaseLabel)} • ${escapeHtml(orderLabel)}</span>
                             </span>
                         </button>
                         <div class="ica--quick-chip-actions">
@@ -1450,6 +1596,8 @@ function renderAgentList() {
                         ${regexCount > 0 ? `<span class="ica--card-pill"><i class="fa-solid fa-wand-magic-sparkles fa-xs"></i> ${regexCount} regex</span>` : ''}
                         ${connectionProfileLabel ? `<span class="ica--card-pill"><i class="fa-solid fa-plug fa-xs"></i> ${escapeHtml(connectionProfileLabel)}</span>` : ''}
                         ${modelOverrideLabel ? `<span class="ica--card-pill"><i class="fa-solid fa-microchip fa-xs"></i> ${escapeHtml(modelOverrideLabel)}</span>` : ''}
+                        ${buildAgentOrderPill(agent)}
+                        ${buildAgentVersionPill(agent)}
                     </div>
                     <div class="ica--card-actions">
                         ${previewPromptButton}
@@ -1500,6 +1648,11 @@ function renderAgentList() {
             card.find('.ica--card-favorite').on('click', async function (event) {
                 stopEvent(event);
                 await toggleAgentFavorite(agent);
+            });
+
+            card.find('.ica--card-pill--version-update').on('click', async event => {
+                stopEvent(event);
+                await updateAgentFromSourceTemplate(agent);
             });
 
             card.find('.ica--btn-edit').on('click', event => {
@@ -2190,9 +2343,36 @@ async function openTemplateBrowser() {
     tplSection.append('<div class="ica--template-section-title"><i class="fa-solid fa-puzzle-piece"></i> Individual Templates</div>');
     tplSection.append('<p class="ica--template-section-desc">Bundled trackers and helpers live here. Click any card to install it into your agent list.</p>');
 
-    const grid = $('<div class="ica--template-grid"></div>');
+    let selectedCategory = '';
+    const categoryOrder = getTemplateBrowserCategoryOrder(templates);
+    const filterBar = $(`
+        <div class="ica--template-filter-bar">
+            <input type="text" class="text_pole ica--template-search" placeholder="Search templates…" value="${escapeHtml(templateBrowserSearchValue)}" />
+            <div class="ica--template-pill-row"></div>
+        </div>
+    `);
+    const pillRow = filterBar.find('.ica--template-pill-row');
+    const templateResults = $('<div class="ica--template-results"></div>');
+    const allPill = $(`
+        <button type="button" class="ica--template-pill is-active" data-category="">
+            <span>All</span>
+            <span class="ica--template-pill-count">0</span>
+        </button>
+    `);
+    pillRow.append(allPill);
 
-    for (const tpl of templates) {
+    for (const category of categoryOrder) {
+        const catInfo = AGENT_CATEGORIES[category] || AGENT_CATEGORIES.custom;
+        pillRow.append(`
+            <button type="button" class="ica--template-pill" data-category="${escapeHtml(category)}">
+                <i class="fa-solid ${catInfo.icon}"></i>
+                <span>${escapeHtml(getTemplateCategoryLabel(category))}</span>
+                <span class="ica--template-pill-count">0</span>
+            </button>
+        `);
+    }
+
+    function buildTemplateCard(tpl) {
         const catInfo = AGENT_CATEGORIES[tpl.category] || AGENT_CATEGORIES.custom;
         const regexCount = getTemplateRegexCount(tpl);
         const trackerBadge = tpl.category === 'tracker'
@@ -2202,15 +2382,14 @@ async function openTemplateBrowser() {
             <div class="ica--template-card" data-id="${tpl.id}">
                 <div class="ica--template-card-header">
                     <span class="ica--template-card-name">${escapeHtml(tpl.name)}</span>
-                    <span class="ica--template-card-category"><i class="fa-solid ${catInfo.icon}"></i> ${catInfo.label}</span>
+                    <span class="ica--template-card-category"><i class="fa-solid ${catInfo.icon}"></i> ${escapeHtml(catInfo.label)}</span>
                 </div>
                 <div class="ica--template-card-description">${escapeHtml(tpl.description)}</div>
-                ${(trackerBadge || regexCount > 0) ? `
-                    <div class="ica--template-card-badges">
-                        ${trackerBadge}
-                        ${regexCount > 0 ? `<span class="ica--card-pill"><i class="fa-solid fa-wand-magic-sparkles fa-xs"></i> ${buildRegexTemplateLabel(regexCount)}</span>` : ''}
-                    </div>
-                ` : ''}
+                <div class="ica--template-card-badges">
+                    <span class="ica--card-pill ica--card-pill--version">v${escapeHtml(getTemplateVersionValue(tpl))}</span>
+                    ${trackerBadge}
+                    ${regexCount > 0 ? `<span class="ica--card-pill"><i class="fa-solid fa-wand-magic-sparkles fa-xs"></i> ${buildRegexTemplateLabel(regexCount)}</span>` : ''}
+                </div>
                 <div class="ica--template-card-prompt">${escapeHtml((tpl.prompt || '').substring(0, 200))}</div>
             </div>
         `);
@@ -2227,11 +2406,112 @@ async function openTemplateBrowser() {
             toastr.success(`Added "${tpl.name}" to your agents.`);
         });
 
-        grid.append(card);
+        return card;
     }
 
-    tplSection.append(grid);
+    function appendTemplateGrid(parent, templateList) {
+        const grid = $('<div class="ica--template-grid"></div>');
+        for (const tpl of templateList) {
+            grid.append(buildTemplateCard(tpl));
+        }
+        parent.append(grid);
+    }
+
+    function updateTemplatePills(searchTerm) {
+        const searchedTemplates = filterTemplates(templates, { searchTerm });
+        const countsByCategory = new Map();
+        for (const template of searchedTemplates) {
+            countsByCategory.set(template.category, (countsByCategory.get(template.category) ?? 0) + 1);
+        }
+
+        pillRow.find('.ica--template-pill').each(function () {
+            const category = $(this).attr('data-category') || '';
+            const count = category ? countsByCategory.get(category) ?? 0 : searchedTemplates.length;
+            $(this).toggleClass('is-active', category === selectedCategory);
+            $(this).find('.ica--template-pill-count').text(count);
+        });
+    }
+
+    function renderTemplateCategorySection(category, categoryTemplates, searchActive) {
+        const catInfo = AGENT_CATEGORIES[category] || AGENT_CATEGORIES.custom;
+        const categorySection = $(`
+            <div class="ica--template-category-section">
+                <div class="ica--template-category-title">
+                    <i class="fa-solid ${catInfo.icon}"></i>
+                    <span>${escapeHtml(getTemplateCategoryLabel(category))}</span>
+                    <span class="ica--template-category-count">${categoryTemplates.length}</span>
+                </div>
+            </div>
+        `);
+
+        if (searchActive || !['tracker', 'content'].includes(category)) {
+            appendTemplateGrid(categorySection, searchActive ? sortTemplatesByName(categoryTemplates) : categoryTemplates);
+            return categorySection;
+        }
+
+        const subcategories = getTemplateSubcategoriesForCategory(category);
+        const knownSubcategoryIds = new Set(subcategories.map(([subcategoryId]) => subcategoryId));
+        const directTemplates = categoryTemplates.filter(template => !knownSubcategoryIds.has(String(template.subcategory ?? '').trim()));
+        if (directTemplates.length > 0) {
+            appendTemplateGrid(categorySection, directTemplates);
+        }
+
+        for (const [subcategoryId, subcategory] of subcategories) {
+            const subgroupTemplates = categoryTemplates.filter(template => String(template.subcategory ?? '').trim() === subcategoryId);
+            if (subgroupTemplates.length === 0) {
+                continue;
+            }
+
+            categorySection.append(`
+                <div class="ica--template-subgroup-title">
+                    <i class="fa-solid ${subcategory.icon}"></i>
+                    <span>${escapeHtml(subcategory.label)}</span>
+                    <span>${subgroupTemplates.length}</span>
+                </div>
+            `);
+            appendTemplateGrid(categorySection, subgroupTemplates);
+        }
+
+        return categorySection;
+    }
+
+    function renderTemplateResults() {
+        const searchTerm = filterBar.find('.ica--template-search').val()?.toString() ?? '';
+        templateBrowserSearchValue = searchTerm;
+        const visibleTemplates = filterTemplates(templates, {
+            searchTerm,
+            category: selectedCategory,
+        });
+        const searchActive = Boolean(searchTerm.trim());
+
+        updateTemplatePills(searchTerm);
+        templateResults.empty();
+
+        if (visibleTemplates.length === 0) {
+            templateResults.append('<div class="ica--template-empty">No templates match your filter.</div>');
+            return;
+        }
+
+        for (const category of categoryOrder) {
+            const categoryTemplates = visibleTemplates.filter(template => template.category === category);
+            if (categoryTemplates.length === 0) {
+                continue;
+            }
+
+            templateResults.append(renderTemplateCategorySection(category, categoryTemplates, searchActive));
+        }
+    }
+
+    filterBar.find('.ica--template-search').on('input', renderTemplateResults);
+    pillRow.on('click', '.ica--template-pill', function () {
+        selectedCategory = $(this).attr('data-category') || '';
+        renderTemplateResults();
+    });
+
+    tplSection.append(filterBar);
+    tplSection.append(templateResults);
     wrapper.append(tplSection);
+    renderTemplateResults();
 
     await new Popup(wrapper, POPUP_TYPE.TEXT, '', { wide: true, large: true }).show();
 }

--- a/public/scripts/extensions/in-chat-agents/settings.html
+++ b/public/scripts/extensions/in-chat-agents/settings.html
@@ -11,6 +11,9 @@
                 <i class="fa-solid fa-book-open"></i>
                 <span>Open Templates</span>
             </button>
+            <button type="button" id="ica--templatesCalloutDismiss" class="ica--templates-callout-dismiss" title="Dismiss" aria-label="Dismiss">
+                <i class="fa-solid fa-xmark"></i>
+            </button>
         </div>
 
         <div class="ica--toolbar">

--- a/public/scripts/extensions/in-chat-agents/settings.html
+++ b/public/scripts/extensions/in-chat-agents/settings.html
@@ -112,6 +112,10 @@
                     <option value="parallel">Parallel (faster)</option>
                     <option value="sequential">Sequential (rate-limit friendly)</option>
                 </select>
+                <small class="ica--profile-help">
+                    Sequential runs append-mode agents one after another in Order ascending.
+                    Order is shown on each agent card.
+                </small>
             </label>
             <label class="checkbox_label" title="Keep enabled In-Chat Agents separate between Individual chats and Group chats.">
                 <input type="checkbox" id="ica--separateRecentChats" />

--- a/public/scripts/extensions/in-chat-agents/style.css
+++ b/public/scripts/extensions/in-chat-agents/style.css
@@ -1259,6 +1259,10 @@ button.ica--card-pill--version-update {
         flex-direction: column;
     }
 
+    .ica--template-search {
+        flex: 0 0 auto;
+    }
+
     .ica--template-pill-row {
         flex-wrap: nowrap;
         overflow-x: auto;

--- a/public/scripts/extensions/in-chat-agents/style.css
+++ b/public/scripts/extensions/in-chat-agents/style.css
@@ -59,6 +59,31 @@
     border-color: color-mix(in srgb, var(--SmartThemeQuoteColor, #8b8) 48%, transparent);
 }
 
+.ica--templates-callout-dismiss {
+    flex: 0 0 auto;
+    align-self: flex-start;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: inherit;
+    opacity: 0.55;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: opacity 0.15s ease, background-color 0.15s ease;
+}
+
+.ica--templates-callout-dismiss:hover,
+.ica--templates-callout-dismiss:focus-visible {
+    opacity: 1;
+    background-color: color-mix(in srgb, var(--SmartThemeQuoteColor, #8b8) 18%, transparent);
+    outline: none;
+}
+
 /* Toolbar */
 .ica--toolbar {
     display: flex;
@@ -1250,8 +1275,19 @@ button.ica--card-pill--version-update {
 
 @media (max-width: 720px) {
     .ica--templates-callout {
+        position: relative;
         flex-direction: column;
         align-items: stretch;
+    }
+
+    .ica--templates-callout-dismiss {
+        position: absolute;
+        top: 8px;
+        right: 8px;
+    }
+
+    .ica--templates-callout-copy {
+        padding-right: 28px;
     }
 
     #ica--templatesCallout {

--- a/public/scripts/extensions/in-chat-agents/style.css
+++ b/public/scripts/extensions/in-chat-agents/style.css
@@ -531,6 +531,53 @@
     opacity: 0.7;
 }
 
+button.ica--card-pill {
+    border: 0;
+    color: inherit;
+    font: inherit;
+    cursor: default;
+}
+
+.ica--card-pill--order {
+    font-variant-numeric: tabular-nums;
+    background: color-mix(in srgb, var(--SmartThemeBorderColor) 34%, transparent);
+}
+
+.ica--card-pill--version {
+    font-variant-numeric: tabular-nums;
+    background: color-mix(in srgb, var(--SmartThemeBorderColor) 28%, transparent);
+}
+
+.ica--card-pill--version-update {
+    cursor: pointer;
+    opacity: 0.95;
+    color: var(--SmartThemeQuoteColor, #8b8);
+    background: color-mix(in srgb, var(--SmartThemeQuoteColor, #8b8) 13%, transparent);
+    transition: background 0.15s, border-color 0.15s, opacity 0.15s;
+}
+
+button.ica--card-pill--version-update {
+    border: 1px solid color-mix(in srgb, var(--SmartThemeQuoteColor, #8b8) 46%, transparent);
+}
+
+.ica--card-pill--version-update:hover,
+.ica--card-pill--version-update:focus-visible {
+    opacity: 1;
+    border-color: color-mix(in srgb, var(--SmartThemeQuoteColor, #8b8) 72%, transparent);
+    background: color-mix(in srgb, var(--SmartThemeQuoteColor, #8b8) 22%, transparent);
+    animation: ica--version-pulse 0.85s ease-in-out;
+}
+
+@keyframes ica--version-pulse {
+    0%, 100% {
+        box-shadow: 0 0 0 0 color-mix(in srgb, var(--SmartThemeQuoteColor, #8b8) 0%, transparent);
+    }
+
+    50% {
+        box-shadow: 0 0 0 4px color-mix(in srgb, var(--SmartThemeQuoteColor, #8b8) 18%, transparent);
+    }
+}
+
 /* Card actions row */
 .ica--card-actions {
     display: flex;
@@ -750,6 +797,7 @@
     display: flex;
     align-items: center;
     gap: 8px;
+    flex-wrap: wrap;
     font-size: calc(var(--mainFontSize) * 0.85);
 }
 
@@ -760,6 +808,13 @@
 
 .ica--profile-label select {
     flex: 1;
+}
+
+.ica--profile-help {
+    flex-basis: 100%;
+    font-size: calc(var(--mainFontSize) * 0.76);
+    line-height: 1.35;
+    opacity: 0.6;
 }
 
 /* ── Prompt Manager button ──────────────────────────── */
@@ -968,6 +1023,90 @@
     opacity: 0.6;
 }
 
+.ica--template-filter-bar {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 4px 10px;
+    background: var(--SmartThemeBlurTintColor, #222);
+}
+
+.ica--template-search {
+    flex: 1 1 220px;
+    min-width: 0;
+}
+
+.ica--template-pill-row {
+    display: flex;
+    flex: 0 1 auto;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+    min-width: 0;
+}
+
+.ica--template-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 10px;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--SmartThemeQuoteColor, #8b8) 28%, transparent);
+    color: inherit;
+    background: color-mix(in srgb, var(--SmartThemeQuoteColor, #8b8) 8%, transparent);
+    font: inherit;
+    font-size: calc(var(--mainFontSize) * 0.78);
+    cursor: pointer;
+    opacity: 0.76;
+    transition: background 0.15s, border-color 0.15s, opacity 0.15s;
+}
+
+.ica--template-pill:hover,
+.ica--template-pill:focus-visible,
+.ica--template-pill.is-active {
+    opacity: 1;
+    border-color: color-mix(in srgb, var(--SmartThemeQuoteColor, #8b8) 58%, transparent);
+    background: color-mix(in srgb, var(--SmartThemeQuoteColor, #8b8) 18%, transparent);
+}
+
+.ica--template-pill-count {
+    font-variant-numeric: tabular-nums;
+    opacity: 0.72;
+}
+
+.ica--template-results,
+.ica--template-category-section {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.ica--template-results {
+    padding-top: 2px;
+}
+
+.ica--template-category-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 3px 2px;
+    font-size: calc(var(--mainFontSize) * 0.88);
+    font-weight: 700;
+    text-transform: uppercase;
+    opacity: 0.72;
+}
+
+.ica--template-category-count,
+.ica--template-subgroup-title span:last-child {
+    margin-left: auto;
+    font-weight: 400;
+    font-variant-numeric: tabular-nums;
+    opacity: 0.72;
+}
+
 /* Group cards */
 .ica--group-grid {
     display: grid;
@@ -1084,6 +1223,22 @@
     word-break: break-word;
 }
 
+.ica--template-subgroup-title {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    padding: 2px 4px 0 14px;
+    font-size: calc(var(--mainFontSize) * 0.78);
+    font-weight: 600;
+    opacity: 0.75;
+}
+
+.ica--template-empty {
+    padding: 24px;
+    text-align: center;
+    opacity: 0.6;
+}
+
 @media (max-width: 720px) {
     .ica--templates-callout {
         flex-direction: column;
@@ -1097,6 +1252,21 @@
 
     .ica--editor-row.flex-container {
         flex-direction: column;
+    }
+
+    .ica--template-filter-bar {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .ica--template-pill-row {
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        padding-bottom: 2px;
+    }
+
+    .ica--template-pill {
+        flex: 0 0 auto;
     }
 }
 

--- a/public/scripts/extensions/in-chat-agents/templates/achievements-tracker.json
+++ b/public/scripts/extensions/in-chat-agents/templates/achievements-tracker.json
@@ -4,6 +4,7 @@
     "description": "Track notable firsts, milestones, and memorable moments",
     "icon": "",
     "category": "tracker",
+    "subcategory": "progress",
     "tags": [
         "achievements",
         "milestones"

--- a/public/scripts/extensions/in-chat-agents/templates/index.json
+++ b/public/scripts/extensions/in-chat-agents/templates/index.json
@@ -5,6 +5,7 @@
     "description": "Track notable firsts, milestones, and memorable moments",
     "icon": "",
     "category": "tracker",
+    "subcategory": "progress",
     "tags": [
       "achievements",
       "milestones"
@@ -127,6 +128,7 @@
     "description": "Append 3-5 numbered action choices at the end of every response",
     "icon": "",
     "category": "tracker",
+    "subcategory": "player-choices",
     "tags": [
       "choices",
       "interactive",
@@ -213,6 +215,7 @@
     "description": "Sharply raise difficulty -- characters protect their interests, resist harder",
     "icon": "",
     "category": "content",
+    "subcategory": "behaviour",
     "tags": [
       "difficulty",
       "challenge",
@@ -254,6 +257,7 @@
     "description": "4 plot-direction prompts at the end of every response (2 grounded + 2 wildcard pivots)",
     "icon": "",
     "category": "tracker",
+    "subcategory": "player-choices",
     "tags": [
       "directions",
       "menu",
@@ -300,6 +304,7 @@
     "description": "Never write {{user}}'s actions or dialogue -- only {{char}} and NPCs",
     "icon": "",
     "category": "content",
+    "subcategory": "pov",
     "tags": [
       "pov",
       "user"
@@ -341,6 +346,7 @@
     "description": "Track upcoming events, deadlines, promises, and unresolved threads",
     "icon": "",
     "category": "tracker",
+    "subcategory": "world",
     "tags": [
       "events",
       "deadlines",
@@ -382,6 +388,7 @@
     "description": "Combats positivity bias -- characters resist, protect their pride, and take time to warm up",
     "icon": "",
     "category": "content",
+    "subcategory": "behaviour",
     "tags": [
       "realism",
       "difficulty",
@@ -507,6 +514,7 @@
     "description": "Anti-slop rules: avoid purple prose, cliches, and AI writing tics",
     "icon": "",
     "category": "content",
+    "subcategory": "prose-quality",
     "tags": [
       "anti-slop",
       "quality",
@@ -550,6 +558,7 @@
     "description": "Post-generation prose cleanup that rewrites repetitive tropes and cliched wording. Created by Geechan.",
     "icon": "",
     "category": "content",
+    "subcategory": "prose-quality",
     "tags": [
       "prose",
       "editing",
@@ -598,6 +607,7 @@
     "description": "Use inline HTML for diegetic in-world objects (signs, letters, screens)",
     "icon": "",
     "category": "content",
+    "subcategory": "prose-quality",
     "tags": [
       "html",
       "artifacts",
@@ -681,6 +691,7 @@
     "description": "Track items {{user}} acquires, loses, or uses that have narrative significance",
     "icon": "",
     "category": "tracker",
+    "subcategory": "progress",
     "tags": [
       "inventory",
       "items",
@@ -722,6 +733,7 @@
     "description": "Generate brief profile cards when introducing new named NPCs",
     "icon": "",
     "category": "tracker",
+    "subcategory": "characters",
     "tags": [
       "npc",
       "characters",
@@ -764,6 +776,7 @@
     "description": "Helps NPCs feel less static and gives them more agency to pursue their own goals",
     "icon": "",
     "category": "content",
+    "subcategory": "behaviour",
     "tags": [
       "npc",
       "motivation",
@@ -825,6 +838,7 @@
     "description": "Track what absent characters and the wider world are doing off-screen",
     "icon": "",
     "category": "tracker",
+    "subcategory": "world",
     "tags": [
       "offscreen",
       "npcs",
@@ -866,6 +880,7 @@
     "description": "Track affection and trust for recurring NPCs with meaningful interactions",
     "icon": "",
     "category": "tracker",
+    "subcategory": "characters",
     "tags": [
       "relationship",
       "npc",
@@ -907,6 +922,7 @@
     "description": "Track how {{user}} is perceived by groups and factions",
     "icon": "",
     "category": "tracker",
+    "subcategory": "characters",
     "tags": [
       "reputation",
       "rumors",
@@ -1030,6 +1046,7 @@
     "description": "Mark scene transitions, time shifts, and location changes",
     "icon": "",
     "category": "tracker",
+    "subcategory": "world",
     "tags": [
       "scene",
       "location",
@@ -1072,6 +1089,7 @@
     "description": "Track secrets, lies, and information asymmetry between characters",
     "icon": "",
     "category": "tracker",
+    "subcategory": "characters",
     "tags": [
       "secrets",
       "lies",
@@ -1113,6 +1131,7 @@
     "description": "Track physical, mental, and behavioral states when they change",
     "icon": "",
     "category": "tracker",
+    "subcategory": "characters",
     "tags": [
       "status",
       "conditions",
@@ -1154,6 +1173,7 @@
     "description": "Track in-story time progression with day/period/hour stamps",
     "icon": "",
     "category": "tracker",
+    "subcategory": "world",
     "tags": [
       "time",
       "day",
@@ -1196,6 +1216,7 @@
     "description": "Add 1 small worldbuilding detail per scene that may matter later",
     "icon": "",
     "category": "tracker",
+    "subcategory": "world",
     "tags": [
       "world",
       "lore",
@@ -1237,6 +1258,7 @@
     "description": "Include {{user}} as a fully realized character -- write their actions, dialogue, and reactions",
     "icon": "",
     "category": "content",
+    "subcategory": "pov",
     "tags": [
       "pov",
       "user"

--- a/public/scripts/extensions/in-chat-agents/templates/npc-motivator.json
+++ b/public/scripts/extensions/in-chat-agents/templates/npc-motivator.json
@@ -4,6 +4,7 @@
     "description": "Helps NPCs feel less static and gives them more agency to pursue their own goals",
     "icon": "",
     "category": "content",
+    "subcategory": "behaviour",
     "tags": [
         "npc",
         "motivation",

--- a/public/scripts/extensions/in-chat-agents/templates/scene-tracker.json
+++ b/public/scripts/extensions/in-chat-agents/templates/scene-tracker.json
@@ -4,6 +4,7 @@
     "description": "Mark scene transitions, time shifts, and location changes",
     "icon": "",
     "category": "tracker",
+    "subcategory": "world",
     "tags": [
         "scene",
         "location",

--- a/tests/in-chat-agents-templates.test.js
+++ b/tests/in-chat-agents-templates.test.js
@@ -1,10 +1,46 @@
 import fs from 'node:fs';
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, jest, test } from '@jest/globals';
 
 const templateDir = new URL('../public/scripts/extensions/in-chat-agents/templates/', import.meta.url);
+const indexSourceUrl = new URL('../public/scripts/extensions/in-chat-agents/index.js', import.meta.url);
 
 function readTemplate(filename) {
     return JSON.parse(fs.readFileSync(new URL(filename, templateDir), 'utf8'));
+}
+
+function readIndexSetBody(name) {
+    const source = fs.readFileSync(indexSourceUrl, 'utf8');
+    const match = source.match(new RegExp(`${name} = new Set\\(\\[([\\s\\S]*?)\\]\\);`));
+
+    if (!match) {
+        throw new Error(`Missing set definition: ${name}`);
+    }
+
+    return match[1];
+}
+
+async function importAgentStore() {
+    jest.resetModules();
+
+    await jest.unstable_mockModule('../public/script.js', () => ({
+        getRequestHeaders: jest.fn(() => ({})),
+        saveSettingsDebounced: jest.fn(),
+    }));
+
+    await jest.unstable_mockModule('../public/scripts/extensions.js', () => ({
+        extension_settings: {},
+        getContext: jest.fn(() => ({ groupId: null })),
+    }));
+
+    await jest.unstable_mockModule('../public/scripts/utils.js', () => ({
+        regexFromString: jest.fn(value => {
+            const match = String(value ?? '').match(/^\/([\s\S]*)\/([a-z]*)$/i);
+            return match ? new RegExp(match[1], match[2]) : new RegExp(String(value ?? ''));
+        }),
+        uuidv4: jest.fn(() => 'test-uuid'),
+    }));
+
+    return await import('../public/scripts/extensions/in-chat-agents/agent-store.js');
 }
 
 function findCatalogTemplate(catalog, templateId) {
@@ -64,5 +100,46 @@ describe('in-chat agent bundled templates', () => {
         expect(template.conditions).toEqual(expect.objectContaining({
             runOnImpersonate: true,
         }));
+    });
+
+    test('uses only known modal subcategories in the catalog', async () => {
+        const { AGENT_SUBCATEGORIES } = await importAgentStore();
+        const knownSubcategories = new Set(Object.keys(AGENT_SUBCATEGORIES));
+        const catalog = readTemplate('index.json');
+        const unknownSubcategories = catalog
+            .map(template => template.subcategory)
+            .filter(subcategory => subcategory !== undefined && subcategory !== null)
+            .filter(subcategory => !knownSubcategories.has(subcategory));
+
+        expect(unknownSubcategories).toEqual([]);
+    });
+
+    test('assigns tracker and content templates to modal subcategories', () => {
+        const catalog = readTemplate('index.json');
+
+        for (const template of catalog.filter(template => ['tracker', 'content'].includes(template.category))) {
+            expect(typeof template.subcategory).toBe('string');
+            expect(template.subcategory.trim()).not.toBe('');
+        }
+    });
+
+    test('does not keep modal subcategory metadata on saved agent shapes', async () => {
+        const { normalizeAgent } = await importAgentStore();
+        const agent = normalizeAgent({
+            id: 'saved-scene-tracker',
+            name: 'Scene Tracker',
+            category: 'tracker',
+            subcategory: 'world',
+            sourceTemplateId: 'tpl-scene-tracker',
+        });
+
+        expect(agent).not.toHaveProperty('subcategory');
+    });
+
+    test('retires Pathfinder from default bundled in-chat agent templates', () => {
+        const pathfinderTemplateId = '\'tpl-pathfinder\'';
+
+        expect(readIndexSetBody('REMOVED_BUNDLED_TEMPLATE_IDS')).toContain(pathfinderTemplateId);
+        expect(readIndexSetBody('DEFAULT_BUNDLED_TEMPLATE_IDS')).not.toContain(pathfinderTemplateId);
     });
 });


### PR DESCRIPTION
Problem

The In-Chat Agents Templates modal showed built-in templates as one flat grid, which made tracker-heavy catalogs hard to scan and left useful metadata such as tags, categories, versions, and append execution order mostly hidden. Pathfinder was also still exposed as an in-chat agent template despite having its own Extensions tab surface.

Approach

This PR adds modal-only template subcategories, groups the browser by category/subcategory with search and single-select filter pills, adds template version badges, and retires Pathfinder from the in-chat agent template/default catalog while keeping its runtime code intact. Agent cards now surface execution order and template versions, including an update-available affordance that refreshes bundled agents from their source template while preserving key user state.

Screenshots

Not attached from this terminal pass. I smoke-tested the dev server at http://127.0.0.1:4444/ after implementation; the intended manual screenshot set is default browser view, filtered view, 720px responsive view, and version-update affordance.

Tests run

- npm ci --ignore-scripts
- npm ci --ignore-scripts --prefix tests
- npm run lint
- npm run lint --prefix tests
- npm run test:unit --prefix tests -- tests/in-chat-agents-templates.test.js
- npm run test:unit --prefix tests
- git diff --check