### PR TITLE
fix: theme Firefox scrollbars

### DIFF
--- a/public/css/scrollable-button.css
+++ b/public/css/scrollable-button.css
@@ -8,7 +8,7 @@
     flex-shrink: 1;
     min-height: 0;
     scrollbar-width: thin;
-    scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
+    scrollbar-color: var(--sb-scrollbar-thumb) transparent;
 }
 
 .scrollable-buttons-container::-webkit-scrollbar {
@@ -16,6 +16,6 @@
 }
 
 .scrollable-buttons-container::-webkit-scrollbar-thumb {
-    background-color: rgba(255, 255, 255, 0.3);
+    background-color: var(--sb-scrollbar-thumb);
     border-radius: 3px;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -40,7 +40,7 @@
     <link rel="apple-touch-icon" sizes="114x114" href="img/apple-icon-114x114.png" />
     <link rel="apple-touch-icon" sizes="144x144" href="img/apple-icon-144x144.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="img/apple-icon-180x180.png" />
-    <link rel="stylesheet" type="text/css" href="style.css?v=20260516d">
+    <link rel="stylesheet" type="text/css" href="style.css?v=20260517a">
     <link rel="stylesheet" type="text/css" href="css/st-tailwind.css">
     <link rel="stylesheet" type="text/css" href="css/toggle-dependent.css">
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css">

--- a/public/style.css
+++ b/public/style.css
@@ -9,7 +9,7 @@
 @import url(css/logprobs.css);
 @import url(css/accounts.css);
 @import url(css/tags.css);
-@import url(css/scrollable-button.css);
+@import url(css/scrollable-button.css?v=20260517a);
 @import url(css/welcome.css?v=20260425a);
 @import url(css/data-maid.css);
 @import url(css/secrets.css);
@@ -99,6 +99,10 @@
     --color-warning: #facc15;
     --color-shadow: var(--SmartThemeShadowColor);
     --color-focus-ring: color-mix(in srgb, var(--color-primary) 72%, transparent);
+    --sb-scrollbar-track: color-mix(in srgb, var(--color-background, var(--SmartThemeBlurTintColor)) 86%, transparent);
+    --sb-scrollbar-track-hover: color-mix(in srgb, var(--color-background, var(--SmartThemeBlurTintColor)) 70%, transparent);
+    --sb-scrollbar-thumb: color-mix(in srgb, var(--color-primary, var(--sb-accent, var(--SmartThemeQuoteColor))) 34%, transparent);
+    --sb-scrollbar-thumb-hover: color-mix(in srgb, var(--color-primary, var(--sb-accent, var(--SmartThemeQuoteColor))) 50%, transparent);
     --color-user-message-bg: var(--SmartThemeUserMesBlurTintColor);
     --color-bot-message-bg: var(--SmartThemeBotMesBlurTintColor);
     --SmartThemeCheckboxTickColorValue: calc(((((var(--SmartThemeCheckboxBgColorR) * 299) + (var(--SmartThemeCheckboxBgColorG) * 587) + (var(--SmartThemeCheckboxBgColorB) * 114)) / 1000) - 128) * -1000);
@@ -204,6 +208,12 @@ body {
     color-scheme: only light;
 }
 
+/* SillyBunny: Firefox ignores WebKit scrollbar pseudo-elements. */
+* {
+    scrollbar-width: thin;
+    scrollbar-color: var(--sb-scrollbar-thumb) var(--sb-scrollbar-track);
+}
+
 ::-webkit-scrollbar {
     width: 10px;
     height: 10px;
@@ -212,23 +222,23 @@ body {
 
 ::-webkit-scrollbar-track {
     cursor: default;
-    background: color-mix(in srgb, var(--color-background, var(--SmartThemeBlurTintColor)) 86%, transparent);
+    background: var(--sb-scrollbar-track);
 }
 
 ::-webkit-scrollbar-track:hover {
-    background-color: color-mix(in srgb, var(--color-background, var(--SmartThemeBlurTintColor)) 70%, transparent);
+    background-color: var(--sb-scrollbar-track-hover);
 }
 
 ::-webkit-scrollbar-thumb {
     cursor: grab;
-    background: color-mix(in srgb, var(--color-primary, var(--sb-accent, var(--SmartThemeQuoteColor))) 34%, transparent);
+    background: var(--sb-scrollbar-thumb);
     border-radius: 999px;
     border: 2px solid transparent;
     background-clip: content-box;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-    background: color-mix(in srgb, var(--color-primary, var(--sb-accent, var(--SmartThemeQuoteColor))) 50%, transparent);
+    background: var(--sb-scrollbar-thumb-hover);
     background-clip: content-box;
 }
 


### PR DESCRIPTION
## What?
Adds Firefox-compatible scrollbar theming so app scrollbars use SillyBunny theme colors instead of the browser default white scrollbar treatment.

## Why?
Firefox does not apply the existing `::-webkit-scrollbar` rules. Users could therefore see bright white scrollbars inside app windows and panels even when the rest of the UI is themed.

## How?
Defines shared scrollbar thumb/track theme variables in the global stylesheet, applies `scrollbar-color` and `scrollbar-width` globally for Firefox, and reuses those same variables for the existing WebKit scrollbar styling.

Also updates the scrollable button container to use the shared scrollbar thumb variable instead of a hardcoded white RGBA value, and bumps the `style.css` asset query so the updated stylesheet is fetched.

## Testing?
- `npm ci --ignore-scripts`
- `npm run lint`
- `npm run check:frontend-budgets`
- `npm ci --ignore-scripts --prefix tests`
- `git diff --check`
- Started SillyBunny with Bun on port `4567` using a temporary isolated data root.
- Verified in Playwright Firefox 142 that `style.css?v=20260517a` loads and `scrollbar-color` resolves to non-default theme colors instead of `auto` or white.
- Verified a temporary overflow fixture in Firefox inherits the themed `scrollbar-color` from the app stylesheet.

## Screenshots (optional)
Not included. This was verified through Firefox computed CSS because the defect is browser scrollbar styling and headless Firefox does not produce a reliable visual scrollbar screenshot in this environment.

## Anything Else?
Headless Firefox reports `scrollbar-width: none` even on a minimal page with `scrollbar-width: thin`; the meaningful Firefox-specific assertion here is that `scrollbar-color` is no longer default/white and resolves to the SillyBunny theme colors.
