### PR TITLE
fix: pre-gen intercept running toast and structured edits view

### DIFF
--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -1614,6 +1614,13 @@ function shouldShowPromptTransformNotifications(agent) {
     );
 }
 
+function shouldShowPreInterceptNotifications(agent) {
+    return Boolean(
+        getGlobalSettings()?.promptTransformShowNotifications &&
+        agent?.preProcess?.mode === 'intercept',
+    );
+}
+
 function describePromptTransformTarget(profileId = '', runner = '') {
     if (runner === 'main') {
         return 'the main model';
@@ -1657,14 +1664,21 @@ function getPromptTransformRunMetadata(agent, profileId = '') {
     };
 }
 
-function showPromptTransformRunningToast(agent, mode, profileId = '') {
+function showPromptTransformRunningToast(agent, mode, profileId = '', options = {}) {
     const agentName = agent?.name || 'In-Chat Agent';
     const modeLabel = describePromptTransformMode(mode);
     const targetLabel = describePromptTransformTarget(profileId, profileId ? 'profile' : 'main');
     const metadata = getPromptTransformRunMetadata(agent, profileId);
     const cancelButtonClass = 'ica--toast-cancel-agent';
+    const kind = options?.kind === 'preIntercept' ? 'preIntercept' : 'postGen';
+    const applyMode = ['wrap', 'patch'].includes(String(options?.applyMode))
+        ? String(options.applyMode)
+        : 'replace';
+    const runningLabel = kind === 'preIntercept'
+        ? `Running pre-generation ${applyMode} intercept...`
+        : `Running ${modeLabel} via ${targetLabel}...`;
     const messageHtml = `
-        <div>${escapeToastHtml(`Running ${modeLabel} via ${targetLabel}...`)}</div>
+        <div>${escapeToastHtml(runningLabel)}</div>
         <div>${escapeToastHtml(`Order ${metadata.order} | Model: ${metadata.modelLabel}`)}</div>
         <button type="button" class="menu_button menu_button_icon caution ${cancelButtonClass}">
             <i class="fa-solid fa-stop"></i>
@@ -1716,7 +1730,7 @@ function clearAllPromptTransformRunningToasts() {
         const title = $(element).find('.toast-title').text().trim();
         const message = $(element).find('.toast-message').text().trim();
         return $(element).find('.ica--toast-cancel-agent').length > 0 ||
-            (title === 'In-Chat Agent' && /^Running prompt (rewrite|append) via /u.test(message));
+            (title === 'In-Chat Agent' && /^Running (?:prompt (?:rewrite|append) via |pre-generation )/u.test(message));
     }).each((_, element) => toastr.clear($(element)));
 }
 
@@ -3226,6 +3240,7 @@ async function runContextInterceptAgent(agent, currentContextText, generationTyp
     const applyMode = ['wrap', 'patch'].includes(String(agent?.preProcess?.applyMode))
         ? String(agent.preProcess.applyMode)
         : 'replace';
+    const profileId = resolveAgentConnectionProfile(agent);
     const baseResult = {
         agentId: agent.id,
         agentName: agent.name,
@@ -3252,31 +3267,50 @@ async function runContextInterceptAgent(agent, currentContextText, generationTyp
     }
 
     const promptMessages = buildContextInterceptMessages(expandedPrompt, currentContextText, generationType, contextFormat);
-    const response = await requestPromptTransform(
-        agent,
-        promptMessages,
-        normalizePreProcessMaxTokens(agent.preProcess?.maxTokens),
-    );
-    const outputText = unwrapContextInterceptOutput(response.output).trim();
+    const cancelRevision = agentGenerationCancelRevision;
+    const runningToast = shouldShowPreInterceptNotifications(agent)
+        ? showPromptTransformRunningToast(agent, applyMode, profileId, { kind: 'preIntercept', applyMode })
+        : null;
 
-    if (!outputText) {
-        console.warn(`[InChatAgents] pre-generation intercept agent "${agent.name}" returned an empty response.`);
+    try {
+        const response = await requestPromptTransform(
+            agent,
+            promptMessages,
+            normalizePreProcessMaxTokens(agent.preProcess?.maxTokens),
+        );
+
+        if (agentGenerationCancelRevision !== cancelRevision) {
+            return {
+                ...baseResult,
+                status: 'cancelled',
+                profileId: response.profileId,
+                runner: response.runner,
+            };
+        }
+
+        const outputText = unwrapContextInterceptOutput(response.output).trim();
+
+        if (!outputText) {
+            console.warn(`[InChatAgents] pre-generation intercept agent "${agent.name}" returned an empty response.`);
+            return {
+                ...baseResult,
+                status: 'empty-response',
+                profileId: response.profileId,
+                runner: response.runner,
+            };
+        }
+
         return {
             ...baseResult,
-            status: 'empty-response',
+            status: 'changed',
+            changed: true,
+            outputText,
             profileId: response.profileId,
             runner: response.runner,
         };
+    } finally {
+        clearPromptTransformRunningToast(runningToast);
     }
-
-    return {
-        ...baseResult,
-        status: 'changed',
-        changed: true,
-        outputText,
-        profileId: response.profileId,
-        runner: response.runner,
-    };
 }
 
 function getGenerationContextSnapshot(generationType = null) {
@@ -3307,10 +3341,17 @@ async function runPreGenerationInterceptorsOnText(initialContextText, generation
 
     const runs = [];
     for (const agent of interceptAgents) {
+        if (generationStopRequested) {
+            break;
+        }
+
         try {
             const result = await runContextInterceptAgent(agent, currentContextText, activationSnapshot.generationType, contextFormat);
             if (result.status !== 'changed') {
                 runs.push(result);
+                if (result.status === 'cancelled') {
+                    break;
+                }
                 continue;
             }
 
@@ -3384,12 +3425,20 @@ async function runPreGenerationInterceptorsOnChat(initialChatMessages, generatio
 
     const runs = [];
     for (const agent of interceptAgents) {
+        if (generationStopRequested) {
+            break;
+        }
+
         const contextText = serializeChatContext(currentChatMessages);
+        let result = null;
 
         try {
-            const result = await runContextInterceptAgent(agent, contextText, activationSnapshot.generationType, 'chat');
+            result = await runContextInterceptAgent(agent, contextText, activationSnapshot.generationType, 'chat');
             if (result.status !== 'changed') {
                 runs.push(result);
+                if (result.status === 'cancelled') {
+                    break;
+                }
                 continue;
             }
 
@@ -3434,10 +3483,10 @@ async function runPreGenerationInterceptorsOnChat(initialChatMessages, generatio
                 error: error instanceof Error ? error.message : String(error),
                 beforeText: contextText,
                 afterText: contextText,
-                outputText: '',
-                profileId: '',
-                runner: 'error',
-                timestamp: new Date().toISOString(),
+                outputText: normalizeContentText(result?.outputText),
+                profileId: result?.profileId ?? '',
+                runner: result?.runner ?? 'error',
+                timestamp: result?.timestamp ?? new Date().toISOString(),
             });
         }
     }

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -2672,11 +2672,209 @@ function getPreGenerationInterceptModeLabel(entry) {
     return 'replace';
 }
 
+function parseChatInterceptSummaryMessages(value) {
+    let parsed;
+    try {
+        parsed = JSON.parse(String(value ?? ''));
+    } catch {
+        return { ok: false, reason: 'parse-error' };
+    }
+
+    if (!Array.isArray(parsed)) {
+        return { ok: false, reason: 'shape-error' };
+    }
+
+    const messages = [];
+    for (const [index, message] of parsed.entries()) {
+        if (!message || typeof message !== 'object' || Array.isArray(message)) {
+            return { ok: false, reason: 'shape-error' };
+        }
+
+        if (typeof message.role !== 'string' || typeof message.content !== 'string') {
+            return { ok: false, reason: 'shape-error' };
+        }
+
+        messages.push({
+            index,
+            role: message.role,
+            content: message.content,
+        });
+    }
+
+    return { ok: true, messages };
+}
+
+export function summarizeChatInterceptChange(beforeText, afterText) {
+    const beforeResult = parseChatInterceptSummaryMessages(beforeText);
+    const afterResult = parseChatInterceptSummaryMessages(afterText);
+
+    if (!beforeResult.ok) {
+        return { ok: false, reason: beforeResult.reason };
+    }
+
+    if (!afterResult.ok) {
+        return { ok: false, reason: afterResult.reason };
+    }
+
+    const beforeMessages = beforeResult.messages;
+    const afterMessages = afterResult.messages;
+    const matchedBefore = new Set();
+    const matchedAfter = new Set();
+
+    for (const beforeMessage of beforeMessages) {
+        const afterMessage = afterMessages.find(candidate =>
+            !matchedAfter.has(candidate.index) &&
+            candidate.role === beforeMessage.role &&
+            candidate.content === beforeMessage.content,
+        );
+
+        if (!afterMessage) {
+            continue;
+        }
+
+        matchedBefore.add(beforeMessage.index);
+        matchedAfter.add(afterMessage.index);
+    }
+
+    const changes = [];
+    for (const beforeMessage of beforeMessages) {
+        if (matchedBefore.has(beforeMessage.index)) {
+            continue;
+        }
+
+        const afterMessage = afterMessages[beforeMessage.index];
+        if (!afterMessage || matchedAfter.has(afterMessage.index)) {
+            continue;
+        }
+
+        matchedBefore.add(beforeMessage.index);
+        matchedAfter.add(afterMessage.index);
+        changes.push({
+            changeKind: 'modified',
+            role: afterMessage.role || beforeMessage.role,
+            beforeIndex: beforeMessage.index,
+            afterIndex: afterMessage.index,
+            beforeContent: beforeMessage.content,
+            afterContent: afterMessage.content,
+        });
+    }
+
+    for (const beforeMessage of beforeMessages) {
+        if (matchedBefore.has(beforeMessage.index)) {
+            continue;
+        }
+
+        changes.push({
+            changeKind: 'removed',
+            role: beforeMessage.role,
+            beforeIndex: beforeMessage.index,
+            afterIndex: null,
+            beforeContent: beforeMessage.content,
+            afterContent: '',
+        });
+    }
+
+    for (const afterMessage of afterMessages) {
+        if (matchedAfter.has(afterMessage.index)) {
+            continue;
+        }
+
+        changes.push({
+            changeKind: 'added',
+            role: afterMessage.role,
+            beforeIndex: null,
+            afterIndex: afterMessage.index,
+            beforeContent: '',
+            afterContent: afterMessage.content,
+        });
+    }
+
+    const changeKindOrder = {
+        removed: 0,
+        modified: 1,
+        added: 2,
+    };
+    changes.sort((left, right) => {
+        const leftIndex = left.afterIndex ?? left.beforeIndex ?? 0;
+        const rightIndex = right.afterIndex ?? right.beforeIndex ?? 0;
+        if (leftIndex !== rightIndex) {
+            return leftIndex - rightIndex;
+        }
+
+        return changeKindOrder[left.changeKind] - changeKindOrder[right.changeKind];
+    });
+
+    return { ok: true, changes };
+}
+
+function buildPreGenerationChatChangeMarkup(change) {
+    let diffMarkup = '';
+    if (change.changeKind === 'added') {
+        diffMarkup = `<span class="ica-transform-diff-part--ins">${escapeHtml(change.afterContent)}</span>`;
+    } else if (change.changeKind === 'removed') {
+        diffMarkup = `<span class="ica-transform-diff-part--del">${escapeHtml(change.beforeContent)}</span>`;
+    } else {
+        diffMarkup = buildPromptTransformDiffMarkup(change.beforeContent, change.afterContent);
+    }
+
+    return `
+        <div class="ica-preintercept-message-change">
+            <div class="ica-preintercept-message-header">
+                <span class="ica-preintercept-role">${escapeHtml(change.role || 'message')}</span>
+                <span class="ica-preintercept-change-kind">${escapeHtml(change.changeKind)}</span>
+            </div>
+            <div class="ica-transform-diff">${diffMarkup}</div>
+        </div>
+    `;
+}
+
+function buildPreGenerationInterceptSummaryMarkup(entry) {
+    const beforeText = entry.beforeText ?? '';
+    const outputText = String(entry.outputText ?? '').trim();
+    const afterText = entry.contextFormat === 'chat' && entry.status === 'error' && outputText
+        ? outputText
+        : entry.afterText ?? '';
+
+    if (entry.contextFormat !== 'chat') {
+        return `
+            <div class="ica-transform-output-title">Prompt diff</div>
+            <div class="ica-transform-diff">${buildPromptTransformDiffMarkup(beforeText, afterText)}</div>
+        `;
+    }
+
+    try {
+        const summary = summarizeChatInterceptChange(beforeText, afterText);
+        if (!summary.ok) {
+            return `
+                <div class="ica-preintercept-fallback-notice">Could not summarize chat messages; showing raw diff.</div>
+                <div class="ica-transform-output-title">Context diff</div>
+                <div class="ica-transform-diff">${buildPromptTransformDiffMarkup(beforeText, afterText)}</div>
+            `;
+        }
+
+        const changesMarkup = summary.changes.length > 0
+            ? summary.changes.map(buildPreGenerationChatChangeMarkup).join('')
+            : '<div class="ica-preintercept-empty">No effective change.</div>';
+
+        return `
+            <div class="ica-transform-output-title">Chat changes</div>
+            ${changesMarkup}
+        `;
+    } catch (error) {
+        console.warn('[InChatAgents] Failed to summarize pre-generation intercept history entry:', error);
+        return `
+            <div class="ica-preintercept-fallback-notice">Could not summarize chat messages; showing raw diff.</div>
+            <div class="ica-transform-output-title">Context diff</div>
+            <div class="ica-transform-diff">${buildPromptTransformDiffMarkup(beforeText, afterText)}</div>
+        `;
+    }
+}
+
 function buildPreGenerationInterceptEntryMarkup(entry, i) {
     const timestamp = entry.timestamp ? new Date(entry.timestamp).toLocaleString() : '';
     const status = String(entry.status ?? 'changed');
     const statusText = status === 'error'
-        ? `Error: ${escapeHtml(entry.error || 'unknown error')}`
+        ? `Error: ${entry.error || 'unknown error'}`
         : `${entry.changed ? 'Changed' : 'No visible change'} the ${entry.contextFormat === 'chat' ? 'chat message array' : 'text prompt'}`;
     const modeLabel = getPreGenerationInterceptModeLabel(entry);
     const output = String(entry.outputText ?? '').trim();
@@ -2685,9 +2883,11 @@ function buildPreGenerationInterceptEntryMarkup(entry, i) {
         <div class="ica-transform-history-entry ica-preintercept-history-entry" data-index="${i}">
             <h5>${escapeHtml(entry.agentName || 'Agent')} <small>(pre-gen ${escapeHtml(modeLabel)})</small></h5>
             <small>${escapeHtml(timestamp)}${timestamp ? ' · ' : ''}${escapeHtml(statusText)}</small>
-            ${output ? `<div class="ica-transform-output-title">Agent output</div><div class="ica-transform-diff">${escapeHtml(output)}</div>` : ''}
-            <div class="ica-transform-output-title">Context diff</div>
-            <div class="ica-transform-diff">${buildPromptTransformDiffMarkup(entry.beforeText ?? '', entry.afterText ?? '')}</div>
+            ${buildPreGenerationInterceptSummaryMarkup(entry)}
+            <details class="ica-preintercept-raw">
+                <summary>Raw agent output</summary>
+                <pre class="ica-transform-diff">${escapeHtml(output)}</pre>
+            </details>
         </div>
     `;
 }

--- a/public/style.css
+++ b/public/style.css
@@ -7461,6 +7461,54 @@ body:not(.movingUI) .drawer-content.maximized {
     flex-wrap: wrap;
 }
 
+.ica-preintercept-message-change {
+    padding: 10px 12px;
+    border: 1px solid color-mix(in srgb, var(--SmartThemeBorderColor, #444) 38%, transparent);
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--SmartThemeBlurTintColor, #222) 14%, transparent);
+}
+
+.ica-preintercept-message-change + .ica-preintercept-message-change {
+    margin-top: 8px;
+}
+
+.ica-preintercept-message-header {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    align-items: center;
+    margin-bottom: 6px;
+}
+
+.ica-preintercept-role {
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.ica-preintercept-change-kind {
+    font-size: 0.78em;
+    padding: 1px 6px;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--SmartThemeBorderColor, #444) 45%, transparent);
+    background: color-mix(in srgb, var(--SmartThemeBodyColor, #ddd) 10%, transparent);
+}
+
+.ica-preintercept-empty,
+.ica-preintercept-fallback-notice {
+    font-style: italic;
+    opacity: 0.72;
+}
+
+.ica-preintercept-raw {
+    margin-top: 10px;
+}
+
+.ica-preintercept-raw > summary {
+    cursor: pointer;
+    opacity: 0.78;
+}
+
 
 .group_speaker_controls {
     display: flex;

--- a/tests/in-chat-agents-pre-intercept-summary.test.js
+++ b/tests/in-chat-agents-pre-intercept-summary.test.js
@@ -1,0 +1,223 @@
+import { afterAll, beforeAll, describe, expect, jest, test } from '@jest/globals';
+
+let summarizeChatInterceptChange;
+let warnSpy;
+
+beforeAll(async () => {
+    jest.resetModules();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await jest.unstable_mockModule('../public/scripts/extensions.js', () => ({
+        extension_settings: {},
+        renderExtensionTemplateAsync: jest.fn(async () => ''),
+        getContext: jest.fn(() => ({})),
+    }));
+
+    await jest.unstable_mockModule('../public/lib.js', () => ({
+        DiffMatchPatch: class DiffMatchPatch {
+            diff_main(beforeText, afterText) {
+                return [[0, beforeText], [1, afterText]];
+            }
+
+            diff_cleanupSemantic() {}
+        },
+    }));
+
+    await jest.unstable_mockModule('../public/scripts/popup.js', () => ({
+        Popup: class Popup {
+            async show() {
+                return null;
+            }
+        },
+        POPUP_TYPE: { CONFIRM: 'confirm' },
+        POPUP_RESULT: { AFFIRMATIVE: 'affirmative' },
+    }));
+
+    await jest.unstable_mockModule('../public/scripts/utils.js', () => ({
+        download: jest.fn(),
+        escapeHtml: jest.fn(value => String(value ?? '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#039;')),
+        escapeRegex: jest.fn(value => String(value ?? '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+        getSortableDelay: jest.fn(() => 0),
+        uuidv4: jest.fn(() => 'test-uuid'),
+    }));
+
+    await jest.unstable_mockModule('../public/script.js', () => ({
+        CLIENT_VERSION: 'test',
+        chat: [],
+        getRequestHeaders: jest.fn(() => ({})),
+        generateQuietPrompt: jest.fn(),
+        normalizeContentText: jest.fn(value => String(value ?? '')),
+        saveSettingsDebounced: jest.fn(),
+        substituteParams: jest.fn(value => String(value ?? '')),
+    }));
+
+    await jest.unstable_mockModule('../public/scripts/events.js', () => ({
+        eventSource: { on: jest.fn() },
+        event_types: {},
+    }));
+
+    await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-store.js', () => ({
+        AGENT_CATEGORIES: {},
+        DEFAULT_AGENT_MAX_TOKENS: 8192,
+        LEGACY_AGENT_MAX_TOKENS: 2048,
+        areAgentsGloballyEnabled: jest.fn(() => true),
+        getAgents: jest.fn(() => []),
+        getEnabledAgents: jest.fn(() => []),
+        getAgentById: jest.fn(() => null),
+        getAgentRegexScripts: jest.fn(() => []),
+        loadAgents: jest.fn(),
+        saveAgent: jest.fn(async () => {}),
+        deleteAgent: jest.fn(async () => {}),
+        createDefaultAgent: jest.fn(() => ({
+            id: 'agent-id',
+            name: 'Agent',
+            prompt: '',
+            injection: {},
+            preProcess: {},
+            postProcess: {},
+            conditions: {},
+        })),
+        importAgents: jest.fn(() => []),
+        exportAllAgents: jest.fn(() => []),
+        exportAgent: jest.fn(() => null),
+        getGlobalSettings: jest.fn(() => ({})),
+        initializeScopedAgentEnableState: jest.fn(() => false),
+        isAgentEnabledForCurrentScope: jest.fn(() => false),
+        normalizeAgentCategory: jest.fn(value => value),
+        getAgentChatScopeLabel: jest.fn(() => 'Individual chat'),
+        getPromptTransformMode: jest.fn(() => 'rewrite'),
+        findTemplateForAgentSnapshot: jest.fn(() => null),
+        getRedundantBundledAgentDuplicateIds: jest.fn(() => []),
+        reconcileScopedEnabledAgentIdsFromLegacyFlags: jest.fn(() => false),
+        resolveConnectionProfile: jest.fn(value => value ?? ''),
+        setAgentEnabledForCurrentScope: jest.fn(),
+        setGlobalSettings: jest.fn(),
+        getGroups: jest.fn(() => []),
+        getCustomGroups: jest.fn(() => []),
+        loadBuiltinGroups: jest.fn(),
+        loadCustomGroups: jest.fn(),
+        saveGroup: jest.fn(async () => {}),
+        deleteGroup: jest.fn(async () => {}),
+        createDefaultGroup: jest.fn(() => ({ id: 'group-id', name: 'Group' })),
+    }));
+
+    await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-runner.js', () => ({
+        cancelAgentGeneration: jest.fn(),
+        buildPromptDynamicMacros: jest.fn(() => ({})),
+        initAgentRunner: jest.fn(),
+        isAgentGenerationActive: jest.fn(() => false),
+        onAgentGenerationStateChanged: jest.fn(),
+        getPreGenerationInterceptHistoryForMessage: jest.fn(() => []),
+        getPromptTransformHistoryForMessage: jest.fn(() => []),
+        runAgentOnMessage: jest.fn(),
+        syncToolAgentRegistrations: jest.fn(),
+        undoPromptTransform: jest.fn(async () => false),
+        redoPromptTransform: jest.fn(async () => false),
+    }));
+
+    await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/regex-scripts.js', () => ({
+        AGENT_REGEX_PLACEMENT: {
+            AI_OUTPUT: 'ai-output',
+            USER_INPUT: 'user-input',
+            SLASH_COMMAND: 'slash-command',
+            WORLD_INFO: 'world-info',
+            REASONING: 'reasoning',
+        },
+        AGENT_REGEX_SUBSTITUTE: {
+            RAW: 'raw',
+            ESCAPED: 'escaped',
+        },
+        createDefaultRegexScript: jest.fn(() => ({})),
+        normalizeRegexScript: jest.fn(value => value),
+    }));
+
+    await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder-init.js', () => ({
+        initPathfinder: jest.fn(),
+    }));
+
+    await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js', () => ({
+        openPathfinderSettings: jest.fn(),
+        isPathfinderAgent: jest.fn(() => false),
+    }));
+
+    await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/tool-definitions.js', () => ({
+        getPathfinderToolDefinitions: jest.fn(() => []),
+    }));
+
+    await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/llm-utils.js', () => ({
+        buildFallbackPromptText: jest.fn(() => ''),
+        extractProfileResponseText: jest.fn(() => ''),
+    }));
+
+    await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/profile-utils.js', () => ({
+        buildConnectionProfileNameMap: jest.fn(() => new Map()),
+        getConnectionManagerRequestService: jest.fn(() => null),
+        populateConnectionProfileSelect: jest.fn(),
+    }));
+
+    ({ summarizeChatInterceptChange } = await import('../public/scripts/extensions/in-chat-agents/index.js'));
+});
+
+afterAll(() => {
+    warnSpy?.mockRestore();
+});
+
+describe('summarizeChatInterceptChange', () => {
+    test('reports a wrapped system message as an added change', () => {
+        const before = JSON.stringify([{ role: 'user', content: 'Original prompt' }], null, 2);
+        const after = JSON.stringify([
+            { role: 'user', content: 'Original prompt' },
+            { role: 'system', content: 'Follow the extra instruction.' },
+        ], null, 2);
+
+        const result = summarizeChatInterceptChange(before, after);
+
+        expect(result).toEqual({
+            ok: true,
+            changes: [expect.objectContaining({
+                changeKind: 'added',
+                role: 'system',
+                beforeIndex: null,
+                afterIndex: 1,
+                afterContent: 'Follow the extra instruction.',
+            })],
+        });
+    });
+
+    test('reports an in-place replacement as a modified change', () => {
+        const before = JSON.stringify([
+            { role: 'system', content: 'Keep tone warm.' },
+            { role: 'user', content: 'Original prompt' },
+        ], null, 2);
+        const after = JSON.stringify([
+            { role: 'system', content: 'Keep tone warm.' },
+            { role: 'user', content: 'Rewritten prompt' },
+        ], null, 2);
+
+        const result = summarizeChatInterceptChange(before, after);
+
+        expect(result).toEqual({
+            ok: true,
+            changes: [expect.objectContaining({
+                changeKind: 'modified',
+                role: 'user',
+                beforeIndex: 1,
+                afterIndex: 1,
+                beforeContent: 'Original prompt',
+                afterContent: 'Rewritten prompt',
+            })],
+        });
+    });
+
+    test('reports malformed JSON as a parse error', () => {
+        expect(summarizeChatInterceptChange('{not-json', '[]')).toEqual({
+            ok: false,
+            reason: 'parse-error',
+        });
+    });
+});

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -752,7 +752,8 @@ describe('in-chat agent post-processing runner', () => {
             initAgentRunner();
 
             for (const [caseName, replacementChat] of invalidReplacementChats) {
-                generateQuietPrompt.mockResolvedValueOnce(JSON.stringify(replacementChat));
+                const invalidOutputText = JSON.stringify(replacementChat);
+                generateQuietPrompt.mockResolvedValueOnce(invalidOutputText);
 
                 await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
                 const originalMessage = { role: 'user', content: `original user prompt for ${caseName}` };
@@ -784,6 +785,7 @@ describe('in-chat agent post-processing runner', () => {
                     changed: false,
                     beforeText: JSON.stringify(originalChat, null, 2),
                     afterText: JSON.stringify(originalChat, null, 2),
+                    outputText: invalidOutputText,
                 })]);
             }
         } finally {


### PR DESCRIPTION
## Summary
- Show a cancelable running toast while pre-generation intercept agents are rewriting context
- Render chat-format intercept history as structured per-message changes instead of raw JSON walls
- Keep text-format intercept history on the existing prompt diff path and collapse raw output in details
- Preserve invalid chat intercept output for fallback history diffs

## Tests
- npm run lint
- npm run lint --prefix tests
- npm run test:unit --prefix tests