### PR TITLE
fix: scroll to sent chat messages immediately

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -3667,13 +3667,14 @@ export function scrollChatToBottom({ waitForFrame, force = false } = {}) {
     requestId = requestAnimationFrame(() => doScroll());
 }
 
-function keepMobileSendScrollAnchored({ settle = false } = {}) {
-    if (!shouldBatchMobileChatRendering()) {
-        return;
+function keepSendScrollAnchored({ settle = false } = {}) {
+    const shouldApplyMobileScrollGuards = shouldBatchMobileChatRendering();
+
+    if (shouldApplyMobileScrollGuards) {
+        scrollLock = false;
+        scrollLockImmunityUntil = Math.max(scrollLockImmunityUntil, Date.now() + MOBILE_SEND_SCROLL_IMMUNITY_MS);
     }
 
-    scrollLock = false;
-    scrollLockImmunityUntil = Math.max(scrollLockImmunityUntil, Date.now() + MOBILE_SEND_SCROLL_IMMUNITY_MS);
     scrollChatToBottom({ waitForFrame: true });
 
     if (!settle) {
@@ -3681,11 +3682,14 @@ function keepMobileSendScrollAnchored({ settle = false } = {}) {
     }
 
     setTimeout(() => {
-        if (Date.now() >= scrollLockImmunityUntil) {
+        if (shouldApplyMobileScrollGuards && Date.now() >= scrollLockImmunityUntil) {
             return;
         }
 
-        scrollLock = false;
+        if (shouldApplyMobileScrollGuards) {
+            scrollLock = false;
+        }
+
         scrollChatToBottom({ waitForFrame: true });
     }, MOBILE_SEND_SCROLL_SETTLE_MS);
 }
@@ -6979,10 +6983,10 @@ export async function sendMessageAsUser(messageText, messageBias, insertAt = nul
         await eventSource.emit(event_types.USER_MESSAGE_RENDERED, insertAt);
     } else {
         chat.push(message);
-        await saveChatConditional();
         const chat_id = (chat.length - 1);
         addOneMessage(message, { scroll: false });
-        keepMobileSendScrollAnchored({ settle: true });
+        keepSendScrollAnchored({ settle: true });
+        await saveChatConditional();
         await eventSource.emit(event_types.MESSAGE_SENT, chat_id);
         await eventSource.emit(event_types.USER_MESSAGE_RENDERED, chat_id);
     }

--- a/tests/chat-send-scroll.e2e.js
+++ b/tests/chat-send-scroll.e2e.js
@@ -1,0 +1,88 @@
+/* global document, requestAnimationFrame, window */
+import { expect, test } from '@playwright/test';
+
+const APP_URL = process.env.SILLYBUNNY_TEST_BASE_URL || '/';
+
+async function dismissOnboardingIfPresent(page) {
+    const onboardingInput = page.locator('dialog[open] textarea.popup-input').first();
+
+    if (await onboardingInput.isVisible().catch(() => false)) {
+        await onboardingInput.fill('Scroll Tester');
+        await page.locator('dialog[open] .popup-button-ok').first().click();
+        await page.locator('dialog[open]').waitFor({ state: 'detached', timeout: 5000 }).catch(() => {});
+    }
+}
+
+async function selectSampleCharacter(page) {
+    await page.locator('#sb-character-toggle').click();
+
+    const sampleCharacter = page.locator('.character_select').filter({ hasText: /Bunny Guide|Seraphina/ }).first();
+    await expect(sampleCharacter).toBeVisible();
+    await sampleCharacter.click();
+
+    const optionalLorebookDecline = page.locator('.popup-button-cancel:visible').first();
+    if (await optionalLorebookDecline.isVisible().catch(() => false)) {
+        await optionalLorebookDecline.click();
+        await page.locator('dialog[open]').waitFor({ state: 'detached', timeout: 5000 }).catch(() => {});
+    }
+
+    await expect(page.locator('#send_textarea')).toBeVisible();
+}
+
+test.describe('chat send scroll', () => {
+    test('scrolls to the latest user message immediately after send', async ({ page }) => {
+        await page.goto(APP_URL);
+        await page.waitForFunction('document.getElementById("preloader") === null', { timeout: 0 });
+        await dismissOnboardingIfPresent(page);
+        await selectSampleCharacter(page);
+
+        await page.route('**/api/chats/save', async route => {
+            await new Promise(resolve => setTimeout(resolve, 1200));
+            await route.fulfill({ status: 200, json: {} });
+        });
+
+        await page.evaluate(async () => {
+            const context = window.SillyTavern.getContext();
+            const chatElement = document.querySelector('#chat');
+
+            for (let index = 0; index < 12; index++) {
+                const message = {
+                    name: 'Scroll Tester',
+                    is_user: true,
+                    is_system: false,
+                    send_date: new Date().toISOString(),
+                    mes: `scroll filler ${index} ${'x '.repeat(60)}`,
+                    extra: {},
+                };
+
+                context.chat.push(message);
+                context.addOneMessage(message, { scroll: false });
+            }
+
+            chatElement.scrollTop = chatElement.scrollHeight;
+            await new Promise(resolve => requestAnimationFrame(resolve));
+        });
+
+        const messageText = `scroll regression ${Date.now()}`;
+        await page.locator('#send_textarea').fill(messageText);
+        await page.locator('#send_textarea').press('Enter');
+
+        const scrolledToSentMessage = await page.waitForFunction((expectedText) => {
+            const chatElement = document.querySelector('#chat');
+            const sentMessage = Array.from(chatElement.querySelectorAll('.mes[is_user="true"]'))
+                .find(message => message.textContent.includes(expectedText));
+
+            if (!sentMessage) {
+                return false;
+            }
+
+            const chatRect = chatElement.getBoundingClientRect();
+            const messageRect = sentMessage.getBoundingClientRect();
+            const bottomDelta = chatElement.scrollHeight - chatElement.clientHeight - chatElement.scrollTop;
+
+            return messageRect.bottom <= chatRect.bottom + 4 && bottomDelta <= 12;
+        }, messageText, { timeout: 1000 });
+
+        expect(await scrolledToSentMessage.jsonValue()).toBe(true);
+    });
+});

--- a/tests/chat-send-scroll.e2e.js
+++ b/tests/chat-send-scroll.e2e.js
@@ -44,6 +44,7 @@ test.describe('chat send scroll', () => {
         await page.evaluate(async () => {
             const context = window.SillyTavern.getContext();
             const chatElement = document.querySelector('#chat');
+            context.powerUserSettings.auto_scroll_chat_to_bottom = true;
 
             for (let index = 0; index < 12; index++) {
                 const message = {


### PR DESCRIPTION
## What?
Fixes normal chat sends so the newly rendered user message is visible immediately after submission. Adds a focused Playwright regression for the send path.

## Why?
The send path waited for the chat save request before rendering and scrolling the new user message. If saving was slow, the UI stayed at the previous scroll position and the latest sent message did not appear right away.

## How?
Render the user message and schedule the existing bottom-scroll anchoring before awaiting `saveChatConditional()`. The send scroll helper now also runs on desktop while preserving the existing mobile scroll-lock/immunity guards only for mobile/narrow layouts.

The regression test opens a sample character, delays `/api/chats/save`, sends a message through the composer, and asserts the sent message is in view at the chat bottom within the immediate window.

## Testing?
- `./node_modules/.bin/eslint public/script.js`
- `./node_modules/.bin/eslint --config tests/.eslintrc.cjs tests/chat-send-scroll.e2e.js`
- `SILLYBUNNY_TEST_BASE_URL=http://127.0.0.1:4455 node tests/node_modules/@playwright/test/cli.js test tests/chat-send-scroll.e2e.js --config tests/playwright.config.js --workers=1`

## Screenshots (optional)
No screenshot included; this is a scroll-position behavior regression verified by the browser test above.

## Anything Else?
Tested on a temporary local server at `127.0.0.1:4455` to avoid the reserved `4444` runtime port.