### PR TITLE
Add prompt manager drag lock

### DIFF
--- a/public/css/promptmanager.css
+++ b/public/css/promptmanager.css
@@ -430,6 +430,31 @@
     gap: 12px;
 }
 
+.prompt_manager_header_controls {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex: 0 0 auto;
+    gap: 6px;
+}
+
+#completion_prompt_manager .prompt_manager_drag_lock_button.menu_button {
+    width: var(--sb-control-min-height, 30px);
+    padding: 0;
+}
+
+#completion_prompt_manager .prompt_manager_drag_lock_button.menu_button.toggleable {
+    padding-left: 0;
+}
+
+#completion_prompt_manager .prompt_manager_drag_lock_button.menu_button.toggleable::before {
+    content: none;
+}
+
+#completion_prompt_manager .prompt_manager_drag_lock_button > i {
+    pointer-events: none;
+}
+
 #completion_prompt_manager .completion_prompt_manager_drawer_content {
     padding-top: 0.35em;
 }
@@ -536,6 +561,21 @@
     padding: 0 5px;
     display: flex;
     align-items: center;
+}
+
+#completion_prompt_manager #completion_prompt_manager_list.prompt-manager-drag-locked .completion_prompt_manager_prompt_draggable {
+    cursor: default;
+}
+
+#completion_prompt_manager #completion_prompt_manager_list.prompt-manager-drag-locked.ui-state-disabled {
+    cursor: default;
+    opacity: 1;
+    pointer-events: auto;
+}
+
+#completion_prompt_manager #completion_prompt_manager_list.prompt-manager-drag-locked .drag-handle {
+    cursor: default;
+    opacity: 0.38;
 }
 
 #completion_prompt_manager_footer_append_prompt {

--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -2,7 +2,7 @@
 
 import { DOMPurify } from '../lib.js';
 
-import { event_types, eventSource, is_send_press, main_api, substituteParams } from '../script.js';
+import { event_types, eventSource, is_send_press, main_api, saveSettingsDebounced, substituteParams } from '../script.js';
 import { is_group_generating } from './group-chats.js';
 import { Message, MessageCollection, TokenHandler } from './openai.js';
 import { power_user } from './power-user.js';
@@ -1980,7 +1980,7 @@ class PromptManager {
 
         const totalActiveTokens = this.tokenUsage;
 
-        const headerHtml = await renderTemplateAsync('promptManagerHeader', { error: this.error, errorDiv, prefix: this.configuration.prefix, totalActiveTokens });
+        const headerHtml = await renderTemplateAsync('promptManagerHeader', { error: this.error, errorDiv, prefix: this.configuration.prefix, totalActiveTokens, dragLocked: power_user.prompt_manager_drag_locked });
         promptManagerDiv.insertAdjacentHTML('beforeend', headerHtml);
 
         this.listElement = promptManagerDiv.querySelector(`#${this.configuration.prefix}prompt_manager_list`);
@@ -2014,6 +2014,7 @@ class PromptManager {
             const footerDiv = promptManagerDiv.querySelector(`.${this.configuration.prefix}prompt_manager_footer`);
             if (!(footerDiv instanceof HTMLElement)) {
                 this.bindDrawerPersistence();
+                this.bindDragLockButton();
                 return;
             }
 
@@ -2029,9 +2030,25 @@ class PromptManager {
         }
 
         this.bindDrawerPersistence();
+        this.bindDragLockButton();
         this.syncPopupPlacement();
         this.syncEditorPaneState();
         this.syncListSelection();
+    }
+
+    bindDragLockButton() {
+        const dragLockButton = this.containerElement?.querySelector(`#${this.configuration.prefix}prompt_manager_drag_lock`);
+        if (!(dragLockButton instanceof HTMLElement)) {
+            return;
+        }
+
+        dragLockButton.addEventListener('click', (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            power_user.prompt_manager_drag_locked = !power_user.prompt_manager_drag_locked;
+            this.updateDragLockState();
+            saveSettingsDebounced();
+        });
     }
 
     /**
@@ -2338,6 +2355,36 @@ class PromptManager {
                 this.saveServiceSettings();
             },
         });
+        this.updateDragLockState();
+    }
+
+    updateDragLockState() {
+        const locked = Boolean(power_user.prompt_manager_drag_locked);
+        const promptList = this.listElement ?? this.containerElement?.querySelector(`#${this.configuration.prefix}prompt_manager_list`);
+        const $promptList = $(`#${this.configuration.prefix}prompt_manager_list`);
+
+        if ($promptList.length && $promptList.data('ui-sortable')) {
+            $promptList.sortable(locked ? 'disable' : 'enable');
+        }
+
+        if (promptList instanceof HTMLElement) {
+            promptList.classList.toggle('prompt-manager-drag-locked', locked);
+            promptList.classList.toggle('prompt-manager-drag-unlocked', !locked);
+        }
+
+        const dragLockButton = this.containerElement?.querySelector(`#${this.configuration.prefix}prompt_manager_drag_lock`);
+        if (dragLockButton instanceof HTMLElement) {
+            dragLockButton.classList.toggle('toggled', locked);
+            dragLockButton.setAttribute('aria-pressed', String(locked));
+
+            const icon = dragLockButton.querySelector('i');
+            if (icon instanceof HTMLElement) {
+                icon.classList.toggle('fa-lock', locked);
+                icon.classList.toggle('fa-unlock', !locked);
+            }
+        }
+
+        this.log(`Prompt reordering ${locked ? 'locked' : 'unlocked'}.`);
     }
 
     /**

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -324,6 +324,7 @@ export const power_user = {
     auto_clear_cache_on_update: true,
     send_on_enter: send_on_enter_options.AUTO,
     console_log_prompts: false,
+    prompt_manager_drag_locked: true,
     request_token_probabilities: false,
     show_group_chat_queue: false,
     allow_name1_display: false,

--- a/public/scripts/templates/promptManagerHeader.html
+++ b/public/scripts/templates/promptManagerHeader.html
@@ -8,6 +8,11 @@
                 <b data-i18n="Prompts">Prompts</b>
                 <small class="sb-group-meta"><span data-i18n="Inspect, reorder, toggle, and edit injected prompts">Inspect, reorder, toggle, and edit injected prompts</span> &middot; <span data-i18n="Total Tokens:">Total Tokens:</span> {{totalActiveTokens}}</small>
             </div>
+            <div class="prompt_manager_header_controls {{prefix}}prompt_manager_header_controls">
+                <button type="button" id="{{prefix}}prompt_manager_drag_lock" class="menu_button menu_button_icon toggleable prompt_manager_drag_lock_button {{#if dragLocked}}toggled{{/if}}" title="Lock/unlock prompt reordering" aria-label="Lock/unlock prompt reordering" aria-pressed="{{#if dragLocked}}true{{else}}false{{/if}}" data-i18n="[title]Lock/unlock prompt reordering;[aria-label]Lock/unlock prompt reordering">
+                    <i class="fa-solid fa-fw {{#if dragLocked}}fa-lock{{else}}fa-unlock{{/if}}" aria-hidden="true"></i>
+                </button>
+            </div>
             <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
         </div>
         <div class="inline-drawer-content {{prefix}}prompt_manager_drawer_content" style="display:none;">


### PR DESCRIPTION
## Summary
- add a persisted `power_user.prompt_manager_drag_locked` preference that defaults to locked
- add a lock/unlock control to the prompt manager header
- disable/enable jQuery UI prompt reordering from the lock state while keeping prompt controls clickable

## Verification
- `git diff --check`
- `npx eslint public/scripts/PromptManager.js public/scripts/power-user.js`
- `node --check public/scripts/PromptManager.js && node --check public/scripts/power-user.js`
- `node --input-type=module -e "import fs from 'node:fs'; import Handlebars from 'handlebars'; Handlebars.compile(fs.readFileSync('public/scripts/templates/promptManagerHeader.html', 'utf8'));"`
- `node --input-type=module -e "import fs from 'node:fs'; import * as cssTools from '@adobe/css-tools'; cssTools.parse(fs.readFileSync('public/css/promptmanager.css', 'utf8'));"`
