### PR TITLE
fix: avoid duplicate text completion close handlers

### DIFF
--- a/src/endpoints/backends/text-completions.js
+++ b/src/endpoints/backends/text-completions.js
@@ -290,15 +290,17 @@ router.post('/generate', async function (request, response) {
 
         const controller = new AbortController();
         abortOnResponseClose(response, controller);
-        response.on('close', async function () {
-            if (response.writableEnded) {
-                return;
-            }
 
-            if (request.body.api_type === TEXTGEN_TYPES.KOBOLDCPP && !response.writableEnded) {
+        // SillyBunny: KoboldCpp needs its own upstream abort endpoint; other backends use the shared fetch abort/stream destroy path.
+        if (request.body.api_type === TEXTGEN_TYPES.KOBOLDCPP) {
+            response.on('close', async function () {
+                if (response.writableEnded) {
+                    return;
+                }
+
                 await abortKoboldCppRequest(request, trimV1(baseUrl));
-            }
-        });
+            });
+        }
 
         let url = trimV1(baseUrl);
 


### PR DESCRIPTION
## Summary
- Scope the KoboldCpp-only response close abort listener to KoboldCpp Text Completions requests
- Keep other Text Completions backends on the shared AbortController and upstream stream destroy path from #154
- Avoid registering an extra close listener for llama.cpp requests

## Tests
- npm run lint