### PR TITLE
fix: abort generation on client disconnect

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -23,7 +23,7 @@ import {
 } from '../../constants.js';
 import {
     forwardFetchResponse,
-    abortOnResponseClose,
+    abortOnRequestClose,
     getConfigValue,
     tryParse,
     uuidv4,
@@ -310,7 +310,7 @@ async function sendClaudeRequest(request, response) {
 
     try {
         const controller = new AbortController();
-        abortOnResponseClose(response, controller);
+        abortOnRequestClose(request, controller);
         const additionalHeaders = {};
         const betaHeaders = ['output-128k-2025-02-19', 'context-1m-2025-08-07'];
         const useTools = Array.isArray(request.body.tools) && request.body.tools.length > 0;
@@ -714,7 +714,7 @@ async function sendMakerSuiteRequest(request, response) {
 
     try {
         const controller = new AbortController();
-        abortOnResponseClose(response, controller);
+        abortOnRequestClose(request, controller);
 
         const apiVersion = getConfigValue('gemini.apiVersion', 'v1beta');
         const responseType = (stream ? 'streamGenerateContent' : 'generateContent');
@@ -850,7 +850,7 @@ async function sendAI21Request(request, response) {
 
     const bodyParams = {};
     const controller = new AbortController();
-    abortOnResponseClose(response, controller);
+    abortOnRequestClose(request, controller);
     // Hack to support JSON schema
     if (request.body.json_schema) {
         bodyParams.response_format = {
@@ -929,7 +929,7 @@ async function sendMistralAIRequest(request, response) {
     try {
         const messages = convertMistralMessages(request.body.messages, getPromptNames(request));
         const controller = new AbortController();
-        abortOnResponseClose(response, controller);
+        abortOnRequestClose(request, controller);
 
         const requestBody = {
             'model': request.body.model,
@@ -1007,7 +1007,7 @@ async function sendMistralAIRequest(request, response) {
 async function sendCohereRequest(request, response) {
     const apiKey = readSecret(request.user.directories, SECRET_KEYS.COHERE);
     const controller = new AbortController();
-    abortOnResponseClose(response, controller);
+    abortOnRequestClose(request, controller);
 
     if (!apiKey) {
         console.warn('Cohere API key is missing.');
@@ -1111,7 +1111,7 @@ async function sendDeepSeekRequest(request, response) {
     }
 
     const controller = new AbortController();
-    abortOnResponseClose(response, controller);
+    abortOnRequestClose(request, controller);
 
     try {
         let bodyParams = {};
@@ -1225,7 +1225,7 @@ async function sendXaiRequest(request, response) {
     }
 
     const controller = new AbortController();
-    abortOnResponseClose(response, controller);
+    abortOnRequestClose(request, controller);
 
     try {
         let bodyParams = {};
@@ -1330,7 +1330,7 @@ async function sendAimlapiRequest(request, response) {
     }
 
     const controller = new AbortController();
-    abortOnResponseClose(response, controller);
+    abortOnRequestClose(request, controller);
 
     try {
         let bodyParams = {};
@@ -1432,7 +1432,7 @@ async function sendElectronHubRequest(request, response) {
     }
 
     const controller = new AbortController();
-    abortOnResponseClose(response, controller);
+    abortOnRequestClose(request, controller);
 
     try {
         let bodyParams = {};
@@ -1541,7 +1541,7 @@ async function sendChutesRequest(request, response) {
     }
 
     const controller = new AbortController();
-    abortOnResponseClose(response, controller);
+    abortOnRequestClose(request, controller);
 
     try {
         let bodyParams = {};
@@ -1640,7 +1640,7 @@ async function sendMinimaxRequest(request, response) {
     }
 
     const controller = new AbortController();
-    abortOnResponseClose(response, controller);
+    abortOnRequestClose(request, controller);
 
     try {
         // MiniMax does not allow consecutive messages with the same role.
@@ -1756,7 +1756,7 @@ async function sendAzureOpenAIRequest(request, response) {
         : undefined;
 
     const controller = new AbortController();
-    abortOnResponseClose(response, controller);
+    abortOnRequestClose(request, controller);
 
     const config = {
         method: 'POST',
@@ -2511,7 +2511,7 @@ async function sendOpenAIResponsesRequest(request, response) {
     }
 
     const controller = new AbortController();
-    abortOnResponseClose(response, controller);
+    abortOnRequestClose(request, controller);
 
     try {
         const { input, instructions } = convertMessagesToResponsesFormat(request.body.messages);
@@ -2970,7 +2970,7 @@ router.post('/generate', async function (request, response) {
             `${apiUrl}/chat/completions`;
 
         const controller = new AbortController();
-        abortOnResponseClose(response, controller);
+        abortOnRequestClose(request, controller);
 
         if (!isTextCompletion && Array.isArray(request.body.tools) && request.body.tools.length > 0) {
             bodyParams['tools'] = request.body.tools;

--- a/src/endpoints/backends/kobold.js
+++ b/src/endpoints/backends/kobold.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import express from 'express';
 import fetch from 'node-fetch';
 
-import { forwardFetchResponse, abortOnResponseClose, delay, summarizeLlmPayloadForLog } from '../../util.js';
+import { forwardFetchResponse, delay, summarizeLlmPayloadForLog } from '../../util.js';
 import { getOverrideHeaders, setAdditionalHeaders, setAdditionalHeadersByType } from '../../additional-headers.js';
 import { TEXTGEN_TYPES } from '../../constants.js';
 
@@ -17,12 +17,8 @@ router.post('/generate', async function (request, response_generate) {
 
     const request_prompt = request.body.prompt;
     const controller = new AbortController();
-    abortOnResponseClose(response_generate, controller);
-    response_generate.on('close', async function () {
-        if (response_generate.writableEnded) {
-            return;
-        }
-
+    request.socket.removeAllListeners('close');
+    request.socket.on('close', async function () {
         if (request.body.can_abort && !response_generate.writableEnded) {
             try {
                 console.info('Aborting Kobold generation...');
@@ -38,6 +34,7 @@ router.post('/generate', async function (request, response_generate) {
                 console.error(error);
             }
         }
+        controller.abort();
     });
 
     let this_settings = {

--- a/src/endpoints/backends/text-completions.js
+++ b/src/endpoints/backends/text-completions.js
@@ -12,7 +12,7 @@ import {
     FEATHERLESS_KEYS,
     OPENAI_KEYS,
 } from '../../constants.js';
-import { forwardFetchResponse, abortOnResponseClose, trimV1, getConfigValue, summarizeLlmPayloadForLog } from '../../util.js';
+import { forwardFetchResponse, trimV1, getConfigValue, summarizeLlmPayloadForLog } from '../../util.js';
 import { setAdditionalHeaders } from '../../additional-headers.js';
 import { createHash } from 'node:crypto';
 
@@ -50,11 +50,7 @@ async function parseOllamaStream(jsonStream, request, response) {
             }
         });
 
-        response.on('close', function () {
-            if (response.writableEnded) {
-                return;
-            }
-
+        request.socket.on('close', function () {
             try {
                 jsonStream.body?.destroy?.();
             } catch {
@@ -289,18 +285,15 @@ router.post('/generate', async function (request, response) {
         console.debug('Text completion request:', summarizeLlmPayloadForLog(request.body));
 
         const controller = new AbortController();
-        abortOnResponseClose(response, controller);
-
-        // SillyBunny: KoboldCpp needs its own upstream abort endpoint; other backends use the shared fetch abort/stream destroy path.
-        if (request.body.api_type === TEXTGEN_TYPES.KOBOLDCPP) {
-            response.on('close', async function () {
-                if (response.writableEnded) {
-                    return;
-                }
-
+        request.socket.removeAllListeners('close');
+        request.socket.on('close', async function () {
+            // SillyBunny: KoboldCpp needs its own upstream abort endpoint; other backends use the shared fetch abort/stream destroy path.
+            if (request.body.api_type === TEXTGEN_TYPES.KOBOLDCPP && !response.writableEnded) {
                 await abortKoboldCppRequest(request, trimV1(baseUrl));
-            });
-        }
+            }
+
+            controller.abort();
+        });
 
         let url = trimV1(baseUrl);
 

--- a/src/util.js
+++ b/src/util.js
@@ -752,15 +752,14 @@ export async function forwardFetchResponse(from, to) {
 }
 
 /**
- * Aborts an upstream request if the client closes the Express response early.
- * @param {import('express').Response} response The Express response to observe.
+ * Aborts an upstream request if the client connection closes early.
+ * @param {import('express').Request} request The Express request to observe.
  * @param {AbortController} controller Abort controller for the upstream request.
  */
-export function abortOnResponseClose(response, controller) {
-    response.on('close', () => {
-        if (!response.writableEnded) {
-            controller.abort();
-        }
+export function abortOnRequestClose(request, controller) {
+    request.socket.removeAllListeners('close');
+    request.socket.on('close', () => {
+        controller.abort();
     });
 }
 

--- a/tests/util.test.js
+++ b/tests/util.test.js
@@ -3,7 +3,7 @@ import { EventEmitter, once } from 'node:events';
 import { PassThrough } from 'node:stream';
 import { Response } from 'node-fetch';
 import { CHAT_COMPLETION_SOURCES } from '../src/constants';
-import { abortOnResponseClose, flattenSchema, forwardFetchResponse } from '../src/util';
+import { abortOnRequestClose, flattenSchema, forwardFetchResponse } from '../src/util';
 
 function createMockExpressResponse() {
     const response = new PassThrough();
@@ -11,6 +11,10 @@ function createMockExpressResponse() {
     response.statusMessage = '';
 
     return response;
+}
+
+function createMockExpressRequest() {
+    return { socket: new EventEmitter() };
 }
 
 async function collectResponseBody(response) {
@@ -196,25 +200,25 @@ describe('forwardFetchResponse', () => {
     });
 });
 
-describe('abortOnResponseClose', () => {
-    test('should abort the upstream controller when the client response closes early', () => {
-        const response = createMockExpressResponse();
+describe('abortOnRequestClose', () => {
+    test('should abort the upstream controller when the client request socket closes', () => {
+        const request = createMockExpressRequest();
         const controller = new AbortController();
 
-        abortOnResponseClose(response, controller);
-        response.emit('close');
+        abortOnRequestClose(request, controller);
+        request.socket.emit('close');
 
         expect(controller.signal.aborted).toBe(true);
     });
 
-    test('should not abort the upstream controller after a normal response end', () => {
-        const response = createMockExpressResponse();
-        const controller = new AbortController();
+    test('should replace existing socket close listeners before registering the abort handler', () => {
+        const request = createMockExpressRequest();
+        const existingListener = jest.fn();
 
-        abortOnResponseClose(response, controller);
-        response.end();
-        response.emit('close');
+        request.socket.on('close', existingListener);
+        abortOnRequestClose(request, new AbortController());
+        request.socket.emit('close');
 
-        expect(controller.signal.aborted).toBe(false);
+        expect(existingListener).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Summary
- switch backend generation abort detection back to the client request socket, matching SillyTavern behavior
- keep Kobold/KoboldCpp explicit upstream abort calls on that same socket-close path
- update util tests for the renamed request-close abort helper

## Why
Some users saw SillyBunny continue generating after stop/end, and LM Studio did not log its expected client disconnect message. SillyTavern listens for `request.socket` close events for these generation routes, while SillyBunny had moved the generic abort helper to `response.on("close")`, which can miss the frontend fetch abort path.

## Validation
- `npm run lint`
- `npm run lint --prefix tests`
- `npm run test:unit --prefix tests`