### PR TITLE
fix: clarify active and editing UI states

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -23,7 +23,23 @@
         border-top-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 56%, transparent);
         box-shadow:
             0 -10px 28px color-mix(in srgb, var(--SmartThemeShadowColor) 16%, transparent),
-            inset 0 1px 0 color-mix(in srgb, var(--color-primary, var(--sb-accent)) 34%, transparent);
+            0 0 0 1px color-mix(in srgb, var(--color-primary, var(--sb-accent)) 24%, transparent),
+            inset 0 1px 0 color-mix(in srgb, var(--color-primary, var(--sb-accent)) 34%, transparent),
+            inset 0 0 0 1px color-mix(in srgb, var(--sb-focus-ring) 24%, transparent);
+    }
+
+    #send_form.sb-generating-controls {
+        border-top-color: color-mix(in srgb, var(--sb-color-warning, var(--SmartThemeQuoteColor)) 62%, transparent);
+        box-shadow:
+            0 -10px 28px color-mix(in srgb, var(--SmartThemeShadowColor) 16%, transparent),
+            0 0 0 1px color-mix(in srgb, var(--sb-color-warning, var(--SmartThemeQuoteColor)) 28%, transparent),
+            inset 0 1px 0 color-mix(in srgb, var(--sb-color-warning, var(--SmartThemeQuoteColor)) 34%, transparent);
+    }
+
+    #send_form.sb-generating-controls::after {
+        top: 3px;
+        inline-size: min(64px, 42%);
+        block-size: 2px;
     }
 
     body:has([data-slide-toggle="shown"]) #send_form {

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -588,9 +588,26 @@ body.sb-topbar-compact #sb-chatbar-layer {
     transform: translateY(-1px);
 }
 
-.sb-chatbar-button.is-active {
+.sb-chatbar-button:is(.is-active, .active, .selected, .is-selected, .is-current, [aria-pressed='true'], [aria-selected='true'], [aria-current]):not(:disabled):not(.is-disabled) {
+    background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 13%, transparent);
     border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 42%, var(--sb-shell-border) 58%);
-    box-shadow: 0 8px 16px color-mix(in srgb, var(--SmartThemeShadowColor) 14%, transparent);
+    box-shadow:
+        inset 0 0 0 1px color-mix(in srgb, var(--color-primary, var(--sb-accent)) 24%, transparent),
+        inset 0 -2px 0 color-mix(in srgb, var(--color-primary, var(--sb-accent)) 46%, transparent),
+        0 8px 16px color-mix(in srgb, var(--SmartThemeShadowColor) 14%, transparent);
+}
+
+.sb-chatbar-button:is(.is-active, .active, .selected, .is-selected, .is-current, [aria-pressed='true'], [aria-selected='true'], [aria-current]):not(:disabled):not(.is-disabled)::after {
+    content: '';
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    inline-size: 5px;
+    block-size: 5px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 84%, var(--SmartThemeBodyColor));
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--sb-shell-main-bg) 82%, transparent);
+    pointer-events: none;
 }
 
 .sb-chatbar-button:focus-visible,
@@ -614,9 +631,9 @@ body.sb-topbar-compact #sb-chatbar-layer {
 
 #sb-chatbar-visibility-toggle:hover,
 #sb-chatbar-visibility-toggle.is-active {
-    border-color: transparent;
-    background: transparent;
-    box-shadow: none;
+    border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 34%, transparent);
+    background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 10%, transparent);
+    box-shadow: inset 0 -2px 0 color-mix(in srgb, var(--color-primary, var(--sb-accent)) 42%, transparent);
 }
 
 #sb-chatbar-visibility-toggle.is-active > i {
@@ -628,6 +645,25 @@ body.sb-topbar-compact #sb-chatbar-layer {
     opacity: 0.46;
     cursor: default;
     transform: none;
+}
+
+.sb-chatbar-button:is(.is-busy, [aria-busy='true']) {
+    opacity: 0.78;
+    background: color-mix(in srgb, var(--sb-color-warning, var(--SmartThemeQuoteColor)) 12%, transparent);
+    border-color: color-mix(in srgb, var(--sb-color-warning, var(--SmartThemeQuoteColor)) 46%, var(--sb-shell-border) 54%);
+    box-shadow: inset 0 -2px 0 color-mix(in srgb, var(--sb-color-warning, var(--SmartThemeQuoteColor)) 48%, transparent);
+}
+
+.sb-chatbar-button:is(.is-busy, [aria-busy='true'])::after {
+    content: '';
+    position: absolute;
+    right: 6px;
+    bottom: 5px;
+    left: 6px;
+    block-size: 2px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--sb-color-warning, var(--SmartThemeQuoteColor)) 82%, var(--SmartThemeBodyColor));
+    pointer-events: none;
 }
 
 .sb-chatbar-field {
@@ -1654,7 +1690,7 @@ body.sb-shell-resizing * {
     display: none;
 }
 
-.sb-shell-tab.is-active {
+.sb-shell-tab:is(.is-active, .active, .selected, .is-selected, .is-current, [aria-selected='true'], [aria-current]) {
     background: var(--sb-shell-tab-active-bg);
     border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 30%, var(--sb-shell-border) 70%);
     box-shadow:
@@ -1663,7 +1699,7 @@ body.sb-shell-resizing * {
     transform: none;
 }
 
-.sb-shell-tab.is-active i {
+.sb-shell-tab:is(.is-active, .active, .selected, .is-selected, .is-current, [aria-selected='true'], [aria-current]) i {
     color: var(--color-primary, var(--sb-accent));
     opacity: 1;
 }
@@ -3923,6 +3959,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 
 .sb-bottom-chat-btn {
     appearance: none;
+    position: relative;
     border: none;
     background: transparent;
     color: var(--SmartThemeBodyColor);
@@ -3946,10 +3983,25 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     background: color-mix(in srgb, var(--SmartThemeBodyColor) 10%, transparent);
 }
 
-.sb-bottom-chat-btn.is-active {
+.sb-bottom-chat-btn:is(.is-active, .active, .selected, .is-selected, .is-current, [aria-pressed='true'], [aria-selected='true'], [aria-current]):not(:disabled):not(.is-disabled) {
     opacity: 1;
     color: var(--color-primary, var(--sb-accent));
     background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 14%, transparent);
+    box-shadow:
+        inset 0 0 0 1px color-mix(in srgb, var(--color-primary, var(--sb-accent)) 26%, transparent),
+        inset 0 -2px 0 color-mix(in srgb, var(--color-primary, var(--sb-accent)) 48%, transparent);
+}
+
+.sb-bottom-chat-btn:is(.is-active, .active, .selected, .is-selected, .is-current, [aria-pressed='true'], [aria-selected='true'], [aria-current]):not(:disabled):not(.is-disabled)::after {
+    content: '';
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    inline-size: 5px;
+    block-size: 5px;
+    border-radius: 999px;
+    background: currentColor;
+    pointer-events: none;
 }
 
 .sb-bottom-chat-collapse-toggle,
@@ -3958,10 +4010,27 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 }
 
 .sb-bottom-chat-btn:disabled,
-.sb-bottom-chat-btn.is-disabled,
-.sb-bottom-chat-btn.is-busy {
+.sb-bottom-chat-btn.is-disabled {
     opacity: 0.38;
     cursor: default;
+    pointer-events: none;
+}
+
+.sb-bottom-chat-btn:is(.is-busy, [aria-busy='true']) {
+    opacity: 0.72;
+    background: color-mix(in srgb, var(--sb-color-warning, var(--SmartThemeQuoteColor)) 13%, transparent);
+    box-shadow: inset 0 -2px 0 color-mix(in srgb, var(--sb-color-warning, var(--SmartThemeQuoteColor)) 50%, transparent);
+}
+
+.sb-bottom-chat-btn:is(.is-busy, [aria-busy='true'])::after {
+    content: '';
+    position: absolute;
+    right: 6px;
+    bottom: 4px;
+    left: 6px;
+    block-size: 2px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--sb-color-warning, var(--SmartThemeQuoteColor)) 82%, var(--SmartThemeBodyColor));
     pointer-events: none;
 }
 

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -112,6 +112,14 @@
     --sb-state-attention: color-mix(in srgb, var(--color-danger, var(--sb-color-danger)) 86%, var(--SmartThemeBodyColor) 14%);
     --sb-state-attention-bg: color-mix(in srgb, var(--sb-state-attention) 18%, transparent);
     --sb-state-attention-border: color-mix(in srgb, var(--sb-state-attention) 44%, transparent);
+    --sb-state-active-bg: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 16%, var(--sb-button-bg));
+    --sb-state-active-border: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 50%, var(--sb-shell-border));
+    --sb-state-active-shadow: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 34%, transparent);
+    --sb-state-busy-bg: color-mix(in srgb, var(--sb-color-warning) 14%, var(--sb-button-bg));
+    --sb-state-busy-border: color-mix(in srgb, var(--sb-color-warning) 48%, var(--sb-shell-border));
+    --sb-editing-bg: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 7%, transparent);
+    --sb-editing-border: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 48%, var(--sb-shell-border));
+    --sb-editing-chip-bg: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 22%, var(--SmartThemeBlurTintColor));
     --sb-on-accent: rgb(0, 0, 0);
     --sb-on-solid-accent: var(--sb-on-accent);
     --sb-warning-fg: color-mix(in srgb, var(--color-danger, var(--sb-color-error)) 72%, var(--SmartThemeBodyColor) 28%);
@@ -611,6 +619,68 @@ h3:not(.popup h3):not(#chat h3) {
     transition: transform 100ms var(--sb-ease-out);
 }
 
+:is(.menu_button, .menu_button_icon, .right_menu_button):is(.is-active, .active, .selected, .is-selected, .is-current, [aria-pressed='true'], [aria-selected='true'], [aria-current]):not(.disabled):not(.is-disabled):not([disabled]) {
+    position: relative;
+    background: var(--sb-state-active-bg);
+    border-color: var(--sb-state-active-border);
+    color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 82%, var(--SmartThemeBodyColor));
+    box-shadow:
+        inset 0 0 0 1px var(--sb-state-active-shadow),
+        inset 0 -2px 0 color-mix(in srgb, var(--color-primary, var(--sb-accent)) 44%, transparent),
+        0 8px 16px color-mix(in srgb, var(--SmartThemeShadowColor) 12%, transparent);
+}
+
+.menu_button_icon:is(.is-active, .active, .selected, .is-selected, .is-current, [aria-pressed='true'], [aria-selected='true'], [aria-current]):not(.disabled):not(.is-disabled):not([disabled])::after,
+.right_menu_button:is(.is-active, .active, .selected, .is-selected, .is-current, [aria-pressed='true'], [aria-selected='true'], [aria-current]):not(.disabled):not(.is-disabled):not([disabled])::after,
+.menu_button:is(.fa, .fa-solid, .fa-regular, .fa-brands):empty:is(.is-active, .active, .selected, .is-selected, .is-current, [aria-pressed='true'], [aria-selected='true'], [aria-current]):not(.disabled):not(.is-disabled):not([disabled])::after,
+.menu_button:not(:has(> span)):not(:has(> small)):not(:has(> b)):not(:has(> strong)):has(> :is(.fa, .fa-solid, .fa-regular, .fa-brands, i, svg, img):only-child):is(.is-active, .active, .selected, .is-selected, .is-current, [aria-pressed='true'], [aria-selected='true'], [aria-current]):not(.disabled):not(.is-disabled):not([disabled])::after {
+    content: '';
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    inline-size: 5px;
+    block-size: 5px;
+    border-radius: 999px;
+    background: currentColor;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--sb-state-active-bg) 86%, transparent);
+    pointer-events: none;
+}
+
+:is(.menu_button, .menu_button_icon, .right_menu_button):is(.is-busy, [aria-busy='true']) {
+    position: relative;
+    opacity: 0.82;
+    background: var(--sb-state-busy-bg);
+    border-color: var(--sb-state-busy-border);
+    box-shadow:
+        inset 0 0 0 1px color-mix(in srgb, var(--sb-color-warning) 28%, transparent),
+        inset 0 -2px 0 color-mix(in srgb, var(--sb-color-warning) 42%, transparent);
+}
+
+:is(.menu_button, .menu_button_icon, .right_menu_button):is(.is-busy, [aria-busy='true'])::after {
+    content: '';
+    position: absolute;
+    right: 7px;
+    bottom: 5px;
+    left: 7px;
+    block-size: 2px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--sb-color-warning) 82%, var(--SmartThemeBodyColor));
+    pointer-events: none;
+}
+
+:is(.menu_button, .menu_button_icon, .right_menu_button):focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--sb-focus-ring) 88%, transparent);
+    outline-offset: 2px;
+    border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 52%, var(--sb-shell-border));
+    box-shadow:
+        inset 0 0 0 2px color-mix(in srgb, var(--sb-focus-ring) 60%, transparent),
+        0 0 0 1px color-mix(in srgb, var(--SmartThemeShadowColor) 20%, transparent);
+}
+
+:is(.menu_button, .menu_button_icon, .right_menu_button):is(.disabled, .is-disabled, [disabled]):not(.is-busy):not([aria-busy='true'])::after {
+    display: none;
+}
+
 .menu_button:is(.fa, .fa-solid, .fa-regular, .fa-brands):empty,
 .menu_button_icon:is(.fa, .fa-solid, .fa-regular, .fa-brands):empty,
 .right_menu_button:is(.fa, .fa-solid, .fa-regular, .fa-brands):empty,
@@ -738,7 +808,10 @@ textarea.text_pole:focus,
 select.text_pole:focus,
 input.text_pole:focus {
     border-color: color-mix(in srgb, var(--sb-focus-ring) 85%, transparent);
-    box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--sb-focus-ring) 35%, transparent);
+    background-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 7%, var(--sb-input-bg));
+    box-shadow:
+        inset 0 0 0 2px color-mix(in srgb, var(--sb-focus-ring) 35%, transparent),
+        0 0 0 1px color-mix(in srgb, var(--SmartThemeShadowColor) 16%, transparent);
     outline: none;
 }
 
@@ -778,8 +851,26 @@ select:where(:not([multiple]):not([size]):not(.select2-hidden-accessible)) {
 
 select:where(:not([multiple]):not([size]):not(.select2-hidden-accessible)):focus {
     border-color: color-mix(in srgb, var(--sb-focus-ring) 85%, transparent);
-    box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--sb-focus-ring) 35%, transparent);
+    background-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 7%, var(--sb-input-bg));
+    box-shadow:
+        inset 0 0 0 2px color-mix(in srgb, var(--sb-focus-ring) 35%, transparent),
+        0 0 0 1px color-mix(in srgb, var(--SmartThemeShadowColor) 16%, transparent);
     outline: none;
+}
+
+:is(textarea, input:not([type]), input:is([type='text'], [type='search'], [type='number'], [type='password'], [type='email'], [type='url'], [type='tel']), select):focus:not([disabled]):not([readonly]) {
+    border-color: color-mix(in srgb, var(--sb-focus-ring) 88%, transparent);
+    box-shadow:
+        inset 0 0 0 2px color-mix(in srgb, var(--sb-focus-ring) 34%, transparent),
+        0 0 0 1px color-mix(in srgb, var(--SmartThemeShadowColor) 14%, transparent);
+}
+
+.select2-container--default.select2-container--focus .select2-selection--single,
+.select2-container--default.select2-container--focus .select2-selection--multiple,
+.select2-container--default.select2-container--open .select2-selection--single,
+.select2-container--default.select2-container--open .select2-selection--multiple {
+    border-color: color-mix(in srgb, var(--sb-focus-ring) 82%, var(--SmartThemeBorderColor));
+    box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--sb-focus-ring) 30%, transparent);
 }
 
 select.margin0:where(:not([multiple]):not([size]):not(.select2-hidden-accessible)) {
@@ -1138,6 +1229,55 @@ select.text_pole:where(:not([multiple]):not([size]):not(.select2-hidden-accessib
     color: color-mix(in srgb, var(--SmartThemeBodyColor) 54%, transparent);
 }
 
+#send_form:focus-within {
+    border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 56%, var(--sb-shell-border));
+    box-shadow:
+        0 -10px 40px color-mix(in srgb, var(--SmartThemeShadowColor) 14%, transparent),
+        0 0 0 1px color-mix(in srgb, var(--color-primary, var(--sb-accent)) 28%, transparent),
+        inset 0 0 0 1px color-mix(in srgb, var(--sb-focus-ring) 32%, transparent);
+}
+
+#send_form:focus-within #nonQRFormItems {
+    border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 42%, var(--sb-shell-border));
+    background:
+        linear-gradient(180deg, color-mix(in srgb, var(--color-primary, var(--sb-accent)) 8%, transparent), transparent 82%),
+        color-mix(in srgb, var(--SmartThemeBodyColor) 5%, var(--sb-composer-surface-base, transparent));
+}
+
+#send_form:focus-within #send_textarea {
+    background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 8%, var(--sb-composer-input-bg));
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--sb-focus-ring) 32%, transparent);
+}
+
+#send_form.sb-generating-controls {
+    border-color: color-mix(in srgb, var(--sb-color-warning) 58%, var(--sb-shell-border));
+    box-shadow:
+        0 -10px 40px color-mix(in srgb, var(--SmartThemeShadowColor) 14%, transparent),
+        0 0 0 1px color-mix(in srgb, var(--sb-color-warning) 32%, transparent),
+        inset 0 0 0 1px color-mix(in srgb, var(--sb-color-warning) 24%, transparent);
+}
+
+#send_form.sb-generating-controls::after {
+    content: '';
+    position: absolute;
+    top: 4px;
+    left: 50%;
+    z-index: 1;
+    inline-size: min(72px, 34%);
+    block-size: 3px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--sb-color-warning) 78%, var(--SmartThemeBodyColor));
+    transform: translateX(-50%);
+    pointer-events: none;
+}
+
+#send_form.sb-generating-controls #nonQRFormItems {
+    border-color: color-mix(in srgb, var(--sb-color-warning) 44%, var(--sb-shell-border));
+    background:
+        linear-gradient(180deg, color-mix(in srgb, var(--sb-color-warning) 9%, transparent), transparent 82%),
+        color-mix(in srgb, var(--SmartThemeBodyColor) 5%, var(--sb-composer-surface-base, transparent));
+}
+
 #leftSendForm > div i,
 #rightSendForm > div i,
 #options_button i {
@@ -1424,6 +1564,142 @@ select.text_pole:where(:not([multiple]):not([size]):not(.select2-hidden-accessib
 #chat .mes .mes_view_agent_changes[style*="display: none"],
 #chat .mes .mes_view_agent_changes[style*="display:none"] {
     display: none !important;
+}
+
+#chat .mes:has(.edit_textarea),
+#chat .mes:has(.reasoning_edit_textarea) {
+    background: var(--sb-editing-bg);
+    box-shadow:
+        inset 0 0 0 1px var(--sb-editing-border),
+        0 12px 24px color-mix(in srgb, var(--SmartThemeShadowColor) 10%, transparent);
+}
+
+body.bubblechat #chat .mes:has(.edit_textarea)::before,
+body.bubblechat #chat .mes:has(.reasoning_edit_textarea)::before {
+    background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 10%, var(--SmartThemeBotMesBlurTintColor));
+}
+
+body.bubblechat #chat .mes[is_user='true']:has(.edit_textarea)::before,
+body.bubblechat #chat .mes[is_user='true']:has(.reasoning_edit_textarea)::before {
+    background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 10%, var(--SmartThemeUserMesBlurTintColor));
+}
+
+#chat .mes:has(.edit_textarea) .mes_block,
+#chat .mes:has(.reasoning_edit_textarea) .mes_block {
+    position: relative;
+    overflow: visible;
+}
+
+#chat .mes:has(.edit_textarea) .mes_block::before,
+#chat .mes:has(.reasoning_edit_textarea) .mes_block::before {
+    content: '';
+    position: absolute;
+    top: 7px;
+    right: max(8px, var(--mes-right-spacing, 0px));
+    z-index: 2;
+    display: inline-flex;
+    align-items: center;
+    inline-size: 34px;
+    block-size: 6px;
+    padding: 0;
+    border: 1px solid color-mix(in srgb, var(--color-primary, var(--sb-accent)) 44%, var(--sb-shell-border));
+    border-radius: 999px;
+    background: var(--sb-editing-chip-bg);
+    box-shadow: 0 8px 16px color-mix(in srgb, var(--SmartThemeShadowColor) 12%, transparent);
+    pointer-events: none;
+}
+
+#chat .mes:has(.edit_textarea) .mes_text,
+#chat .mes:has(.reasoning_edit_textarea) .mes_reasoning_details {
+    padding-top: 22px;
+}
+
+#chat .edit_textarea,
+#chat .reasoning_edit_textarea {
+    width: 100%;
+    box-sizing: border-box;
+    margin: 0;
+    padding: 12px 14px;
+    border: 1px solid var(--sb-editing-border);
+    border-radius: var(--sb-radius-button);
+    background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 8%, var(--sb-input-bg));
+    color: var(--SmartThemeBodyColor);
+    caret-color: var(--color-primary, var(--sb-accent));
+    box-shadow:
+        inset 0 0 0 1px color-mix(in srgb, var(--color-primary, var(--sb-accent)) 18%, transparent),
+        0 10px 24px color-mix(in srgb, var(--SmartThemeShadowColor) 10%, transparent);
+    line-height: calc(var(--mainFontSize) + 0.35rem);
+}
+
+#chat .edit_textarea:focus,
+#chat .reasoning_edit_textarea:focus {
+    border-color: color-mix(in srgb, var(--sb-focus-ring) 88%, var(--SmartThemeBorderColor));
+    background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 12%, var(--sb-input-bg));
+    box-shadow:
+        inset 0 0 0 2px color-mix(in srgb, var(--sb-focus-ring) 36%, transparent),
+        0 12px 26px color-mix(in srgb, var(--SmartThemeShadowColor) 12%, transparent);
+}
+
+#chat .mes_edit_buttons,
+#chat .mes_reasoning_actions {
+    align-items: center;
+    gap: 5px;
+}
+
+#chat .mes_edit_buttons .menu_button,
+#chat .mes_reasoning_actions .edit_button {
+    --sb-edit-action-color: var(--color-primary, var(--sb-accent));
+    position: relative;
+    opacity: 0.92;
+    color: color-mix(in srgb, var(--sb-edit-action-color) 80%, var(--SmartThemeBodyColor));
+    border: 1px solid color-mix(in srgb, var(--sb-edit-action-color) 36%, transparent);
+    background: color-mix(in srgb, var(--sb-edit-action-color) 12%, var(--sb-button-bg));
+    box-shadow: inset 0 -2px 0 color-mix(in srgb, var(--sb-edit-action-color) 28%, transparent);
+    filter: none;
+}
+
+#chat :is(.mes_edit_done, .mes_reasoning_edit_done).menu_button {
+    --sb-edit-action-color: var(--sb-color-success);
+}
+
+#chat :is(.mes_edit_cancel, .mes_reasoning_edit_cancel).menu_button {
+    --sb-edit-action-color: var(--sb-color-warning);
+}
+
+#chat :is(.mes_edit_delete, .mes_reasoning_delete).menu_button {
+    --sb-edit-action-color: var(--sb-color-danger);
+}
+
+#chat .mes_edit_add_reasoning.menu_button {
+    --sb-edit-action-color: var(--sb-accent-soft);
+}
+
+#chat :is(.mes_edit_copy, .mes_reasoning_copy).menu_button,
+#chat .mes_reasoning_copy.mes_button {
+    --sb-edit-action-color: var(--color-primary, var(--sb-accent));
+}
+
+#chat :is(.mes_edit_up, .mes_edit_down).menu_button {
+    --sb-edit-action-color: color-mix(in srgb, var(--SmartThemeBodyColor) 70%, var(--color-primary, var(--sb-accent)));
+}
+
+#chat .mes_edit_buttons .menu_button:not(.disabled):not([disabled]):hover,
+#chat .mes_reasoning_actions .edit_button:not(.disabled):not([disabled]):hover {
+    opacity: 1;
+    background: color-mix(in srgb, var(--sb-edit-action-color) 18%, var(--sb-button-bg));
+    border-color: color-mix(in srgb, var(--sb-edit-action-color) 48%, transparent);
+    box-shadow:
+        inset 0 0 0 1px color-mix(in srgb, var(--sb-edit-action-color) 24%, transparent),
+        inset 0 -2px 0 color-mix(in srgb, var(--sb-edit-action-color) 36%, transparent);
+}
+
+#chat .mes_edit_buttons .menu_button:is(.disabled, .is-disabled, [disabled]),
+#chat .mes_reasoning_actions .edit_button:is(.disabled, .is-disabled, [disabled]) {
+    opacity: 0.42;
+    color: color-mix(in srgb, var(--SmartThemeBodyColor) 52%, transparent);
+    border-color: color-mix(in srgb, var(--sb-shell-border) 62%, transparent);
+    background: color-mix(in srgb, var(--SmartThemeBodyColor) 5%, transparent);
+    box-shadow: none;
 }
 
 #chat .mes .swipeRightBlock {

--- a/public/index.html
+++ b/public/index.html
@@ -45,9 +45,9 @@
     <link rel="stylesheet" type="text/css" href="css/toggle-dependent.css">
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css">
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260516d" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260516b">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260516d">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260516c" media="(max-width: 1000px)">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260518a">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260518a">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260518a" media="(max-width: 1000px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
 </head>


### PR DESCRIPTION
## What?

Clarifies active, busy, focused, and editing states across the SillyBunny UI.

- Adds stronger visual affordances for active/toggled/selected/current controls.
- Adds static busy/in-use cues for controls using `.is-busy` or `aria-busy`.
- Improves focus-visible and focus-within styling for controls and editing fields.
- Makes composer focus and generating states clearer on desktop and mobile.
- Makes message and reasoning edit mode persistent and visible on the message container while edit textareas exist.
- Differentiates message edit action buttons for save, cancel, delete, copy, move, and add-reasoning actions.
- Bumps cache query strings for the changed SillyBunny CSS files.

## Why?

Message editing was too subtle: most edit controls used similar icon color, and the edited message itself did not read strongly as being in edit mode.

This pass makes editing and active/in-use states visible through persistent container treatment, borders/rings, dots/markers, tints, and action-specific button styling instead of relying on color or focus alone.

## How?

- Uses existing state conventions rather than rewriting JS state:
  - `.is-active`
  - `.active`
  - `.selected`
  - `.is-selected`
  - `.is-current`
  - `[aria-pressed='true']`
  - `[aria-selected='true']`
  - `[aria-current]`
  - `.is-busy`
  - `[aria-busy='true']`
- Uses CSS-first message edit detection:
  - `#chat .mes:has(.edit_textarea)`
  - `#chat .mes:has(.reasoning_edit_textarea)`
- Keeps disabled active states guarded so disabled controls do not show active affordances.
- Uses semantic SillyBunny theme tokens and existing CSS state patterns.
- Avoids JS changes and avoids new persisted state.

## Testing?

- `git status --short --branch`
- `git diff --name-status`
- `git diff --check`
- Lightweight CSS delimiter/syntax sanity check
- `npm run check:frontend-budgets`
- Static verification confirmed:
  - only intended files changed
  - cache query strings updated
  - no generated `content: 'Editing'` text remains
  - disabled bottom chat buttons do not receive active styling or active dot selectors

Not run:

- `npm run lint`, no JS was changed and this was a CSS/HTML-only pass.
- Browser/e2e smoke tests, no server was started and port `4444` is reserved in this workspace.

## Screenshots (optional)

Not included. No browser server was started for this CSS/HTML-only PR because port `4444` is reserved in this workspace.

## Anything Else?

None.
