### PR TITLE
fix: chat scroll and prompt manager scroll position issues

### DIFF
--- a/public/scripts/extensions/third-party/BunnyPresetTools/content.js
+++ b/public/scripts/extensions/third-party/BunnyPresetTools/content.js
@@ -529,6 +529,10 @@ function refreshPromptSections() {
         promptListObserver.disconnect();
     }
 
+    // SillyBunny: Keep PromptManager's scroller anchored while rebuilding section rows.
+    const scrollContainer = promptListElement.closest('.sb-shell-panel-scroller, .scrollableInner');
+    const savedScrollTop = scrollContainer?.scrollTop ?? 0;
+
     try {
         cleanupPromptSections();
 
@@ -649,6 +653,10 @@ function refreshPromptSections() {
                 childList: true,
                 subtree: true,
             });
+        }
+
+        if (scrollContainer) {
+            scrollContainer.scrollTop = savedScrollTop;
         }
     }
 }

--- a/public/style.css
+++ b/public/style.css
@@ -1296,14 +1296,9 @@ body.is-macos #chat {
     vertical-align: middle;
 }
 
-.auto_hide {
-    content-visibility: auto;
-}
-
 .mes {
     display: flex;
     align-items: flex-start;
-    content-visibility: auto;
     contain: layout paint style;
     contain-intrinsic-size: auto 180px;
     padding: 12px 14px 4px 14px;


### PR DESCRIPTION
Fixes two scroll-related bugs:

1. Chat not scrolling to bottom on initial load for long chats (1k+ messages)
2. Prompt manager jumping to top when saving an edited prompt

Root causes:
- `content-visibility: auto` on `.mes` caused `scrollHeight` to be underestimated during initial load and streaming, breaking scroll-to-bottom logic
- BunnyPresetTools' `refreshPromptSections()` rebuilt DOM without preserving scroll position, overriding PromptManager's scroll restoration

Changes:
- Remove `content-visibility: auto` from `.mes` in `style.css` and drop the unused `.auto_hide` helper
- Add scroll position capture/restore to BunnyPresetTools' `refreshPromptSections()`

Testing:
- `git diff --check`
- `node --check public/scripts/extensions/third-party/BunnyPresetTools/content.js`

Manual verification still recommended:
- Load a long chat and confirm it lands at the bottom
- Stream on mobile and confirm there is no upward jump
- Edit and save a prompt in the middle of Prompt Manager and confirm the list does not jump to top