### PR TITLE
fix: normalize character book positions

### DIFF
--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -14,6 +14,7 @@ import { t } from './i18n.js';
 import { isMobile } from './RossAscends-mods.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { getPromptDisplayTokenCounts } from './prompt-token-counts.js';
+import { getRenderedMarkerPrompt } from './prompt-manager-marker-preview.js';
 
 function debouncePromise(func, delay) {
     let timeoutId;
@@ -688,6 +689,7 @@ class PromptManager {
                 '.drag-handle',
                 '.prompt-manager-detach-action',
                 '.prompt-manager-edit-action',
+                '.prompt-manager-inspect-action',
                 '.prompt-manager-toggle-action',
                 '.prompt-manager-send-to-agents-action',
                 'input',
@@ -1805,10 +1807,22 @@ class PromptManager {
         if (!roleField || !promptField || !roleValue || !tokenCount || !previewText) return;
 
         const previewRequest = ++this.previewTokenCountRequest;
-        const preparedPrompt = this.preparePrompt({
-            role: roleField.value || 'system',
-            content: promptField.value || '',
-        });
+        const selectedPrompt = this.getPromptById(this.selectedPromptId);
+        // SillyBunny: marker prompt definitions are usually empty placeholders.
+        // Preview their latest rendered message from the dry-run prompt assembly instead.
+        const renderedMarkerPrompt = selectedPrompt?.marker
+            ? getRenderedMarkerPrompt(selectedPrompt.identifier, this.messages)
+            : null;
+        const preparedPrompt = renderedMarkerPrompt?.content
+            ? {
+                role: renderedMarkerPrompt.role,
+                content: renderedMarkerPrompt.content,
+                identifier: selectedPrompt.identifier,
+            }
+            : this.preparePrompt({
+                role: roleField.value || 'system',
+                content: promptField.value || '',
+            });
         const previewContent = preparedPrompt.content || '';
 
         roleValue.textContent = preparedPrompt.role || 'system';

--- a/public/scripts/prompt-manager-marker-preview.js
+++ b/public/scripts/prompt-manager-marker-preview.js
@@ -1,0 +1,43 @@
+'use strict';
+
+/**
+ * Flattens a rendered prompt message or message collection into message-like items.
+ *
+ * @param {object|null|undefined} item Rendered message or message collection.
+ * @returns {object[]} Rendered message-like items.
+ */
+function flattenRenderedMessages(item) {
+    if (!item) {
+        return [];
+    }
+
+    if (typeof item.flatten === 'function') {
+        return item.flatten();
+    }
+
+    if (typeof item.getCollection === 'function') {
+        return item.getCollection().flatMap(flattenRenderedMessages);
+    }
+
+    return [item];
+}
+
+/**
+ * Gets the latest rendered content for a marker prompt from a chat completion message tree.
+ * Marker prompt definitions usually have empty content; the resolved runtime content lives in
+ * the generated MessageCollection keyed by marker identifier.
+ *
+ * @param {string} identifier Prompt identifier, e.g. worldInfoBefore.
+ * @param {object|null|undefined} messages Root message collection.
+ * @returns {{ role: string, content: string }} Rendered marker role and content.
+ */
+export function getRenderedMarkerPrompt(identifier, messages) {
+    const renderedItem = messages?.getItemByIdentifier?.(identifier);
+    const renderedMessages = flattenRenderedMessages(renderedItem)
+        .filter(message => typeof message?.content === 'string' && message.content.length > 0);
+
+    return {
+        role: renderedMessages[0]?.role || 'system',
+        content: renderedMessages.map(message => message.content).join('\n\n'),
+    };
+}

--- a/public/scripts/world-info-character-book.js
+++ b/public/scripts/world-info-character-book.js
@@ -1,0 +1,65 @@
+/**
+ * Normalizes character-book entry positions into SillyTavern/SillyBunny World Info position IDs.
+ *
+ * Character cards commonly store positions as CC/ST strings such as `before_char` or `after_char`.
+ * Imported World Info entries must use numeric position IDs; leaving the strings intact prevents
+ * activated entries from being inserted into the prompt.
+ *
+ * @param {unknown} extensionPosition Position from entry.extensions.position
+ * @param {unknown} entryPosition Position from entry.position
+ * @param {{ before: number, after: number, ANTop: number, ANBottom: number, atDepth: number, EMTop: number, EMBottom: number, outlet: number }} positions World Info position enum
+ * @returns {number} Normalized World Info position
+ */
+export function normalizeCharacterBookPosition(extensionPosition, entryPosition, positions) {
+    const normalize = (position) => {
+        if (typeof position === 'number' && Number.isFinite(position)) {
+            return position;
+        }
+
+        if (typeof position !== 'string') {
+            return undefined;
+        }
+
+        const value = position.trim().toLowerCase();
+        if (!value) {
+            return undefined;
+        }
+
+        const numeric = Number(value);
+        if (Number.isInteger(numeric)) {
+            return numeric;
+        }
+
+        switch (value) {
+            case 'before':
+            case 'before_char':
+            case 'before character':
+                return positions.before;
+            case 'after':
+            case 'after_char':
+            case 'after character':
+                return positions.after;
+            case 'an_top':
+            case 'author_note_top':
+                return positions.ANTop;
+            case 'an_bottom':
+            case 'author_note_bottom':
+                return positions.ANBottom;
+            case 'at_depth':
+            case 'depth':
+                return positions.atDepth;
+            case 'em_top':
+            case 'examples_top':
+                return positions.EMTop;
+            case 'em_bottom':
+            case 'examples_bottom':
+                return positions.EMBottom;
+            case 'outlet':
+                return positions.outlet;
+            default:
+                return undefined;
+        }
+    };
+
+    return normalize(extensionPosition) ?? normalize(entryPosition) ?? positions.after;
+}

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -23,6 +23,7 @@ import { renderTemplateAsync } from './templates.js';
 import { t } from './i18n.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { getOrCreatePersonaDescriptor, setPersonaDescription, user_avatar } from './personas.js';
+import { normalizeCharacterBookPosition } from './world-info-character-book.js';
 
 export const world_info_insertion_strategy = {
     evenly: 0,
@@ -5829,7 +5830,7 @@ export function convertCharacterBook(characterBook) {
             constant: entry.constant || false,
             selective: entry.selective || false,
             order: entry.insertion_order,
-            position: entry.extensions?.position ?? (entry.position === 'before_char' ? world_info_position.before : world_info_position.after),
+            position: normalizeCharacterBookPosition(entry.extensions?.position, entry.position, world_info_position),
             excludeRecursion: entry.extensions?.exclude_recursion ?? false,
             preventRecursion: entry.extensions?.prevent_recursion ?? false,
             delayUntilRecursion: entry.extensions?.delay_until_recursion ?? false,

--- a/tests/prompt-manager-marker-preview.test.js
+++ b/tests/prompt-manager-marker-preview.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, test } from '@jest/globals';
+import { getRenderedMarkerPrompt } from '../public/scripts/prompt-manager-marker-preview.js';
+
+function makeMessage(role, content) {
+    return { role, content };
+}
+
+function makeCollection(identifier, collection) {
+    return {
+        identifier,
+        getCollection: () => collection,
+    };
+}
+
+function makeRoot(items) {
+    return {
+        getItemByIdentifier: identifier => items.find(item => item.identifier === identifier),
+    };
+}
+
+describe('prompt manager marker preview', () => {
+    test('reads rendered marker content from a message collection', () => {
+        const messages = makeRoot([
+            makeCollection('worldInfoBefore', [
+                makeMessage('system', 'First world info entry.'),
+                makeMessage('system', 'Second world info entry.'),
+            ]),
+        ]);
+
+        expect(getRenderedMarkerPrompt('worldInfoBefore', messages)).toEqual({
+            role: 'system',
+            content: 'First world info entry.\n\nSecond world info entry.',
+        });
+    });
+
+    test('flattens nested rendered marker collections', () => {
+        const messages = makeRoot([
+            makeCollection('worldInfoAfter', [
+                makeCollection('nested', [makeMessage('user', 'Nested world info.')]),
+            ]),
+        ]);
+
+        expect(getRenderedMarkerPrompt('worldInfoAfter', messages)).toEqual({
+            role: 'user',
+            content: 'Nested world info.',
+        });
+    });
+
+    test('returns an empty system prompt when marker was not rendered', () => {
+        expect(getRenderedMarkerPrompt('worldInfoBefore', makeRoot([]))).toEqual({
+            role: 'system',
+            content: '',
+        });
+    });
+});

--- a/tests/world-info-character-book.test.js
+++ b/tests/world-info-character-book.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { normalizeCharacterBookPosition } from '../public/scripts/world-info-character-book.js';
+
+const positions = {
+    before: 0,
+    after: 1,
+    ANTop: 2,
+    ANBottom: 3,
+    atDepth: 4,
+    EMTop: 5,
+    EMBottom: 6,
+    outlet: 7,
+};
+
+describe('normalizeCharacterBookPosition', () => {
+    test('normalizes CC/ST before_char extension positions', () => {
+        expect(normalizeCharacterBookPosition('before_char', 'after_char', positions)).toBe(positions.before);
+    });
+
+    test('normalizes CC/ST after_char entry positions', () => {
+        expect(normalizeCharacterBookPosition(undefined, 'after_char', positions)).toBe(positions.after);
+    });
+
+    test('preserves numeric World Info positions', () => {
+        expect(normalizeCharacterBookPosition(positions.atDepth, 'before_char', positions)).toBe(positions.atDepth);
+    });
+
+    test('normalizes numeric string positions from imported metadata', () => {
+        expect(normalizeCharacterBookPosition('0', 'after_char', positions)).toBe(positions.before);
+    });
+
+    test('falls back to after when no known position exists', () => {
+        expect(normalizeCharacterBookPosition('unknown', undefined, positions)).toBe(positions.after);
+    });
+});


### PR DESCRIPTION
## Summary\n- Normalize CC/ST character-book string positions like `before_char` and `after_char` into numeric World Info positions during embedded lorebook import\n- Preserve existing numeric World Info positions and numeric strings\n- Add a focused unit test for character-book position compatibility\n\n## Testing\n- `npm run test:unit --prefix tests -- world-info-character-book.test.js`\n- `npx eslint public/scripts/world-info.js public/scripts/world-info-character-book.js`\n- `npm run lint --prefix tests -- world-info-character-book.test.js`