### PR TITLE
fix: Add reasoning request settings to Connection Profiles

### DIFF
--- a/public/scripts/custom-request.js
+++ b/public/scripts/custom-request.js
@@ -6,6 +6,42 @@ import { formatInstructModeChat, formatInstructModePrompt, getInstructStoppingSe
 import { chat_completion_sources, getStreamingReply, tryParseStreamingError, createGenerationParameters, settingsToUpdate, oai_settings } from './openai.js';
 import EventSourceStream from './sse-stream.js';
 
+const BOOLEAN_CHAT_COMPLETION_FIELDS = [
+    'include_reasoning',
+    'enable_web_search',
+    'request_images',
+];
+
+function coerceRequestBoolean(value) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+
+    if (typeof value === 'string') {
+        const normalized = value.trim().toLowerCase();
+        if (['true', 'on', '1'].includes(normalized)) {
+            return true;
+        }
+        if (['false', 'off', '0'].includes(normalized)) {
+            return false;
+        }
+    }
+
+    return Boolean(value);
+}
+
+function normalizeChatCompletionBooleanFields(payload) {
+    if (!payload || typeof payload !== 'object') {
+        return;
+    }
+
+    for (const field of BOOLEAN_CHAT_COMPLETION_FIELDS) {
+        if (payload[field] !== undefined) {
+            payload[field] = coerceRequestBoolean(payload[field]);
+        }
+    }
+}
+
 // #region Type Definitions
 /**
  * @typedef {Object} TextCompletionRequestBase
@@ -464,6 +500,8 @@ export class ChatCompletionService {
             ...props,
         };
 
+        normalizeChatCompletionBooleanFields(payload);
+
         // Remove undefined values to avoid API errors
         Object.keys(payload).forEach(key => {
             if (payload[key] === undefined) {
@@ -483,6 +521,8 @@ export class ChatCompletionService {
      * @throws {Error}
      */
     static async sendRequest(data, extractData = true, signal = null) {
+        delete data.__connectionProfileRequestFields;
+        delete data.modelOverride;
         const response = await fetch('/api/backends/chat-completions/generate', {
             method: 'POST',
             headers: getRequestHeaders(),
@@ -677,10 +717,68 @@ export class ChatCompletionService {
         if (overridePayload.custom_include_headers !== undefined) {
             settings.custom_include_headers = overridePayload.custom_include_headers;
         }
+        const connectionProfileRequestFields = Array.isArray(overridePayload.__connectionProfileRequestFields)
+            ? overridePayload.__connectionProfileRequestFields
+            : [];
+        const shouldUseConnectionProfileField = (field) => connectionProfileRequestFields.includes(field);
+        normalizeChatCompletionBooleanFields(overridePayload);
+
+        // SillyBunny: Connection Profile requests can carry reasoning/image behavior without mutating global UI settings.
+        if (overridePayload.include_reasoning !== undefined) {
+            settings.show_thoughts = coerceRequestBoolean(overridePayload.include_reasoning);
+            if (!settings.show_thoughts) {
+                settings.auto_append_reasoning_tags = false;
+            }
+        }
+        if (overridePayload.reasoning_effort !== undefined) {
+            settings.reasoning_effort = overridePayload.reasoning_effort;
+        }
+        if (overridePayload.verbosity !== undefined) {
+            settings.verbosity = overridePayload.verbosity;
+        }
+        if (overridePayload.enable_web_search !== undefined) {
+            settings.enable_web_search = coerceRequestBoolean(overridePayload.enable_web_search);
+        }
+        if (overridePayload.request_images !== undefined) {
+            settings.request_images = coerceRequestBoolean(overridePayload.request_images);
+        }
+        if (overridePayload.request_image_resolution !== undefined) {
+            settings.request_image_resolution = overridePayload.request_image_resolution;
+        }
+        if (overridePayload.request_image_aspect_ratio !== undefined) {
+            settings.request_image_aspect_ratio = overridePayload.request_image_aspect_ratio;
+        }
+        if (overridePayload.custom_reasoning_preset !== undefined) {
+            settings.custom_reasoning_preset = overridePayload.custom_reasoning_preset;
+        }
+        if (overridePayload.custom_reasoning_param_name !== undefined) {
+            settings.custom_reasoning_param_name = overridePayload.custom_reasoning_param_name;
+        }
+        if (overridePayload.custom_reasoning_param_format !== undefined) {
+            settings.custom_reasoning_param_format = overridePayload.custom_reasoning_param_format;
+        }
+        if (overridePayload.custom_reasoning_enabled_value !== undefined) {
+            settings.custom_reasoning_enabled_value = overridePayload.custom_reasoning_enabled_value;
+        }
+        if (overridePayload.custom_reasoning_disabled_value !== undefined) {
+            settings.custom_reasoning_disabled_value = overridePayload.custom_reasoning_disabled_value;
+        }
 
         // Convert from settings to generation payload
         const data = await createGenerationParameters(settings, overridePayload.model, 'quiet', overridePayload.messages);
         const payload = data.generate_data;
+
+        if (shouldUseConnectionProfileField('include_reasoning')) {
+            overridePayload.include_reasoning = payload.include_reasoning;
+        }
+        if (shouldUseConnectionProfileField('reasoning_effort')) {
+            overridePayload.reasoning_effort = payload.reasoning_effort;
+        }
+        if (shouldUseConnectionProfileField('verbosity')) {
+            overridePayload.verbosity = payload.verbosity;
+        }
+        delete overridePayload.__connectionProfileRequestFields;
+        delete overridePayload.modelOverride;
 
         // apply overrides
         return this.createRequestData({ ...payload, ...overridePayload });

--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -35,6 +35,11 @@ const DEFAULT_SETTINGS = {
 const ALLOW_EMPTY = [
     'stop-strings',
     'start-reply-with',
+    'request-image-resolution',
+    'request-image-aspect-ratio',
+    'custom-reasoning-param-name',
+    'custom-reasoning-enabled-value',
+    'custom-reasoning-disabled-value',
 ];
 
 const CC_COMMANDS = [
@@ -48,6 +53,19 @@ const CC_COMMANDS = [
     'stop-strings',
     'start-reply-with',
     'reasoning-template',
+    // SillyBunny: persist Chat Completion reasoning and request behavior in connection profiles.
+    'request-reasoning',
+    'reasoning-effort',
+    'verbosity',
+    'enable-web-search',
+    'request-images',
+    'request-image-resolution',
+    'request-image-aspect-ratio',
+    'custom-reasoning-preset',
+    'custom-reasoning-param-format',
+    'custom-reasoning-param-name',
+    'custom-reasoning-enabled-value',
+    'custom-reasoning-disabled-value',
     'prompt-post-processing',
     'secret-id',
     'regex-preset',
@@ -86,6 +104,18 @@ const FANCY_NAMES = {
     'stop-strings': 'Custom Stopping Strings',
     'start-reply-with': 'Start Reply With',
     'reasoning-template': 'Reasoning Template',
+    'request-reasoning': 'Request Model Reasoning',
+    'reasoning-effort': 'Reasoning Effort',
+    'verbosity': 'Verbosity',
+    'enable-web-search': 'Enable Web Search',
+    'request-images': 'Request Inline Images',
+    'request-image-resolution': 'Request Image Resolution',
+    'request-image-aspect-ratio': 'Request Image Aspect Ratio',
+    'custom-reasoning-preset': 'Custom Reasoning Preset',
+    'custom-reasoning-param-format': 'Custom Reasoning Parameter Format',
+    'custom-reasoning-param-name': 'Custom Reasoning Parameter Name',
+    'custom-reasoning-enabled-value': 'Custom Reasoning Enabled Value',
+    'custom-reasoning-disabled-value': 'Custom Reasoning Disabled Value',
     'prompt-post-processing': 'Prompt Post-Processing',
     'secret-id': 'Secret',
     'regex-preset': 'Regex Preset',
@@ -198,6 +228,18 @@ const profilesProvider = () => [
  * @property {string} [stop-strings] Custom Stopping Strings
  * @property {string} [start-reply-with] Start Reply With
  * @property {string} [reasoning-template] Reasoning Template
+ * @property {string} [request-reasoning] Request model reasoning
+ * @property {string} [reasoning-effort] Reasoning effort
+ * @property {string} [verbosity] Verbosity
+ * @property {string} [enable-web-search] Enable web search
+ * @property {string} [request-images] Request inline images
+ * @property {string} [request-image-resolution] Request image resolution
+ * @property {string} [request-image-aspect-ratio] Request image aspect ratio
+ * @property {string} [custom-reasoning-preset] Custom reasoning preset
+ * @property {string} [custom-reasoning-param-format] Custom reasoning parameter format
+ * @property {string} [custom-reasoning-param-name] Custom reasoning parameter name
+ * @property {string} [custom-reasoning-enabled-value] Custom reasoning enabled value
+ * @property {string} [custom-reasoning-disabled-value] Custom reasoning disabled value
  * @property {string} [prompt-post-processing] Prompt Post-Processing
  * @property {string} [sysprompt] System Prompt Name
  * @property {string} [sysprompt-state] Use System Prompt

--- a/public/scripts/extensions/shared.js
+++ b/public/scripts/extensions/shared.js
@@ -5,7 +5,38 @@ import { oai_settings, proxies, ZAI_ENDPOINT } from '../openai.js';
 import { SECRET_KEYS, secret_state } from '../secrets.js';
 import { textgen_types, textgenerationwebui_settings } from '../textgen-settings.js';
 import { getTokenCountAsync } from '../tokenizers.js';
-import { createThumbnail, isValidUrl } from '../utils.js';
+import { createThumbnail, isTrueBoolean, isValidUrl } from '../utils.js';
+
+const CHAT_COMPLETION_PROFILE_REQUEST_FIELDS = {
+    'request-reasoning': ['include_reasoning', value => isTrueBoolean(String(value))],
+    'reasoning-effort': ['reasoning_effort', value => String(value ?? '')],
+    'verbosity': ['verbosity', value => String(value ?? '')],
+    'enable-web-search': ['enable_web_search', value => isTrueBoolean(String(value))],
+    'request-images': ['request_images', value => isTrueBoolean(String(value))],
+    'request-image-resolution': ['request_image_resolution', value => String(value ?? '')],
+    'request-image-aspect-ratio': ['request_image_aspect_ratio', value => String(value ?? '')],
+    'custom-reasoning-preset': ['custom_reasoning_preset', value => String(value ?? '')],
+    'custom-reasoning-param-format': ['custom_reasoning_param_format', value => String(value ?? '')],
+    'custom-reasoning-param-name': ['custom_reasoning_param_name', value => String(value ?? '')],
+    'custom-reasoning-enabled-value': ['custom_reasoning_enabled_value', value => String(value ?? '')],
+    'custom-reasoning-disabled-value': ['custom_reasoning_disabled_value', value => String(value ?? '')],
+};
+
+function getChatCompletionProfileRequestOverrides(profile, overridePayload) {
+    const overrides = {};
+    const profileFieldNames = [];
+
+    for (const [profileKey, [requestKey, coerceValue]] of Object.entries(CHAT_COMPLETION_PROFILE_REQUEST_FIELDS)) {
+        if (!Object.hasOwn(profile, profileKey) || Object.hasOwn(overridePayload, requestKey)) {
+            continue;
+        }
+
+        overrides[requestKey] = coerceValue(profile[profileKey]);
+        profileFieldNames.push(requestKey);
+    }
+
+    return { overrides, profileFieldNames };
+}
 
 /**
  * Generates a caption for an image using a multimodal model.
@@ -393,6 +424,7 @@ export class ConnectionManagerRequestService {
         includePreset: true,
         includeInstruct: true,
         instructSettings: {},
+        modelOverride: '',
     };
 
     static getAllowedTypes() {
@@ -413,11 +445,12 @@ export class ConnectionManagerRequestService {
      * @param {boolean?} [custom.includePreset=true]
      * @param {boolean?} [custom.includeInstruct=true]
      * @param {Partial<InstructSettings>?} [custom.instructSettings] Override instruct settings
+     * @param {string?} [custom.modelOverride] Override model name
      * @param {Record<string, any>} [overridePayload] - Override payload for the request
      * @returns {Promise<import('../custom-request.js').ExtractedData | (() => AsyncGenerator<import('../custom-request.js').StreamResponse>)>} If not streaming, returns extracted data; if streaming, returns a function that creates an AsyncGenerator
      */
     static async sendRequest(profileId, prompt, maxTokens, custom = this.defaultSendRequestParams, overridePayload = {}) {
-        const { stream, signal, extractData, includePreset, includeInstruct, instructSettings } = { ...this.defaultSendRequestParams, ...custom };
+        const { stream, signal, extractData, includePreset, includeInstruct, instructSettings, modelOverride } = { ...this.defaultSendRequestParams, ...custom };
 
         const context = SillyTavern.getContext();
         if (context.extensionSettings.disabledExtensions.includes('connection-manager')) {
@@ -426,6 +459,7 @@ export class ConnectionManagerRequestService {
 
         const profile = this.getProfile(profileId);
         const selectedApiMap = this.validateProfile(profile);
+        const profileRequestOverrides = getChatCompletionProfileRequestOverrides(profile, overridePayload);
 
         try {
             switch (selectedApiMap.selected) {
@@ -436,18 +470,24 @@ export class ConnectionManagerRequestService {
 
                     const proxyPreset = proxies.find((p) => p.name === profile.proxy);
 
+                    const model = typeof modelOverride === 'string' && modelOverride.trim()
+                        ? modelOverride.trim()
+                        : profile.model;
                     const messages = Array.isArray(prompt) ? prompt : [{ role: 'user', content: prompt }];
                     const ccRequestData = {
                         stream,
                         messages,
                         max_tokens: maxTokens,
-                        model: profile.model,
+                        model,
                         chat_completion_source: selectedApiMap.source,
                         secret_id: profile['secret-id'],
                         reverse_proxy: proxyPreset?.url,
                         proxy_password: proxyPreset?.password,
                         custom_prompt_post_processing: profile['prompt-post-processing'],
+                        // SillyBunny: persist profile-scoped reasoning and image request settings through the shared request path.
+                        ...profileRequestOverrides.overrides,
                         ...overridePayload,
+                        __connectionProfileRequestFields: profileRequestOverrides.profileFieldNames,
                     };
 
                     // Only set the URL field for the actual API source to avoid contaminating

--- a/public/scripts/extensions/shared.js
+++ b/public/scripts/extensions/shared.js
@@ -22,7 +22,7 @@ const CHAT_COMPLETION_PROFILE_REQUEST_FIELDS = {
     'custom-reasoning-disabled-value': ['custom_reasoning_disabled_value', value => String(value ?? '')],
 };
 
-function getChatCompletionProfileRequestOverrides(profile, overridePayload) {
+export function getChatCompletionProfileRequestOverrides(profile, overridePayload) {
     const overrides = {};
     const profileFieldNames = [];
 

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -59,6 +59,8 @@ import {
     getStringHash,
     getVideoDurationFromDataURL,
     isDataURL,
+    isFalseBoolean,
+    isTrueBoolean,
     isUuid,
     isValidUrl,
     parseJsonFile,
@@ -72,7 +74,7 @@ import { isMobile } from './RossAscends-mods.js';
 import { saveLogprobsForActiveMessage } from './logprobs.js';
 import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
 import { SlashCommand } from './slash-commands/SlashCommand.js';
-import { ARGUMENT_TYPE, SlashCommandArgument } from './slash-commands/SlashCommandArgument.js';
+import { ARGUMENT_TYPE, SlashCommandArgument, SlashCommandNamedArgument } from './slash-commands/SlashCommandArgument.js';
 import { renderTemplateAsync } from './templates.js';
 import { SlashCommandEnumValue } from './slash-commands/SlashCommandEnumValue.js';
 import { callGenericPopup, Popup, POPUP_RESULT, POPUP_TYPE } from './popup.js';
@@ -8002,18 +8004,7 @@ async function onCustomizeParametersClick() {
     };
 
     const applyCustomReasoningPreset = (preset, { preserveValues = false } = {}) => {
-        oai_settings.custom_reasoning_preset = preset;
-
-        if (preset !== custom_reasoning_preset_types.CUSTOM) {
-            const presetConfig = getCustomReasoningPresetConfig(preset);
-            oai_settings.custom_reasoning_param_name = presetConfig.paramName;
-            oai_settings.custom_reasoning_param_format = presetConfig.format;
-            if (!preserveValues) {
-                oai_settings.custom_reasoning_enabled_value = presetConfig.enabledValue;
-                oai_settings.custom_reasoning_disabled_value = presetConfig.disabledValue;
-            }
-        }
-
+        setCustomReasoningPreset(preset, { preserveValues });
         syncCustomReasoningPopup();
         saveSettingsDebounced();
     };
@@ -8427,6 +8418,230 @@ function runProxyCallback(_, value) {
     return foundName;
 }
 
+function getSlashCommandStringValue(value) {
+    return String(value ?? '');
+}
+
+function getSlashCommandBooleanValue(value, commandName) {
+    if (isTrueBoolean(value)) {
+        return true;
+    }
+
+    if (isFalseBoolean(value)) {
+        return false;
+    }
+
+    throw new Error(t`Invalid value "${value}" for /${commandName}. Use true or false.`);
+}
+
+function getSlashCommandEnumValue(value, validValues, commandName) {
+    if (!validValues.includes(value)) {
+        throw new Error(t`Invalid value "${value}" for /${commandName}. Valid values are: ${validValues.join(', ')}`);
+    }
+
+    return value;
+}
+
+function hasSlashCommandValue(args, value) {
+    return isTrueBoolean(String(args?.force ?? 'false'))
+        || args?._hasUnnamedArgument
+        || String(value ?? '').trim().length > 0;
+}
+
+function syncCustomReasoningSettingControls() {
+    $('#custom_reasoning_preset').val(oai_settings.custom_reasoning_preset);
+    $('#custom_reasoning_param_name').val(oai_settings.custom_reasoning_param_name);
+    $('#custom_reasoning_param_format').val(oai_settings.custom_reasoning_param_format);
+    $('#custom_reasoning_enabled_value').val(oai_settings.custom_reasoning_enabled_value);
+    $('#custom_reasoning_disabled_value').val(oai_settings.custom_reasoning_disabled_value);
+
+    const format = String(oai_settings.custom_reasoning_param_format ?? custom_reasoning_param_formats.OPENAI);
+    const showToggleValues = [custom_reasoning_param_formats.STRING, custom_reasoning_param_formats.THINKING_OBJECT].includes(format);
+    $('.sb-custom-reasoning-toggle-values').toggle(showToggleValues);
+}
+
+function setCustomReasoningPreset(preset, { preserveValues = false } = {}) {
+    oai_settings.custom_reasoning_preset = preset;
+
+    if (preset !== custom_reasoning_preset_types.CUSTOM) {
+        const presetConfig = getCustomReasoningPresetConfig(preset);
+        oai_settings.custom_reasoning_param_name = presetConfig.paramName;
+        oai_settings.custom_reasoning_param_format = presetConfig.format;
+        if (!preserveValues) {
+            oai_settings.custom_reasoning_enabled_value = presetConfig.enabledValue;
+            oai_settings.custom_reasoning_disabled_value = presetConfig.disabledValue;
+        }
+    }
+
+    syncCustomReasoningSettingControls();
+}
+
+function markCustomReasoningPreset() {
+    oai_settings.custom_reasoning_preset = custom_reasoning_preset_types.CUSTOM;
+    syncCustomReasoningSettingControls();
+}
+
+function markCustomReasoningPresetForManualCommand(args) {
+    if (!isTrueBoolean(String(args?.quiet ?? 'false'))) {
+        markCustomReasoningPreset();
+    }
+}
+
+function runBooleanChatCompletionSettingCallback(commandName, settingName, selector, onChange = null) {
+    return (args, value) => {
+        const stringValue = getSlashCommandStringValue(value).trim();
+        if (!hasSlashCommandValue(args, value)) {
+            return String(Boolean(oai_settings[settingName]));
+        }
+
+        oai_settings[settingName] = getSlashCommandBooleanValue(stringValue, commandName);
+        $(selector).prop('checked', oai_settings[settingName]);
+        onChange?.();
+        saveSettingsDebounced();
+        return String(oai_settings[settingName]);
+    };
+}
+
+function runEnumChatCompletionSettingCallback(commandName, settingName, selector, validValues, onChange = null) {
+    return (args, value) => {
+        const stringValue = getSlashCommandStringValue(value).trim();
+        if (!hasSlashCommandValue(args, value)) {
+            return getSlashCommandStringValue(oai_settings[settingName]);
+        }
+
+        oai_settings[settingName] = getSlashCommandEnumValue(stringValue, validValues, commandName);
+        $(selector).val(oai_settings[settingName]);
+        onChange?.(args);
+        saveSettingsDebounced();
+        return getSlashCommandStringValue(oai_settings[settingName]);
+    };
+}
+
+function runStringChatCompletionSettingCallback(commandName, settingName, selector, onChange = null, validValues = null, normalizeValue = value => value) {
+    return (args, value) => {
+        if (!hasSlashCommandValue(args, value)) {
+            return getSlashCommandStringValue(oai_settings[settingName]);
+        }
+
+        const stringValue = normalizeValue(getSlashCommandStringValue(value).trim());
+        if (Array.isArray(validValues) && stringValue) {
+            getSlashCommandEnumValue(stringValue, validValues, commandName);
+        }
+
+        oai_settings[settingName] = stringValue;
+        $(selector).val(oai_settings[settingName]);
+        onChange?.(args);
+        saveSettingsDebounced();
+        return getSlashCommandStringValue(oai_settings[settingName]);
+    };
+}
+
+const REQUEST_IMAGE_RESOLUTION_VALUES = ['', '1K', '2K', '4K'];
+const REQUEST_IMAGE_ASPECT_RATIO_VALUES = ['', '1:1', '9:16', '16:9', '3:4', '4:3', '3:2', '2:3', '5:4', '4:5', '21:9'];
+
+function registerChatCompletionProfileSlashCommand({ name, callback, description, typeList = [ARGUMENT_TYPE.STRING], enumList = [], forceEnum = false }) {
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name,
+        callback,
+        returns: t`current value`,
+        namedArgumentList: [
+            SlashCommandNamedArgument.fromProps({
+                name: 'quiet',
+                description: t`suppress UI side effects where supported`,
+                typeList: [ARGUMENT_TYPE.BOOLEAN],
+                defaultValue: 'false',
+            }),
+        ],
+        unnamedArgumentList: [
+            SlashCommandArgument.fromProps({
+                description,
+                typeList,
+                enumList,
+                forceEnum,
+            }),
+        ],
+        helpString: `Sets the Chat Completion ${description}. Gets the current value if no argument is provided.`,
+    }));
+}
+
+function registerChatCompletionProfileSlashCommands() {
+    registerChatCompletionProfileSlashCommand({
+        name: 'request-reasoning',
+        callback: runBooleanChatCompletionSettingCallback('request-reasoning', 'show_thoughts', '#openai_show_thoughts', setToolReasoningControls),
+        description: 'request model reasoning setting',
+        typeList: [ARGUMENT_TYPE.BOOLEAN],
+    });
+    registerChatCompletionProfileSlashCommand({
+        name: 'reasoning-effort',
+        callback: runEnumChatCompletionSettingCallback('reasoning-effort', 'reasoning_effort', '#openai_reasoning_effort', Object.values(reasoning_effort_types)),
+        description: 'reasoning effort',
+        enumList: Object.values(reasoning_effort_types),
+        forceEnum: true,
+    });
+    registerChatCompletionProfileSlashCommand({
+        name: 'verbosity',
+        callback: runEnumChatCompletionSettingCallback('verbosity', 'verbosity', '#openai_verbosity', Object.values(verbosity_levels)),
+        description: 'verbosity',
+        enumList: Object.values(verbosity_levels),
+        forceEnum: true,
+    });
+    registerChatCompletionProfileSlashCommand({
+        name: 'enable-web-search',
+        callback: runBooleanChatCompletionSettingCallback('enable-web-search', 'enable_web_search', '#openai_enable_web_search', calculateOpenRouterCost),
+        description: 'web search request setting',
+        typeList: [ARGUMENT_TYPE.BOOLEAN],
+    });
+    registerChatCompletionProfileSlashCommand({
+        name: 'request-images',
+        callback: runBooleanChatCompletionSettingCallback('request-images', 'request_images', '#openai_request_images'),
+        description: 'inline image request setting',
+        typeList: [ARGUMENT_TYPE.BOOLEAN],
+    });
+    registerChatCompletionProfileSlashCommand({
+        name: 'request-image-resolution',
+        callback: runStringChatCompletionSettingCallback('request-image-resolution', 'request_image_resolution', '#request_image_resolution', null, REQUEST_IMAGE_RESOLUTION_VALUES, value => value.toLowerCase() === 'auto' ? '' : value),
+        description: 'requested image resolution',
+        enumList: ['auto', ...REQUEST_IMAGE_RESOLUTION_VALUES.filter(Boolean)],
+        forceEnum: true,
+    });
+    registerChatCompletionProfileSlashCommand({
+        name: 'request-image-aspect-ratio',
+        callback: runStringChatCompletionSettingCallback('request-image-aspect-ratio', 'request_image_aspect_ratio', '#request_image_aspect_ratio', null, REQUEST_IMAGE_ASPECT_RATIO_VALUES, value => value.toLowerCase() === 'auto' ? '' : value),
+        description: 'requested image aspect ratio',
+        enumList: ['auto', ...REQUEST_IMAGE_ASPECT_RATIO_VALUES.filter(Boolean)],
+        forceEnum: true,
+    });
+    registerChatCompletionProfileSlashCommand({
+        name: 'custom-reasoning-preset',
+        callback: runEnumChatCompletionSettingCallback('custom-reasoning-preset', 'custom_reasoning_preset', '#custom_reasoning_preset', Object.values(custom_reasoning_preset_types), () => setCustomReasoningPreset(oai_settings.custom_reasoning_preset)),
+        description: 'custom reasoning preset',
+        enumList: Object.values(custom_reasoning_preset_types),
+        forceEnum: true,
+    });
+    registerChatCompletionProfileSlashCommand({
+        name: 'custom-reasoning-param-format',
+        callback: runEnumChatCompletionSettingCallback('custom-reasoning-param-format', 'custom_reasoning_param_format', '#custom_reasoning_param_format', Object.values(custom_reasoning_param_formats), markCustomReasoningPresetForManualCommand),
+        description: 'custom reasoning parameter format',
+        enumList: Object.values(custom_reasoning_param_formats),
+        forceEnum: true,
+    });
+    registerChatCompletionProfileSlashCommand({
+        name: 'custom-reasoning-param-name',
+        callback: runStringChatCompletionSettingCallback('custom-reasoning-param-name', 'custom_reasoning_param_name', '#custom_reasoning_param_name', markCustomReasoningPresetForManualCommand),
+        description: 'custom reasoning parameter name',
+    });
+    registerChatCompletionProfileSlashCommand({
+        name: 'custom-reasoning-enabled-value',
+        callback: runStringChatCompletionSettingCallback('custom-reasoning-enabled-value', 'custom_reasoning_enabled_value', '#custom_reasoning_enabled_value', markCustomReasoningPresetForManualCommand),
+        description: 'custom reasoning enabled value',
+    });
+    registerChatCompletionProfileSlashCommand({
+        name: 'custom-reasoning-disabled-value',
+        callback: runStringChatCompletionSettingCallback('custom-reasoning-disabled-value', 'custom_reasoning_disabled_value', '#custom_reasoning_disabled_value', markCustomReasoningPresetForManualCommand),
+        description: 'custom reasoning disabled value',
+    });
+}
+
 /**
  * Handle Vertex AI authentication mode change
  */
@@ -8593,6 +8808,8 @@ export function initOpenAI() {
         ],
         helpString: 'Sets a proxy preset by name.',
     }));
+    // SillyBunny: Connection Manager snapshots Chat Completion request behavior via slash commands.
+    registerChatCompletionProfileSlashCommands();
 
     $('#test_api_button').on('click', testApiConnection);
 

--- a/tests/connection-profile-request-fields.test.js
+++ b/tests/connection-profile-request-fields.test.js
@@ -1,0 +1,160 @@
+import { describe, expect, jest, test } from '@jest/globals';
+
+await jest.unstable_mockModule('../public/script.js', () => ({
+    CONNECT_API_MAP: {},
+    createModelIcon: jest.fn(),
+    getRequestHeaders: jest.fn(() => ({})),
+}));
+
+await jest.unstable_mockModule('../public/scripts/extensions.js', () => ({
+    extension_settings: {
+        caption: {},
+    },
+    openThirdPartyExtensionMenu: jest.fn(),
+}));
+
+await jest.unstable_mockModule('../public/scripts/i18n.js', () => ({
+    t: (strings, ...values) => strings.reduce((text, part, index) => `${text}${part}${values[index] ?? ''}`, ''),
+}));
+
+await jest.unstable_mockModule('../public/scripts/openai.js', () => ({
+    oai_settings: {},
+    proxies: [],
+    ZAI_ENDPOINT: {
+        COMMON: 'common',
+    },
+}));
+
+await jest.unstable_mockModule('../public/scripts/secrets.js', () => ({
+    SECRET_KEYS: {},
+    secret_state: {},
+}));
+
+await jest.unstable_mockModule('../public/scripts/textgen-settings.js', () => ({
+    textgen_types: {},
+    textgenerationwebui_settings: {},
+}));
+
+await jest.unstable_mockModule('../public/scripts/tokenizers.js', () => ({
+    getTokenCountAsync: jest.fn(async () => 0),
+}));
+
+await jest.unstable_mockModule('../public/scripts/utils.js', () => ({
+    createThumbnail: jest.fn(async value => value),
+    isTrueBoolean: value => ['on', 'true', '1'].includes(String(value ?? '').trim().toLowerCase()),
+    isValidUrl: jest.fn(() => true),
+}));
+
+const { getChatCompletionProfileRequestOverrides } = await import('../public/scripts/extensions/shared.js');
+
+const mappedRequestFieldNames = [
+    'include_reasoning',
+    'reasoning_effort',
+    'verbosity',
+    'enable_web_search',
+    'request_images',
+    'request_image_resolution',
+    'request_image_aspect_ratio',
+    'custom_reasoning_preset',
+    'custom_reasoning_param_format',
+    'custom_reasoning_param_name',
+    'custom_reasoning_enabled_value',
+    'custom_reasoning_disabled_value',
+];
+
+function createReasoningProfile(overrides = {}) {
+    return {
+        id: 'profile-reasoning',
+        mode: 'cc',
+        name: 'Reasoning Profile',
+        api: 'openai',
+        model: 'gpt-5.2',
+        'request-reasoning': 'true',
+        'reasoning-effort': 'high',
+        'verbosity': 'low',
+        'enable-web-search': '1',
+        'request-images': 'off',
+        'request-image-resolution': '2K',
+        'request-image-aspect-ratio': '16:9',
+        'custom-reasoning-preset': 'custom',
+        'custom-reasoning-param-format': 'thinking_object',
+        'custom-reasoning-param-name': 'thinking',
+        'custom-reasoning-enabled-value': 'enabled',
+        'custom-reasoning-disabled-value': 'disabled',
+        ...overrides,
+    };
+}
+
+describe('Connection Profile chat-completion request field mapping', () => {
+    test('leaves existing profiles without reasoning request keys unchanged', () => {
+        const legacyProfile = {
+            id: 'profile-legacy',
+            mode: 'cc',
+            name: 'Legacy Profile',
+            api: 'openai',
+            model: 'gpt-4o-mini',
+            preset: 'Default',
+        };
+
+        const result = getChatCompletionProfileRequestOverrides(legacyProfile, {});
+
+        expect(result).toEqual({
+            overrides: {},
+            profileFieldNames: [],
+        });
+        expect(legacyProfile).toEqual({
+            id: 'profile-legacy',
+            mode: 'cc',
+            name: 'Legacy Profile',
+            api: 'openai',
+            model: 'gpt-4o-mini',
+            preset: 'Default',
+        });
+    });
+
+    test('maps reasoning, web search, image, and custom reasoning profile keys to request fields', () => {
+        const result = getChatCompletionProfileRequestOverrides(createReasoningProfile(), {});
+
+        expect(result).toEqual({
+            overrides: {
+                include_reasoning: true,
+                reasoning_effort: 'high',
+                verbosity: 'low',
+                enable_web_search: true,
+                request_images: false,
+                request_image_resolution: '2K',
+                request_image_aspect_ratio: '16:9',
+                custom_reasoning_preset: 'custom',
+                custom_reasoning_param_format: 'thinking_object',
+                custom_reasoning_param_name: 'thinking',
+                custom_reasoning_enabled_value: 'enabled',
+                custom_reasoning_disabled_value: 'disabled',
+            },
+            profileFieldNames: mappedRequestFieldNames,
+        });
+    });
+
+    test('lets explicit caller overrides beat profile values', () => {
+        const overridePayload = {
+            include_reasoning: false,
+            reasoning_effort: 'low',
+            enable_web_search: false,
+            request_image_resolution: '1K',
+            custom_reasoning_param_name: 'caller_reasoning',
+        };
+
+        const result = getChatCompletionProfileRequestOverrides(createReasoningProfile(), overridePayload);
+
+        expect(result.overrides).toEqual({
+            verbosity: 'low',
+            request_images: false,
+            request_image_aspect_ratio: '16:9',
+            custom_reasoning_preset: 'custom',
+            custom_reasoning_param_format: 'thinking_object',
+            custom_reasoning_enabled_value: 'enabled',
+            custom_reasoning_disabled_value: 'disabled',
+        });
+        expect(result.profileFieldNames).toEqual(mappedRequestFieldNames.filter(field => !Object.hasOwn(overridePayload, field)));
+        expect({ ...result.overrides, ...overridePayload }).toEqual(expect.objectContaining(overridePayload));
+    });
+});


### PR DESCRIPTION
## What?
- Add Chat Completion Connection Profile support for reasoning, verbosity, web search, image request, image request shape, and custom reasoning settings.
- Replay those settings through profile apply and shared profile-generation request paths.
- Preserve explicit profile booleans and caller override precedence when profile-backed requests include these fields.

## Why?
Connection Profiles could save provider, model, preset, and related request basics, but newer Chat Completion request behavior was not captured. Users had to manually reapply reasoning, search, image, and custom reasoning settings after switching profiles, and profile-backed generation could drift from the saved UI state.

## How?
- Adds Connection Manager command and friendly-name coverage for the new Chat Completion fields.
- Registers slash command callbacks that read and write the corresponding OpenAI settings and UI controls.
- Maps profile fields into profile-backed request overrides while leaving direct caller overrides authoritative.
- Normalizes profile boolean payload fields before backend generation.

## Testing?
- `git diff --check`
- `node --check public/scripts/custom-request.js`
- `node --check public/scripts/extensions/shared.js`
- `node --check public/scripts/extensions/connection-manager/index.js`
- `node --check public/scripts/openai.js`
- `npm run lint`
- `npm run lint --prefix tests`
- `npm run test:unit --prefix tests -- openai-preset-utils.test.js`
- `npm run test:unit --prefix tests`
- `npm run check:frontend-budgets`
- Local Chrome DevTools smoke on isolated data with non-4444 `127.0.0.1:4461`: completed first-run onboarding, opened API / Connection Profile, set request reasoning=true, reasoning effort=high, verbosity=medium, web search=true, request images=true, image resolution=2K, image aspect ratio=16:9, custom reasoning preset=custom, custom reasoning format=string, custom reasoning parameter name=reasoning_mode, enabled value=enabled, disabled value=disabled; created a Chat Completion profile through the live Connection Manager runtime, verified profile details contained every new field, changed all fields away, reloaded the profile, verified settings and UI controls returned to the profiled values, and shut the server down.

## Screenshots (optional)
- Local smoke screenshot captured; not attached to avoid adding local artifacts to the PR body. Chrome DevTools accessibility snapshot confirmed the profile details rows for Request Model Reasoning, Reasoning Effort, Verbosity, Enable Web Search, Request Inline Images, image resolution/aspect ratio, and all custom reasoning fields.

## Anything Else?
- Smoke used an isolated temporary data root and no real provider key.
- No `data/default-user` changes, secrets, dependency changes, or lockfile churn are included.