### PR TITLE
Fix chat save flushing before cache clear

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -461,7 +461,8 @@ export let chat = [];
  * @type {import('./scripts/constants.js').SWIPE_STATE}
  */
 export let swipeState = SWIPE_STATE.NONE;
-let chatSaveTimeout;
+let chatSaveTimeout = null;
+let chatSavePromise = null;
 let importFlashTimeout;
 export let isChatSaving = false;
 export let firstRun = false;
@@ -8547,6 +8548,8 @@ export function saveChatDebounced() {
     cancelDebouncedChatSave();
 
     chatSaveTimeout = setTimeout(async () => {
+        chatSaveTimeout = null;
+
         if (selectedGroup !== selected_group) {
             console.warn('Chat save timeout triggered, but group changed. Aborting.');
             return;
@@ -8558,9 +8561,70 @@ export function saveChatDebounced() {
         }
 
         console.debug('Chat save timeout triggered');
-        await saveChatConditional();
-        console.debug('Chat saved');
+        chatSavePromise = saveChatConditional();
+        try {
+            await chatSavePromise;
+            console.debug('Chat saved');
+        } finally {
+            chatSavePromise = null;
+        }
     }, DEFAULT_SAVE_EDIT_TIMEOUT);
+}
+
+function hasPendingChatSave() {
+    return chatSaveTimeout !== null || chatSavePromise !== null;
+}
+
+/**
+ * Flushes any pending chat save, waits for in-flight saves, and saves the current chat immediately.
+ * @returns {Promise<boolean>} Whether the chat save completed successfully.
+ */
+export async function flushPendingChatSaves() {
+    const chatId = getCurrentChatId();
+
+    if (!chatId) {
+        return true;
+    }
+
+    cancelDebouncedChatSave();
+
+    if (chatSavePromise) {
+        try {
+            await chatSavePromise;
+        } catch (error) {
+            console.error('Error waiting for pending chat save', error);
+        }
+    }
+
+    await waitUntilCondition(() => !isChatSaving, debounce_timeout.extended, 100, { rejectOnTimeout: false });
+    if (isChatSaving) {
+        toastr.error(t`The current chat is still saving. Try again in a moment.`, t`Chat save still in progress`);
+        return false;
+    }
+
+    toastr.info(t`Saving chat...`, t`Saving chat`);
+
+    try {
+        isChatSaving = true;
+
+        const didSave = selected_group
+            ? await saveGroupChat(selected_group, true, false, true)
+            : await saveChat({ throwOnError: true });
+
+        if (!didSave) {
+            return false;
+        }
+
+        saveTokenCache();
+        await saveItemizedPrompts(chatId);
+        toastr.success(t`Chat saved successfully.`, t`Chat saved`);
+        return true;
+    } catch (error) {
+        console.error('Error flushing pending chat saves', error);
+        return false;
+    } finally {
+        isChatSaving = false;
+    }
 }
 
 /**
@@ -9371,6 +9435,19 @@ export async function saveSettings(loopCounter = 0) {
     }
 }
 
+async function confirmCacheClearAfterChatSaveFailure() {
+    const confirmation = await Popup.show.confirm(
+        t`Chat save failed`,
+        t`The cache will still be cleared if you continue, but unsaved chat changes may be lost. Do you want to continue?`,
+        {
+            okButton: t`Continue`,
+            cancelButton: t`Cancel`,
+        },
+    );
+
+    return confirmation === POPUP_RESULT.AFFIRMATIVE;
+}
+
 export async function clearFrontendCache({ skipConfirmation = false, saveBeforeClear = true } = {}) {
     if (!skipConfirmation) {
         const confirmation = await Popup.show.confirm(
@@ -9391,9 +9468,17 @@ export async function clearFrontendCache({ skipConfirmation = false, saveBeforeC
 
     if (saveBeforeClear) {
         try {
-            await saveChatConditional();
+            const didSaveChat = await flushPendingChatSaves();
+            if (!didSaveChat) {
+                if (!await confirmCacheClearAfterChatSaveFailure()) {
+                    return false;
+                }
+            }
         } catch (error) {
             console.warn('Failed to save chat before clearing cache', error);
+            if (!await confirmCacheClearAfterChatSaveFailure()) {
+                return false;
+            }
         }
 
         try {
@@ -9452,7 +9537,7 @@ async function clearAllCacheAndReload() {
     }
 
     toastr.success(t`Cache cleared. Reloading SillyBunny...`, t`Cache cleared`);
-    window.setTimeout(() => window.location.reload(), 450);
+    window.setTimeout(() => window.location.reload(), 1000);
     return true;
 }
 
@@ -9478,7 +9563,7 @@ async function maybeAutoClearCacheOnVersionChange(isVersionChanged) {
     }
 
     toastr.info(t`SillyBunny updated. Clearing cached UI data and reloading...`, t`Update detected`);
-    window.setTimeout(() => window.location.reload(true), 450);
+    window.setTimeout(() => window.location.reload(true), 1000);
     return true;
 }
 
@@ -15392,7 +15477,7 @@ jQuery(async function () {
     await firstLoadInit();
 
     window.addEventListener('beforeunload', (e) => {
-        if (isChatSaving || this_edit_mes_id >= 0) {
+        if (isChatSaving || hasPendingChatSave() || this_edit_mes_id >= 0) {
             e.preventDefault();
             e.returnValue = true;
         }

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -1514,13 +1514,14 @@ function resetSelectedGroup() {
  * @param {string} groupId Group ID
  * @param {boolean} shouldSaveGroup Whether to save the group after saving the chat
  * @param {boolean} force Force the saving on integrity error
- * @returns {Promise<void>} A promise that resolves when the group chat has been saved.
+ * @param {boolean} throwOnError Rethrow save errors after notifying the user
+ * @returns {Promise<boolean>} A promise that resolves when the group chat has been saved.
  */
-async function saveGroupChat(groupId, shouldSaveGroup, force = false) {
+async function saveGroupChat(groupId, shouldSaveGroup, force = false, throwOnError = false) {
     const group = groups.find(x => x.id == groupId);
     if (!group) {
         console.warn('Group not found', groupId);
-        return;
+        return false;
     }
     const chatId = group.chat_id;
     if (chatId && Array.isArray(group.chats) && !group.chats.includes(chatId)) {
@@ -1547,7 +1548,10 @@ async function saveGroupChat(groupId, shouldSaveGroup, force = false) {
         if (!isIntegrityError) {
             toastr.error(t`Check the server connection and reload the page to prevent data loss.`, t`Group Chat could not be saved`);
             console.error('Group chat could not be saved', response);
-            return;
+            if (throwOnError) {
+                throw new Error('Group chat could not be saved');
+            }
+            return false;
         }
 
         const popupResult = await Popup.show.input(
@@ -1563,15 +1567,17 @@ async function saveGroupChat(groupId, shouldSaveGroup, force = false) {
         if (!forceSaveConfirmed) {
             console.warn('Chat integrity check failed, and user did not confirm the overwrite. Reloading the page.');
             window.location.reload();
-            return;
+            return false;
         }
 
-        await saveGroupChat(groupId, shouldSaveGroup, true);
+        return await saveGroupChat(groupId, shouldSaveGroup, true, throwOnError);
     }
 
     if (shouldSaveGroup) {
         await editGroup(groupId, false, false);
     }
+
+    return true;
 }
 
 /**

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -2848,7 +2848,7 @@ async function handleClearCookiesAndCacheClick(event) {
         const clearedCookieCount = clearAllBrowserCookies();
         globalThis.toastr?.success?.('Cookies and cache cleared. Reloading SillyBunny...', 'Cookies cleared');
         console.info(`[Cache] Expired ${clearedCookieCount} browser cookies and queued ${serverCookieResult?.expirationAttempts ?? 0} server cookie expirations before reload`);
-        window.setTimeout(() => window.location.reload(), 450);
+        window.setTimeout(() => window.location.reload(), 1000);
     } catch (error) {
         console.error('Failed to clear cookies and cache', error);
         globalThis.toastr?.error?.(String(error?.message || error), 'Clear failed');


### PR DESCRIPTION
## Summary
- flush pending debounced/in-flight chat saves before clearing frontend cache
- prompt before continuing cache clear if chat save fails
- harden group chat save failure reporting and beforeunload pending-save protection
- increase cache-clear reload delay to 1000ms

## Verification
- `node --check public/script.js public/scripts/group-chats.js public/scripts/sillybunny-tabs.js`
- `git diff --check -- public/script.js public/scripts/group-chats.js public/scripts/sillybunny-tabs.js`
- `npm run lint -- --quiet`
- `npm run build:frontend`