### PR TITLE
fix: improve mobile group and editor spacing

### DIFF
--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -1921,6 +1921,95 @@
         background: color-mix(in srgb, var(--SmartThemeBodyColor) 8%, transparent) !important;
     }
 
+    /* SillyBunny: Mobile-specific group member touch targets for Add Members screen */
+    #rm_group_add_members .group_member {
+        cursor: pointer;
+        padding: 8px 5px;
+    }
+
+    #rm_group_add_members .group_member:active {
+        background-color: var(--white30a);
+    }
+
+    /* Increase touch target size for action buttons on mobile */
+    #rm_group_add_members .right_menu_button,
+    #rm_group_members .right_menu_button {
+        min-width: var(--sb-mobile-touch-target, 44px);
+        min-height: var(--sb-mobile-touch-target, 44px);
+        width: var(--sb-mobile-touch-target, 44px);
+        height: var(--sb-mobile-touch-target, 44px);
+        padding: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        -webkit-tap-highlight-color: transparent;
+    }
+
+    /* Adjust grid layout for mobile to accommodate larger touch targets */
+    #rm_group_add_members .group_member {
+        --sb-group-actions-width: calc(var(--sb-mobile-touch-target, 44px) + var(--sb-mobile-touch-target, 44px) + 4px);
+        grid-template-columns: auto minmax(0, 1fr) var(--sb-group-actions-width);
+        column-gap: 8px;
+    }
+
+    #rm_group_members .group_member {
+        --sb-group-actions-width: calc(var(--sb-mobile-touch-target, 44px) + var(--sb-mobile-touch-target, 44px) + var(--sb-mobile-touch-target, 44px) + 8px);
+        grid-template-columns: auto minmax(0, 1fr) minmax(var(--sb-mobile-touch-target, 44px), var(--sb-group-actions-width));
+        column-gap: 8px;
+    }
+
+    /* Hide model input and queue position on mobile to save space */
+    #rm_group_add_members .group_member_model,
+    #rm_group_add_members .queue_position,
+    #rm_group_members .group_member_model,
+    #rm_group_members .queue_position {
+        display: none;
+    }
+
+    /* Ensure action icons container has proper sizing */
+    #rm_group_add_members .group_member_icon,
+    #rm_group_members .group_member_icon {
+        min-width: var(--sb-mobile-touch-target, 44px);
+        gap: 4px;
+        justify-content: flex-end;
+    }
+
+    #rm_group_add_members .group_member_icon {
+        width: var(--sb-group-actions-width);
+    }
+
+    #rm_group_members .group_member_icon {
+        max-width: var(--sb-group-actions-width);
+        flex-wrap: wrap;
+    }
+
+    /* SillyBunny: Prevent text overflow on Generate Schedule button */
+    #rm_group_generate_schedule {
+        max-width: 100%;
+        min-width: 0;
+    }
+
+    #rm_group_generate_schedule span {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        min-width: 0;
+    }
+
+    /* General fix for menu_button_icon with text on mobile */
+    .menu_button_icon:has(> span) {
+        max-width: 100%;
+        min-width: 0;
+    }
+
+    .menu_button_icon > span {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        min-width: 0;
+    }
+
 }
 
 @media screen and (max-width: 1000px) {

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -562,8 +562,8 @@
 
     #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) > .scrollableInner,
     #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) > .scrollableInnerFull {
-        padding-inline-start: 20px !important;
-        padding-inline-end: calc(20px + var(--sb-character-scroll-gutter, 8px)) !important;
+        scrollbar-gutter: auto !important;
+        padding-inline: var(--sb-character-editor-mobile-edge, 6px) !important;
     }
 
     #right-nav-panel.openDrawer #rm_print_characters_block,
@@ -571,6 +571,15 @@
         box-sizing: border-box !important;
         scrollbar-gutter: stable !important;
         padding-inline-end: var(--sb-character-scroll-gutter, 8px) !important;
+    }
+
+    #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) #rm_ch_create_block {
+        scrollbar-gutter: auto !important;
+        padding-inline: 0 !important;
+    }
+
+    #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) #form_create {
+        padding-inline: 0 !important;
     }
 
     #right-nav-panel.openDrawer .sb-shell-panel-scroller {


### PR DESCRIPTION
## Summary
- Increase mobile group member action touch targets and tighten the Add Members layout.
- Add mobile text truncation for Generate Schedule and icon/text menu buttons.
- Reduce character editor mobile edge padding so the left and right insets are minimal and equal.

## Verification
- git diff --check -- public/css/mobile-styles.css public/css/sillybunny-mobile-shell.css
- node/@adobe css-tools parse for public/css/sillybunny-mobile-shell.css
- node/@adobe css-tools targeted parse for the new mobile-styles.css block
- brace balance check for public/css/mobile-styles.css and public/css/sillybunny-mobile-shell.css

## Notes
- No device/browser visual smoke test was run.