### PR TITLE
fix: keep input history menu above composer

### DIFF
--- a/public/scripts/extensions/input-history/style.css
+++ b/public/scripts/extensions/input-history/style.css
@@ -43,6 +43,7 @@
   z-index: 30000;
   overflow-x: clip;
   overflow-y: auto;
+  overscroll-behavior: contain;
   border-radius: 10px;
   aspect-ratio: unset;
   padding: 5px;
@@ -51,15 +52,22 @@
   background-color: var(--secondaryBg, var(--SmartThemeBlurTintColor));
   container-type: inline-size;
   position: absolute;
-  top: calc(100% + 4px);
+  top: auto;
+  bottom: calc(100% + 4px);
   left: 0;
   min-height: 2em;
   max-height: calc(50dvh);
   width: min(420px, calc(100vw - 16px));
   transition: 200ms;
-  transform-origin: 0 0;
+  transform-origin: 0 100%;
   scale: 1 0;
   font-size: calc(var(--bottomFormIconSize, 20px) * 0.5);
+}
+#send_form:has(.stih--history),
+.gg-action-buttons-container:has(> .stih--buttons .stih--history) {
+  /* SillyBunny: the composer-bound history menu opens upward and must not
+     create scrollable overflow below the chat input. */
+  overflow: visible;
 }
 .stih--history.stih--active {
   scale: 1;

--- a/tests/input-history-overflow.e2e.js
+++ b/tests/input-history-overflow.e2e.js
@@ -1,0 +1,104 @@
+/* global document, window */
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, test } from '@playwright/test';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+test.describe('input history overflow menu', () => {
+    test('opens above the composer without adding page scroll below it', async ({ page }) => {
+        const inputHistoryCss = await fs.readFile(
+            path.join(repoRoot, 'public/scripts/extensions/input-history/style.css'),
+            'utf8',
+        );
+        const historyItems = Array.from({ length: 80 }, (_, index) => (
+            `<div class="stih--item"><div class="stih--label"><div class="stih--title">history ${index} prompt text</div></div></div>`
+        )).join('');
+
+        await page.setViewportSize({ width: 390, height: 740 });
+        await page.setContent(`<!doctype html>
+            <html>
+            <head>
+                <style>
+                    html,
+                    body {
+                        margin: 0;
+                        min-height: 100%;
+                        --bottomFormIconSize: 20px;
+                    }
+
+                    #sheld {
+                        position: absolute;
+                        inset: 0;
+                        height: 100dvh;
+                        display: flex;
+                        flex-direction: column;
+                        overflow-x: hidden;
+                    }
+
+                    #chat {
+                        flex: 1 1 auto;
+                    }
+
+                    #form_sheld {
+                        width: 100%;
+                        margin-top: auto;
+                    }
+
+                    #send_form {
+                        display: flex;
+                        flex-wrap: wrap;
+                        width: 100%;
+                        overflow: hidden;
+                    }
+
+                    #nonQRFormItems {
+                        width: 100%;
+                        min-height: 48px;
+                    }
+
+                    ${inputHistoryCss}
+                </style>
+            </head>
+            <body>
+                <div id="sheld">
+                    <div id="chat"></div>
+                    <div id="form_sheld">
+                        <div id="send_form">
+                            <div class="stih--buttons stih--standalone">
+                                <button type="button" class="stih--button"></button>
+                                <div class="stih--history stih--active">${historyItems}</div>
+                            </div>
+                            <div id="nonQRFormItems">
+                                <textarea id="send_textarea"></textarea>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </body>
+            </html>`);
+
+        const geometry = await page.evaluate(() => {
+            const history = document.querySelector('.stih--history');
+            const buttons = document.querySelector('.stih--buttons');
+            const form = document.querySelector('#form_sheld');
+            const pageScrollHeight = Math.max(document.body.scrollHeight, document.documentElement.scrollHeight);
+
+            return {
+                buttonsTop: buttons.getBoundingClientRect().top,
+                formBottom: form.getBoundingClientRect().bottom,
+                historyBottom: history.getBoundingClientRect().bottom,
+                historyClientHeight: history.clientHeight,
+                historyScrollHeight: history.scrollHeight,
+                maxScrollY: pageScrollHeight - window.innerHeight,
+            };
+        });
+
+        expect(geometry.historyBottom).toBeLessThanOrEqual(geometry.buttonsTop - 3);
+        expect(geometry.formBottom).toBeLessThanOrEqual(740);
+        expect(geometry.maxScrollY).toBeLessThanOrEqual(1);
+        expect(geometry.historyScrollHeight).toBeGreaterThan(geometry.historyClientHeight);
+    });
+});


### PR DESCRIPTION
## What?
Fixes the Input History overflow menu so it opens above the chat composer instead of extending below the text field, and adds a Playwright regression test for that geometry.

## Why?
When the history menu opened below the composer, its overflow could increase the page scrollable area and let users scroll past the chat text field. The chat input should remain the bottom boundary of the chat surface.

## How?
The menu is anchored with `bottom: calc(100% + 4px)` and `top: auto`, with the transform origin moved to the bottom edge so the existing scale animation opens upward. The menu also contains its own overscroll, and composer overflow is made visible only while the Input History menu is present so the upward menu is not clipped.

The regression test renders the real Input History stylesheet in a minimal composer fixture at a mobile-sized viewport and asserts that the menu sits above the composer, does not add page scroll below it, and still scrolls internally.

## Testing?
Ran from the PR worktree:

- `npm ci --ignore-scripts --prefix tests`
- `npm run test:e2e --prefix tests -- input-history-overflow.e2e.js`
- `npx eslint input-history-overflow.e2e.js`
- CSS anchor smoke check with Node
- `graphify update .`

## Screenshots (optional)
Not captured. The regression test checks the rendered menu geometry at a `390x740` viewport and verifies the page cannot scroll below the composer.

## Anything Else?
The worktree has local Graphify-generated output from the required update run, but the PR commit is intentionally scoped to the stylesheet fix and regression test.
