### PR TITLE
fix: stop generation before cleanup listeners lose state

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -4426,12 +4426,14 @@ function showStopButton() {
     $('#mes_stop').css({ 'display': 'flex' });
 }
 
-function hideStopButton() {
+function hideStopButton({ emitGenerationEnded = true } = {}) {
     $('#send_form').removeClass('sb-generating-controls');
     // prevent NOOP, because hideStopButton() gets called multiple times
     if ($('#mes_stop').css('display') !== 'none') {
         $('#mes_stop').css({ 'display': 'none' });
-        eventSource.emit(event_types.GENERATION_ENDED, chat.length);
+        if (emitGenerationEnded) {
+            eventSource.emit(event_types.GENERATION_ENDED, chat.length);
+        }
     }
 }
 
@@ -6673,7 +6675,6 @@ export function stopGeneration() {
     let stopped = false;
     if (activeStreamingProcessor) {
         activeStreamingProcessor.onStopStreaming();
-        clearStreamingProcessorIfCurrent(activeStreamingProcessor);
         stopped = true;
     }
     if (shouldAbortRequest && abortController) {
@@ -6681,9 +6682,9 @@ export function stopGeneration() {
         stopped = true;
     }
     if (stopped) {
-        unblockGeneration(activeGenerationType);
-        hideStopButton();
-        eventSource.emit(event_types.GENERATION_STOPPED);
+        eventSource.emitAndWait(event_types.GENERATION_STOPPED);
+        clearStreamingProcessorIfCurrent(activeStreamingProcessor);
+        unblockGeneration(activeGenerationType, { emitGenerationEnded: false });
     }
     return stopped;
 }
@@ -6759,14 +6760,14 @@ function flushWIInjections() {
  * Unblocks the UI after a generation is complete.
  * @param {string} [type] Generation type (optional)
  */
-function unblockGeneration(type) {
+function unblockGeneration(type, { emitGenerationEnded = true } = {}) {
     // Don't unblock if a parallel stream is still running
     if (type === 'quiet' && streamingProcessor && !streamingProcessor.isFinished) {
         return;
     }
 
     is_send_press = false;
-    activateSendButtons();
+    activateSendButtons({ emitGenerationEnded });
     setGenerationProgress(0);
     flushEphemeralStoppingStrings();
     flushWIInjections();
@@ -8254,9 +8255,9 @@ export function getGeneratingModel(mes) {
 /**
  * A function mainly used to switch 'generating' state - setting it to false and activating the buttons again
  */
-export function activateSendButtons() {
+export function activateSendButtons({ emitGenerationEnded = true } = {}) {
     is_send_press = false;
-    hideStopButton();
+    hideStopButton({ emitGenerationEnded });
     showSwipeButtons();
     delete document.body.dataset.generating;
 }

--- a/public/scripts/extensions/guided-generations/scripts/guidedSwipe.js
+++ b/public/scripts/extensions/guided-generations/scripts/guidedSwipe.js
@@ -76,7 +76,18 @@ async function generateNewSwipe() {
         context.swipe.right();
 
         await new Promise(resolve => {
-            eventSource.once(event_types.GENERATION_ENDED, resolve);
+            let resolved = false;
+            const resolveOnce = () => {
+                if (resolved) {
+                    return;
+                }
+                resolved = true;
+                eventSource.removeListener(event_types.GENERATION_ENDED, resolveOnce);
+                eventSource.removeListener(event_types.GENERATION_STOPPED, resolveOnce);
+                resolve();
+            };
+            eventSource.once(event_types.GENERATION_ENDED, resolveOnce);
+            eventSource.once(event_types.GENERATION_STOPPED, resolveOnce);
         });
         await new Promise(resolve => setTimeout(resolve, 200));
         return true;

--- a/tests/event-emitter.test.js
+++ b/tests/event-emitter.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, test } from '@jest/globals';
+import { EventEmitter } from '../public/lib/eventemitter.js';
+
+/* global globalThis */
+
+describe('EventEmitter', () => {
+    beforeEach(() => {
+        globalThis.localStorage = {
+            getItem: () => null,
+        };
+    });
+
+    afterEach(() => {
+        delete globalThis.localStorage;
+    });
+
+    test('runs emitAndWait listeners before subsequent cleanup', () => {
+        const emitter = new EventEmitter();
+        const calls = [];
+
+        emitter.on('stop', () => {
+            calls.push('first');
+        });
+        emitter.on('stop', () => {
+            calls.push('second');
+        });
+
+        emitter.emitAndWait('stop');
+        calls.push('after');
+
+        expect(calls).toEqual(['first', 'second', 'after']);
+    });
+});


### PR DESCRIPTION
## What?
Fixes the stop-generation path so clicking Stop emits the stop lifecycle before cleanup clears the active streaming processor. Also updates Guided Generations swipe waiting so it resolves on either normal generation end or generation stop.

## Why?
Stop-generation listeners, especially in-chat agent cleanup, need access to the active streaming state while handling `GENERATION_STOPPED`. The old order cleared and unblocked first, which could make stop listeners miss the state they needed and allow generation-related work to continue after Stop was clicked.

## How?
`stopGeneration()` now emits `GENERATION_STOPPED` synchronously before clearing the current streaming processor, then unblocks the UI without also faking a normal `GENERATION_ENDED` event. The send-button cleanup helpers keep their previous default behavior for normal completion but can suppress `GENERATION_ENDED` for the stop path. Guided swipe now waits for either stopped or ended so the changed stop semantics do not leave it pending.

## Testing?
- `npm run test:unit --prefix tests -- event-emitter.test.js in-chat-agents-runner.test.js`
- `npx eslint public/script.js public/scripts/extensions/guided-generations/scripts/guidedSwipe.js tests/event-emitter.test.js tests/in-chat-agents-runner.test.js`

## Screenshots (optional)
Not included; this is lifecycle/event-order behavior rather than a visual UI change.

## Anything Else?
Requesting Platberlitz review before merge. During pre-review, Guided Generations swipe was identified as a stop/ended event consumer and patched so it does not hang when a generation is stopped.