### PR TITLE
fix: normalize Google reverse proxy API versions

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -66,7 +66,7 @@ import {
     webTokenizers,
     getWebTokenizer,
 } from '../tokenizers.js';
-import { getVertexAIAuth, getProjectIdFromServiceAccount } from '../google.js';
+import { getVertexAIAuth, getProjectIdFromServiceAccount, getGoogleApiBaseUrl } from '../google.js';
 
 const API_OPENAI = 'https://api.openai.com/v1';
 const API_CLAUDE = 'https://api.anthropic.com/v1';
@@ -766,11 +766,13 @@ async function sendMakerSuiteRequest(request, response) {
                 headers['Authorization'] = authHeader;
             } else {
                 // For proxy mode, use the original URL with Authorization header
-                url = `${apiUrl.toString().replace(/\/$/, '')}/v1/publishers/google/models/${model}:${responseType}${stream ? '?alt=sse' : ''}`;
+                const baseUrl = getGoogleApiBaseUrl(apiUrl.toString(), 'v1');
+                url = `${baseUrl}/publishers/google/models/${model}:${responseType}${stream ? '?alt=sse' : ''}`;
                 headers['Authorization'] = authHeader;
             }
         } else {
-            url = `${apiUrl.toString().replace(/\/$/, '')}/${apiVersion}/models/${model}:${responseType}?key=${apiKey}${stream ? '&alt=sse' : ''}`;
+            const baseUrl = getGoogleApiBaseUrl(apiUrl.toString(), apiVersion);
+            url = `${baseUrl}/models/${model}:${responseType}?key=${apiKey}${stream ? '&alt=sse' : ''}`;
         }
 
         const generateResponse = await fetch(url, {
@@ -1879,9 +1881,10 @@ router.post('/status', async function (request, statusResponse) {
             apiKey = request.body.reverse_proxy ? request.body.proxy_password : readSecret(request.user.directories, SECRET_KEYS.MAKERSUITE);
             apiUrl = trimTrailingSlash(request.body.reverse_proxy || API_MAKERSUITE);
             const apiVersion = getConfigValue('gemini.apiVersion', 'v1beta');
+            const baseUrl = getGoogleApiBaseUrl(apiUrl, apiVersion);
             const modelsUrl = !apiKey && request.body.reverse_proxy
-                ? `${apiUrl}/${apiVersion}/models`
-                : `${apiUrl}/${apiVersion}/models?key=${apiKey}`;
+                ? `${baseUrl}/models`
+                : `${baseUrl}/models?key=${apiKey}`;
 
             if (!apiKey && !request.body.reverse_proxy) {
                 console.warn('Google AI Studio API key is missing.');

--- a/src/endpoints/google.js
+++ b/src/endpoints/google.js
@@ -13,6 +13,44 @@ import { delay, getConfigValue, trimTrailingSlash } from '../util.js';
 
 const API_MAKERSUITE = 'https://generativelanguage.googleapis.com';
 const API_VERTEX_AI = 'https://us-central1-aiplatform.googleapis.com';
+const GOOGLE_API_VERSION_PATTERN = /^v\d+(?:alpha|beta)?$/i;
+
+/**
+ * Gets a Google API base URL, preserving bases that already end in an API version.
+ * @param {string} apiUrl Root or versioned API/proxy base URL
+ * @param {string} apiVersion API version to append when the base is not versioned
+ * @returns {string} Google API base URL
+ */
+export function getGoogleApiBaseUrl(apiUrl, apiVersion) {
+    const baseUrl = String(apiUrl ?? '');
+
+    try {
+        const url = new URL(baseUrl);
+        const pathSegments = url.pathname.split('/').filter(Boolean);
+        const finalPathSegment = pathSegments[pathSegments.length - 1] || '';
+
+        if (GOOGLE_API_VERSION_PATTERN.test(finalPathSegment)) {
+            // SillyBunny: some reverse proxies already expose a versioned Google base.
+            url.pathname = url.pathname.replace(/\/$/, '');
+            return url.toString();
+        }
+
+        // SillyBunny: preserve custom proxy paths like /gemini before appending the requested version.
+        url.pathname = `${url.pathname.replace(/\/$/, '')}/${apiVersion}`;
+        return url.toString();
+    } catch {
+        const trimmedBaseUrl = trimTrailingSlash(baseUrl);
+        const pathPart = trimmedBaseUrl.split(/[?#]/, 1)[0];
+        const pathSegments = pathPart.split('/').filter(Boolean);
+        const finalPathSegment = pathSegments[pathSegments.length - 1] || '';
+
+        if (GOOGLE_API_VERSION_PATTERN.test(finalPathSegment)) {
+            return trimmedBaseUrl;
+        }
+
+        return `${trimmedBaseUrl}/${apiVersion}`;
+    }
+}
 
 function createWavHeader(dataSize, sampleRate, numChannels = 1, bitsPerSample = 16) {
     const header = Buffer.alloc(44);
@@ -212,7 +250,7 @@ export async function getGoogleApiConfig(request, model, endpoint = 'generateCon
         } else {
             // Proxy mode: use Authorization header
             const apiUrl = trimTrailingSlash(request.body.reverse_proxy || API_VERTEX_AI);
-            baseUrl = `${apiUrl}/v1`;
+            baseUrl = getGoogleApiBaseUrl(apiUrl, 'v1');
             url = `${baseUrl}/publishers/google/models/${model}:${endpoint}`;
             headers['Authorization'] = authHeader;
         }
@@ -221,7 +259,7 @@ export async function getGoogleApiConfig(request, model, endpoint = 'generateCon
         const apiKey = request.body.reverse_proxy ? request.body.proxy_password : readSecret(request.user.directories, SECRET_KEYS.MAKERSUITE);
         const apiUrl = trimTrailingSlash(request.body.reverse_proxy || API_MAKERSUITE);
         const apiVersion = getConfigValue('gemini.apiVersion', 'v1beta');
-        baseUrl = `${apiUrl}/${apiVersion}`;
+        baseUrl = getGoogleApiBaseUrl(apiUrl, apiVersion);
         url = `${baseUrl}/models/${model}:${endpoint}`;
         headers['x-goog-api-key'] = apiKey;
     }

--- a/tests/google-api-base-url.test.js
+++ b/tests/google-api-base-url.test.js
@@ -1,0 +1,44 @@
+import { beforeAll, describe, expect, test } from '@jest/globals';
+import { fileURLToPath } from 'node:url';
+
+import { setConfigFilePath } from '../src/util.js';
+
+setConfigFilePath(fileURLToPath(new URL('../default/config.yaml', import.meta.url)));
+
+let getGoogleApiBaseUrl;
+
+beforeAll(async () => {
+    ({ getGoogleApiBaseUrl } = await import('../src/endpoints/google.js'));
+});
+
+describe('getGoogleApiBaseUrl', () => {
+    test('appends configured version to the root Google AI Studio API URL', () => {
+        expect(getGoogleApiBaseUrl('https://generativelanguage.googleapis.com', 'v1beta'))
+            .toBe('https://generativelanguage.googleapis.com/v1beta');
+    });
+
+    test('appends configured version to a root proxy URL', () => {
+        expect(getGoogleApiBaseUrl('https://proxy.example/gemini', 'v1beta'))
+            .toBe('https://proxy.example/gemini/v1beta');
+    });
+
+    test('does not append a second version to a v1 proxy URL', () => {
+        expect(getGoogleApiBaseUrl('https://proxy.example/v1', 'v1beta'))
+            .toBe('https://proxy.example/v1');
+    });
+
+    test('trims a trailing slash from a v1beta proxy URL', () => {
+        expect(getGoogleApiBaseUrl('https://proxy.example/v1beta/', 'v1beta'))
+            .toBe('https://proxy.example/v1beta');
+    });
+
+    test('does not append a second version to a nested versioned proxy URL', () => {
+        expect(getGoogleApiBaseUrl('https://proxy.example/google/v1', 'v1beta'))
+            .toBe('https://proxy.example/google/v1');
+    });
+
+    test('does not append a second version to a Vertex v1 proxy URL', () => {
+        expect(getGoogleApiBaseUrl('https://vertex-proxy.example/v1', 'v1'))
+            .toBe('https://vertex-proxy.example/v1');
+    });
+});


### PR DESCRIPTION
## What?
Fixes Google AI Studio / Gemini reverse proxy URL construction so versioned proxy base URLs are not versioned again. This prevents requests such as `/v1/v1beta/models/...` for Gemini and `/v1/v1/publishers/...` for Vertex AI proxy mode.

## Why?
When a reverse proxy already exposes a versioned Google API base such as `/v1` or `/v1beta`, SillyBunny was still appending the configured Gemini API version before adding provider endpoints. That broke Gemini agent/tool-use requests routed through those proxies with 404 errors from invalid paths.

## How?
- Adds a Google-specific base URL helper that appends the requested API version only when the proxy/root URL does not already end in a Google API version segment.
- Uses the helper for Gemini / MakerSuite chat generation, MakerSuite model listing, Vertex proxy generation, and the shared Google endpoint helper paths.
- Preserves direct Google API behavior and root proxy behavior, while avoiding duplicate version segments for versioned proxy bases.
- Leaves unrelated OpenAI-compatible provider URL construction unchanged.

## Testing?
- `git diff --check`
- `npm run lint`
- `npm run lint --prefix tests`
- `npm run test:unit --prefix tests -- google-api-base-url.test.js`

## Screenshots (optional)
Not applicable; backend URL construction change only.

## Anything Else?
No live provider request was made. The added unit tests cover root Google URLs, root proxy URLs, versioned `/v1` and `/v1beta` proxy URLs, nested versioned proxy paths, and Vertex `/v1` proxy bases.