### PR TITLE
fix: use main chat helper for prompt transforms

### DIFF
--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -2268,6 +2268,54 @@ function consolidateAppendPromptTransformOutputs(baseText, agents, results) {
     };
 }
 
+function getUserFinalPromptTransformMessages(promptMessages) {
+    const messages = (Array.isArray(promptMessages) ? promptMessages : [])
+        .filter(message => message && typeof message === 'object')
+        .map(message => ({
+            ...message,
+            role: String(message.role ?? 'user').trim().toLowerCase() || 'user',
+        }));
+
+    if (messages.length === 0) {
+        return [{ role: 'user', content: 'Return only the requested transformed text.' }];
+    }
+
+    const hasToolCallContext = messages.some(message => message.role === 'tool' || Array.isArray(message.tool_calls));
+    const lastMessage = messages[messages.length - 1];
+    if (lastMessage.role === 'user' || hasToolCallContext) {
+        return messages;
+    }
+
+    // Prompt-transform helper prompts are synthetic requests, not real chat/tool-call tails.
+    // Keep providers that reject assistant-prefill tails happy by appending a tiny user turn
+    // instead of role-flipping any existing assistant content.
+    return [
+        ...messages,
+        { role: 'user', content: 'Return only the requested transformed text.' },
+    ];
+}
+
+function canUseMainChatCompletionHelper(context) {
+    return context?.mainApi === 'openai' && typeof context?.generateRaw === 'function';
+}
+
+async function requestMainChatCompletionPromptTransform(context, promptMessages, maxTokens) {
+    const output = await context.generateRaw({
+        prompt: getUserFinalPromptTransformMessages(promptMessages),
+        api: 'openai',
+        instructOverride: true,
+        responseLength: maxTokens,
+        trimNames: false,
+        cacheScope: 'auxiliary',
+    });
+
+    return {
+        output: extractProfileResponseText({ content: output }),
+        runner: 'main',
+        profileId: '',
+    };
+}
+
 async function requestProfilePromptTransform(CMRS, profileId, promptMessages, maxTokens, modelOverride = '') {
     const requestOptions = {
         extractData: true,
@@ -2351,6 +2399,12 @@ async function requestPromptTransform(agent, promptMessages, maxTokens) {
 
         return await runAsInternalPromptTransform(async () =>
             await requestProfilePromptTransform(CMRS, profileId, promptMessages, maxTokens, modelOverride),
+        );
+    }
+
+    if (canUseMainChatCompletionHelper(context)) {
+        return await runAsInternalPromptTransform(async () =>
+            await requestMainChatCompletionPromptTransform(context, promptMessages, maxTokens),
         );
     }
 

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -34,6 +34,7 @@ describe('in-chat agent post-processing runner', () => {
     let saveChatDebounced;
     let saveChat;
     let generateQuietPrompt;
+    let generateRaw;
     let runSidecarRetrieval;
     let streamingProcessor;
     let updateMessageTokenAccounting;
@@ -41,6 +42,7 @@ describe('in-chat agent post-processing runner', () => {
     let connectionManagerRequestService;
     let globalSettings;
     let currentChatId;
+    let mainApi;
     let documentListeners;
     let windowListeners;
 
@@ -75,6 +77,7 @@ describe('in-chat agent post-processing runner', () => {
         saveChatDebounced = jest.fn();
         saveChat = jest.fn();
         generateQuietPrompt = jest.fn(async () => 'quiet result');
+        generateRaw = jest.fn(async () => 'raw result');
         runSidecarRetrieval = jest.fn();
         streamingProcessor = {
             messageId: -1,
@@ -106,6 +109,7 @@ describe('in-chat agent post-processing runner', () => {
             appendAgentsExecutionMode: 'parallel',
         };
         currentChatId = 'chat-a';
+        mainApi = 'kobold';
         documentListeners = new Map();
         windowListeners = new Map();
 
@@ -197,6 +201,8 @@ describe('in-chat agent post-processing runner', () => {
                 saveChat,
                 updateMessageMetaBadges,
                 ConnectionManagerRequestService: connectionManagerRequestService,
+                generateRaw,
+                mainApi,
             })),
         }));
 
@@ -1541,6 +1547,48 @@ describe('in-chat agent post-processing runner', () => {
         expect(textarea.value).toBe('Polished impersonation');
         expect(textarea.dispatchEvent).toHaveBeenCalledTimes(1);
         expect(textarea.dispatchEvent.mock.calls[0][0].type).toBe('input');
+        expect(saveChatDebounced).not.toHaveBeenCalled();
+    });
+
+    test('uses direct user-final chat helper for no-profile impersonation prompt transforms', async () => {
+        useImpersonateTransformAgent({ runOnImpersonate: true });
+        mainApi = 'openai';
+        generateRaw.mockResolvedValue('<assistant_response>Polished impersonation</assistant_response>');
+
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+
+        const textarea = {
+            value: 'Draft impersonation',
+            dispatchEvent: jest.fn(),
+        };
+        document.querySelector = jest.fn(selector => selector === '#send_textarea' ? textarea : null);
+        connectionManagerRequestService = null;
+
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'impersonate', {}, false);
+        await eventSource.emit(eventTypes.GENERATION_AFTER_COMMANDS, 'impersonate', {}, false);
+        await eventSource.emit(eventTypes.IMPERSONATE_READY, 'Draft impersonation');
+
+        expect(generateQuietPrompt).not.toHaveBeenCalled();
+        expect(generateRaw).toHaveBeenCalledTimes(1);
+        expect(generateRaw).toHaveBeenCalledWith(expect.objectContaining({
+            api: 'openai',
+            instructOverride: true,
+            responseLength: 8192,
+            trimNames: false,
+            cacheScope: 'auxiliary',
+        }));
+
+        const sentPrompt = generateRaw.mock.calls[0][0].prompt;
+        expect(sentPrompt).toEqual([
+            expect.objectContaining({ role: 'system' }),
+            expect.objectContaining({ role: 'user' }),
+        ]);
+        expect(sentPrompt.at(-1).role).toBe('user');
+        expect(sentPrompt[0].content).toContain('generated impersonation text');
+        expect(sentPrompt[1].content).toContain('Draft impersonation');
+        expect(textarea.value).toBe('Polished impersonation');
+        expect(textarea.dispatchEvent).toHaveBeenCalledTimes(1);
         expect(saveChatDebounced).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## What?
- Added a direct `generateRaw` path for prompt-transform requests when the main API is OpenAI, so no-profile impersonation prompt transforms can use the main chat helper instead of the quiet prompt path.
- Added a regression test that covers the OpenAI main-API path and verifies the prompt stays user-final.

## Why?
- Some prompt-transform flows need the message tail to stay user-final to satisfy providers that reject assistant-prefill tails.
- The existing quiet prompt path works, but the main chat helper is the better fit for this narrow OpenAI main-API case.

## How?
- In `public/scripts/extensions/in-chat-agents/agent-runner.js`, added a small helper that normalizes prompt-transform messages and appends a tiny user turn only when needed, then routes OpenAI main-API prompt transforms through `context.generateRaw(...)` with `instructOverride`, `trimNames: false`, and `cacheScope: 'auxiliary'`.
- Left profile-based prompt transforms unchanged.
- In `tests/in-chat-agents-runner.test.js`, mocked `generateRaw` and `mainApi` in the test context and added a regression test for no-profile impersonation prompt transforms.

## Testing?
- `npm ci --ignore-scripts`
- `npm ci --ignore-scripts --prefix tests`
- `npx eslint public/scripts/extensions/in-chat-agents/agent-runner.js`
- `npm run lint --prefix tests -- in-chat-agents-runner.test.js`
- `npm run test:unit --prefix tests -- in-chat-agents-runner.test.js`

## Screenshots (optional)
- Not applicable for this backend/runtime fix.

## Anything Else?
- This PR is intentionally limited to `public/scripts/extensions/in-chat-agents/agent-runner.js` and `tests/in-chat-agents-runner.test.js`.
- Unrelated runtime-checkout deletions under `public/scripts/extensions/third-party/ChatCompletionTabs/...` were excluded from the branch.