### PR TITLE
fix: isolate local prompt cache lanes

### DIFF
--- a/public/scripts/local-url-utils.js
+++ b/public/scripts/local-url-utils.js
@@ -46,3 +46,12 @@ export function isLikelyLocalServerUrl(serverUrl, baseUrl = undefined) {
         return FALLBACK_LOCAL_URL_PATTERN.test(serverUrl);
     }
 }
+
+/**
+ * Gets the llama.cpp-compatible prompt cache flag for a generation lane.
+ * @param {'main'|'auxiliary'|'none'|string|undefined|null} cacheScope Prompt cache lane
+ * @returns {boolean} True only for the main chat lane
+ */
+export function getLocalPromptCacheValue(cacheScope) {
+    return String(cacheScope ?? 'auxiliary') === 'main';
+}

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -23,7 +23,7 @@ import { power_user, registerDebugFunction } from './power-user.js';
 import { getActiveManualApiSamplers, loadApiSelectedSamplers, isSamplerManualPriorityEnabled } from './samplerSelect.js';
 import { SECRET_KEYS, writeSecret } from './secrets.js';
 import { getEventSourceStream } from './sse-stream.js';
-import { isLikelyLocalServerUrl } from './local-url-utils.js';
+import { getLocalPromptCacheValue, isLikelyLocalServerUrl } from './local-url-utils.js';
 import { getCurrentDreamGenModelTokenizer, getCurrentOpenRouterModelTokenizer, loadAphroditeModels, loadDreamGenModels, loadFeatherlessModels, loadGenericModels, loadInfermaticAIModels, loadLlamaCppModels, loadMancerModels, loadOllamaModels, loadOpenRouterModels, loadTabbyModels, loadTogetherAIModels, loadVllmModels, updateOpenRouterProvidersWarning } from './textgen-models.js';
 import { ENCODE_TOKENIZERS, TEXTGEN_TOKENIZERS, TOKENIZER_SUPPORTED_KEY, getTextTokens, getTokenizerBestMatch, tokenizers } from './tokenizers.js';
 import { AbortReason } from './util/AbortReason.js';
@@ -1874,13 +1874,9 @@ export function createTextGenGenerationData(settings, model, finalPrompt = null,
     }
 
     if (shouldUseLocalPromptCache(settings)) {
-        // SillyBunny: helper generations use the auxiliary cache lane unless the
-        // caller explicitly requests the main chat lane.
-        if (cacheScope === 'main') {
-            params.cache_prompt = true;
-        } else {
-            delete params.cache_prompt;
-        }
+        // SillyBunny: helper generations must explicitly opt out, because some
+        // local llama.cpp servers default to --cache-prompt for every request.
+        params.cache_prompt = getLocalPromptCacheValue(cacheScope);
     }
 
     // Grammar conflicts with with json_schema

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -3,7 +3,7 @@ import process from 'node:process';
 import express from 'express';
 import fetch from 'node-fetch';
 import urlJoin from 'url-join';
-import { isLikelyLocalServerUrl } from '../../../public/scripts/local-url-utils.js';
+import { getLocalPromptCacheValue, isLikelyLocalServerUrl } from '../../../public/scripts/local-url-utils.js';
 
 import {
     AIMLAPI_HEADERS,
@@ -271,12 +271,9 @@ function applyLocalPromptCacheScope(bodyParams, requestBody) {
         return;
     }
 
-    // SillyBunny: isolate helper generations so local prompt caches keep the main chat lane hot.
-    if (String(requestBody.cacheScope ?? 'auxiliary') === 'main') {
-        bodyParams.cache_prompt = true;
-    } else {
-        delete bodyParams.cache_prompt;
-    }
+    // SillyBunny: helper generations must explicitly opt out, because some
+    // local llama.cpp servers default to --cache-prompt for every request.
+    bodyParams.cache_prompt = getLocalPromptCacheValue(requestBody.cacheScope);
 }
 
 /**

--- a/tests/local-url-utils.test.js
+++ b/tests/local-url-utils.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, test } from '@jest/globals';
 
-import { isLikelyLocalServerUrl } from '../public/scripts/local-url-utils.js';
+import { getLocalPromptCacheValue, isLikelyLocalServerUrl } from '../public/scripts/local-url-utils.js';
 
 describe('isLikelyLocalServerUrl', () => {
     const localServerUrls = [
@@ -35,4 +35,16 @@ describe('isLikelyLocalServerUrl', () => {
             expect(isLikelyLocalServerUrl(serverUrl)).toBe(false);
         });
     }
+});
+
+describe('getLocalPromptCacheValue', () => {
+    test('enables prompt cache only for the main chat lane', () => {
+        expect(getLocalPromptCacheValue('main')).toBe(true);
+    });
+
+    test('explicitly disables prompt cache for auxiliary and uncached lanes', () => {
+        expect(getLocalPromptCacheValue('auxiliary')).toBe(false);
+        expect(getLocalPromptCacheValue('none')).toBe(false);
+        expect(getLocalPromptCacheValue(undefined)).toBe(false);
+    });
 });


### PR DESCRIPTION
## What?
Send local prompt-cache requests with an explicit cache value based on cache scope. Main chat requests keep `cache_prompt: true`; auxiliary and uncached helper lanes now send `cache_prompt: false` for local text-completions and Custom chat-completions paths.

## Why?
Local llama.cpp-compatible servers can default prompt caching on for every request, so helper generations may evict or overwrite the main chat cache lane. That can show up as periodic full-context reprocessing during longer chats or after rerolls/new turns.

## How?
Adds `getLocalPromptCacheValue(cacheScope)` beside the existing local URL helpers, then uses it when building local textgen and Custom chat-completions request payloads. This keeps the change scoped to local backends and avoids changing remote provider behavior.

## Testing?
- `npm run test:unit --prefix tests -- local-url-utils.test.js`
- `npx eslint public/scripts/local-url-utils.js public/scripts/textgen-settings.js src/endpoints/backends/chat-completions.js tests/local-url-utils.test.js`

## Screenshots (optional)
Not applicable; backend/request-payload behavior only.

## Anything Else?
This PR intentionally excludes the Graphify map and local AGENTS cleanup so the cache fix can be reviewed independently.
