### PR TITLE
Fix local generation aborts after stop

### DIFF
--- a/default/config.yaml
+++ b/default/config.yaml
@@ -260,6 +260,11 @@ performance:
   memoryCacheCapacity: '100mb'
   # Enables disk caching for character cards. Improves performances with large card libraries.
   useDiskCache: true
+  streaming:
+    # Polls the OS connection table during streaming generation so local backends stop when browser disconnect events are missed.
+    enableConnectionPolling: true
+    # Poll interval in milliseconds. Lower values detect stop requests sooner but do slightly more OS work.
+    connectionPollingInterval: 150
   # Configures gzip compression for client requests with large payloads (e.g. settings or chat saves).
   requestCompression:
     # Enable request compression.

--- a/src/connection-state-checker.js
+++ b/src/connection-state-checker.js
@@ -1,0 +1,386 @@
+import fs from 'node:fs';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import os from 'node:os';
+
+const execFileAsync = promisify(execFile);
+const TCP_ESTABLISHED = '01';
+const CONNECTION_TABLE_CACHE_MS = 50;
+const DEFAULT_POLL_INTERVAL_MS = 150;
+const NETSTAT_TIMEOUT_MS = 1000;
+
+/**
+ * @typedef {object} SocketAddress
+ * @property {string} localAddress Local socket address
+ * @property {number} localPort Local socket port
+ * @property {string} remoteAddress Remote socket address
+ * @property {number} remotePort Remote socket port
+ */
+
+/** @type {{ platform: string, expiresAt: number, promise: Promise<Set<string>> } | null} */
+let connectionTableCache = null;
+
+function normalizeAddress(address) {
+    if (!address) {
+        return '';
+    }
+
+    let normalized = String(address).trim().toLowerCase();
+
+    if (normalized.startsWith('::ffff:')) {
+        normalized = normalized.slice(7);
+    }
+
+    if (normalized === 'localhost') {
+        return '127.0.0.1';
+    }
+
+    if (normalized === '::1' || normalized === '0:0:0:0:0:0:0:1') {
+        return '::1';
+    }
+
+    return normalized;
+}
+
+function connectionKey(localAddress, localPort, remoteAddress, remotePort) {
+    return `${normalizeAddress(localAddress)}:${Number(localPort)}>${normalizeAddress(remoteAddress)}:${Number(remotePort)}`;
+}
+
+function reverseConnectionKey(localAddress, localPort, remoteAddress, remotePort) {
+    return connectionKey(remoteAddress, remotePort, localAddress, localPort);
+}
+
+function expandIpv6Address(address) {
+    if (!address.includes('::')) {
+        return address.split(':').map(part => part.padStart(4, '0')).join(':');
+    }
+
+    const [left, right = ''] = address.split('::');
+    const leftParts = left ? left.split(':') : [];
+    const rightParts = right ? right.split(':') : [];
+    const missingParts = Math.max(0, 8 - leftParts.length - rightParts.length);
+    const parts = [...leftParts, ...Array(missingParts).fill('0'), ...rightParts];
+
+    return parts.map(part => part.padStart(4, '0')).join(':');
+}
+
+function collapseIpv6Address(address) {
+    const parts = expandIpv6Address(address).split(':').map(part => part.replace(/^0+/, '') || '0');
+    let bestStart = -1;
+    let bestLength = 0;
+    let currentStart = -1;
+    let currentLength = 0;
+
+    for (let i = 0; i <= parts.length; i++) {
+        if (parts[i] === '0') {
+            if (currentStart === -1) currentStart = i;
+            currentLength++;
+        } else {
+            if (currentLength > bestLength) {
+                bestStart = currentStart;
+                bestLength = currentLength;
+            }
+            currentStart = -1;
+            currentLength = 0;
+        }
+    }
+
+    if (bestLength < 2) {
+        return parts.join(':');
+    }
+
+    const before = parts.slice(0, bestStart).join(':');
+    const after = parts.slice(bestStart + bestLength).join(':');
+
+    if (!before && !after) return '::';
+    if (!before) return `::${after}`;
+    if (!after) return `${before}::`;
+    return `${before}::${after}`;
+}
+
+function parseLinuxIpv4Address(hexAddress) {
+    const bytes = hexAddress.match(/.{2}/g);
+    if (!bytes || bytes.length !== 4) {
+        return '';
+    }
+
+    return bytes.reverse().map(byte => Number.parseInt(byte, 16)).join('.');
+}
+
+function parseLinuxIpv6Address(hexAddress) {
+    const groups = hexAddress.match(/.{8}/g);
+    if (!groups || groups.length !== 4) {
+        return '';
+    }
+
+    const normalized = groups
+        .map(group => group.match(/.{2}/g)?.reverse().join('') ?? '')
+        .join('')
+        .match(/.{4}/g)
+        ?.join(':');
+
+    if (!normalized) {
+        return '';
+    }
+
+    if (normalized.startsWith('0000:0000:0000:0000:0000:ffff:')) {
+        const ipv4Hex = normalized.split(':').slice(-2).join('');
+        const bytes = ipv4Hex.match(/.{2}/g);
+        if (bytes?.length === 4) {
+            return bytes.map(byte => Number.parseInt(byte, 16)).join('.');
+        }
+    }
+
+    return collapseIpv6Address(normalized);
+}
+
+function parseLinuxEndpoint(endpoint, isIpv6) {
+    const [addressHex, portHex] = endpoint.split(':');
+    const address = isIpv6 ? parseLinuxIpv6Address(addressHex) : parseLinuxIpv4Address(addressHex);
+    const port = Number.parseInt(portHex, 16);
+
+    return { address, port };
+}
+
+function parseLinuxTcpTable(text, isIpv6 = false) {
+    const connections = new Set();
+    const lines = String(text || '').trim().split('\n').slice(1);
+
+    for (const line of lines) {
+        const fields = line.trim().split(/\s+/);
+        const localEndpoint = fields[1];
+        const remoteEndpoint = fields[2];
+        const state = fields[3];
+
+        if (!localEndpoint || !remoteEndpoint || state !== TCP_ESTABLISHED) {
+            continue;
+        }
+
+        const local = parseLinuxEndpoint(localEndpoint, isIpv6);
+        const remote = parseLinuxEndpoint(remoteEndpoint, isIpv6);
+
+        if (!local.address || !remote.address || !local.port || !remote.port) {
+            continue;
+        }
+
+        connections.add(connectionKey(local.address, local.port, remote.address, remote.port));
+    }
+
+    return connections;
+}
+
+function parseNetstatEndpoint(endpoint) {
+    const bracketMatch = String(endpoint || '').match(/^\[(.+)\]:(\d+)$/);
+    if (bracketMatch) {
+        return { address: bracketMatch[1], port: Number(bracketMatch[2]) };
+    }
+
+    const endpointMatch = String(endpoint || '').match(/^(.+)[:.](\d+)$/);
+    if (!endpointMatch) {
+        return null;
+    }
+
+    return { address: endpointMatch[1], port: Number(endpointMatch[2]) };
+}
+
+function parseNetstatOutput(text) {
+    const connections = new Set();
+
+    for (const line of String(text || '').split('\n')) {
+        const fields = line.trim().split(/\s+/);
+        const tcpIndex = fields.findIndex(field => /^tcp/i.test(field));
+
+        if (tcpIndex < 0) {
+            continue;
+        }
+
+        const hasQueueColumns = /^\d+$/.test(fields[tcpIndex + 1]) && /^\d+$/.test(fields[tcpIndex + 2]);
+        const endpointOffset = hasQueueColumns ? 3 : 1;
+        const localEndpoint = fields[tcpIndex + endpointOffset];
+        const remoteEndpoint = fields[tcpIndex + endpointOffset + 1];
+        const state = fields[tcpIndex + endpointOffset + 2];
+
+        if (!localEndpoint || !remoteEndpoint || !/^established$/i.test(state)) {
+            continue;
+        }
+
+        const local = parseNetstatEndpoint(localEndpoint);
+        const remote = parseNetstatEndpoint(remoteEndpoint);
+
+        if (!local || !remote || !local.port || !remote.port) {
+            continue;
+        }
+
+        connections.add(connectionKey(local.address, local.port, remote.address, remote.port));
+    }
+
+    return connections;
+}
+
+async function getLinuxConnections() {
+    const connections = new Set();
+
+    for (const [file, isIpv6] of [['/proc/net/tcp', false], ['/proc/net/tcp6', true]]) {
+        try {
+            const text = await fs.promises.readFile(file, 'utf8');
+            for (const key of parseLinuxTcpTable(text, isIpv6)) {
+                connections.add(key);
+            }
+        } catch (error) {
+            if (error?.code !== 'ENOENT') {
+                throw error;
+            }
+        }
+    }
+
+    return connections;
+}
+
+async function getNetstatConnections(platform) {
+    const args = platform === 'win32' ? ['-ano', '-p', 'TCP'] : ['-an', '-p', 'tcp'];
+    const result = await execFileAsync('netstat', args, { timeout: NETSTAT_TIMEOUT_MS });
+    const stdout = typeof result === 'string' ? result : result?.stdout;
+
+    return parseNetstatOutput(stdout);
+}
+
+async function getConnectionTable(platform = os.platform()) {
+    switch (platform) {
+        case 'linux':
+            return getLinuxConnections();
+        case 'darwin':
+        case 'win32':
+            return getNetstatConnections(platform);
+        default:
+            return null;
+    }
+}
+
+function getSocketAddress(socket) {
+    if (!socket?.localAddress || !socket?.localPort || !socket?.remoteAddress || !socket?.remotePort) {
+        return null;
+    }
+
+    return {
+        localAddress: socket.localAddress,
+        localPort: Number(socket.localPort),
+        remoteAddress: socket.remoteAddress,
+        remotePort: Number(socket.remotePort),
+    };
+}
+
+async function getCachedConnectionTable(platform = os.platform()) {
+    const now = Date.now();
+
+    if (connectionTableCache && connectionTableCache.platform === platform && connectionTableCache.expiresAt > now) {
+        return connectionTableCache.promise;
+    }
+
+    const promise = getConnectionTable(platform);
+    connectionTableCache = {
+        platform,
+        expiresAt: now + CONNECTION_TABLE_CACHE_MS,
+        promise,
+    };
+
+    try {
+        return await promise;
+    } catch (error) {
+        if (connectionTableCache?.promise === promise) {
+            connectionTableCache = null;
+        }
+        throw error;
+    }
+}
+
+/**
+ * Checks the OS connection table for the given socket.
+ * Falls back to connected when the platform check is unavailable.
+ * @param {import('node:net').Socket} socket Socket to check
+ * @returns {Promise<boolean>} True if the socket appears connected or cannot be checked
+ */
+export async function isSocketConnected(socket) {
+    if (!socket || socket.destroyed) {
+        return false;
+    }
+
+    const address = getSocketAddress(socket);
+    if (!address) {
+        return true;
+    }
+
+    let table;
+    try {
+        table = await getCachedConnectionTable();
+    } catch (error) {
+        console.debug('Unable to read client socket connection table:', error?.message ?? error);
+        return true;
+    }
+
+    if (!table) {
+        return true;
+    }
+
+    const key = connectionKey(address.localAddress, address.localPort, address.remoteAddress, address.remotePort);
+    const reverseKey = reverseConnectionKey(address.localAddress, address.localPort, address.remoteAddress, address.remotePort);
+
+    return table.has(key) || table.has(reverseKey);
+}
+
+/**
+ * Polls an HTTP request socket and runs a callback once an OS-level disconnect is detected.
+ * @param {import('node:net').Socket} socket Socket to poll
+ * @param {number} intervalMs Polling interval in milliseconds
+ * @param {() => void} onDisconnect Disconnect callback
+ * @returns {() => void} Stops polling
+ */
+export function pollSocketConnection(socket, intervalMs = DEFAULT_POLL_INTERVAL_MS, onDisconnect = () => undefined) {
+    if (!socket || typeof onDisconnect !== 'function') {
+        return () => undefined;
+    }
+
+    let stopped = false;
+    let checking = false;
+    const interval = Math.max(50, Number(intervalMs) || DEFAULT_POLL_INTERVAL_MS);
+
+    async function checkConnection() {
+        if (stopped || checking) {
+            return;
+        }
+
+        checking = true;
+        try {
+            const connected = await isSocketConnected(socket);
+            if (!connected && !stopped) {
+                stopped = true;
+                clearInterval(timer);
+                console.info('Detected disconnected client socket during streaming request');
+                onDisconnect();
+            }
+        } catch (error) {
+            console.debug('Unable to poll client socket connection state:', error?.message ?? error);
+        } finally {
+            checking = false;
+        }
+    }
+
+    const timer = setInterval(checkConnection, interval);
+    timer.unref?.();
+    void checkConnection();
+
+    return () => {
+        stopped = true;
+        clearInterval(timer);
+    };
+}
+
+export const testExports = {
+    clearConnectionTableCache: () => {
+        connectionTableCache = null;
+    },
+    connectionKey,
+    collapseIpv6Address,
+    normalizeAddress,
+    parseLinuxTcpTable,
+    parseNetstatOutput,
+};

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -25,6 +25,7 @@ import {
     forwardFetchResponse,
     abortOnRequestClose,
     getConfigValue,
+    pollStreamingRequestConnection,
     tryParse,
     uuidv4,
     mergeObjectWithYaml,
@@ -469,7 +470,7 @@ async function sendClaudeRequest(request, response) {
 
         if (request.body.stream) {
             // Pipe remote SSE stream to Express response
-            forwardFetchResponse(generateResponse, response);
+            forwardFetchResponse(generateResponse, response, request, () => controller.abort());
         } else {
             if (!generateResponse.ok) {
                 const generateResponseText = await generateResponse.text();
@@ -782,7 +783,7 @@ async function sendMakerSuiteRequest(request, response) {
         if (stream) {
             try {
                 // Pipe remote SSE stream to Express response
-                forwardFetchResponse(generateResponse, response);
+                forwardFetchResponse(generateResponse, response, request, () => controller.abort());
             } catch (error) {
                 console.error('Error forwarding streaming response:', error);
                 if (!response.headersSent) {
@@ -890,7 +891,7 @@ async function sendAI21Request(request, response) {
     try {
         const generateResponse = await fetch(API_AI21 + '/chat/completions', options);
         if (request.body.stream) {
-            forwardFetchResponse(generateResponse, response);
+            forwardFetchResponse(generateResponse, response, request, () => controller.abort());
         } else {
             if (!generateResponse.ok) {
                 const errorText = await generateResponse.text();
@@ -977,7 +978,7 @@ async function sendMistralAIRequest(request, response) {
 
         const generateResponse = await fetch(apiUrl + '/chat/completions', config);
         if (request.body.stream) {
-            forwardFetchResponse(generateResponse, response);
+            forwardFetchResponse(generateResponse, response, request, () => controller.abort());
         } else {
             if (!generateResponse.ok) {
                 const errorText = await generateResponse.text();
@@ -1073,7 +1074,7 @@ async function sendCohereRequest(request, response) {
 
         if (request.body.stream) {
             const stream = await fetch(apiUrl, config);
-            forwardFetchResponse(stream, response);
+            forwardFetchResponse(stream, response, request, () => controller.abort());
         } else {
             const generateResponse = await fetch(apiUrl, config);
             if (!generateResponse.ok) {
@@ -1188,7 +1189,7 @@ async function sendDeepSeekRequest(request, response) {
         const generateResponse = await fetch(apiUrl + '/chat/completions', config);
 
         if (request.body.stream) {
-            forwardFetchResponse(generateResponse, response);
+            forwardFetchResponse(generateResponse, response, request, () => controller.abort());
         } else {
             if (!generateResponse.ok) {
                 const errorText = await generateResponse.text();
@@ -1293,7 +1294,7 @@ async function sendXaiRequest(request, response) {
         const generateResponse = await fetch(apiUrl + '/chat/completions', config);
 
         if (request.body.stream) {
-            forwardFetchResponse(generateResponse, response);
+            forwardFetchResponse(generateResponse, response, request, () => controller.abort());
         } else {
             if (!generateResponse.ok) {
                 const errorText = await generateResponse.text();
@@ -1395,7 +1396,7 @@ async function sendAimlapiRequest(request, response) {
         const generateResponse = await fetch(apiUrl + '/chat/completions', config);
 
         if (request.body.stream) {
-            forwardFetchResponse(generateResponse, response);
+            forwardFetchResponse(generateResponse, response, request, () => controller.abort());
         } else {
             if (!generateResponse.ok) {
                 const errorText = await generateResponse.text();
@@ -1504,7 +1505,7 @@ async function sendElectronHubRequest(request, response) {
         const generateResponse = await fetch(apiUrl + '/chat/completions', config);
 
         if (request.body.stream) {
-            forwardFetchResponse(generateResponse, response);
+            forwardFetchResponse(generateResponse, response, request, () => controller.abort());
         } else {
             if (!generateResponse.ok) {
                 const errorText = await generateResponse.text();
@@ -1602,7 +1603,7 @@ async function sendChutesRequest(request, response) {
         const generateResponse = await fetch(apiUrl + '/chat/completions', config);
 
         if (request.body.stream) {
-            forwardFetchResponse(generateResponse, response);
+            forwardFetchResponse(generateResponse, response, request, () => controller.abort());
         } else {
             if (!generateResponse.ok) {
                 const errorText = await generateResponse.text();
@@ -1679,7 +1680,7 @@ async function sendMinimaxRequest(request, response) {
         const generateResponse = await fetch(apiUrl + '/chat/completions', config);
 
         if (request.body.stream) {
-            return forwardFetchResponse(generateResponse, response);
+            return forwardFetchResponse(generateResponse, response, request, () => controller.abort());
         }
 
         if (!generateResponse.ok) {
@@ -1774,7 +1775,7 @@ async function sendAzureOpenAIRequest(request, response) {
         const fetchResponse = await fetch(endpointUrl, config);
 
         if (request.body.stream) {
-            return forwardFetchResponse(fetchResponse, response);
+            return forwardFetchResponse(fetchResponse, response, request, () => controller.abort());
         }
 
         if (fetchResponse.ok) {
@@ -2343,8 +2344,10 @@ function isExpectedStreamAbort(error) {
  * Transforms a Responses API SSE stream into Chat Completions SSE format.
  * @param {import('node-fetch').Response} fetchResponse The upstream Responses API response
  * @param {import('express').Response} expressResponse The Express response to write to
+ * @param {import('express').Request} request The Express request to poll for OS-level disconnects
+ * @param {() => void} onDisconnect Upstream disconnect callback
  */
-function forwardResponsesApiStream(fetchResponse, expressResponse) {
+function forwardResponsesApiStream(fetchResponse, expressResponse, request, onDisconnect = null) {
     let statusCode = fetchResponse.status;
     const statusText = fetchResponse.statusText;
 
@@ -2370,10 +2373,32 @@ function forwardResponsesApiStream(fetchResponse, expressResponse) {
 
     let buffer = '';
     let done = false;
+    const stopPolling = pollStreamingRequestConnection(request, expressResponse, closeStream);
+
+    function closeStream() {
+        if (done) {
+            return;
+        }
+
+        done = true;
+        stopPolling();
+        try {
+            onDisconnect?.();
+        } catch (error) {
+            console.warn('Error handling Responses API stream disconnect:', error);
+        }
+        if (fetchResponse.body && typeof fetchResponse.body.destroy === 'function') {
+            fetchResponse.body.destroy();
+        }
+        if (!expressResponse.destroyed && !expressResponse.writableEnded) {
+            expressResponse.end();
+        }
+    }
 
     function finishStream() {
         if (done) return;
         done = true;
+        stopPolling();
         if (!expressResponse.writableEnded) {
             expressResponse.write('data: [DONE]\n\n');
             expressResponse.end();
@@ -2423,6 +2448,7 @@ function forwardResponsesApiStream(fetchResponse, expressResponse) {
     });
 
     fetchResponse.body.on('error', (err) => {
+        stopPolling();
         if (done || isExpectedStreamAbort(err) || expressResponse.destroyed) {
             done = true;
             if (!expressResponse.destroyed && !expressResponse.writableEnded) {
@@ -2439,14 +2465,7 @@ function forwardResponsesApiStream(fetchResponse, expressResponse) {
     });
 
     expressResponse.on('close', () => {
-        if (done) {
-            return;
-        }
-
-        done = true;
-        if (fetchResponse.body && typeof fetchResponse.body.destroy === 'function') {
-            fetchResponse.body.destroy();
-        }
+        closeStream();
     });
 }
 
@@ -2575,7 +2594,7 @@ async function sendOpenAIResponsesRequest(request, response) {
 
         if (request.body.stream) {
             console.info('Streaming Responses API request in progress');
-            return forwardResponsesApiStream(fetchResponse, response);
+            return forwardResponsesApiStream(fetchResponse, response, request, () => controller.abort());
         }
 
         if (fetchResponse.ok) {
@@ -3029,7 +3048,7 @@ router.post('/generate', async function (request, response) {
 
         if (request.body.stream) {
             console.info('Streaming request in progress');
-            return forwardFetchResponse(fetchResponse, response);
+            return forwardFetchResponse(fetchResponse, response, request, () => controller.abort());
         }
 
         if (fetchResponse.ok) {

--- a/src/endpoints/backends/kobold.js
+++ b/src/endpoints/backends/kobold.js
@@ -99,7 +99,23 @@ router.post('/generate', async function (request, response_generate) {
 
             if (request.body.streaming) {
                 // Pipe remote SSE stream to Express response
-                await forwardFetchResponse(response, response_generate);
+                await forwardFetchResponse(response, response_generate, request, async () => {
+                    if (request.body.can_abort && !response_generate.writableEnded) {
+                        try {
+                            console.info('Aborting Kobold generation...');
+                            const abortResponse = await fetch(`${request.body.api_server}/extra/abort`, {
+                                method: 'POST',
+                            });
+
+                            if (!abortResponse.ok) {
+                                console.error('Error sending abort request to Kobold:', abortResponse.status);
+                            }
+                        } catch (error) {
+                            console.error(error);
+                        }
+                    }
+                    controller.abort();
+                });
                 return;
             } else {
                 if (!response.ok) {

--- a/src/endpoints/backends/text-completions.js
+++ b/src/endpoints/backends/text-completions.js
@@ -12,7 +12,7 @@ import {
     FEATHERLESS_KEYS,
     OPENAI_KEYS,
 } from '../../constants.js';
-import { forwardFetchResponse, trimV1, getConfigValue, summarizeLlmPayloadForLog } from '../../util.js';
+import { forwardFetchResponse, trimV1, getConfigValue, pollStreamingRequestConnection, summarizeLlmPayloadForLog } from '../../util.js';
 import { setAdditionalHeaders } from '../../additional-headers.js';
 import { createHash } from 'node:crypto';
 
@@ -23,16 +23,44 @@ export const router = express.Router();
  * @param {import('node-fetch').Response} jsonStream JSON stream
  * @param {import('express').Request} request Express request
  * @param {import('express').Response} response Express response
+ * @param {() => void} onDisconnect Upstream disconnect callback
  * @returns {Promise<any>} Nothing valuable
  */
-async function parseOllamaStream(jsonStream, request, response) {
+async function parseOllamaStream(jsonStream, request, response, onDisconnect = null) {
     try {
         if (!jsonStream.body) {
             throw new Error('No body in the response');
         }
 
+        let done = false;
+        function closeStream() {
+            if (done) {
+                return;
+            }
+
+            done = true;
+            stopPolling();
+            try {
+                onDisconnect?.();
+            } catch (error) {
+                console.warn('Error handling Ollama stream disconnect:', error);
+            }
+            try {
+                jsonStream.body?.destroy?.();
+            } catch {
+                // Best effort; the client response is already closing.
+            }
+            if (!response.writableEnded) {
+                response.end();
+            }
+        }
+        const stopPolling = pollStreamingRequestConnection(request, response, closeStream);
         let partialData = '';
         jsonStream.body.on('data', (data) => {
+            if (done) {
+                return;
+            }
+
             const chunk = data.toString();
             partialData += chunk;
             while (true) {
@@ -50,19 +78,22 @@ async function parseOllamaStream(jsonStream, request, response) {
             }
         });
 
-        request.socket.on('close', function () {
-            try {
-                jsonStream.body?.destroy?.();
-            } catch {
-                // Best effort; the client response is already closing.
-            }
-            response.end();
-        });
+        request.socket.on('close', closeStream);
 
         jsonStream.body.on('end', () => {
+            if (done) {
+                return;
+            }
+
+            done = true;
+            stopPolling();
             console.info('Streaming request finished');
             response.write('data: [DONE]\n\n');
             response.end();
+        });
+
+        jsonStream.body.on('error', () => {
+            stopPolling();
         });
     } catch (error) {
         console.error('Error forwarding streaming response:', error);
@@ -404,11 +435,16 @@ router.post('/generate', async function (request, response) {
 
         if (request.body.api_type === TEXTGEN_TYPES.OLLAMA && request.body.stream) {
             const stream = await fetch(url, args);
-            parseOllamaStream(stream, request, response);
+            parseOllamaStream(stream, request, response, () => controller.abort());
         } else if (request.body.stream) {
             const completionsStream = await fetch(url, args);
             // Pipe remote SSE stream to Express response
-            await forwardFetchResponse(completionsStream, response);
+            await forwardFetchResponse(completionsStream, response, request, async () => {
+                if (request.body.api_type === TEXTGEN_TYPES.KOBOLDCPP && !response.writableEnded) {
+                    await abortKoboldCppRequest(request, trimV1(baseUrl));
+                }
+                controller.abort();
+            });
         } else {
             const completionsReply = await fetch(url, args);
 

--- a/src/endpoints/novelai.js
+++ b/src/endpoints/novelai.js
@@ -270,7 +270,7 @@ router.post('/generate', async function (req, res) {
 
         if (req.body.streaming) {
             // Pipe remote SSE stream to Express response
-            await forwardFetchResponse(response, res);
+            await forwardFetchResponse(response, res, req, () => controller.abort());
         } else {
             if (!response.ok) {
                 const text = await response.text();

--- a/src/util.js
+++ b/src/util.js
@@ -21,6 +21,9 @@ import { LOG_LEVELS, CHAT_COMPLETION_SOURCES, MEDIA_REQUEST_TYPE } from './const
 import { serverDirectory } from './server-directory.js';
 import { sync as writeFileAtomicSync } from 'write-file-atomic';
 import { isFirefox } from './express-common.js';
+import { pollSocketConnection } from './connection-state-checker.js';
+
+const DEFAULT_STREAMING_CONNECTION_POLLING_INTERVAL_MS = 150;
 
 /**
  * Parsed config object.
@@ -688,13 +691,65 @@ export function getImages(directoryPath, sortBy = 'name', type = MEDIA_REQUEST_T
         .sort(getSortFunction());
 }
 
+function getStreamingConnectionPollingInterval() {
+    if (CONFIG_PATH === null) {
+        return DEFAULT_STREAMING_CONNECTION_POLLING_INTERVAL_MS;
+    }
+
+    const enabled = getConfigValue('performance.streaming.enableConnectionPolling', true, 'boolean');
+    if (!enabled) {
+        return null;
+    }
+
+    const intervalMs = getConfigValue('performance.streaming.connectionPollingInterval', DEFAULT_STREAMING_CONNECTION_POLLING_INTERVAL_MS, 'number');
+
+    return Number.isFinite(intervalMs) && intervalMs > 0
+        ? intervalMs
+        : DEFAULT_STREAMING_CONNECTION_POLLING_INTERVAL_MS;
+}
+
+/**
+ * Starts OS-level polling for a streaming request socket.
+ * @param {import('express').Request} request The Express request to observe.
+ * @param {import('express').Response} response The Express response being streamed.
+ * @param {() => void | Promise<void>} onDisconnect Disconnect callback.
+ * @returns {() => void} Stops polling.
+ */
+export function pollStreamingRequestConnection(request, response, onDisconnect) {
+    if (!request?.socket || response?.writableEnded || response?.destroyed) {
+        return () => undefined;
+    }
+
+    const intervalMs = getStreamingConnectionPollingInterval();
+    if (!intervalMs) {
+        return () => undefined;
+    }
+
+    return pollSocketConnection(request.socket, intervalMs, () => {
+        if (response?.writableEnded || response?.destroyed) {
+            return;
+        }
+
+        try {
+            const disconnectResult = onDisconnect?.();
+            if (disconnectResult && typeof disconnectResult.catch === 'function') {
+                disconnectResult.catch(error => console.warn('Error handling streaming client disconnect:', error));
+            }
+        } catch (error) {
+            console.warn('Error handling streaming client disconnect:', error);
+        }
+    });
+}
+
 /**
  * Pipe a fetch() response to an Express.js Response, including status code.
  * @param {import('node-fetch').Response} from The Fetch API response to pipe from.
  * @param {import('express').Response} to The Express response to pipe to.
+ * @param {import('express').Request} [request] The Express request to poll for OS-level disconnects.
+ * @param {() => void | Promise<void>} [onDisconnect] Additional disconnect callback.
  * @returns {Promise<void>}
  */
-export async function forwardFetchResponse(from, to) {
+export async function forwardFetchResponse(from, to, request = null, onDisconnect = null) {
     let statusCode = from.status;
     let statusText = from.statusText;
 
@@ -726,9 +781,32 @@ export async function forwardFetchResponse(from, to) {
     }
 
     if (from.body && to.socket) {
+        const stopPolling = pollStreamingRequestConnection(request, to, () => {
+            try {
+                const disconnectResult = onDisconnect?.();
+                if (disconnectResult && typeof disconnectResult.catch === 'function') {
+                    disconnectResult.catch(error => console.warn('Error handling streaming client disconnect:', error));
+                }
+            } catch (error) {
+                console.warn('Error handling streaming client disconnect:', error);
+            }
+
+            try {
+                from.body?.destroy?.();
+            } catch {
+                // Best effort; the client response is already gone.
+            }
+
+            if (!to.writableEnded) {
+                to.end();
+            }
+        });
+
         from.body.pipe(to);
 
         to.on('close', function () {
+            stopPolling();
+
             if (to.writableEnded) {
                 return;
             }
@@ -743,8 +821,13 @@ export async function forwardFetchResponse(from, to) {
         });
 
         from.body.on('end', function () {
+            stopPolling();
             console.info('Streaming request finished');
             to.end();
+        });
+
+        from.body.on('error', function () {
+            stopPolling();
         });
     } else {
         to.end();

--- a/tests/connection-state-checker.test.js
+++ b/tests/connection-state-checker.test.js
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { once } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { Response } from 'node-fetch';
+
+const mockReadFile = jest.fn();
+const mockExecFile = jest.fn();
+const mockPlatform = jest.fn();
+
+jest.unstable_mockModule('node:fs', () => ({
+    default: {
+        promises: {
+            readFile: mockReadFile,
+        },
+    },
+}));
+
+jest.unstable_mockModule('node:child_process', () => ({
+    execFile: mockExecFile,
+}));
+
+jest.unstable_mockModule('node:os', () => ({
+    default: {
+        platform: mockPlatform,
+    },
+}));
+
+const connectionStateChecker = await import('../src/connection-state-checker.js');
+const { forwardFetchResponse } = await import('../src/util.js');
+
+const {
+    isSocketConnected,
+    pollSocketConnection,
+    testExports,
+} = connectionStateChecker;
+
+function createSocket(overrides = {}) {
+    return {
+        destroyed: false,
+        localAddress: '127.0.0.1',
+        localPort: 8080,
+        remoteAddress: '127.0.0.2',
+        remotePort: 5555,
+        ...overrides,
+    };
+}
+
+function createMockResponse() {
+    const response = new PassThrough();
+    response.statusCode = 200;
+    response.statusMessage = '';
+    response.socket = {};
+
+    return response;
+}
+
+function createLinuxTcpTable(state = '01') {
+    return [
+        '  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode',
+        `   0: 0100007F:1F90 0200007F:15B3 ${state} 00000000:00000000 00:00000000 00000000   100        0 0`,
+    ].join('\n');
+}
+
+function createEmptyLinuxTable() {
+    return '  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n';
+}
+
+beforeEach(() => {
+    mockReadFile.mockReset();
+    mockExecFile.mockReset();
+    mockPlatform.mockReset();
+    testExports.clearConnectionTableCache();
+});
+
+afterEach(() => {
+    jest.restoreAllMocks();
+    testExports.clearConnectionTableCache();
+});
+
+describe('connection-state-checker parsers', () => {
+    test('parses Linux tcp tables and keeps only established connections', () => {
+        const table = testExports.parseLinuxTcpTable(createLinuxTcpTable());
+
+        expect(table).toEqual(new Set(['127.0.0.1:8080>127.0.0.2:5555']));
+        expect(testExports.parseLinuxTcpTable(createLinuxTcpTable('08'))).toEqual(new Set());
+    });
+
+    test('parses netstat output with bracketed IPv6 endpoints', () => {
+        const table = testExports.parseNetstatOutput([
+            '  tcp6       0      0  [::1]:8080    [::ffff:127.0.0.2]:5555    ESTABLISHED',
+            '  TCP    127.0.0.1:9000    127.0.0.3:4444    TIME_WAIT    1234',
+        ].join('\n'));
+
+        expect(table).toEqual(new Set(['::1:8080>127.0.0.2:5555']));
+    });
+});
+
+describe('isSocketConnected', () => {
+    test('uses Linux proc tables to detect an active socket', async () => {
+        mockPlatform.mockReturnValue('linux');
+        mockReadFile.mockImplementation(async file => file === '/proc/net/tcp'
+            ? createLinuxTcpTable()
+            : createEmptyLinuxTable());
+
+        await expect(isSocketConnected(createSocket())).resolves.toBe(true);
+        expect(mockReadFile).toHaveBeenCalledWith('/proc/net/tcp', 'utf8');
+        expect(mockReadFile).toHaveBeenCalledWith('/proc/net/tcp6', 'utf8');
+    });
+
+    test('returns false when the Linux proc table no longer contains the socket', async () => {
+        mockPlatform.mockReturnValue('linux');
+        mockReadFile.mockImplementation(async file => file === '/proc/net/tcp'
+            ? createLinuxTcpTable('08')
+            : createEmptyLinuxTable());
+
+        await expect(isSocketConnected(createSocket())).resolves.toBe(false);
+    });
+
+    test('uses netstat on Windows', async () => {
+        mockPlatform.mockReturnValue('win32');
+        mockExecFile.mockImplementation((command, args, options, callback) => {
+            callback(null, '  TCP    127.0.0.1:8080    127.0.0.2:5555    ESTABLISHED    1234\n', '');
+        });
+
+        await expect(isSocketConnected(createSocket())).resolves.toBe(true);
+        expect(mockExecFile).toHaveBeenCalledWith('netstat', ['-ano', '-p', 'TCP'], expect.objectContaining({ timeout: 1000 }), expect.any(Function));
+    });
+
+    test('falls back to connected on unsupported platforms', async () => {
+        mockPlatform.mockReturnValue('sunos');
+
+        await expect(isSocketConnected(createSocket())).resolves.toBe(true);
+        expect(mockReadFile).not.toHaveBeenCalled();
+        expect(mockExecFile).not.toHaveBeenCalled();
+    });
+});
+
+describe('pollSocketConnection', () => {
+    test('detects a disconnected socket and runs the callback once', async () => {
+        mockPlatform.mockReturnValue('linux');
+        mockReadFile.mockImplementation(async file => file === '/proc/net/tcp'
+            ? createLinuxTcpTable('08')
+            : createEmptyLinuxTable());
+        const disconnectHandler = jest.fn();
+        const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => undefined);
+        const stopPolling = pollSocketConnection(createSocket(), 50, disconnectHandler);
+
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(disconnectHandler).toHaveBeenCalledTimes(1);
+        expect(infoSpy).toHaveBeenCalledWith('Detected disconnected client socket during streaming request');
+
+        stopPolling();
+    });
+});
+
+describe('forwardFetchResponse disconnect polling', () => {
+    test('stops upstream streaming when the socket disappears', async () => {
+        mockPlatform.mockReturnValue('linux');
+        mockReadFile.mockImplementation(async file => file === '/proc/net/tcp'
+            ? createLinuxTcpTable('08')
+            : createEmptyLinuxTable());
+
+        const upstreamBody = new PassThrough();
+        const destroySpy = jest.spyOn(upstreamBody, 'destroy');
+        const response = createMockResponse();
+        const disconnectHandler = jest.fn();
+        const finished = once(response, 'finish');
+
+        await forwardFetchResponse(new Response(upstreamBody), response, { socket: createSocket() }, disconnectHandler);
+
+        await finished;
+
+        expect(disconnectHandler).toHaveBeenCalledTimes(1);
+        expect(destroySpy).toHaveBeenCalled();
+        expect(response.writableEnded).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- add OS-level client socket connection polling for streaming generation requests
- wire polling into chat, text, Kobold, Ollama, Responses API, and NovelAI streaming paths so upstream requests abort when the browser disconnect is missed
- add config controls and unit coverage for Linux proc tables, netstat parsing, polling, and stream cleanup

Fixes #190

## Tests
- npm run test:unit -- connection-state-checker.test.js util.test.js
- npm run test:unit
- npx eslint src/connection-state-checker.js src/util.js src/endpoints/backends/chat-completions.js src/endpoints/backends/text-completions.js src/endpoints/backends/kobold.js src/endpoints/novelai.js tests/connection-state-checker.test.js