### PR TITLE
feat(cards): add opt-in card script sandbox runtime

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ This update consolidates the v1.6.0 staging work since v1.5.3: preset and connec
 
 ### Character Cards
 - fix(cards): warn when card HTML contains stripped `<script>`/`<iframe>` blocks (#94).
+- feat(cards): add opt-in sandboxed execution for supported card scripts (#94).
 
 ### Presets And Connection Profiles
 - Connection profile changes now serialize in order, abort superseded applications cleanly, save only after the latest selected profile finishes applying, and expose expanded summaries for easier review.

--- a/lessons.md
+++ b/lessons.md
@@ -190,6 +190,16 @@ The current project instructions already point agents toward runtime, verificati
 
 Future optimization should add deeper, linked artifacts only when they can stay short, owned, and mechanically useful.
 
+## Card Script Sandbox Invariants
+
+- Card scripts must never auto-run on message render.
+- Card scripts run only after explicit user action when the global setting is enabled.
+- Iframe sandbox must not use `allow-same-origin`.
+- Parent code must validate event source, nonce, messageId, schema, allowlist, and rate limit.
+- Sandbox code must not receive command results, chat contents, settings, or parent DOM access.
+- Unknown slash commands must fail closed.
+- Sandbox state must be torn down on chat/message lifecycle changes.
+
 ## Commit History Clusters
 
 ### 2026-04-04 to 2026-04-05: bootstrap and first mobile stabilization

--- a/public/index.html
+++ b/public/index.html
@@ -5745,10 +5745,9 @@
                                     <input id="forbid_external_media" type="checkbox" />
                                     <small data-i18n="Forbid External Media">Forbid External Media</small>
                                 </label>
-                                <label class="checkbox_label" for="allow_card_scripts" title="Run sandboxed scripts embedded in character cards. Off by default. Coming soon - PR3 will enable this control." data-i18n="[title]Run sandboxed scripts embedded in character cards. Off by default. Coming soon">
-                                    <input id="allow_card_scripts" type="checkbox" disabled />
+                                <label class="checkbox_label" for="allow_card_scripts" title="Run sandboxed scripts embedded in character cards. Off by default." data-i18n="[title]Run sandboxed scripts embedded in character cards. Off by default.">
+                                    <input id="allow_card_scripts" type="checkbox" />
                                     <small data-i18n="Allow Card Scripts (sandboxed)">Allow Card Scripts (sandboxed)</small>
-                                    <small class="opacity50p" data-i18n="Coming soon">Coming soon</small>
                                 </label>
                                 <label class="checkbox_label" for="allow_name2_display">
                                     <input id="allow_name2_display" type="checkbox" />
@@ -8016,6 +8015,7 @@
                                 <div title="Narrate" class="mes_button mes_narrate fa-solid fa-bullhorn" data-i18n="[title]Narrate" data-requires-extension="tts"></div>
                                 <div title="Prompt" class="mes_button mes_prompt fa-solid fa-square-poll-horizontal " data-i18n="[title]Prompt" style="display: none;"></div>
                                 <div title="View agent changes" class="mes_button mes_view_agent_changes fa-solid fa-file-lines" data-i18n="[title]View agent changes" style="display: none;"></div>
+                                <div title="Run card scripts" class="mes_button mes_run_card_scripts fa-solid fa-play" data-i18n="[title]Run card scripts" style="display: none;"></div>
                                 <div title="Exclude message from prompts" class="mes_button mes_hide fa-solid fa-eye" data-i18n="[title]Exclude message from prompts"></div>
                                 <div title="Include message in prompts" class="mes_button mes_unhide fa-solid fa-eye-slash" data-i18n="[title]Include message in prompts"></div>
                                 <div title="Toggle media display style" class="mes_button mes_media_gallery fa-solid fa-photo-film" data-i18n="[title]Toggle media display style"></div>

--- a/public/script.js
+++ b/public/script.js
@@ -201,7 +201,7 @@ import {
 import { debounce_timeout, GENERATION_TYPE_TRIGGERS, IGNORE_SYMBOL, inject_ids, MEDIA_DISPLAY, MEDIA_SOURCE, MEDIA_TYPE, OVERSWIPE_BEHAVIOR, SCROLL_BEHAVIOR, SWIPE_DIRECTION, SWIPE_SOURCE, SWIPE_STATE } from './scripts/constants.js';
 
 import { cancelDebouncedMetadataSave, doDailyExtensionUpdatesCheck, extension_settings, initExtensions, loadExtensionSettings, runGenerationInterceptors } from './scripts/extensions.js';
-import { COMMENT_NAME_DEFAULT, CONNECT_API_MAP, executeSlashCommandsOnChatInput, initDefaultSlashCommands, initSlashCommandAutoComplete, isExecutingCommandsFromChatInput, pauseScriptExecution, stopScriptExecution, UNIQUE_APIS } from './scripts/slash-commands.js';
+import { COMMENT_NAME_DEFAULT, CONNECT_API_MAP, executeSlashCommandsOnChatInput, executeSlashCommandsWithOptions, initDefaultSlashCommands, initSlashCommandAutoComplete, isExecutingCommandsFromChatInput, pauseScriptExecution, stopScriptExecution, UNIQUE_APIS } from './scripts/slash-commands.js';
 import { initMacroAutoComplete } from './scripts/autocomplete/MacroAutoComplete.js';
 import {
     tag_map,
@@ -314,6 +314,7 @@ import {
     markCardScriptHtml,
     markCardScriptToastShown,
 } from './scripts/card-script-detection.js';
+import { configureCardScriptRuntime, initCardScriptRuntime } from './scripts/card-script-runtime.js';
 
 const DEFERRED_STARTUP_STYLESHEETS = Object.freeze([
     { href: 'css/bright.min.css', id: 'deferred-highlight-theme-css' },
@@ -929,6 +930,11 @@ async function firstLoadInit() {
         addDOMPurifyHooks();
         // SillyBunny: card script detection - see #94.
         eventSource.on(event_types.CHAT_CHANGED, forgetAllCardScripts);
+        configureCardScriptRuntime({
+            getPowerUser: () => power_user,
+            executeSlashCommandsWithOptions,
+        });
+        initCardScriptRuntime();
         reloadMarkdownProcessor();
         applyBrowserFixes();
         await getClientVersion();

--- a/public/scripts/card-script-runtime.js
+++ b/public/scripts/card-script-runtime.js
@@ -1,0 +1,611 @@
+import { CARD_SCRIPT_MARKER_TAG, getCardScriptSnapshot } from './card-script-detection.js';
+import {
+    DEFAULT_LIMITS,
+    POLICY_MODES,
+    createDefaultPolicy,
+    parseSlashCommandRequest,
+} from './card-script-sandbox/allowlist.js';
+import { validateSlashRequestMessage } from './card-script-sandbox/messages.js';
+import { createRateLimiter } from './card-script-sandbox/rate-limiter.js';
+import { buildSandboxDocument } from './card-script-sandbox/wrapper.js';
+import { eventSource, event_types } from './events.js';
+
+export const CARD_SCRIPT_CONFIRMATION_STORAGE_KEY = 'card_scripts_confirmed';
+export const CARD_SCRIPT_RUN_BUTTON_SELECTOR = '.mes_run_card_scripts';
+export const MAX_ACTIVE_CARD_SCRIPT_SANDBOXES = 5;
+
+const activeSandboxes = new Map();
+const completedSandboxRuns = new Set();
+
+let runtimeInitialized = false;
+let runtimeWindow = null;
+let runtimeDocument = null;
+
+const runtimeHandlers = {
+    message: event => void handleSandboxMessage(event),
+    click: event => void handleRunButtonClick(event),
+    settingInput: event => handleSettingInput(event),
+    chatChanged: () => {
+        destroyAllSandboxes({ clearRunHistory: true });
+    },
+    messageDeleted: () => {
+        destroyAllSandboxes({ clearRunHistory: true });
+    },
+    messageSwiped: messageId => {
+        const normalizedMessageId = normalizeMessageId(messageId);
+        if (normalizedMessageId !== null) {
+            completedSandboxRuns.delete(normalizedMessageId);
+            destroySandbox(normalizedMessageId);
+            void syncCardScriptButtonForMessage(normalizedMessageId);
+        }
+    },
+    userMessageRendered: messageId => void syncCardScriptButtonForMessage(messageId),
+    characterMessageRendered: messageId => void syncCardScriptButtonForMessage(messageId),
+    settingsLoaded: () => void syncAllCardScriptButtons(),
+};
+
+const defaultRuntimeDependencies = Object.freeze({
+    getDocument: () => globalThis.document,
+    getWindow: () => globalThis.window,
+    getMutationObserver: () => globalThis.MutationObserver,
+    getLocalStorage: () => globalThis.localStorage,
+    getPowerUser: async () => {
+        const module = await import('./power-user.js');
+        return module.power_user;
+    },
+    getSlashExecutor: async () => {
+        const module = await import('./slash-commands.js');
+        return module.executeSlashCommandsWithOptions;
+    },
+    getCardScriptSnapshot,
+    buildSandboxDocument,
+    createRateLimiter,
+    createNonce: createSecureNonce,
+    now: () => Date.now(),
+    showConfirmation: null,
+    toastr: () => globalThis.toastr,
+});
+
+let runtimeDependencies = { ...defaultRuntimeDependencies };
+
+export function configureCardScriptRuntime(dependencies = {}) {
+    runtimeDependencies = {
+        ...runtimeDependencies,
+        ...dependencies,
+    };
+}
+
+export function resetCardScriptRuntimeForTests() {
+    teardownCardScriptRuntime();
+    destroyAllSandboxes({ clearRunHistory: true });
+    runtimeDependencies = { ...defaultRuntimeDependencies };
+}
+
+export function initCardScriptRuntime() {
+    if (runtimeInitialized) {
+        return;
+    }
+
+    runtimeWindow = getRuntimeWindow();
+    runtimeDocument = getRuntimeDocument();
+
+    runtimeWindow?.addEventListener?.('message', runtimeHandlers.message);
+    runtimeDocument?.addEventListener?.('click', runtimeHandlers.click);
+    runtimeDocument?.getElementById?.('allow_card_scripts')?.addEventListener?.('input', runtimeHandlers.settingInput);
+
+    eventSource.on(event_types.CHAT_CHANGED, runtimeHandlers.chatChanged);
+    eventSource.on(event_types.MESSAGE_DELETED, runtimeHandlers.messageDeleted);
+    eventSource.on(event_types.MESSAGE_SWIPED, runtimeHandlers.messageSwiped);
+    eventSource.on(event_types.USER_MESSAGE_RENDERED, runtimeHandlers.userMessageRendered);
+    eventSource.on(event_types.CHARACTER_MESSAGE_RENDERED, runtimeHandlers.characterMessageRendered);
+    eventSource.on(event_types.SETTINGS_LOADED_AFTER, runtimeHandlers.settingsLoaded);
+    eventSource.on(event_types.APP_READY, runtimeHandlers.settingsLoaded);
+
+    runtimeInitialized = true;
+}
+
+export function teardownCardScriptRuntime() {
+    if (!runtimeInitialized) {
+        return;
+    }
+
+    runtimeWindow?.removeEventListener?.('message', runtimeHandlers.message);
+    runtimeDocument?.removeEventListener?.('click', runtimeHandlers.click);
+    runtimeDocument?.getElementById?.('allow_card_scripts')?.removeEventListener?.('input', runtimeHandlers.settingInput);
+
+    eventSource.removeListener(event_types.CHAT_CHANGED, runtimeHandlers.chatChanged);
+    eventSource.removeListener(event_types.MESSAGE_DELETED, runtimeHandlers.messageDeleted);
+    eventSource.removeListener(event_types.MESSAGE_SWIPED, runtimeHandlers.messageSwiped);
+    eventSource.removeListener(event_types.USER_MESSAGE_RENDERED, runtimeHandlers.userMessageRendered);
+    eventSource.removeListener(event_types.CHARACTER_MESSAGE_RENDERED, runtimeHandlers.characterMessageRendered);
+    eventSource.removeListener(event_types.SETTINGS_LOADED_AFTER, runtimeHandlers.settingsLoaded);
+    eventSource.removeListener(event_types.APP_READY, runtimeHandlers.settingsLoaded);
+
+    runtimeWindow = null;
+    runtimeDocument = null;
+    runtimeInitialized = false;
+}
+
+export async function createSandbox(messageId) {
+    const normalizedMessageId = normalizeMessageId(messageId);
+    if (normalizedMessageId === null) {
+        throw createRuntimeError('Invalid card script message id.', 'bad_message_id');
+    }
+
+    const policy = await getCardScriptRuntimePolicy();
+    if (policy.mode === POLICY_MODES.DISABLED) {
+        throw createRuntimeError('Card script execution is disabled.', 'policy_disabled');
+    }
+
+    const documentRef = getRuntimeDocument();
+    if (!documentRef?.createElement) {
+        throw createRuntimeError('Card script runtime requires a document.', 'missing_document');
+    }
+
+    const snapshot = runtimeDependencies.getCardScriptSnapshot(normalizedMessageId);
+    if (!snapshot?.html) {
+        throw createRuntimeError('No card script snapshot is available for this message.', 'missing_snapshot');
+    }
+
+    const messageElement = getMessageElement(normalizedMessageId, documentRef);
+    if (!messageElement) {
+        throw createRuntimeError('Message element is no longer available.', 'missing_message');
+    }
+
+    if (!activeSandboxes.has(normalizedMessageId) && activeSandboxes.size >= MAX_ACTIVE_CARD_SCRIPT_SANDBOXES) {
+        throw createRuntimeError('Too many card script sandboxes are already running.', 'too_many_sandboxes');
+    }
+
+    destroySandbox(normalizedMessageId);
+
+    const nonce = runtimeDependencies.createNonce();
+    const iframeElement = documentRef.createElement('iframe');
+    iframeElement.className = 'card-script-sandbox-frame';
+    iframeElement.setAttribute('sandbox', 'allow-scripts');
+    iframeElement.setAttribute('title', `Card script sandbox for message ${normalizedMessageId}`);
+    iframeElement.setAttribute('aria-hidden', 'true');
+    iframeElement.tabIndex = -1;
+    iframeElement.srcdoc = runtimeDependencies.buildSandboxDocument({
+        html: snapshot.html,
+        messageId: normalizedMessageId,
+        nonce,
+    });
+
+    if (iframeElement.style) {
+        iframeElement.style.position = 'absolute';
+        iframeElement.style.width = '0';
+        iframeElement.style.height = '0';
+        iframeElement.style.border = '0';
+        iframeElement.style.visibility = 'hidden';
+        iframeElement.style.pointerEvents = 'none';
+    }
+
+    messageElement.appendChild(iframeElement);
+
+    const sandbox = {
+        iframeElement,
+        iframeWindow: iframeElement.contentWindow,
+        messageId: normalizedMessageId,
+        nonce,
+        createdAt: runtimeDependencies.now(),
+        rateLimiter: runtimeDependencies.createRateLimiter(),
+        observer: createSandboxRemovalObserver(messageElement, normalizedMessageId, documentRef),
+    };
+
+    if (!sandbox.iframeWindow) {
+        iframeElement.remove?.();
+        sandbox.observer?.disconnect?.();
+        sandbox.rateLimiter?.dispose?.();
+        throw createRuntimeError('Card script sandbox window could not be created.', 'missing_iframe_window');
+    }
+
+    activeSandboxes.set(normalizedMessageId, sandbox);
+    completedSandboxRuns.add(normalizedMessageId);
+    await syncCardScriptButtonForMessage(normalizedMessageId, { messageElement });
+
+    return sandbox;
+}
+
+export async function handleSandboxMessage(event) {
+    const sandbox = getSandboxBySource(event?.source);
+    if (!sandbox) {
+        return rejectSandboxMessage('unknown_source');
+    }
+
+    const policy = await getCardScriptRuntimePolicy();
+    const schema = validateSlashRequestMessage(event?.data, {
+        maxCommandLength: policy.limits?.maxCommandLength ?? DEFAULT_LIMITS.maxCommandLength,
+    });
+
+    if (!schema.ok) {
+        return rejectSandboxMessage(schema.reason, sandbox);
+    }
+
+    const message = schema.value;
+
+    if (message.nonce !== sandbox.nonce) {
+        return rejectSandboxMessage('bad_nonce', sandbox);
+    }
+
+    if (message.messageId !== sandbox.messageId) {
+        return rejectSandboxMessage('bad_message_id', sandbox);
+    }
+
+    const rateLimit = sandbox.rateLimiter.tryAcquire();
+    if (!rateLimit.ok) {
+        return rejectSandboxMessage(rateLimit.reason, sandbox);
+    }
+
+    const parsed = parseSlashCommandRequest(message.command, policy);
+    if (!parsed.ok) {
+        return rejectSandboxMessage(parsed.reason, sandbox);
+    }
+
+    return executeSandboxCommand(parsed.command, sandbox.messageId, { alreadyValidated: true });
+}
+
+export async function executeSandboxCommand(command, messageId, { alreadyValidated = false } = {}) {
+    const normalizedMessageId = normalizeMessageId(messageId);
+    if (normalizedMessageId === null) {
+        return { ok: false, reason: 'bad_message_id' };
+    }
+
+    if (!activeSandboxes.has(normalizedMessageId)) {
+        return { ok: false, reason: 'sandbox_not_found' };
+    }
+
+    let commandToExecute = command;
+    if (!alreadyValidated) {
+        const policy = await getCardScriptRuntimePolicy();
+        const parsed = parseSlashCommandRequest(command, policy);
+        if (!parsed.ok) {
+            return { ok: false, reason: parsed.reason };
+        }
+        commandToExecute = parsed.command;
+    }
+
+    const executeSlashCommandsWithOptions = await getSlashExecutor();
+    if (typeof executeSlashCommandsWithOptions !== 'function') {
+        return { ok: false, reason: 'missing_slash_executor' };
+    }
+
+    try {
+        await executeSlashCommandsWithOptions(commandToExecute, {
+            handleParserErrors: false,
+            handleExecutionErrors: true,
+            source: `card-script-sandbox:${normalizedMessageId}`,
+        });
+        return { ok: true };
+    } catch (error) {
+        console.warn('Card script sandbox command failed.', error);
+        return { ok: false, reason: 'execution_failed' };
+    }
+}
+
+export function destroySandbox(messageId) {
+    const normalizedMessageId = normalizeMessageId(messageId);
+    if (normalizedMessageId === null) {
+        return false;
+    }
+
+    const sandbox = activeSandboxes.get(normalizedMessageId);
+    if (!sandbox) {
+        return false;
+    }
+
+    const messageElement = sandbox.iframeElement?.parentElement ?? getMessageElement(normalizedMessageId);
+    activeSandboxes.delete(normalizedMessageId);
+    sandbox.observer?.disconnect?.();
+    sandbox.rateLimiter?.dispose?.();
+    sandbox.iframeElement?.remove?.();
+    syncDestroyedButtonState(messageElement);
+
+    sandbox.iframeElement = null;
+    sandbox.iframeWindow = null;
+    sandbox.rateLimiter = null;
+    sandbox.observer = null;
+
+    void syncCardScriptButtonForMessage(normalizedMessageId);
+    return true;
+}
+
+export function destroyAllSandboxes({ clearRunHistory = false } = {}) {
+    const messageIds = [...activeSandboxes.keys()];
+    for (const messageId of messageIds) {
+        destroySandbox(messageId);
+    }
+
+    if (clearRunHistory) {
+        completedSandboxRuns.clear();
+    }
+}
+
+export function isSandboxActive(messageId) {
+    const normalizedMessageId = normalizeMessageId(messageId);
+    return normalizedMessageId !== null && activeSandboxes.has(normalizedMessageId);
+}
+
+export function getActiveSandboxCount() {
+    return activeSandboxes.size;
+}
+
+export function getActiveSandbox(messageId) {
+    const normalizedMessageId = normalizeMessageId(messageId);
+    return normalizedMessageId === null ? null : activeSandboxes.get(normalizedMessageId) ?? null;
+}
+
+export async function syncAllCardScriptButtons() {
+    const documentRef = getRuntimeDocument();
+    const buttons = Array.from(documentRef?.querySelectorAll?.(CARD_SCRIPT_RUN_BUTTON_SELECTOR) ?? []);
+
+    await Promise.all(buttons.map(button => {
+        const messageElement = button.closest?.('.mes');
+        const messageId = normalizeMessageId(messageElement?.getAttribute?.('mesid'));
+        return syncCardScriptButtonForMessage(messageId, { messageElement });
+    }));
+}
+
+export async function syncCardScriptButtonForMessage(messageId, { messageElement = null } = {}) {
+    const normalizedMessageId = normalizeMessageId(messageId);
+    if (normalizedMessageId === null) {
+        return false;
+    }
+
+    const documentRef = getRuntimeDocument();
+    const resolvedMessageElement = messageElement ?? getMessageElement(normalizedMessageId, documentRef);
+    const button = resolvedMessageElement?.querySelector?.(CARD_SCRIPT_RUN_BUTTON_SELECTOR);
+
+    if (!button) {
+        return false;
+    }
+
+    const enabled = await isCardScriptRuntimeEnabled();
+    const hasScriptMarker = messageHasCardScriptMarker(resolvedMessageElement, normalizedMessageId);
+    const hasSnapshot = Boolean(runtimeDependencies.getCardScriptSnapshot(normalizedMessageId));
+    const shouldShow = enabled && hasScriptMarker && hasSnapshot;
+    const isActive = activeSandboxes.has(normalizedMessageId);
+    const hasRun = completedSandboxRuns.has(normalizedMessageId);
+
+    button.style.display = shouldShow ? '' : 'none';
+    button.classList.toggle('script-running', shouldShow && isActive);
+    button.classList.toggle('script-ran', shouldShow && hasRun && !isActive);
+    button.classList.toggle('fa-play', !isActive);
+    button.classList.toggle('fa-stop', isActive);
+    button.setAttribute('title', isActive ? 'Stop card scripts' : 'Run card scripts');
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+
+    return shouldShow;
+}
+
+export function messageHasCardScriptMarker(messageElement, messageId) {
+    const normalizedMessageId = normalizeMessageId(messageId);
+    if (!messageElement?.querySelectorAll || normalizedMessageId === null) {
+        return false;
+    }
+
+    const markers = Array.from(messageElement.querySelectorAll(CARD_SCRIPT_MARKER_TAG));
+    return markers.some(marker => Number(marker?.dataset?.msgId) === normalizedMessageId);
+}
+
+export async function isCardScriptRuntimeEnabled() {
+    const powerUser = await getPowerUserSettings();
+    return Boolean(powerUser?.allow_card_scripts);
+}
+
+export async function getCardScriptRuntimePolicy() {
+    const enabled = await isCardScriptRuntimeEnabled();
+    return createDefaultPolicy({
+        mode: enabled ? POLICY_MODES.ALLOWLIST : POLICY_MODES.DISABLED,
+    });
+}
+
+export function normalizeMessageId(messageId) {
+    if (messageId === null || messageId === undefined || messageId === '') {
+        return null;
+    }
+
+    const normalized = Number(messageId);
+    return Number.isInteger(normalized) && normalized >= 0 ? normalized : null;
+}
+
+async function handleRunButtonClick(event) {
+    const button = event?.target?.closest?.(CARD_SCRIPT_RUN_BUTTON_SELECTOR);
+    if (!button) {
+        return;
+    }
+
+    event.preventDefault?.();
+    event.stopPropagation?.();
+
+    const messageElement = button.closest?.('.mes');
+    const messageId = normalizeMessageId(messageElement?.getAttribute?.('mesid'));
+    if (messageId === null) {
+        return;
+    }
+
+    if (activeSandboxes.has(messageId)) {
+        destroySandbox(messageId);
+        return;
+    }
+
+    if (!await confirmCardScriptExecution()) {
+        return;
+    }
+
+    button.classList.add('script-running');
+
+    try {
+        await createSandbox(messageId);
+    } catch (error) {
+        button.classList.remove('script-running');
+        console.warn('Could not start card script sandbox.', error);
+        runtimeDependencies.toastr?.()?.warning?.('Could not start card scripts for this message.', 'Card scripts blocked', {
+            timeOut: 6000,
+            preventDuplicates: true,
+        });
+        await syncCardScriptButtonForMessage(messageId, { messageElement });
+    }
+}
+
+function handleSettingInput(event) {
+    if (!event?.currentTarget?.checked) {
+        destroyAllSandboxes({ clearRunHistory: true });
+    }
+
+    getRuntimeWindow()?.setTimeout?.(() => void syncAllCardScriptButtons(), 0);
+}
+
+async function confirmCardScriptExecution() {
+    const storage = runtimeDependencies.getLocalStorage?.();
+
+    try {
+        if (storage?.getItem?.(CARD_SCRIPT_CONFIRMATION_STORAGE_KEY) === 'true') {
+            return true;
+        }
+    } catch {
+        // Storage can be unavailable in hardened browser modes; fall through to confirmation.
+    }
+
+    const confirmed = await showCardScriptConfirmation();
+    if (!confirmed) {
+        return false;
+    }
+
+    try {
+        storage?.setItem?.(CARD_SCRIPT_CONFIRMATION_STORAGE_KEY, 'true');
+    } catch {
+        // Confirmation remains valid for this click even if it cannot be persisted.
+    }
+
+    return true;
+}
+
+async function showCardScriptConfirmation() {
+    if (typeof runtimeDependencies.showConfirmation === 'function') {
+        return Boolean(await runtimeDependencies.showConfirmation());
+    }
+
+    const { callGenericPopup, POPUP_RESULT, POPUP_TYPE } = await import('./popup.js');
+    const content = `
+        <h3>Run card scripts?</h3>
+        <p>This will run scripts embedded in this card inside a sandboxed iframe. Only a narrow allowlist of slash commands can cross back into SillyBunny.</p>
+        <p>Do not run card scripts from cards you do not trust.</p>
+    `;
+    const result = await callGenericPopup(content, POPUP_TYPE.CONFIRM, null, {
+        okButton: 'Run Scripts',
+        cancelButton: 'Cancel',
+        wide: false,
+        large: false,
+    });
+
+    return result === POPUP_RESULT.AFFIRMATIVE;
+}
+
+async function getPowerUserSettings() {
+    const powerUser = runtimeDependencies.getPowerUser?.();
+    return powerUser instanceof Promise ? await powerUser : powerUser;
+}
+
+async function getSlashExecutor() {
+    if (typeof runtimeDependencies.executeSlashCommandsWithOptions === 'function') {
+        return runtimeDependencies.executeSlashCommandsWithOptions;
+    }
+
+    const executor = runtimeDependencies.getSlashExecutor?.();
+    return executor instanceof Promise ? await executor : executor;
+}
+
+function getSandboxBySource(source) {
+    for (const sandbox of activeSandboxes.values()) {
+        if (sandbox.iframeWindow === source) {
+            return sandbox;
+        }
+    }
+
+    return null;
+}
+
+function rejectSandboxMessage(reason, sandbox = null) {
+    if (reason !== 'unknown_source') {
+        console.debug('Rejected card script sandbox message.', {
+            reason,
+            messageId: sandbox?.messageId,
+        });
+    }
+
+    return { ok: false, reason };
+}
+
+function getMessageElement(messageId, documentRef = getRuntimeDocument()) {
+    return documentRef?.querySelector?.(`#chat .mes[mesid="${messageId}"]`)
+        ?? documentRef?.querySelector?.(`.mes[mesid="${messageId}"]`)
+        ?? null;
+}
+
+function createSandboxRemovalObserver(messageElement, messageId, documentRef) {
+    const MutationObserverCtor = runtimeDependencies.getMutationObserver?.();
+    const chatContainer = documentRef?.querySelector?.('#chat') ?? messageElement?.parentElement;
+
+    if (!MutationObserverCtor || !chatContainer) {
+        return null;
+    }
+
+    const observer = new MutationObserverCtor((mutations) => {
+        for (const mutation of mutations) {
+            for (const node of mutation.removedNodes ?? []) {
+                if (node === messageElement || node?.contains?.(messageElement)) {
+                    completedSandboxRuns.delete(messageId);
+                    destroySandbox(messageId);
+                    return;
+                }
+            }
+        }
+    });
+
+    observer.observe(chatContainer, { childList: true, subtree: true });
+    return observer;
+}
+
+function syncDestroyedButtonState(messageElement) {
+    const button = messageElement?.querySelector?.(CARD_SCRIPT_RUN_BUTTON_SELECTOR);
+    if (!button) {
+        return;
+    }
+
+    button.classList.remove('script-running');
+    button.classList.add('script-ran');
+    button.classList.add('fa-play');
+    button.classList.remove('fa-stop');
+    button.setAttribute('title', 'Run card scripts');
+    button.setAttribute('aria-pressed', 'false');
+}
+
+function getRuntimeDocument() {
+    return runtimeDependencies.getDocument?.();
+}
+
+function getRuntimeWindow() {
+    return runtimeDependencies.getWindow?.();
+}
+
+function createSecureNonce() {
+    const cryptoRef = globalThis.crypto;
+
+    if (typeof cryptoRef?.randomUUID === 'function') {
+        return cryptoRef.randomUUID();
+    }
+
+    if (typeof cryptoRef?.getRandomValues === 'function') {
+        const bytes = new Uint8Array(16);
+        cryptoRef.getRandomValues(bytes);
+        return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+    }
+
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+function createRuntimeError(message, reason) {
+    const error = new Error(message);
+    error.reason = reason;
+    return error;
+}

--- a/public/style.css
+++ b/public/style.css
@@ -4891,6 +4891,19 @@ input[type="range"]::-webkit-slider-thumb {
     opacity: 1;
 }
 
+.card-script-sandbox-frame {
+    display: none !important;
+}
+
+.mes_run_card_scripts.script-running {
+    opacity: 0.85;
+    color: var(--SmartThemeQuoteColor);
+}
+
+.mes_run_card_scripts.script-ran {
+    opacity: 0.6;
+}
+
 .mes_bookmark {
     display: none;
 }

--- a/tests/card-script-runtime.test.js
+++ b/tests/card-script-runtime.test.js
@@ -1,0 +1,498 @@
+/* global globalThis */
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { eventSource, event_types } from '../public/scripts/events.js';
+import { MESSAGE_TYPE, MESSAGE_VERSION } from '../public/scripts/card-script-sandbox/messages.js';
+import {
+    configureCardScriptRuntime,
+    createSandbox,
+    destroySandbox,
+    executeSandboxCommand,
+    getActiveSandboxCount,
+    handleSandboxMessage,
+    initCardScriptRuntime,
+    resetCardScriptRuntimeForTests,
+    syncCardScriptButtonForMessage,
+} from '../public/scripts/card-script-runtime.js';
+
+class FakeClassList {
+    constructor(initialClasses = []) {
+        this.classes = new Set(initialClasses);
+    }
+
+    add(...classes) {
+        classes.forEach(className => this.classes.add(className));
+    }
+
+    remove(...classes) {
+        classes.forEach(className => this.classes.delete(className));
+    }
+
+    toggle(className, force) {
+        if (force === true) {
+            this.classes.add(className);
+            return true;
+        }
+
+        if (force === false) {
+            this.classes.delete(className);
+            return false;
+        }
+
+        if (this.classes.has(className)) {
+            this.classes.delete(className);
+            return false;
+        }
+
+        this.classes.add(className);
+        return true;
+    }
+
+    contains(className) {
+        return this.classes.has(className);
+    }
+}
+
+class FakeElement extends EventTarget {
+    constructor(tagName, classNames = []) {
+        super();
+        this.tagName = tagName.toUpperCase();
+        this.children = [];
+        this.parentElement = null;
+        this.parentNode = null;
+        this.attributes = new Map();
+        this.dataset = {};
+        this.style = {};
+        this.classList = new FakeClassList(classNames);
+        this.removed = false;
+
+        if (tagName.toLowerCase() === 'iframe') {
+            this.contentWindow = { postMessage: jest.fn() };
+        }
+    }
+
+    set className(value) {
+        this.classList = new FakeClassList(String(value ?? '').split(/\s+/).filter(Boolean));
+    }
+
+    get className() {
+        return [...this.classList.classes].join(' ');
+    }
+
+    appendChild(child) {
+        child.parentElement = this;
+        child.parentNode = this;
+        this.children.push(child);
+        return child;
+    }
+
+    remove() {
+        this.removed = true;
+        if (!this.parentElement) {
+            return;
+        }
+
+        this.parentElement.children = this.parentElement.children.filter(child => child !== this);
+        this.parentElement = null;
+        this.parentNode = null;
+    }
+
+    contains(node) {
+        if (node === this) {
+            return true;
+        }
+
+        return this.children.some(child => child.contains?.(node));
+    }
+
+    setAttribute(name, value) {
+        this.attributes.set(name, String(value));
+    }
+
+    getAttribute(name) {
+        return this.attributes.get(name) ?? null;
+    }
+
+    querySelector(selector) {
+        return this.querySelectorAll(selector)[0] ?? null;
+    }
+
+    querySelectorAll(selector) {
+        const matches = [];
+
+        const visit = (node) => {
+            if (node.matches?.(selector)) {
+                matches.push(node);
+            }
+
+            for (const child of node.children ?? []) {
+                visit(child);
+            }
+        };
+
+        for (const child of this.children) {
+            visit(child);
+        }
+
+        return matches;
+    }
+
+    matches(selector) {
+        if (selector === '.mes') {
+            return this.classList.contains('mes');
+        }
+
+        if (selector === '.mes_run_card_scripts') {
+            return this.classList.contains('mes_run_card_scripts');
+        }
+
+        if (selector === 'custom-card-script-marker') {
+            return this.tagName.toLowerCase() === 'custom-card-script-marker';
+        }
+
+        const messageMatch = selector.match(/^\.mes\[mesid="(\d+)"\]$/);
+        if (messageMatch) {
+            return this.classList.contains('mes') && this.getAttribute('mesid') === messageMatch[1];
+        }
+
+        return false;
+    }
+
+    closest(selector) {
+        let node = this;
+        while (node) {
+            if (node.matches?.(selector)) {
+                return node;
+            }
+            node = node.parentElement;
+        }
+
+        return null;
+    }
+}
+
+class FakeDocument extends EventTarget {
+    constructor() {
+        super();
+        this.chat = new FakeElement('div');
+        this.chat.setAttribute('id', 'chat');
+        this.setting = new FakeElement('input');
+    }
+
+    createElement(tagName) {
+        return new FakeElement(tagName);
+    }
+
+    getElementById(id) {
+        return id === 'allow_card_scripts' ? this.setting : null;
+    }
+
+    querySelector(selector) {
+        if (selector === '#chat') {
+            return this.chat;
+        }
+
+        const chatMessageMatch = selector.match(/^#chat \.mes\[mesid="(\d+)"\]$/);
+        if (chatMessageMatch) {
+            return this.findMessage(chatMessageMatch[1]);
+        }
+
+        const messageMatch = selector.match(/^\.mes\[mesid="(\d+)"\]$/);
+        if (messageMatch) {
+            return this.findMessage(messageMatch[1]);
+        }
+
+        return null;
+    }
+
+    querySelectorAll(selector) {
+        if (selector === '.mes_run_card_scripts') {
+            return this.chat.querySelectorAll(selector);
+        }
+
+        return [];
+    }
+
+    findMessage(messageId) {
+        return this.chat.children.find(child => child.getAttribute('mesid') === String(messageId)) ?? null;
+    }
+}
+
+class FakeMutationObserver {
+    static instances = [];
+
+    constructor(callback) {
+        this.callback = callback;
+        this.disconnected = false;
+        this.observed = null;
+        FakeMutationObserver.instances.push(this);
+    }
+
+    observe(target, options) {
+        this.observed = { target, options };
+    }
+
+    disconnect() {
+        this.disconnected = true;
+    }
+}
+
+function createMessage(documentRef, messageId = 7) {
+    const message = new FakeElement('div', ['mes']);
+    message.setAttribute('mesid', String(messageId));
+
+    const button = new FakeElement('div', ['mes_button', 'mes_run_card_scripts', 'fa-solid', 'fa-play']);
+    button.style.display = 'none';
+
+    const marker = new FakeElement('custom-card-script-marker');
+    marker.dataset.msgId = String(messageId);
+
+    message.appendChild(button);
+    message.appendChild(marker);
+    documentRef.chat.appendChild(message);
+
+    return { message, button, marker };
+}
+
+function setupRuntime({
+    enabled = true,
+    snapshotHtml = '<script>triggerSlash("/echo hello")</script>',
+    messageId = 7,
+    limiter = null,
+} = {}) {
+    const documentRef = new FakeDocument();
+    const windowRef = new EventTarget();
+    windowRef.setTimeout = callback => callback();
+    const { message, button } = createMessage(documentRef, messageId);
+    const executeSlashCommandsWithOptions = jest.fn(async () => ({ pipe: 'not returned' }));
+    const buildSandboxDocument = jest.fn(({ html, messageId: sandboxMessageId, nonce }) => `sandbox:${sandboxMessageId}:${nonce}:${html}`);
+    const rateLimiter = limiter ?? {
+        tryAcquire: jest.fn(() => ({ ok: true })),
+        reset: jest.fn(),
+        dispose: jest.fn(),
+    };
+
+    configureCardScriptRuntime({
+        getDocument: () => documentRef,
+        getWindow: () => windowRef,
+        getMutationObserver: () => FakeMutationObserver,
+        getLocalStorage: () => ({
+            getItem: jest.fn(() => 'true'),
+            setItem: jest.fn(),
+        }),
+        getPowerUser: () => ({ allow_card_scripts: enabled }),
+        getCardScriptSnapshot: id => id === messageId && snapshotHtml ? { html: snapshotHtml, hash: 'hash' } : null,
+        buildSandboxDocument,
+        createRateLimiter: () => rateLimiter,
+        createNonce: () => 'nonce-7',
+        now: () => 1234,
+        executeSlashCommandsWithOptions,
+        showConfirmation: jest.fn(async () => true),
+        toastr: () => ({ warning: jest.fn() }),
+    });
+
+    return { documentRef, windowRef, message, button, executeSlashCommandsWithOptions, buildSandboxDocument, rateLimiter };
+}
+
+function createSlashMessage(overrides = {}) {
+    return {
+        type: MESSAGE_TYPE,
+        version: MESSAGE_VERSION,
+        messageId: 7,
+        nonce: 'nonce-7',
+        command: '/echo hello',
+        ...overrides,
+    };
+}
+
+beforeEach(() => {
+    FakeMutationObserver.instances = [];
+    globalThis.localStorage = {
+        getItem: jest.fn(() => 'false'),
+        setItem: jest.fn(),
+    };
+    jest.spyOn(console, 'debug').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    resetCardScriptRuntimeForTests();
+    delete globalThis.localStorage;
+    jest.restoreAllMocks();
+});
+
+describe('card script runtime bridge', () => {
+    test('creates a sandbox with a valid message id', async () => {
+        const { message, button, buildSandboxDocument } = setupRuntime();
+
+        const sandbox = await createSandbox(7);
+
+        expect(getActiveSandboxCount()).toBe(1);
+        expect(sandbox.messageId).toBe(7);
+        expect(sandbox.nonce).toBe('nonce-7');
+        expect(sandbox.createdAt).toBe(1234);
+        const sandboxAttribute = sandbox.iframeElement.attributes.get('sandbox');
+        expect(sandboxAttribute).toBe('allow-scripts');
+        expect(sandbox.iframeElement.srcdoc).toContain('sandbox:7:nonce-7');
+        expect(message.children).toContain(sandbox.iframeElement);
+        expect(buildSandboxDocument).toHaveBeenCalledWith({
+            html: '<script>triggerSlash("/echo hello")</script>',
+            messageId: 7,
+            nonce: 'nonce-7',
+        });
+        expect(button.style.display).toBe('');
+        expect(button.classList.contains('script-running')).toBe(true);
+    });
+
+    test('accepts a valid postMessage from the registered iframe and executes the command', async () => {
+        const { executeSlashCommandsWithOptions } = setupRuntime();
+        const sandbox = await createSandbox(7);
+
+        const result = await handleSandboxMessage({
+            source: sandbox.iframeWindow,
+            data: createSlashMessage(),
+        });
+
+        expect(result).toEqual({ ok: true });
+        expect(executeSlashCommandsWithOptions).toHaveBeenCalledWith('/echo hello', {
+            handleParserErrors: false,
+            handleExecutionErrors: true,
+            source: 'card-script-sandbox:7',
+        });
+        expect(sandbox.iframeWindow.postMessage).not.toHaveBeenCalled();
+    });
+
+    test('rejects postMessage events from unknown sources', async () => {
+        const { executeSlashCommandsWithOptions } = setupRuntime();
+        await createSandbox(7);
+
+        const result = await handleSandboxMessage({
+            source: {},
+            data: createSlashMessage(),
+        });
+
+        expect(result).toEqual({ ok: false, reason: 'unknown_source' });
+        expect(executeSlashCommandsWithOptions).not.toHaveBeenCalled();
+    });
+
+    test('rejects wrong nonce and wrong message id', async () => {
+        const { executeSlashCommandsWithOptions } = setupRuntime();
+        const sandbox = await createSandbox(7);
+
+        await expect(handleSandboxMessage({
+            source: sandbox.iframeWindow,
+            data: createSlashMessage({ nonce: 'wrong' }),
+        })).resolves.toEqual({ ok: false, reason: 'bad_nonce' });
+
+        await expect(handleSandboxMessage({
+            source: sandbox.iframeWindow,
+            data: createSlashMessage({ messageId: 8 }),
+        })).resolves.toEqual({ ok: false, reason: 'bad_message_id' });
+
+        expect(executeSlashCommandsWithOptions).not.toHaveBeenCalled();
+    });
+
+    test('rejects disallowed and oversized commands', async () => {
+        const { executeSlashCommandsWithOptions } = setupRuntime();
+        const sandbox = await createSandbox(7);
+
+        await expect(handleSandboxMessage({
+            source: sandbox.iframeWindow,
+            data: createSlashMessage({ command: '/send hello' }),
+        })).resolves.toEqual({ ok: false, reason: 'command_not_allowed' });
+
+        await expect(handleSandboxMessage({
+            source: sandbox.iframeWindow,
+            data: createSlashMessage({ command: 'x'.repeat(2001) }),
+        })).resolves.toEqual({ ok: false, reason: 'command_too_long' });
+
+        expect(executeSlashCommandsWithOptions).not.toHaveBeenCalled();
+    });
+
+    test('rate-limits repeated sandbox command requests', async () => {
+        const limiter = {
+            tryAcquire: jest.fn()
+                .mockReturnValueOnce({ ok: true })
+                .mockReturnValueOnce({ ok: false, reason: 'rate_limited' }),
+            dispose: jest.fn(),
+        };
+        const { executeSlashCommandsWithOptions } = setupRuntime({ limiter });
+        const sandbox = await createSandbox(7);
+
+        await expect(handleSandboxMessage({
+            source: sandbox.iframeWindow,
+            data: createSlashMessage(),
+        })).resolves.toEqual({ ok: true });
+        await expect(handleSandboxMessage({
+            source: sandbox.iframeWindow,
+            data: createSlashMessage(),
+        })).resolves.toEqual({ ok: false, reason: 'rate_limited' });
+
+        expect(executeSlashCommandsWithOptions).toHaveBeenCalledTimes(1);
+    });
+
+    test('executes allowed commands through the slash-command API but requires an active sandbox', async () => {
+        const { executeSlashCommandsWithOptions } = setupRuntime();
+
+        await expect(executeSandboxCommand('/echo hello', 7)).resolves.toEqual({
+            ok: false,
+            reason: 'sandbox_not_found',
+        });
+
+        await createSandbox(7);
+        await expect(executeSandboxCommand('/echo hello', 7)).resolves.toEqual({ ok: true });
+        await expect(executeSandboxCommand('/delchat', 7)).resolves.toEqual({
+            ok: false,
+            reason: 'command_not_allowed',
+        });
+
+        expect(executeSlashCommandsWithOptions).toHaveBeenCalledTimes(1);
+    });
+
+    test('destroys a sandbox and cleans up owned resources', async () => {
+        const { message, button, rateLimiter } = setupRuntime();
+        const sandbox = await createSandbox(7);
+        const observer = sandbox.observer;
+
+        expect(destroySandbox(7)).toBe(true);
+
+        expect(getActiveSandboxCount()).toBe(0);
+        expect(rateLimiter.dispose).toHaveBeenCalledTimes(1);
+        expect(observer.disconnected).toBe(true);
+        expect(sandbox.iframeElement).toBeNull();
+        expect(message.children.some(child => child.tagName === 'IFRAME')).toBe(false);
+        await Promise.resolve();
+        expect(button.classList.contains('script-running')).toBe(false);
+    });
+
+    test('destroys active sandboxes on chat change lifecycle events', async () => {
+        setupRuntime();
+        initCardScriptRuntime();
+        await createSandbox(7);
+
+        await eventSource.emit(event_types.CHAT_CHANGED);
+
+        expect(getActiveSandboxCount()).toBe(0);
+    });
+
+    test('destroys a sandbox when the owning message leaves the DOM', async () => {
+        const { message, rateLimiter } = setupRuntime();
+        await createSandbox(7);
+        const observer = FakeMutationObserver.instances[0];
+
+        observer.callback([{ removedNodes: [message] }]);
+
+        expect(getActiveSandboxCount()).toBe(0);
+        expect(rateLimiter.dispose).toHaveBeenCalledTimes(1);
+        expect(observer.disconnected).toBe(true);
+    });
+
+    test('hides the run button when the global setting is disabled', async () => {
+        const { button } = setupRuntime({ enabled: false });
+
+        const visible = await syncCardScriptButtonForMessage(7);
+
+        expect(visible).toBe(false);
+        expect(button.style.display).toBe('none');
+        await expect(createSandbox(7)).rejects.toMatchObject({ reason: 'policy_disabled' });
+    });
+});

--- a/tests/card-script-sandbox.e2e.js
+++ b/tests/card-script-sandbox.e2e.js
@@ -1,0 +1,101 @@
+/* global document, localStorage */
+import { expect, test } from '@playwright/test';
+
+const MESSAGE_ID = 9876;
+
+async function installMarkedCardScriptMessage(page, scriptHtml) {
+    await page.evaluate(async ({ messageId, html }) => {
+        const { rememberCardScript } = await import('/scripts/card-script-detection.js');
+        const { power_user } = await import('/scripts/power-user.js');
+        const runtime = await import('/scripts/card-script-runtime.js');
+
+        power_user.allow_card_scripts = true;
+        localStorage.setItem(runtime.CARD_SCRIPT_CONFIRMATION_STORAGE_KEY, 'true');
+
+        const appChat = document.querySelector('#chat:not([data-card-script-e2e="true"])');
+        if (appChat) {
+            appChat.id = 'chat-e2e-original';
+        }
+
+        let chat = document.querySelector('#chat[data-card-script-e2e="true"]');
+        if (!chat) {
+            chat = document.createElement('div');
+            chat.id = 'chat';
+            chat.dataset.cardScriptE2e = 'true';
+            document.body.appendChild(chat);
+        }
+        chat.style.display = 'block';
+        chat.style.visibility = 'visible';
+        chat.style.position = 'fixed';
+        chat.style.left = '16px';
+        chat.style.top = '16px';
+        chat.style.zIndex = '10000';
+
+        const existingMessage = chat.querySelector(`.mes[mesid="${messageId}"]`);
+        existingMessage?.remove();
+
+        const message = document.createElement('div');
+        message.className = 'mes';
+        message.setAttribute('mesid', String(messageId));
+        message.innerHTML = `
+            <div class="mes_block">
+                <div class="mes_buttons">
+                    <div class="extraMesButtons" style="display: flex;">
+                        <div title="Run card scripts" class="mes_button mes_run_card_scripts fa-solid fa-play" style="display: none;"></div>
+                    </div>
+                </div>
+                <div class="mes_text">
+                    <custom-card-script-marker data-msg-id="${messageId}"></custom-card-script-marker>
+                </div>
+            </div>
+        `;
+
+        chat.appendChild(message);
+        rememberCardScript(messageId, html);
+        await runtime.syncCardScriptButtonForMessage(messageId);
+    }, { messageId: MESSAGE_ID, html: scriptHtml });
+}
+
+test.describe('card script sandbox runtime', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/');
+        await page.waitForFunction('document.getElementById("preloader") === null', { timeout: 0 });
+    });
+
+    test('shows the opt-in run button and creates a locked iframe sandbox', async ({ page }) => {
+        await installMarkedCardScriptMessage(page, '<script>window.triggerSlash("/echo sandbox e2e")</script>');
+
+        const runButton = page.locator(`.mes[mesid="${MESSAGE_ID}"] .mes_run_card_scripts`);
+        await expect(runButton).toBeVisible();
+
+        await runButton.click();
+
+        const sandbox = page.locator(`.mes[mesid="${MESSAGE_ID}"] iframe.card-script-sandbox-frame`);
+        await expect(sandbox).toHaveAttribute('sandbox', 'allow-scripts');
+        await expect(sandbox).not.toHaveAttribute('sandbox', /allow-same-origin/);
+        await expect(runButton).toHaveClass(/script-running/);
+    });
+
+    test('rejects blocked slash commands from the sandbox bridge', async ({ page }) => {
+        await installMarkedCardScriptMessage(page, '<script></script>');
+
+        const result = await page.evaluate(async (messageId) => {
+            const { MESSAGE_TYPE, MESSAGE_VERSION } = await import('/scripts/card-script-sandbox/messages.js');
+            const runtime = await import('/scripts/card-script-runtime.js');
+            const sandbox = await runtime.createSandbox(messageId);
+
+            return runtime.handleSandboxMessage({
+                source: sandbox.iframeWindow,
+                data: {
+                    type: MESSAGE_TYPE,
+                    version: MESSAGE_VERSION,
+                    messageId,
+                    nonce: sandbox.nonce,
+                    command: '/delchat',
+                },
+            });
+        }, MESSAGE_ID);
+
+        expect(result).toEqual({ ok: false, reason: 'command_not_allowed' });
+    });
+});


### PR DESCRIPTION
## Summary
- add the card script runtime bridge for sandboxed iframe execution
- wire the opt-in message action and enabled setting into the main UI
- validate postMessage source, nonce, messageId, schema, allowlist, and rate limits before executing slash commands
- add unit and Playwright E2E coverage plus changelog/security invariant notes

## Security
- execution stays off by default and requires a per-message user action
- iframe sandbox uses `allow-scripts` only, without `allow-same-origin`
- sandbox receives no command results, chat contents, settings, or parent DOM access
- default runtime policy stays on the narrow allowlist tier

## Verification
- `npm run lint`
- `npm run lint --prefix tests`
- `npm run test:unit --prefix tests`
- `npm run test:e2e --prefix tests -- card-script-sandbox.e2e.js`
- `npm run check:frontend-budgets`
- `git diff --check`