### PR TITLE
fix: strip reasoning blocks from profile-based prompt transform output

### DIFF
--- a/public/scripts/extensions/in-chat-agents/llm-utils.js
+++ b/public/scripts/extensions/in-chat-agents/llm-utils.js
@@ -1,7 +1,8 @@
 import { normalizeContentText } from '../../../script.js';
+import { removeReasoningFromString } from '../../reasoning.js';
 
 export function extractProfileResponseText(response) {
-    return normalizeContentText(response?.content)
+    const text = normalizeContentText(response?.content)
         || normalizeContentText(response?.choices?.[0]?.message?.content)
         || normalizeContentText(response?.candidates?.[0]?.content?.parts)
         || normalizeContentText(response?.candidates?.[0]?.output?.parts)
@@ -11,6 +12,7 @@ export function extractProfileResponseText(response) {
         || normalizeContentText(response?.message?.tool_plan)
         || normalizeContentText(response?.message)
         || '';
+    return removeReasoningFromString(text);
 }
 
 export function buildFallbackPromptText(promptMessages) {

--- a/tests/in-chat-agents-pre-intercept-summary.test.js
+++ b/tests/in-chat-agents-pre-intercept-summary.test.js
@@ -63,6 +63,7 @@ beforeAll(async () => {
 
     await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-store.js', () => ({
         AGENT_CATEGORIES: {},
+        AGENT_SUBCATEGORIES: {},
         DEFAULT_AGENT_MAX_TOKENS: 8192,
         LEGACY_AGENT_MAX_TOKENS: 2048,
         areAgentsGloballyEnabled: jest.fn(() => true),

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -204,6 +204,10 @@ describe('in-chat agent post-processing runner', () => {
             event_types: eventTypes,
         }));
 
+        await jest.unstable_mockModule('../public/scripts/reasoning.js', () => ({
+            removeReasoningFromString: jest.fn(value => String(value ?? '')),
+        }));
+
         await jest.unstable_mockModule('../public/scripts/tool-calling.js', () => ({
             ToolManager: {
                 RECURSE_LIMIT: 5,


### PR DESCRIPTION
Text-completion reasoning models (DeepSeek-R1 family, Qwen3-thinking, etc.) emit `<think>...</think>` inline inside `choices[0].text`. The profile-based path used by post-gen agents, `refineLLMCall`, and the Pathfinder sidecar pulled that raw text via `extractProfileResponseText` and surfaced it verbatim, so the model's reasoning leaked into the chat-visible message. The non-profile path already strips reasoning via `generateQuietPrompt({ removeReasoning: true })`.

Fix: route the helper's return through the existing `removeReasoningFromString` utility so all profile-path callers get parity with the main-model path. Honors auto-parse settings (returns input unchanged if the user has disabled reasoning auto-parse).

Test maintenance: update the affected Jest mocks so the runner test stays Node-friendly after `llm-utils.js` imports the browser-side reasoning module, and so the pre-intercept summary mock matches the current `agent-store.js` exports.

Verification:
- `npm run test:unit -- --runInBand tests/in-chat-agents-pre-intercept-summary.test.js tests/in-chat-agents-runner.test.js`
- `npm test -- in-chat-agents` runs all 33 Jest suites successfully (492 tests), then exits nonzero because Playwright reports `No tests found` for the `in-chat-agents` selector.
