### PR TITLE
fix(cards): block remote sandbox resource loads

### DIFF
--- a/public/scripts/card-script-sandbox/wrapper.js
+++ b/public/scripts/card-script-sandbox/wrapper.js
@@ -1,6 +1,6 @@
 import { MESSAGE_TYPE, MESSAGE_VERSION } from './messages.js';
 
-export const CARD_SCRIPT_SANDBOX_CSP = 'default-src \'none\'; script-src \'unsafe-inline\'; style-src \'unsafe-inline\'; img-src data: blob: https:; media-src data: blob: https:; font-src data: https:; connect-src \'none\'; form-action \'none\'; base-uri \'none\'';
+export const CARD_SCRIPT_SANDBOX_CSP = 'default-src \'none\'; script-src \'unsafe-inline\'; style-src \'unsafe-inline\'; img-src data: blob:; media-src data: blob:; font-src data:; connect-src \'none\'; form-action \'none\'; base-uri \'none\'';
 
 const TRIGGER_SLASH_BRIDGE_NAME = 'triggerSlash';
 

--- a/tests/card-script-sandbox-wrapper.test.js
+++ b/tests/card-script-sandbox-wrapper.test.js
@@ -10,9 +10,11 @@ describe('card script sandbox wrapper', () => {
         expect(srcdoc).toContain('<html>');
         expect(srcdoc).toContain('<meta charset="utf-8">');
         expect(srcdoc).toContain(`<meta http-equiv="Content-Security-Policy" content="${CARD_SCRIPT_SANDBOX_CSP}">`);
-        expect(CARD_SCRIPT_SANDBOX_CSP).toContain('img-src data: blob: https:');
-        expect(CARD_SCRIPT_SANDBOX_CSP).toContain('media-src data: blob: https:');
-        expect(CARD_SCRIPT_SANDBOX_CSP).toContain('font-src data: https:');
+        expect(CARD_SCRIPT_SANDBOX_CSP).toContain('img-src data: blob:');
+        expect(CARD_SCRIPT_SANDBOX_CSP).toContain('media-src data: blob:');
+        expect(CARD_SCRIPT_SANDBOX_CSP).toContain('font-src data:');
+        expect(CARD_SCRIPT_SANDBOX_CSP).not.toContain('https:');
+        expect(CARD_SCRIPT_SANDBOX_CSP).not.toContain('http:');
         expect(CARD_SCRIPT_SANDBOX_CSP).not.toContain('frame-ancestors');
         expect(CARD_SCRIPT_SANDBOX_CSP).not.toContain('files.catbox.moe');
         expect(srcdoc).toContain('<p>Hello</p>');


### PR DESCRIPTION
## Summary
- tighten the card script iframe CSP so image, media, and font directives only permit inline `data:`/`blob:` resources
- add wrapper test assertions that the sandbox CSP does not allow `http:` or `https:` resource loads

## Context
The native card script runner is already on `origin/staging` via PR #143. This PR closes the remaining network-isolation gap from the implementation plan: remote resource loads were still possible through CSP resource directives even though `connect-src` was blocked.

## Tests
- `npm run test:unit -- --runTestsByPath card-script-sandbox-wrapper.test.js`
- `npx eslint public/scripts/card-script-sandbox/wrapper.js`
- `npx eslint card-script-sandbox-wrapper.test.js` from `tests/`
- `npm run test:unit -- --runTestsByPath card-script-detection.test.js card-script-runtime.test.js card-script-sandbox-allowlist.test.js card-script-sandbox-messages.test.js card-script-sandbox-rate-limiter.test.js card-script-sandbox-wrapper.test.js`
- `npm run test:e2e -- card-script-sandbox.e2e.js` with local server on `127.0.0.1:4444`
