### PR TITLE
chore: v1.6.0 pre-release cleanup

### DIFF
--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -706,6 +706,8 @@ class PromptManager {
             }
         };
 
+        // SillyBunny: the prompt editor now exposes a preview tab that needs its own
+        // click handler and state sync separate from upstream edit/inspect flows.
         this.handlePromptEditorTabClick = (event) => {
             const tabName = event.currentTarget?.dataset?.tab;
             if (!['edit', 'preview'].includes(tabName)) return;
@@ -1099,6 +1101,7 @@ class PromptManager {
         // Clear forms on closing the popup
         document.getElementById(this.configuration.prefix + 'prompt_manager_popup_entry_form_close').addEventListener('click', closeAndClearPopup);
         document.getElementById(this.configuration.prefix + 'prompt_manager_popup_close_button').addEventListener('click', closeAndClearPopup);
+        // SillyBunny: preview mode has its own close button and field listeners.
         document.getElementById(this.configuration.prefix + 'prompt_manager_popup_preview_close_button').addEventListener('click', closeAndClearPopup);
         document.querySelectorAll('.' + this.configuration.prefix + 'prompt_manager_tab_button').forEach(button => {
             button.addEventListener('click', this.handlePromptEditorTabClick);

--- a/public/scripts/browser-fixes.js
+++ b/public/scripts/browser-fixes.js
@@ -162,6 +162,8 @@ function applyBrowserFixes() {
         const applyPositionFix = ({ force = false } = {}) => {
             updateViewportBaseline();
 
+            // SillyBunny: do not force the viewport fix while the mobile shell is
+            // actively editing an input; that can disrupt IME composition and text fixes.
             // Avoid force-pinning the root while Android IMEs are actively
             // editing text. That can break replacement/correction targets and
             // make accepted suggestions append at the end of the field instead.

--- a/public/scripts/chats.js
+++ b/public/scripts/chats.js
@@ -166,6 +166,8 @@ export async function hideChatMessageRange(start, end, unhide, nameFitler = null
     refreshSwipeButtons();
 
     await saveChatConditional();
+    // SillyBunny: keep chat listeners in sync after range-hiding messages so the
+    // shell and footer controls can refresh immediately.
     await eventSource.emit(event_types.MESSAGE_UPDATED, start);
 }
 
@@ -907,6 +909,7 @@ function expandMessageMedia(messageId, mediaIndex) {
         function getImageElement() {
             const img = document.createElement('img');
             img.src = mediaAttachment.url;
+            // SillyBunny: defer enlarged image decoding to keep large chats responsive.
             img.loading = 'lazy';
             img.decoding = 'async';
             img.classList.add('img_enlarged');

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -431,7 +431,7 @@ function maybeShowMoonlitEchoesMovedNotice() {
             const button = toast?.querySelector?.(`.${buttonClass}`);
             button?.addEventListener('click', async () => {
                 accountStorage.setItem(MOONLIT_ECHOES_NOTICE_STORAGE_KEY, 'true');
-                await window.SillyBunnyShell?.highlightLaunchpadItem?.(SILLYBUNNY_MOONLIT_ECHOES_EXTENSION_NAME);
+                await globalThis.SillyBunnyShell?.highlightLaunchpadItem?.(SILLYBUNNY_MOONLIT_ECHOES_EXTENSION_NAME);
             });
         },
         onCloseClick() {

--- a/public/scripts/extensions/caption/index.js
+++ b/public/scripts/extensions/caption/index.js
@@ -162,6 +162,8 @@ async function captionExistingMessage(message, mediaIndex) {
         message.mes = wrappedCaption;
         mediaAttachment.title = wrappedCaption;
         mediaAttachment.captioned = true;
+        // SillyBunny: caption-only messages need their token counts refreshed after
+        // the synthetic caption text replaces the empty user body.
         await updateMessageTokenAccounting(message);
     } else {
         message.extra.inline_image = true;

--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -348,6 +348,8 @@ function getWorldInfoActiveCount() {
 }
 
 function enrichProfileSnapshot(profile) {
+    // SillyBunny: include fork-only connection summary fields so exported profile
+    // snapshots still reflect the active shell state when reopened later.
     profile['active-agents'] = getActiveAgentsSummary();
     profile.samplers = getSamplerSummary();
     profile['instruct-template'] = readInputDisplayValue('#instruct_presets') || profile.instruct || NONE;
@@ -972,7 +974,7 @@ export async function init() {
         const profile = extension_settings.connectionManager.profiles.find(p => p.id === profileId);
 
         if (!profile) {
-            console.log(`Profile not found: ${profileId}`);
+            console.debug(`Profile not found: ${profileId}`);
             return;
         }
 
@@ -1002,7 +1004,7 @@ export async function init() {
         const selectedProfile = extension_settings.connectionManager.selectedProfile;
         const profile = extension_settings.connectionManager.profiles.find(p => p.id === selectedProfile);
         if (!profile) {
-            console.log('No profile selected');
+            console.debug('No profile selected');
             return;
         }
         ++profileApplySequence;
@@ -1045,7 +1047,7 @@ export async function init() {
         const selectedProfile = extension_settings.connectionManager.selectedProfile;
         const profile = extension_settings.connectionManager.profiles.find(p => p.id === selectedProfile);
         if (!profile) {
-            console.log('No profile selected');
+            console.debug('No profile selected');
             return;
         }
         const oldProfile = structuredClone(profile);
@@ -1088,7 +1090,7 @@ export async function init() {
         const selectedProfile = extension_settings.connectionManager.selectedProfile;
         const profile = extension_settings.connectionManager.profiles.find(p => p.id === selectedProfile);
         if (!profile) {
-            console.log('No profile selected');
+            console.debug('No profile selected');
             return;
         }
         if (!Array.isArray(profile.exclude)) {

--- a/public/scripts/extensions/translate/index.js
+++ b/public/scripts/extensions/translate/index.js
@@ -533,6 +533,8 @@ async function translateOutgoingMessage(messageId) {
     const originalText = message.mes;
     message.extra.display_text = originalText;
     message.mes = await translate(originalText, extension_settings.translate.internal_language);
+    // SillyBunny: translated assistant text should keep token accounting aligned
+    // with the visible message body.
     await updateMessageTokenAccounting(message);
     updateMessageBlock(messageId, message);
 

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -3788,7 +3788,7 @@ jQuery(() => {
         const groupId = $(this).attr('data-chid') || $(this).attr('data-grid');
         openGroupById(groupId);
         if (shouldCloseCharacterMenu) {
-            window.SillyBunnyShell?.closeCharacters?.();
+            globalThis.SillyBunnyShell?.closeCharacters?.();
         }
     });
     $('#rm_group_filter').on('input', filterGroupMembers);

--- a/public/scripts/logprobs.js
+++ b/public/scripts/logprobs.js
@@ -82,6 +82,8 @@ function renderAlternativeTokensView() {
     renderTopLogprobs();
 
     const { messageLogprobs, continueFrom } = getActiveMessageLogprobData() || {};
+    // SillyBunny: honor the iOS WebKit smooth-streaming bypass so token
+    // probability UI state matches the stream renderer's effective mode.
     const usingSmoothStreaming = isStreamingEnabled() && isSmoothStreamingEffectivelyEnabled({
         smoothStreaming: power_user.smooth_streaming,
         iosWebKitDisableSmoothStreaming: power_user.ios_webkit_disable_smooth_streaming,

--- a/public/scripts/mobile-streaming.js
+++ b/public/scripts/mobile-streaming.js
@@ -16,6 +16,8 @@ export function isSmoothStreamingEffectivelyEnabled({
     iosWebKitDisableSmoothStreaming = false,
     navigatorRef = globalThis.navigator,
 } = {}) {
+    // SillyBunny: let iOS WebKit opt out of smooth streaming even when the global
+    // preference is enabled, because that platform is the main regression target.
     return Boolean(smoothStreaming) && !(Boolean(iosWebKitDisableSmoothStreaming) && isIOSWebKitPlatform(navigatorRef));
 }
 

--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -157,6 +157,8 @@ function snapshotAllPresetManagers() {
 }
 
 function registerPresetDirtySnapshots() {
+    // SillyBunny: keep preset dirty-state tracking aligned with the extra
+    // text fields and template drawers added outside the upstream preset UI.
     eventSource.on(event_types.SETTINGS_LOADED, snapshotAllPresetManagers);
     eventSource.on(event_types.APP_READY, snapshotAllPresetManagers);
     eventSource.on(event_types.PRESET_CHANGED, (data = {}) => {
@@ -198,6 +200,8 @@ class PresetManager {
         this._textInputHandler = () => this._checkDirty();
         this._selectChangeHandler = (event) => this._handleSelectChange(event);
         this._capturePreviousSelectValueHandler = () => this._capturePreviousSelectValue();
+        // SillyBunny: snapshot and guard all connected text fields before preset
+        // changes so unsaved changes in fork-specific drawers can still warn.
         this._bindDirtyGuard();
     }
 

--- a/public/scripts/reasoning.js
+++ b/public/scripts/reasoning.js
@@ -685,6 +685,8 @@ export class ReasoningHandler {
         // SillyBunny: iOS WebKit can force-reload under reasoning-heavy streams if we
         // format and morph a growing hidden reasoning block on every live tick.
         if (shouldRenderReasoning) {
+            // SillyBunny: throttle live reasoning DOM work on iOS WebKit so large
+            // hidden reasoning blocks do not cause aggressive repaint or reload loops.
             const reasoning = trimSpaces(this.reasoningDisplayText ?? this.reasoning);
             const displayReasoning = messageFormatting(reasoning, '', false, false, messageId, {}, true);
 
@@ -1456,6 +1458,8 @@ function setReasoningEventHandlers() {
             return;
         }
         updateReasoningFromValue(message, newReasoning);
+        // SillyBunny: keep edited reasoning blocks counted the same way as the
+        // fork's live reasoning parse path so token totals stay consistent.
         await updateMessageTokenAccounting(message, {
             reasoning: message.extra.reasoning,
             reasoningTokens: 0,
@@ -1523,6 +1527,7 @@ function setReasoningEventHandlers() {
         message.extra.reasoning = '';
         delete message.extra.reasoning_type;
         delete message.extra.reasoning_duration;
+        // SillyBunny: clearing reasoning must also clear its token accounting.
         await updateMessageTokenAccounting(message, {
             reasoning: '',
             reasoningTokens: 0,

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -12398,7 +12398,7 @@ function initAll() {
     // Group Advanced Formatting sections into collapsible drawers
     groupAdvancedFormattingIntoDrawers();
 
-    window.SillyBunnyShell = Object.assign(window.SillyBunnyShell || {}, {
+    globalThis.SillyBunnyShell = Object.assign(globalThis.SillyBunnyShell || {}, {
         openTab(shellKey, tabId) {
             if (shellKey === 'characters') {
                 openCharacterPanelTab(tabId);

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -1500,6 +1500,8 @@ export function initDefaultSlashCommands() {
         aliases: ['default'],
         helpString: t`Sets the message style to flat chat mode.`,
     }));
+    // SillyBunny: expose extra chat style aliases so shell-specific styles can be
+    // switched from slash commands without touching the upstream style list.
     registerChatStyleSlashCommand({
         name: 'echostyle',
         callback: setEchoModeCallback,

--- a/public/scripts/sse-stream.js
+++ b/public/scripts/sse-stream.js
@@ -380,6 +380,8 @@ export class SmoothEventSourceStream extends EventSourceStream {
 }
 
 export function getEventSourceStream() {
+    // SillyBunny: smooth streaming can be disabled specifically for iOS
+    // WebKit even when the normal upstream setting remains enabled.
     if (isSmoothStreamingEffectivelyEnabled({
         smoothStreaming: power_user.smooth_streaming,
         iosWebKitDisableSmoothStreaming: power_user.ios_webkit_disable_smooth_streaming,

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -145,6 +145,8 @@ const KOBOLDCPP_ORDER = [6, 0, 1, 3, 4, 2, 5];
 
 function shouldUseLocalPromptCache(settings) {
     const serverUrl = getTextGenServer(settings?.type);
+    // SillyBunny: only keep prompt cache hot for local backends; remote servers
+    // should not inherit the helper-generation cache lane.
     return isLikelyLocalServerUrl(serverUrl, window.location.href);
 }
 
@@ -1837,6 +1839,8 @@ export function createTextGenGenerationData(settings, model, finalPrompt = null,
     }
 
     if (shouldUseLocalPromptCache(settings)) {
+        // SillyBunny: helper generations use the auxiliary cache lane unless the
+        // caller explicitly requests the main chat lane.
         if (cacheScope === 'main') {
             params.cache_prompt = true;
         } else {

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -2634,6 +2634,8 @@ export async function showFontAwesomePicker(customList = null) {
                         }
                     }
 
+                    // SillyBunny: keep matching icons at the front while preserving
+                    // the full icon grid so keyboard navigation remains stable.
                     const ordered = query
                         ? [...result, ...faList.filter(fa => !resultSet.has(fa))]
                         : faList;

--- a/public/scripts/welcome-screen.js
+++ b/public/scripts/welcome-screen.js
@@ -1039,8 +1039,8 @@ async function highlightLaunchpadItem(extensionId) {
     return true;
 }
 
-window.SillyBunnyShell = window.SillyBunnyShell || {};
-window.SillyBunnyShell.highlightLaunchpadItem = highlightLaunchpadItem;
+globalThis.SillyBunnyShell = globalThis.SillyBunnyShell || {};
+globalThis.SillyBunnyShell.highlightLaunchpadItem = highlightLaunchpadItem;
 
 /**
  * Gets the filter bucket used by the Recent Chats tabs.
@@ -1124,8 +1124,8 @@ function openShellTab(route) {
         return;
     }
 
-    if (window.SillyBunnyShell?.openTab) {
-        window.SillyBunnyShell.openTab(shellKey, tabId);
+    if (globalThis.SillyBunnyShell?.openTab) {
+        globalThis.SillyBunnyShell.openTab(shellKey, tabId);
         return;
     }
 
@@ -1375,13 +1375,13 @@ async function handleWelcomeAction(button, sendTextArea) {
             }
             break;
         case 'open-characters-menu':
-            window.SillyBunnyShell?.openCharacters?.();
+            globalThis.SillyBunnyShell?.openCharacters?.();
             break;
         case 'open-global-search':
-            window.SillyBunnyShell?.openGlobalSearch?.({ focusInput: true });
+            globalThis.SillyBunnyShell?.openGlobalSearch?.({ focusInput: true });
             break;
         case 'open-import-characters': {
-            window.SillyBunnyShell?.openCharacters?.();
+            globalThis.SillyBunnyShell?.openCharacters?.();
             const importButton = document.getElementById('character_import_button')
                 || document.getElementById('character_import_paste_button')
                 || document.querySelector('.open_characters_library');

--- a/src/endpoints/secrets.js
+++ b/src/endpoints/secrets.js
@@ -475,6 +475,8 @@ export function deleteSecret(directories, key) {
  * @returns {string} Secret value
  */
 export function readSecret(directories, key, id = null) {
+    // SillyBunny: preserve the upstream call shape while allowing profile-linked
+    // secrets to be resolved by explicit ID when the caller has one.
     return new SecretManager(directories).readSecret(key, id);
 }
 

--- a/tests/default-preset-deletions.test.js
+++ b/tests/default-preset-deletions.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable playwright/no-duplicate-hooks */
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';

--- a/tests/frontend/MacroEngine.e2e.js
+++ b/tests/frontend/MacroEngine.e2e.js
@@ -518,7 +518,7 @@ test.describe('MacroEngine', () => {
 
             const testWarnings = warnings.filter(w => w.includes('Macro "test-list-bounds"') && w.includes('unnamed arguments'));
             // We expect one warning for each invalid invocation (too few and too many list args)
-            expect(testWarnings.length).toBe(2);
+            expect(testWarnings).toHaveLength(2);
         });
 
         test('should resolve nested macros in arguments, even though the outer macro has wrong number of arguments', async ({ page }) => {
@@ -722,7 +722,7 @@ test.describe('MacroEngine', () => {
             });
 
             const parts = output.split('###');
-            expect(parts.length).toBe(2);
+            expect(parts).toHaveLength(2);
 
             // Extract seeds from both results
             const seed1 = parts[0].match(/seed:([^|]+)/)?.[1];
@@ -760,7 +760,7 @@ test.describe('MacroEngine', () => {
             });
 
             const parts = output.split('###');
-            expect(parts.length).toBe(2);
+            expect(parts).toHaveLength(2);
 
             const seed1 = parts[0].match(/seed:([^|]+)/)?.[1];
             const seed2 = parts[1].match(/seed:([^|]+)/)?.[1];
@@ -787,7 +787,7 @@ test.describe('MacroEngine', () => {
             });
 
             const parts = output.split('###');
-            expect(parts.length).toBe(2);
+            expect(parts).toHaveLength(2);
 
             const seed1 = parts[0].match(/seed:([^|]+)/)?.[1];
             const seed2 = parts[1].match(/seed:([^|]+)/)?.[1];
@@ -840,7 +840,7 @@ test.describe('MacroEngine', () => {
             });
 
             const parts = output.split('###');
-            expect(parts.length).toBe(2);
+            expect(parts).toHaveLength(2);
 
             const seed1 = parts[0].match(/seed:([^|]+)/)?.[1];
             const seed2 = parts[1].match(/seed:([^|]+)/)?.[1];

--- a/tests/frontend/MacroLexer.e2e.js
+++ b/tests/frontend/MacroLexer.e2e.js
@@ -23,6 +23,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{}}
         test('should handle empty macro', async ({ page }) => {
             const input = '{{}}';
@@ -35,6 +36,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{   user   }}
         test('should handle macro with leading and trailing whitespace inside', async ({ page }) => {
             const input = '{{   user   }}';
@@ -48,6 +50,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{macro1}}{{macro2}}
         test('should handle multiple sequential macros', async ({ page }) => {
             const input = '{{macro1}}{{macro2}}';
@@ -83,6 +86,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{doStuff "inner {{nested}} string"}}
         test('should handle macros with nested quotation marks', async ({ page }) => {
             const input = '{{doStuff "inner {{nested}} string"}}';
@@ -119,6 +123,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{ some macro }}
         test('should only capture the first identifier as macro identifier when there are whitespaces between two valid identifiers', async ({ page }) => {
             const input = '{{ some macro }}';
@@ -133,6 +138,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{my2cents}}
         test('should allow numerics inside the macro identifier', async ({ page }) => {
             const input = '{{my2cents}}';
@@ -146,6 +152,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{SCREAM}}
         test('should allow capslock macro', async ({ page }) => {
             const input = '{{SCREAM}}';
@@ -159,6 +166,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{some-longer-macro}}
         test('should allow dashes in macro identifiers', async ({ page }) => {
             const input = '{{some-longer-macro}}';
@@ -172,6 +180,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{legacy_macro}}
         test('should allow underscores as legacy in macro identifiers', async ({ page }) => {
             const input = '{{legacy_macro}}';
@@ -207,6 +216,7 @@ test.describe('MacroLexer', () => {
 
                 expect(tokens).toEqual(expectedTokens);
             });
+
             // {{ma!@#%ro}}
             test('[Error] should not parse invalid chars in macro identifier as valid macro identifier', async ({ page }) => {
                 const input = '{{ma!@#%ro}}';
@@ -251,6 +261,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{doStuff key=MyValue another=AnotherValue}}
         test('should handle named arguments with key=value syntax', async ({ page }) => {
             const input = '{{doStuff key=MyValue another=AnotherValue}}';
@@ -270,6 +281,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{getvar key="My variable"}}
         test('should handle named arguments with quotation marks', async ({ page }) => {
             const input = '{{getvar key="My variable"}}';
@@ -289,6 +301,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{getvar KEY=big}}
         test('should handle capslock argument name identifiers', async ({ page }) => {
             const input = '{{getvar KEY=big}}';
@@ -305,6 +318,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{dostuff longer-key=value}}
         test('should handle argument name identifiers with dashes', async ({ page }) => {
             const input = '{{dostuff longer-key=value}}';
@@ -321,6 +335,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{macro legacy_key=blah}}
         test('should handle legacy argument name identifiers', async ({ page }) => {
             const input = '{{macro legacy_key=blah}}';
@@ -337,6 +352,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{roll:1d4}}
         test('should handle argument with legacy one colon syntax to start the arguments', async ({ page }) => {
             const input = '{{roll:1d4}}';
@@ -353,6 +369,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{random "this" "and that" "and some more"}}
         test('should handle multiple unnamed arguments in quotation marks', async ({ page }) => {
             const input = '{{random "this" "and that" "and some more"}}';
@@ -378,6 +395,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{doStuff key="My Spaced Value" otherKey=SingleKey}}
         test('should handle named arguments with mixed style', async ({ page }) => {
             const input = '{{doStuff key="My Spaced Value" otherKey=SingleKey}}';
@@ -401,6 +419,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{doStuff key=}}
         test('should handle macros with empty named arguments', async ({ page }) => {
             const input = '{{doStuff key=}}';
@@ -416,6 +435,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{random "" ""}}
         test('should handle empty unnamed arguments if quoted', async ({ page }) => {
             const input = '{{random "" ""}}';
@@ -433,6 +453,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{doStuff special chars #!@&*()}}
         test('should handle macros with special characters in arguments', async ({ page }) => {
             const input = '{{doStuff special chars #!@&*()}}';
@@ -455,6 +476,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{longMacro arg1="value1" arg2="value2" arg3="value3"}}
         test('should handle long macros with multiple arguments', async ({ page }) => {
             const input = '{{longMacro arg1="value1" arg2="value2" arg3="value3"}}';
@@ -483,6 +505,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{complexMacro "text with {{nested}} content" key=val}}
         test('should handle macros with complex argument patterns', async ({ page }) => {
             const input = '{{complexMacro "text with {{nested}} content" key=val}}';
@@ -525,6 +548,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{?lazy}}
         test('should support ? flag', async ({ page }) => {
             const input = '{{?lazy}}';
@@ -539,6 +563,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{~reevaluate}}
         test('should support ~ flag', async ({ page }) => {
             const input = '{{~reevaluate}}';
@@ -553,6 +578,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{/if}}
         test('should support / flag', async ({ page }) => {
             const input = '{{/if}}';
@@ -567,6 +593,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{#legacy}}
         test('should support legacy # flag', async ({ page }) => {
             const input = '{{#legacy}}';
@@ -581,6 +608,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{  !  identifier  }}
         test('should allow whitespaces around flags', async ({ page }) => {
             const input = '{{  !  identifier  }}';
@@ -595,6 +623,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{ ?~lateragain }}
         test('should support multiple flags', async ({ page }) => {
             const input = '{{ ?~lateragain }}';
@@ -610,6 +639,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{ ! .importantvariable }}
         test('should support multiple flags with whitespace', async ({ page }) => {
             const input = '{{ !#importantvariable }}';
@@ -625,6 +655,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{>filtered}}
         test('should support > filter flag as separate token', async ({ page }) => {
             const input = '{{>filtered}}';
@@ -639,6 +670,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{ ! > user }}
         test('should support filter flag combined with other flags', async ({ page }) => {
             const input = '{{ ! > user }}';
@@ -654,6 +686,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{ a shaaark }}
         test('should not capture single letter as flag, but as macro identifiers', async ({ page }) => {
             const input = '{{ a shaaark }}';
@@ -686,6 +719,7 @@ test.describe('MacroLexer', () => {
 
                 expect(tokens).toEqual(expectedTokens);
             });
+
             // {{ 2 cents }}
             test('should not capture numbers as flag - they are also invalid macro identifiers', async ({ page }) => {
                 const input = '{{ 2 cents }}';
@@ -947,6 +981,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{macro | outputModifier arg1=val1 arg2=val2}}
         test('should support output modifier with named arguments', async ({ page }) => {
             const input = '{{macro | outputModifier arg1=val1 arg2=val2}}';
@@ -968,6 +1003,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{macro | outputModifier "unnamed1" "unnamed2"}}
         test('should support output modifier with unnamed arguments', async ({ page }) => {
             const input = '{{macro | outputModifier "unnamed1" "unnamed2"}}';
@@ -989,6 +1025,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{macro arg1=val1 | outputModifier arg2=val2 "unnamed1"}}
         test('should support macro arguments before output modifier', async ({ page }) => {
             const input = '{{macro arg1=val1 | outputModifier arg2=val2 "unnamed1"}}';
@@ -1013,6 +1050,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{macro | outputModifier1 | outputModifier2}}
         test('should support chaining multiple output modifiers', async ({ page }) => {
             const input = '{{macro | outputModifier1 | outputModifier2}}';
@@ -1030,6 +1068,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{macro | outputModifier1 arg1=val1 | outputModifier2 arg2=val2}}
         test('should support chaining multiple output modifiers with arguments', async ({ page }) => {
             const input = '{{macro | outputModifier1 arg1=val1 | outputModifier2 arg2=val2}}';
@@ -1053,6 +1092,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{macro|outputModifier}}
         test('should support output modifiers without whitespace', async ({ page }) => {
             const input = '{{macro|outputModifier}}';
@@ -1068,6 +1108,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // {{ macro test escaped \| pipe }}
         test('should support escaped pipes, not treating them as output modifiers', async ({ page }) => {
             const input = '{{ macro test escaped \\| pipe }}';
@@ -1102,6 +1143,7 @@ test.describe('MacroLexer', () => {
 
                 expect(tokens).toEqual(expectedTokens);
             });
+
             // {{macro | Iam$peci@l}}
             test('[Error] should not allow special characters inside output modifier identifier', async ({ page }) => {
                 const input = '{{macro | Iam$peci@l}}';
@@ -1123,6 +1165,7 @@ test.describe('MacroLexer', () => {
 
                 expect(tokens).toEqual(expectedTokens);
             });
+
             // {{macro | !cannotBeImportant }}
             test('[Error] should not allow output modifiers to have execution modifiers', async ({ page }) => {
                 const input = '{{macro | !cannotBeImportant }}';
@@ -1144,6 +1187,7 @@ test.describe('MacroLexer', () => {
 
                 expect(tokens).toEqual(expectedTokens);
             });
+
             // {{macro | 2invalidIdentifier}}
             test('[Error] should not allow invalid identifier starting with a number', async ({ page }) => {
                 const input = '{{macro | 2invalidIdentifier}}';
@@ -1165,6 +1209,7 @@ test.describe('MacroLexer', () => {
 
                 expect(tokens).toEqual(expectedTokens);
             });
+
             // {{macro || outputModifier}}
             test('[Error] should not allow double pipe used without an identifier', async ({ page }) => {
                 const input = '{{macro || outputModifier}}';
@@ -1227,6 +1272,7 @@ test.describe('MacroLexer', () => {
             // Compare the actual result with expected tokens
             expect(tokens).toEqual(expectedTokens);
         });
+
         // Just some text here.
         test('should tokenize plaintext only', async ({ page }) => {
             const input = 'Just some text here.';
@@ -1252,6 +1298,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // { { not a macro } }
         test('should treat opening/closing with whitspaces between brackets not as macros', async ({ page }) => {
             const input = '{ { not a macro } }';
@@ -1263,6 +1310,7 @@ test.describe('MacroLexer', () => {
 
             expect(tokens).toEqual(expectedTokens);
         });
+
         // invalid {{ 000 }} followed by correct {{ macro }}
         test('should handle valid macro correctly after an invalid macro', async ({ page }) => {
             const input = 'invalid {{ 000 }} followed by correct {{ macro }}';

--- a/tests/frontend/MacroParser.e2e.js
+++ b/tests/frontend/MacroParser.e2e.js
@@ -32,6 +32,7 @@ test.describe('MacroParser', () => {
 
             expect(macroCst).toEqual(expectedCst);
         });
+
         // {{  user  }}
         test('should generally handle whitespaces', async ({ page }) => {
             const input = '{{  user  }}';
@@ -61,6 +62,7 @@ test.describe('MacroParser', () => {
                 expect(errors).toMatchObject(expectedErrors);
                 expect(errors[0].message).toMatch(expectedMessage);
             });
+
             // {{§%€blah}}
             test('[Error] should throw an error for invalid identifier', async ({ page }) => {
                 const input = '{{§%€blah}}';
@@ -75,6 +77,7 @@ test.describe('MacroParser', () => {
                 expect(errors).toMatchObject(expectedErrors);
                 expect(errors[0].message).toMatch(expectedMessage);
             });
+
             // {{user
             test('[Error] should throw an error for incomplete macro', async ({ page }) => {
                 const input = '{{user';

--- a/tests/frontend/MacroRegistry.e2e.js
+++ b/tests/frontend/MacroRegistry.e2e.js
@@ -198,7 +198,7 @@ test.describe('MacroRegistry', () => {
                 options: {},
             });
             expect(result.registered).not.toBeNull();
-            expect(result.errors.length).toBe(0);
+            expect(result.errors).toHaveLength(0);
         });
 
         test('should accept valid identifier with hyphens', async ({ page }) => {
@@ -207,7 +207,7 @@ test.describe('MacroRegistry', () => {
                 options: {},
             });
             expect(result.registered).not.toBeNull();
-            expect(result.errors.length).toBe(0);
+            expect(result.errors).toHaveLength(0);
         });
 
         test('should accept valid identifier with underscores', async ({ page }) => {
@@ -216,7 +216,7 @@ test.describe('MacroRegistry', () => {
                 options: {},
             });
             expect(result.registered).not.toBeNull();
-            expect(result.errors.length).toBe(0);
+            expect(result.errors).toHaveLength(0);
         });
 
         test('should accept valid identifier with digits after first char', async ({ page }) => {
@@ -225,7 +225,7 @@ test.describe('MacroRegistry', () => {
                 options: {},
             });
             expect(result.registered).not.toBeNull();
-            expect(result.errors.length).toBe(0);
+            expect(result.errors).toHaveLength(0);
         });
 
         test('should reject identifier starting with digit', async ({ page }) => {
@@ -276,7 +276,7 @@ test.describe('MacroRegistry', () => {
                 },
             });
             expect(result.registered).not.toBeNull();
-            expect(result.errors.length).toBe(0);
+            expect(result.errors).toHaveLength(0);
         });
 
         test('should reject invalid alias identifier', async ({ page }) => {

--- a/tests/frontend/MacroStoryString.e2e.js
+++ b/tests/frontend/MacroStoryString.e2e.js
@@ -6,8 +6,6 @@ import { testSetup } from './frontent-test-utils.js';
 import { serverDirectory } from '../../src/server-directory.js';
 
 test.describe('MacroStoryString', () => {
-    test.beforeEach(testSetup.awaitST);
-
     /** @type {any[]} */
     const defaultContextPresets = [];
 
@@ -21,6 +19,8 @@ test.describe('MacroStoryString', () => {
             defaultContextPresets.push(preset);
         }
     });
+
+    test.beforeEach(testSetup.awaitST);
 
     test('should produce equivalent story strings with new macro engine', async ({ page }) => {
         const output = await page.evaluate(async ([defaultContextPresets]) => {

--- a/tests/frontend/frontent-test-utils.js
+++ b/tests/frontend/frontent-test-utils.js
@@ -15,7 +15,7 @@ export const testSetup = {
      */
     awaitST: async ({ page }) => {
         await page.goto('/');
-        await page.click('#userList .userSelect:last-child');
+        await page.locator('#userList .userSelect').last().click();
         await page.waitForURL('http://127.0.0.1:4444');
         await page.waitForFunction('document.getElementById("preloader") === null', { timeout: 0 });
     },

--- a/tests/in-chat-agents-pre-intercept-summary.test.js
+++ b/tests/in-chat-agents-pre-intercept-summary.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable playwright/no-duplicate-hooks */
 import { afterAll, beforeAll, describe, expect, jest, test } from '@jest/globals';
 
 let summarizeChatInterceptChange;

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable playwright/no-duplicate-hooks */
 /* global document, globalThis */
 import { describe, test, expect, jest, beforeEach, afterEach } from '@jest/globals';
 

--- a/tests/mock-server.test.js
+++ b/tests/mock-server.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable playwright/no-duplicate-hooks */
 import { describe, test, expect, beforeAll, afterAll } from '@jest/globals';
 import { MockServer } from './util/mock-server.js';
 

--- a/tests/openai-responses.test.js
+++ b/tests/openai-responses.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable playwright/no-duplicate-hooks */
 import { beforeAll, afterAll, describe, expect, jest, test } from '@jest/globals';
 import express from 'express';
 import { fileURLToPath } from 'node:url';

--- a/tests/pathfinder-diagnostics.test.js
+++ b/tests/pathfinder-diagnostics.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable playwright/no-duplicate-hooks */
 /* global globalThis */
 import { describe, test, expect, jest, beforeEach, afterEach } from '@jest/globals';
 

--- a/tests/pathfinder-tool-bridge.test.js
+++ b/tests/pathfinder-tool-bridge.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable playwright/no-duplicate-hooks */
 /* global globalThis */
 import { describe, test, expect, jest, beforeEach, afterEach } from '@jest/globals';
 

--- a/tests/private-request-filter.test.js
+++ b/tests/private-request-filter.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable playwright/no-duplicate-hooks */
 import { describe, test, expect, jest, beforeAll, beforeEach, afterAll } from '@jest/globals';
 
 const mockNetConnect = jest.fn(() => ({ type: 'net-socket' }));

--- a/tests/prompt-converters.test.js
+++ b/tests/prompt-converters.test.js
@@ -105,15 +105,21 @@ describe('calculateClaudeBudgetTokens', () => {
         test('auto returns null', () => {
             expect(mod.calculateClaudeBudgetTokens(8192, 'auto', true, true)).toBeNull();
         });
+
         test('none returns null', () => {
             expect(mod.calculateClaudeBudgetTokens(8192, 'none', true, true)).toBeNull();
         });
 
         test('min returns "low"', () => expect(mod.calculateClaudeBudgetTokens(8192, 'min', true, true)).toBe('low'));
+
         test('low returns "low"', () => expect(mod.calculateClaudeBudgetTokens(8192, 'low', true, true)).toBe('low'));
+
         test('medium returns "medium"', () => expect(mod.calculateClaudeBudgetTokens(8192, 'medium', true, true)).toBe('medium'));
+
         test('high returns "high"', () => expect(mod.calculateClaudeBudgetTokens(8192, 'high', true, true)).toBe('high'));
+
         test('max returns "max"', () => expect(mod.calculateClaudeBudgetTokens(8192, 'max', true, true)).toBe('max'));
+
         test('xhigh returns "max"', () => expect(mod.calculateClaudeBudgetTokens(8192, 'xhigh', true, true)).toBe('max'));
     });
 
@@ -121,6 +127,7 @@ describe('calculateClaudeBudgetTokens', () => {
         test('auto returns null', () => {
             expect(mod.calculateClaudeBudgetTokens(8192, 'auto', true, false)).toBeNull();
         });
+
         test('none returns null', () => {
             expect(mod.calculateClaudeBudgetTokens(8192, 'none', true, false)).toBeNull();
         });
@@ -170,23 +177,37 @@ describe('calculateGoogleBudgetTokens', () => {
 
     describe('gemini-3 flash', () => {
         test('auto returns null', () => expect(mod.calculateGoogleBudgetTokens(8192, 'auto', 'gemini-3.5-flash')).toBeNull());
+
         test('none returns null', () => expect(mod.calculateGoogleBudgetTokens(8192, 'none', 'gemini-3.5-flash')).toBeNull());
+
         test('min returns minimal', () => expect(mod.calculateGoogleBudgetTokens(8192, 'min', 'gemini-3.5-flash')).toBe('minimal'));
+
         test('low returns low', () => expect(mod.calculateGoogleBudgetTokens(8192, 'low', 'gemini-3.5-flash')).toBe('low'));
+
         test('medium returns medium', () => expect(mod.calculateGoogleBudgetTokens(8192, 'medium', 'gemini-3.5-flash')).toBe('medium'));
+
         test('high returns high', () => expect(mod.calculateGoogleBudgetTokens(8192, 'high', 'gemini-3.5-flash')).toBe('high'));
+
         test('max returns high', () => expect(mod.calculateGoogleBudgetTokens(8192, 'max', 'gemini-3.5-flash')).toBe('high'));
+
         test('xhigh returns high', () => expect(mod.calculateGoogleBudgetTokens(8192, 'xhigh', 'gemini-3.5-flash')).toBe('high'));
     });
 
     describe('gemini-3 pro', () => {
         test('auto returns null', () => expect(mod.calculateGoogleBudgetTokens(8192, 'auto', 'gemini-3.0-pro')).toBeNull());
+
         test('none returns null', () => expect(mod.calculateGoogleBudgetTokens(8192, 'none', 'gemini-3.0-pro')).toBeNull());
+
         test('min returns low', () => expect(mod.calculateGoogleBudgetTokens(8192, 'min', 'gemini-3.0-pro')).toBe('low'));
+
         test('low returns low', () => expect(mod.calculateGoogleBudgetTokens(8192, 'low', 'gemini-3.0-pro')).toBe('low'));
+
         test('medium returns low', () => expect(mod.calculateGoogleBudgetTokens(8192, 'medium', 'gemini-3.0-pro')).toBe('low'));
+
         test('high returns high', () => expect(mod.calculateGoogleBudgetTokens(8192, 'high', 'gemini-3.0-pro')).toBe('high'));
+
         test('max returns high', () => expect(mod.calculateGoogleBudgetTokens(8192, 'max', 'gemini-3.0-pro')).toBe('high'));
+
         test('xhigh returns high', () => expect(mod.calculateGoogleBudgetTokens(8192, 'xhigh', 'gemini-3.0-pro')).toBe('high'));
     });
 

--- a/tests/tokenizers-runtime.test.js
+++ b/tests/tokenizers-runtime.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable playwright/no-duplicate-hooks */
 /* global globalThis */
 import { fileURLToPath } from 'node:url';
 import { describe, test, expect, jest, beforeEach, afterEach } from '@jest/globals';


### PR DESCRIPTION
This PR cleans up any code inconsistencies, leftovers, and duplication to prepare for release v1.6.0, checked against the CONTRIBUTING.md.

Changes:
- Added // SillyBunny: divergence comments across upstream-touching files.
- Standardized SillyBunnyShell access to globalThis.
- Changed connection-manager debug leftovers from console.log to console.debug.
- Reduced and then fully cleared test lint warnings via safe fixes and targeted Jest hook disables.

Remaining PR branches need to be cleaned up (merged or removed) separately before release.