### PR TITLE
fix: make bottom chat jump land at true edge

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
     </style>
     <link rel="preload" as="style" href="style.css">
     <link rel="modulepreload" href="script.js">
-    <link rel="modulepreload" href="scripts/sillybunny-tabs.js?v=20260516c">
+    <link rel="modulepreload" href="scripts/sillybunny-tabs.js?v=20260519a">
     <link rel="preload" as="font" type="font/woff2" href="webfonts/Figtree/Figtree-Regular.woff2?v=20260422b" crossorigin>
     <link rel="manifest" crossorigin="use-credentials" href="manifest.json">
     <link href="webfonts/Figtree/stylesheet.css?v=20260422b" rel="stylesheet">
@@ -8844,7 +8844,7 @@
     <script type="module" src="scripts/i18n.js"></script>
     <script type="module" src="scripts/performance-loader.js"></script>
     <script type="module" src="script.js"></script>
-    <script type="module" src="scripts/sillybunny-tabs.js?v=20260516c"></script>
+    <script type="module" src="scripts/sillybunny-tabs.js?v=20260519a"></script>
     <script>
         window.addEventListener('load', (event) => {
             const documentHeight = () => {

--- a/public/scripts/chat-scroll-edges.js
+++ b/public/scripts/chat-scroll-edges.js
@@ -1,0 +1,81 @@
+export const DEFAULT_SCROLL_EDGE_SETTLE_DELAYS = Object.freeze([80, 250, 400]);
+const NOOP_CANCEL_SCROLL_EDGE_JUMP = () => undefined;
+
+function toFiniteScrollSize(value) {
+    const number = Number(value);
+    return Number.isFinite(number) ? number : 0;
+}
+
+export function getScrollEdgePosition(scrollElement, edge) {
+    if (!scrollElement || typeof scrollElement !== 'object') {
+        return 0;
+    }
+
+    if (edge !== 'bottom') {
+        return 0;
+    }
+
+    const scrollHeight = toFiniteScrollSize(scrollElement.scrollHeight);
+    const clientHeight = toFiniteScrollSize(scrollElement.clientHeight);
+    return Math.max(0, scrollHeight - clientHeight);
+}
+
+export function jumpScrollElementToEdge(scrollElement, edge, {
+    requestAnimationFrameRef = globalThis.requestAnimationFrame,
+    cancelAnimationFrameRef = globalThis.cancelAnimationFrame,
+    setTimeoutRef = globalThis.setTimeout,
+    clearTimeoutRef = globalThis.clearTimeout,
+    settleDelays = [],
+} = {}) {
+    if (!scrollElement || typeof scrollElement !== 'object') {
+        return NOOP_CANCEL_SCROLL_EDGE_JUMP;
+    }
+
+    let cancelled = false;
+    let frameId = null;
+    const timeoutIds = [];
+
+    const cancel = () => {
+        if (cancelled) {
+            return;
+        }
+
+        cancelled = true;
+
+        if (frameId !== null && typeof cancelAnimationFrameRef === 'function') {
+            cancelAnimationFrameRef(frameId);
+        }
+
+        if (typeof clearTimeoutRef === 'function') {
+            for (const timeoutId of timeoutIds) {
+                clearTimeoutRef(timeoutId);
+            }
+        }
+
+        frameId = null;
+        timeoutIds.length = 0;
+    };
+
+    const jump = () => {
+        if (cancelled) {
+            return;
+        }
+
+        scrollElement.scrollTop = getScrollEdgePosition(scrollElement, edge);
+    };
+
+    jump();
+
+    if (typeof requestAnimationFrameRef === 'function') {
+        frameId = requestAnimationFrameRef(jump);
+    }
+
+    if (typeof setTimeoutRef === 'function' && Array.isArray(settleDelays)) {
+        for (const delay of settleDelays) {
+            const delayMs = Math.max(0, toFiniteScrollSize(delay));
+            timeoutIds.push(setTimeoutRef(jump, delayMs));
+        }
+    }
+
+    return cancel;
+}

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -1,3 +1,5 @@
+import { DEFAULT_SCROLL_EDGE_SETTLE_DELAYS, jumpScrollElementToEdge } from './chat-scroll-edges.js';
+
 const SB_STORAGE_KEYS = Object.freeze({
     leftTab: 'sb-left-tab',
     rightTab: 'sb-right-tab',
@@ -95,6 +97,7 @@ let sbComposerControlsSyncQueued = false;
 let sbStorageFlushTimer = 0;
 let sbStorageFlushEventsBound = false;
 let sbMessageActionEventsBound = false;
+let sbPendingBottomChatScrollCancel = null;
 const sbStorageCache = new Map();
 const sbStoragePendingWrites = new Map();
 const SB_EXTENSION_ALIASES = {
@@ -4116,7 +4119,16 @@ function getReducedMotionScrollBehavior() {
     return window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth';
 }
 
+function cancelPendingBottomChatScroll() {
+    if (typeof sbPendingBottomChatScrollCancel === 'function') {
+        sbPendingBottomChatScrollCancel();
+        sbPendingBottomChatScrollCancel = null;
+    }
+}
+
 function scrollCurrentChatToTop() {
+    cancelPendingBottomChatScroll();
+
     const chatRoot = getChatScrollElement();
     if (!(chatRoot instanceof HTMLElement)) {
         return;
@@ -4129,21 +4141,18 @@ function scrollCurrentChatToTop() {
 }
 
 function scrollCurrentChatToBottom() {
+    cancelPendingBottomChatScroll();
+
     const context = getSillyTavernContext();
 
     if (typeof context?.scrollChatToBottom === 'function') {
         context.scrollChatToBottom({ force: true });
-        context.scrollChatToBottom({ waitForFrame: true, force: true });
-        return;
     }
 
     const chatRoot = getChatScrollElement();
-    if (chatRoot instanceof HTMLElement) {
-        chatRoot.scrollTo({
-            top: chatRoot.scrollHeight,
-            behavior: getReducedMotionScrollBehavior(),
-        });
-    }
+    sbPendingBottomChatScrollCancel = jumpScrollElementToEdge(chatRoot, 'bottom', {
+        settleDelays: DEFAULT_SCROLL_EDGE_SETTLE_DELAYS,
+    });
 }
 
 function countRegexMatches(value, regex) {

--- a/tests/chat-scroll-edges.test.js
+++ b/tests/chat-scroll-edges.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, test } from '@jest/globals';
+
+import {
+    DEFAULT_SCROLL_EDGE_SETTLE_DELAYS,
+    getScrollEdgePosition,
+    jumpScrollElementToEdge,
+} from '../public/scripts/chat-scroll-edges.js';
+
+describe('chat scroll edge helpers', () => {
+    test('keeps the intended default delayed re-pin timings', () => {
+        expect(DEFAULT_SCROLL_EDGE_SETTLE_DELAYS).toEqual([80, 250, 400]);
+    });
+
+    test('computes the bottom edge as the maximum scrollTop', () => {
+        expect(getScrollEdgePosition({ scrollHeight: 1200, clientHeight: 300 }, 'bottom')).toBe(900);
+        expect(getScrollEdgePosition({ scrollHeight: 200, clientHeight: 300 }, 'bottom')).toBe(0);
+        expect(getScrollEdgePosition({ scrollHeight: 1200, clientHeight: 300 }, 'top')).toBe(0);
+    });
+
+    test('jumps immediately and then re-pins after delayed layout growth', () => {
+        const scrollElement = {
+            scrollHeight: 1000,
+            clientHeight: 250,
+            scrollTop: 120,
+        };
+        const frames = [];
+        const timers = [];
+
+        const cancelJump = jumpScrollElementToEdge(scrollElement, 'bottom', {
+            requestAnimationFrameRef: callback => frames.push(callback),
+            setTimeoutRef: (callback, delay) => timers.push({ callback, delay }),
+            settleDelays: DEFAULT_SCROLL_EDGE_SETTLE_DELAYS,
+        });
+
+        expect(typeof cancelJump).toBe('function');
+        expect(scrollElement.scrollTop).toBe(750);
+        expect(frames).toHaveLength(1);
+        expect(timers.map(timer => timer.delay)).toEqual(DEFAULT_SCROLL_EDGE_SETTLE_DELAYS);
+
+        scrollElement.scrollHeight = 1300;
+        frames[0]();
+        expect(scrollElement.scrollTop).toBe(1050);
+
+        scrollElement.scrollHeight = 1600;
+        timers.at(-1).callback();
+        expect(scrollElement.scrollTop).toBe(1350);
+    });
+
+    test('cancels pending delayed re-pins before they can override a later action', () => {
+        const scrollElement = {
+            scrollHeight: 1000,
+            clientHeight: 250,
+            scrollTop: 120,
+        };
+        const frames = [];
+        const timers = [];
+
+        const cancelJump = jumpScrollElementToEdge(scrollElement, 'bottom', {
+            requestAnimationFrameRef: callback => frames.push(callback),
+            setTimeoutRef: (callback, delay) => timers.push({ callback, delay }),
+            settleDelays: DEFAULT_SCROLL_EDGE_SETTLE_DELAYS,
+        });
+
+        expect(scrollElement.scrollTop).toBe(750);
+        cancelJump();
+
+        scrollElement.scrollTop = 0;
+        scrollElement.scrollHeight = 1600;
+        frames[0]();
+        timers.at(-1).callback();
+
+        expect(scrollElement.scrollTop).toBe(0);
+    });
+});


### PR DESCRIPTION
## What?
- Fixes the bottom toolbar down-arrow so one click lands at the true bottom of the chat.
- Adds a small scroll-edge helper for deterministic bottom-edge jumps and delayed layout settling.
- Adds targeted regression coverage for delayed scroll-height growth and cancellation.

## Why?
The previous button used the app autoscroll helper, which only chased the current bottom immediately and on the next frame. If the chat height changed shortly after the click, such as from delayed rendering, media/layout settling, or mobile safe-area updates, the actual bottom moved lower and users needed multiple clicks. The top button did not have the same issue because top is a stable edge.

## How?
- Keeps the existing `context.scrollChatToBottom({ force: true })` call for app-state compatibility.
- Then explicitly sets `#chat.scrollTop` to `scrollHeight - clientHeight`.
- Re-pins on animation frame and at `[80, 250, 400]ms` to absorb short layout settling.
- Returns a cancellation function so top-arrow clicks and repeated bottom-arrow clicks do not leave stale bottom re-pin callbacks active.
- Does not add broad wheel/touch listeners; if manual-scroll stickiness is ever reported during the 400ms settle window, that can be handled with a narrowly scoped follow-up.

## Testing?
- `npm run test:unit --prefix tests -- chat-scroll-edges.test.js`
- `npx eslint public/scripts/chat-scroll-edges.js public/scripts/sillybunny-tabs.js`
- `cd tests && npx eslint chat-scroll-edges.test.js`
- `git diff --check`
- No live browser/server smoke was run; port `4444` was not used.

## Screenshots (optional)
Not included. This is a scroll-behavior fix covered by targeted unit tests rather than a visual layout change.

## Anything Else?
- The delayed bottom re-pin cancels on top-arrow clicks and repeated bottom-arrow clicks. It intentionally does not install broad manual-scroll listeners in this patch.