### PR TITLE
fix: tighten advanced formatting mobile header

### DIFF
--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -4883,6 +4883,15 @@ input[type='range']::-moz-range-thumb {
         min-width: 68px;
     }
 
+    #AdvancedFormatting > .flex-container.alignItemsBaseline {
+        gap: 8px;
+    }
+
+    #af_master_import > span,
+    #af_master_export > span {
+        display: none;
+    }
+
     #PersonaManagement .persona-management-actions {
         display: grid;
         grid-template-columns: repeat(3, minmax(0, 1fr));


### PR DESCRIPTION
## Summary
- Hide Advanced Formatting master import/export labels on mobile so the header does not overlap
- Slightly reduce the mobile header gap for the Text Completions Advanced Formatting drawer

## Testing
- git diff --check