### PR TITLE
fix: prevent text completion reasoning leaks in agents

### DIFF
--- a/public/scripts/extensions/in-chat-agents/llm-utils.js
+++ b/public/scripts/extensions/in-chat-agents/llm-utils.js
@@ -1,17 +1,103 @@
 import { normalizeContentText } from '../../../script.js';
 import { removeReasoningFromString } from '../../reasoning.js';
 
+const HIDDEN_RESPONSE_PART_TYPES = new Set([
+    'reasoning',
+    'reasoning_content',
+    'reasoning_text',
+    'thinking',
+    'thought',
+]);
+
+function isHiddenResponsePart(value) {
+    if (!value || typeof value !== 'object') {
+        return false;
+    }
+
+    const type = String(value.type ?? '').trim().toLowerCase();
+    if (value.thought === true || HIDDEN_RESPONSE_PART_TYPES.has(type) || /reasoning|thinking|thought/.test(type)) {
+        return true;
+    }
+
+    const hasVisibleText = typeof value.text === 'string'
+        || typeof value.content === 'string'
+        || Array.isArray(value.content)
+        || typeof value.output === 'string'
+        || Array.isArray(value.output)
+        || typeof value.message === 'string'
+        || (value.message && typeof value.message === 'object' && typeof value.message.content !== 'undefined');
+
+    return !hasVisibleText && (
+        typeof value.reasoning === 'string'
+        || typeof value.reasoning_content === 'string'
+        || typeof value.thinking === 'string'
+        || Array.isArray(value.reasoning)
+        || Array.isArray(value.thinking)
+    );
+}
+
+function normalizeVisibleContentText(value) {
+    if (typeof value === 'string') {
+        return value;
+    }
+
+    if (typeof value === 'number' || typeof value === 'boolean') {
+        return String(value);
+    }
+
+    if (value == null) {
+        return '';
+    }
+
+    if (Array.isArray(value)) {
+        return value
+            .map(item => normalizeVisibleContentText(item))
+            .filter(Boolean)
+            .join('\n\n');
+    }
+
+    if (typeof value === 'object') {
+        if (isHiddenResponsePart(value)) {
+            return '';
+        }
+
+        for (const candidate of [value.text, value.content, value.parts, value.output, value.message, value.tool_plan]) {
+            const text = normalizeVisibleContentText(candidate);
+            if (text) {
+                return text;
+            }
+        }
+    }
+
+    return '';
+}
+
+function firstVisibleContentText(...values) {
+    for (const value of values) {
+        const text = normalizeVisibleContentText(value);
+        if (text) {
+            return text;
+        }
+    }
+
+    return '';
+}
+
 export function extractProfileResponseText(response) {
-    const text = normalizeContentText(response?.content)
-        || normalizeContentText(response?.choices?.[0]?.message?.content)
-        || normalizeContentText(response?.candidates?.[0]?.content?.parts)
-        || normalizeContentText(response?.candidates?.[0]?.output?.parts)
-        || normalizeContentText(response?.text)
-        || normalizeContentText(response?.output)
-        || normalizeContentText(response?.message?.content)
-        || normalizeContentText(response?.message?.tool_plan)
-        || normalizeContentText(response?.message)
-        || '';
+    const text = firstVisibleContentText(
+        response?.content,
+        response?.choices?.[0]?.text,
+        response?.choices?.[0]?.message?.content,
+        response?.choices?.[0]?.content,
+        response?.responseContent?.parts,
+        response?.candidates?.[0]?.content?.parts,
+        response?.candidates?.[0]?.output?.parts,
+        response?.text,
+        response?.output,
+        response?.message?.content,
+        response?.message?.tool_plan,
+        response?.message,
+    );
     return removeReasoningFromString(text);
 }
 

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -1304,6 +1304,54 @@ describe('in-chat agent post-processing runner', () => {
         );
     });
 
+    test('keeps text-completion profile reasoning out of post-transform replacements', async () => {
+        usePromptTransformPostAgent();
+        enabledAgents[0].connectionProfile = 'profile-textgen-reasoning';
+        connectionManagerRequestService = {
+            getProfile: jest.fn(() => ({ name: 'Textgen Reasoner', model: 'r1-textgen' })),
+            sendRequest: jest.fn(async () => ({
+                choices: [{
+                    text: 'Visible rewrite',
+                    reasoning: 'hidden choice reasoning',
+                    thinking: 'hidden choice thinking',
+                    message: {
+                        content: [
+                            { type: 'reasoning', reasoning: 'hidden content reasoning' },
+                            { type: 'thinking', thinking: 'hidden content thinking' },
+                            { type: 'text', text: 'Visible rewrite' },
+                        ],
+                        reasoning: 'hidden message reasoning',
+                        reasoning_content: 'hidden message reasoning content',
+                    },
+                }],
+            })),
+        };
+
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+
+        chat.push({
+            name: 'Assistant',
+            mes: 'Needs rewrite',
+            is_user: false,
+            is_system: false,
+            extra: {},
+        });
+
+        await eventSource.emit(eventTypes.MESSAGE_RECEIVED, 0, 'normal');
+
+        expect(chat[0].mes).toBe('Visible rewrite');
+        expect(chat[0].mes).not.toContain('hidden');
+        expect(chat[0].extra.inChatAgentPromptRuns[0]).toEqual(expect.objectContaining({
+            nextMessageText: 'Visible rewrite',
+            runner: 'profile',
+            profileId: 'profile-textgen-reasoning',
+        }));
+        expect(chat[0].extra.inChatAgentTransformHistory[0]).toEqual(expect.objectContaining({
+            afterText: 'Visible rewrite',
+        }));
+    });
+
     test('keeps prompt-transform storage separate for each swipe', async () => {
         usePromptTransformPostAgent();
         generateQuietPrompt


### PR DESCRIPTION
## What?

Fixes the in-chat agent profile response extractor so text-completion style responses prefer visible text fields and skip structured reasoning/thinking parts before post-transform replacements are written back to chat.

Adds a regression test for a text-completion profile response that includes hidden reasoning at the choice, message, and content-part levels.

## Why?

Reasoning-capable text-completion models can return scratchpad or thinking fields alongside the visible replacement text. The post-agent pass should never copy those hidden fields into the final chat message. Fixes #170.

## How?

The extractor now walks common response shapes with a visible-content normalizer that drops response parts marked as reasoning, thinking, thought, or reasoning-like type names. It preserves existing visible structured content handling, including `parts` and `message.tool_plan`, and still applies the existing string-level reasoning stripper as a final safety pass.

## Testing?

- `npm run test:unit --prefix tests -- in-chat-agents-runner.test.js`
- `npx eslint "public/scripts/extensions/in-chat-agents/llm-utils.js"`
- `git diff --check -- public/scripts/extensions/in-chat-agents/llm-utils.js tests/in-chat-agents-runner.test.js`
- `graphify update .`

## Screenshots (optional)

Not applicable; this is response parsing and test coverage, not a UI change.

## Anything Else?

Targets `staging`. The large generated graphify map/cache output was left out of the committed PR diff so reviewers can focus on the source fix and regression test.