### PR TITLE
fix(webpack): alias chevrotain to its prebundled ESM file

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ import { serverDirectory } from './src/server-directory.js';
 import { getVersion, color } from './src/util.js';
 
 const BUN_LIB_BUNDLE_SIGNATURE = 'bun-no-minify-v1';
+const PUBLIC_LIB_CONFIG_SIGNATURE = 'chevrotain-esm-alias-v1';
 const WEBPACK_CACHE_KEEP_COUNT = 3;
 const PUBLIC_LIB_FILENAME = 'lib.js';
 
@@ -42,6 +43,7 @@ function getWebpackCacheVersion() {
         .update(JSON.stringify([
             appVersion.pkgVersion,
             webpack.version,
+            PUBLIC_LIB_CONFIG_SIGNATURE,
             isBunRuntime() ? BUN_LIB_BUNDLE_SIGNATURE : 'default',
             getPublicLibInputsSignature(),
         ]))

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -195,6 +195,12 @@ export default function getPublicLibConfig({ forceDist = false, pruneCache = fal
         },
         devtool: false,
         watch: false,
+        resolve: {
+            alias: {
+                // Use Chevrotain's bundled ESM build to avoid Windows + Bun walking lodash-es source files.
+                chevrotain$: path.resolve(serverDirectory, 'node_modules/chevrotain/lib/chevrotain.mjs'),
+            },
+        },
         module: {},
         stats: {
             preset: 'minimal',


### PR DESCRIPTION
## Summary

- Alias bare `chevrotain` imports in the public lib webpack build to `node_modules/chevrotain/lib/chevrotain.mjs`.
- Avoid walking the Chevrotain `lodash-es` source dependency tree, which can fail on Windows + Bun with webpack 5.105.4.
- Keep the change scoped to the browser-side public library bundle; Node-side imports are untouched.

## Verification

- `bun --eval "import getWebpackServeMiddleware from './src/middleware/webpack-serve.js'; await getWebpackServeMiddleware({ forceDist: true }).runWebpackCompiler({ forceDist: true, pruneCache: true });"`
- `node --input-type=module --eval "import getWebpackServeMiddleware from './src/middleware/webpack-serve.js'; await getWebpackServeMiddleware({ forceDist: true }).runWebpackCompiler({ forceDist: true, pruneCache: true });"`
- `./node_modules/.bin/eslint webpack.config.js`
- `git diff --check`

## Notes

- Linux smoke verification passed, but the original Windows + Bun environment is required for final confirmation before merge.
