### PR TITLE
fix: destroy upstream stream on stop under Bun runtime

### DIFF
--- a/src/endpoints/backends/text-completions.js
+++ b/src/endpoints/backends/text-completions.js
@@ -1,4 +1,3 @@
-import { Readable } from 'node:stream';
 import fetch from 'node-fetch';
 import express from 'express';
 import _ from 'lodash';
@@ -56,7 +55,11 @@ async function parseOllamaStream(jsonStream, request, response) {
                 return;
             }
 
-            if (jsonStream.body instanceof Readable) jsonStream.body.destroy();
+            try {
+                jsonStream.body?.destroy?.();
+            } catch {
+                // Best effort; the client response is already closing.
+            }
             response.end();
         });
 

--- a/src/util.js
+++ b/src/util.js
@@ -1,7 +1,6 @@
 import path from 'node:path';
 import fs from 'node:fs';
 import process from 'node:process';
-import { Readable } from 'node:stream';
 import { createRequire } from 'node:module';
 import { Buffer } from 'node:buffer';
 import { promises as dnsPromise } from 'node:dns';
@@ -734,7 +733,11 @@ export async function forwardFetchResponse(from, to) {
                 return;
             }
 
-            if (from.body instanceof Readable) from.body.destroy(); // Close the remote stream
+            try {
+                from.body?.destroy?.(); // Close the remote stream
+            } catch {
+                // Best effort; the client response is already closing.
+            }
 
             to.end(); // End the Express response
         });

--- a/tests/util.test.js
+++ b/tests/util.test.js
@@ -1,5 +1,5 @@
 import { afterEach, describe, test, expect, jest } from '@jest/globals';
-import { once } from 'node:events';
+import { EventEmitter, once } from 'node:events';
 import { PassThrough } from 'node:stream';
 import { Response } from 'node-fetch';
 import { CHAT_COMPLETION_SOURCES } from '../src/constants';
@@ -142,6 +142,25 @@ describe('forwardFetchResponse', () => {
         response.emit('close');
 
         expect(destroySpy).toHaveBeenCalled();
+    });
+
+    test('should destroy upstream streaming bodies that are not Node Readable instances', async () => {
+        const upstreamBody = Object.assign(new EventEmitter(), {
+            pipe: jest.fn(),
+            destroy: jest.fn(),
+        });
+        const response = createMockExpressResponse();
+        response.socket = {};
+
+        await forwardFetchResponse({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            body: upstreamBody,
+        }, response);
+        response.emit('close');
+
+        expect(upstreamBody.destroy).toHaveBeenCalled();
     });
 
     test('should log JSON error bodies and return the original body for non-2xx streaming responses', async () => {


### PR DESCRIPTION
## Summary
- destroy upstream fetch bodies by capability instead of `instanceof Readable` when the client response closes early
- apply the same best-effort destroy path to the Ollama JSON stream wrapper
- add coverage for non-Node-Readable streaming bodies with `pipe`/`destroy` methods

## Context
When using LM Studio through Generic OpenAI-compatible Text Completion, clicking Stop unblocks the UI but LM Studio can keep generating server-side. PR #152 improved frontend listener cleanup around `GENERATION_STOPPED`, but this failure is in the backend upstream request lifecycle.

The regression appears after `9f09aa7`, where upstream abort plumbing moved to response-close handling. Under Bun, node-fetch response bodies do not always satisfy `body instanceof Readable`, so the close handler skipped `body.destroy()`. Once response headers have arrived and the body is being piped, destroying the body is the part that tears down the upstream socket.

SillyTavern v1.17.0 does not hit this exact path, which matches the user report that it cancels LM Studio correctly while SillyBunny leaves generation running.

## Verification
- `bun test ./tests/util.test.js`
- `bun run lint`

`npm test` was attempted, but this checkout has no `test` script in `package.json`.

Manual LM Studio end-to-end verification was not run in this environment.