### PR TITLE
fix: cover Guided Generations steering commands

### DIFF
--- a/tests/guided-generations-steering.test.js
+++ b/tests/guided-generations-steering.test.js
@@ -1,0 +1,137 @@
+/* global globalThis */
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+
+function createEventSource() {
+    const handlers = new Map();
+
+    return {
+        once: jest.fn((event, handler) => {
+            const eventHandlers = handlers.get(event) ?? [];
+            eventHandlers.push(handler);
+            handlers.set(event, eventHandlers);
+        }),
+        removeListener: jest.fn((event, handler) => {
+            const eventHandlers = handlers.get(event) ?? [];
+            handlers.set(event, eventHandlers.filter(item => item !== handler));
+        }),
+        emit: jest.fn(async (event, ...args) => {
+            const eventHandlers = [...(handlers.get(event) ?? [])];
+            handlers.set(event, []);
+            for (const handler of eventHandlers) {
+                await handler(...args);
+            }
+        }),
+    };
+}
+
+describe('Guided Generations steering commands', () => {
+    let textarea;
+    let context;
+    let eventSource;
+    let eventTypes;
+    let extensionSettings;
+
+    beforeEach(async () => {
+        jest.resetModules();
+        jest.useRealTimers();
+
+        class TestTextAreaElement {}
+        globalThis.HTMLTextAreaElement = TestTextAreaElement;
+        globalThis.Event = class Event {
+            constructor(type, options = {}) {
+                this.type = type;
+                this.options = options;
+            }
+        };
+
+        textarea = new TestTextAreaElement();
+        textarea.value = 'aim for a colder, suspicious reply';
+        textarea.dispatchEvent = jest.fn();
+
+        eventTypes = {
+            GENERATION_ENDED: 'generation_ended',
+            GENERATION_STOPPED: 'generation_stopped',
+            MESSAGE_SWIPED: 'message_swiped',
+        };
+        eventSource = createEventSource();
+
+        context = {
+            chat: [{ name: 'Bot', mes: 'Previous reply', swipes: ['Previous reply'], swipe_id: 0 }],
+            chatMetadata: { script_injects: {} },
+            executeSlashCommandsWithOptions: jest.fn(async (command) => {
+                if (command.includes('/inject id=instruct')) {
+                    context.chatMetadata.script_injects.instruct = { value: command };
+                }
+
+                if (command.includes('/flushinject instruct')) {
+                    delete context.chatMetadata.script_injects.instruct;
+                }
+            }),
+            groupId: null,
+            groups: [],
+            messageFormatting: jest.fn(value => value),
+            swipe: {
+                right: jest.fn(() => {
+                    setTimeout(() => eventSource.emit(eventTypes.GENERATION_ENDED), 0);
+                }),
+            },
+        };
+        extensionSettings = {
+            'guided-generations': {
+                injectionEndRole: 'assistant',
+                depthPromptGuidedResponse: 2,
+                depthPromptGuidedSwipe: 3,
+                promptGuidedResponse: 'GUIDE: {{input}}',
+                promptGuidedSwipe: 'SWIPE GUIDE: {{input}}',
+            },
+        };
+
+        globalThis.document = {
+            getElementById: jest.fn(id => id === 'send_textarea' ? textarea : null),
+            querySelector: jest.fn(() => null),
+        };
+        globalThis.alert = jest.fn();
+
+        await jest.unstable_mockModule('../public/script.js', () => ({
+            eventSource,
+            event_types: eventTypes,
+        }));
+        await jest.unstable_mockModule('../public/scripts/extensions.js', () => ({
+            extension_settings: extensionSettings,
+            getContext: jest.fn(() => context),
+        }));
+        await jest.unstable_mockModule('../public/scripts/extensions/guided-generations/scripts/presetUtils.js', () => ({
+            getCurrentProfile: jest.fn(async () => ''),
+            getPresetsForApiType: jest.fn(async () => []),
+            getProfileApiType: jest.fn(async () => ''),
+            getProfileList: jest.fn(async () => []),
+            handleSwitching: jest.fn(async () => ({ switch: jest.fn(), restore: jest.fn() })),
+        }));
+    });
+
+    test('guided response injects guidance before triggering generation', async () => {
+        const { guidedResponse } = await import('../public/scripts/extensions/guided-generations/scripts/guidedResponse.js');
+
+        await guidedResponse();
+
+        expect(context.executeSlashCommandsWithOptions).toHaveBeenCalledTimes(1);
+        const command = context.executeSlashCommandsWithOptions.mock.calls[0][0];
+        expect(command).toContain('/inject id=instruct position=chat ephemeral=true scan=true depth=2 role=assistant GUIDE: aim for a colder, suspicious reply|');
+        expect(command).toContain('/trigger await=true|');
+        expect(textarea.value).toBe('aim for a colder, suspicious reply');
+        expect(textarea.dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'input' }));
+    });
+
+    test('guided swipe keeps guidance injected until the swipe generation starts', async () => {
+        const { guidedSwipe } = await import('../public/scripts/extensions/guided-generations/scripts/guidedSwipe.js');
+
+        await guidedSwipe();
+
+        expect(context.executeSlashCommandsWithOptions).toHaveBeenCalledWith('/inject id=instruct position=chat ephemeral=true scan=true depth=3 role=assistant SWIPE GUIDE: aim for a colder, suspicious reply |');
+        expect(context.swipe.right).toHaveBeenCalledTimes(1);
+        expect(context.executeSlashCommandsWithOptions).toHaveBeenLastCalledWith('/flushinject instruct');
+        expect(context.chatMetadata.script_injects.instruct).toBeUndefined();
+        expect(textarea.value).toBe('aim for a colder, suspicious reply');
+        expect(textarea.dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'input' }));
+    });
+});


### PR DESCRIPTION
## What?
Adds a focused regression test for the embedded Guided Generations response and swipe command paths. This is test-only; no runtime Guided Generations code changes were needed.

## Why?
Issue #183 reported that embedded Guided Generations did not appear to steer output. Verification against current `staging` showed the native port already emits the original-extension-compatible chat injection command, so this PR locks that behavior down for future changes.

Refs #183.

## How?
The new Jest test mocks the SillyBunny textarea, extension settings, context, and generation events, then verifies:
- Guided Response injects `/inject id=instruct position=chat ephemeral=true scan=true ...` before `/trigger await=true`.
- Guided Swipe keeps the same guidance injection present until `swipe.right()` starts generation, then flushes it afterward.
- Both flows restore the original textarea input.

## Testing?
- `npm run test:unit --prefix tests -- guided-generations-toast.test.js guided-generations-steering.test.js`
- `npm run lint --prefix tests -- guided-generations-steering.test.js`
- `graphify update .` was run locally after the test edit; it produced a large generated graph refresh because the checked-in graph was stale, so the generated graph diff was intentionally excluded from this focused PR.

## Screenshots (optional)
Not included; this PR covers command/generation setup behavior with automated tests rather than visible UI changes.

## Anything Else?
Manual source comparison against `Samueras/GuidedGenerations-Extension` showed the embedded response/swipe commands use the same `/inject ... position=chat ...` steering path as the original extension. If steering still feels weak in live use, the next useful artifact would be a concrete failing prompt/provider fixture rather than a code-path fix.
