### PR TITLE
fix: stop disabled extensions injecting prompts

### DIFF
--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -504,8 +504,25 @@ function isAlwaysEnabledExtension(externalId) {
     return ['core', 'bundled'].includes(getExtensionType(externalId));
 }
 
+function areExtensionIdsEqual(left, right) {
+    return getExtensionDedupKey(left) === getExtensionDedupKey(right);
+}
+
+function resolveExtensionName(name) {
+    return extensionNames.find(extName => {
+        return equalsIgnoreCaseAndAccents(extName, name) || equalsIgnoreCaseAndAccents(extName, `third-party/${name}`);
+    }) ?? name;
+}
+
 function isExtensionDisabled(externalId) {
-    return !isAlwaysEnabledExtension(externalId) && extension_settings.disabledExtensions.includes(externalId);
+    return !isAlwaysEnabledExtension(externalId) && extension_settings.disabledExtensions.some(name => areExtensionIdsEqual(name, externalId));
+}
+
+function markExtensionInactive(name) {
+    const extensionKey = getExtensionDedupKey(name);
+    activeExtensions.delete(name);
+    activeExtensionDedupKeys.delete(extensionKey);
+    activatingExtensionDedupKeys.delete(extensionKey);
 }
 
 /**
@@ -700,8 +717,9 @@ async function callExtensionHook(name, hookName) {
  * @param {boolean} [reload=true] If true, reload the page after enabling the extension
  */
 export async function enableExtension(name, reload = true) {
-    await callExtensionHook(name, 'enable');
-    extension_settings.disabledExtensions = extension_settings.disabledExtensions.filter(x => x !== name);
+    const extensionName = resolveExtensionName(name);
+    await callExtensionHook(extensionName, 'enable');
+    extension_settings.disabledExtensions = extension_settings.disabledExtensions.filter(x => !areExtensionIdsEqual(x, extensionName));
     stateChanged = true;
     await saveSettings();
     if (reload) {
@@ -717,13 +735,17 @@ export async function enableExtension(name, reload = true) {
  * @param {boolean} [reload=true] If true, reload the page after disabling the extension
  */
 export async function disableExtension(name, reload = true) {
-    if (isAlwaysEnabledExtension(name)) {
-        console.warn(`Extension "${name}" is always enabled and cannot be disabled.`);
+    const extensionName = resolveExtensionName(name);
+
+    if (isAlwaysEnabledExtension(extensionName)) {
+        console.warn(`Extension "${extensionName}" is always enabled and cannot be disabled.`);
         return;
     }
 
-    await callExtensionHook(name, 'disable');
-    extension_settings.disabledExtensions.push(name);
+    await callExtensionHook(extensionName, 'disable');
+    extension_settings.disabledExtensions = extension_settings.disabledExtensions.filter(x => !areExtensionIdsEqual(x, extensionName));
+    extension_settings.disabledExtensions.push(extensionName);
+    markExtensionInactive(extensionName);
     stateChanged = true;
     await saveSettings();
     if (reload) {
@@ -740,10 +762,8 @@ export async function disableExtension(name, reload = true) {
  * @returns {{name: string, enabled: boolean}|null} Object with name and enabled properties, or null if not found
  */
 export function findExtension(name) {
-    const internalExtensionName = extensionNames.find(extName => {
-        return equalsIgnoreCaseAndAccents(extName, name) || equalsIgnoreCaseAndAccents(extName, `third-party/${name}`);
-    });
-    if (!internalExtensionName) return null;
+    const internalExtensionName = resolveExtensionName(name);
+    if (!extensionNames.includes(internalExtensionName)) return null;
     const isEnabled = !isExtensionDisabled(internalExtensionName);
     return { name: internalExtensionName, enabled: isEnabled };
 }
@@ -2426,7 +2446,11 @@ export async function runGenerationInterceptors(chat, contextSize, type) {
         exitImmediately = immediately;
     };
 
-    for (const manifest of Object.values(manifests).filter(x => x.generate_interceptor).sort((a, b) => sortManifestsByOrder(a, b))) {
+    for (const [name, manifest] of Object.entries(manifests).filter(([, x]) => x.generate_interceptor).sort((a, b) => sortManifestsByOrder(a[1], b[1]))) {
+        if (isExtensionDisabled(name) || !activeExtensions.has(name)) {
+            continue;
+        }
+
         const interceptorKey = manifest.generate_interceptor;
         if (typeof globalThis[interceptorKey] === 'function') {
             try {

--- a/public/scripts/extensions/memory/index.js
+++ b/public/scripts/extensions/memory/index.js
@@ -38,6 +38,7 @@ const MODULE_NAME = '1_memory';
 let lastMessageHash = null;
 let lastMessageId = null;
 let inApiCall = false;
+let isExtensionActive = false;
 
 /**
  * Count the number of tokens in the provided text.
@@ -171,6 +172,19 @@ function loadSettings() {
     $('#memory_max_messages_per_request').val(extension_settings.memory.maxMessagesPerRequest).trigger('input');
     $('#memory_include_wi_scan').prop('checked', extension_settings.memory.scan).trigger('input');
     switchSourceControls(extension_settings.memory.source);
+}
+
+function getMemoryPromptSettings() {
+    const settings = extension_settings.memory && typeof extension_settings.memory === 'object'
+        ? extension_settings.memory
+        : {};
+    return { ...defaultSettings, ...settings };
+}
+
+function clearMemoryContext() {
+    const settings = getMemoryPromptSettings();
+    setExtensionPrompt(MODULE_NAME, '', settings.position, settings.depth, settings.scan, settings.role);
+    $('#memory_contents').val('');
 }
 
 async function onPromptForceWordsAutoClick() {
@@ -416,12 +430,20 @@ function isContextChanged(context) {
 }
 
 function onChatChanged() {
+    if (!isExtensionActive) {
+        return;
+    }
+
     const context = getContext();
     const latestMemory = getLatestMemoryFromChat(context.chat);
     setMemoryContext(latestMemory, false);
 }
 
 async function onChatEvent() {
+    if (!isExtensionActive) {
+        return;
+    }
+
     // Module not enabled
     if (extension_settings.memory.source === summary_sources.extras && !modules.includes('summarize')) {
         return;
@@ -483,6 +505,10 @@ async function onChatEvent() {
  * @returns {Promise<string>} Summarized text
  */
 async function forceSummarizeChat(quiet) {
+    if (!isExtensionActive) {
+        return '';
+    }
+
     if (extension_settings.memory.source === summary_sources.extras) {
         toastr.warning('Force summarization is not supported for Extras API');
         return;
@@ -969,6 +995,10 @@ function reinsertMemory() {
  * @param {number|null} index Index of the chat message to save the summary to. If null, the pre-last message is used.
  */
 function setMemoryContext(value, saveToMessage, index = null) {
+    if (!isExtensionActive && value) {
+        return;
+    }
+
     setExtensionPrompt(MODULE_NAME, formatMemoryValue(value), extension_settings.memory.position, extension_settings.memory.depth, extension_settings.memory.scan, extension_settings.memory.role);
     $('#memory_contents').val(value);
 
@@ -1071,6 +1101,12 @@ function setupListeners() {
 }
 
 export async function init() {
+    if (isExtensionActive) {
+        return;
+    }
+
+    isExtensionActive = true;
+
     async function addExtensionControls() {
         const settingsHtml = await renderExtensionTemplateAsync('memory', 'settings', { defaultSettings });
         $('#summarize_container').append(settingsHtml);
@@ -1134,5 +1170,16 @@ export async function init() {
         MacrosParser.registerMacro('summary',
             () => summaryMacroHandler(),
             'Returns the latest memory/summary from the current chat.');
+    }
+}
+
+export function deactivate() {
+    isExtensionActive = false;
+    inApiCall = false;
+    clearMemoryContext();
+    eventSource.removeListener(event_types.CHAT_CHANGED, onChatChanged);
+    eventSource.removeListener(event_types.CHARACTER_MESSAGE_RENDERED, onChatEvent);
+    for (const event of [event_types.MESSAGE_DELETED, event_types.MESSAGE_UPDATED, event_types.MESSAGE_SWIPED]) {
+        eventSource.removeListener(event, onChatEvent);
     }
 }

--- a/public/scripts/extensions/memory/manifest.json
+++ b/public/scripts/extensions/memory/manifest.json
@@ -11,6 +11,7 @@
     "version": "1.0.0",
     "homePage": "https://github.com/SillyTavern/SillyTavern",
     "hooks": {
-        "activate": "init"
+        "activate": "init",
+        "disable": "deactivate"
     }
 }

--- a/tests/extensions-disable.test.js
+++ b/tests/extensions-disable.test.js
@@ -1,0 +1,172 @@
+/* global globalThis */
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { readFile } from 'node:fs/promises';
+
+function createJqueryMock(value = '') {
+    const api = {
+        addClass: jest.fn(() => api),
+        append: jest.fn(() => api),
+        attr: jest.fn(() => api),
+        children: jest.fn(() => api),
+        css: jest.fn(() => ''),
+        each: jest.fn(() => api),
+        empty: jest.fn(() => api),
+        fadeOut: jest.fn((_, callback) => {
+            if (typeof callback === 'function') callback();
+            return api;
+        }),
+        filter: jest.fn(() => api),
+        find: jest.fn(() => api),
+        first: jest.fn(() => api),
+        html: jest.fn(() => api),
+        length: 0,
+        off: jest.fn(() => api),
+        on: jest.fn(() => api),
+        parent: jest.fn(() => api),
+        prop: jest.fn(() => api),
+        remove: jest.fn(() => api),
+        slideToggle: jest.fn(() => api),
+        text: jest.fn(() => api),
+        toggle: jest.fn(() => api),
+        toggleClass: jest.fn(() => api),
+        transition: jest.fn(() => api),
+        trigger: jest.fn(() => api),
+        val: jest.fn((nextValue) => nextValue === undefined ? value : api),
+    };
+
+    return api;
+}
+
+function installExtensionModuleMocks() {
+    jest.unstable_mockModule('../public/lib.js', () => ({
+        DOMPurify: { sanitize: jest.fn(value => String(value ?? '')) },
+        Popper: { createPopper: jest.fn(() => ({ update: jest.fn() })) },
+    }));
+
+    jest.unstable_mockModule('../public/script.js', () => ({
+        CLIENT_VERSION: 'SillyBunny:v1.6.0',
+        animation_duration: 0,
+        eventSource: { emit: jest.fn(async () => {}) },
+        event_types: { EXTENSIONS_FIRST_LOAD: 'extensions_first_load', EXTRAS_CONNECTED: 'extras_connected', EXTENSION_SETTINGS_LOADED: 'extension_settings_loaded' },
+        getRequestHeaders: jest.fn(() => ({})),
+        saveSettings: jest.fn(async () => {}),
+        saveSettingsDebounced: jest.fn(),
+    }));
+
+    jest.unstable_mockModule('../public/scripts/popup.js', () => ({
+        POPUP_RESULT: { AFFIRMATIVE: 1 },
+        POPUP_TYPE: { CONFIRM: 'confirm', INPUT: 'input', TEXT: 'text' },
+        Popup: class Popup {
+            static util = { popups: [] };
+            static show = { confirm: jest.fn(async () => true) };
+            constructor(content) {
+                this.content = content?.get?.(0) ?? { querySelector: jest.fn(), scrollTop: 0 };
+                this.inputResults = new Map();
+            }
+            show = jest.fn(async () => null);
+            complete = jest.fn(async () => {});
+            completeCancelled = jest.fn(async () => {});
+        },
+        callGenericPopup: jest.fn(async () => 1),
+    }));
+
+    jest.unstable_mockModule('../public/scripts/templates.js', () => ({
+        renderTemplate: jest.fn(() => ''),
+        renderTemplateAsync: jest.fn(async () => ''),
+    }));
+
+    jest.unstable_mockModule('../public/scripts/utils.js', () => ({
+        delay: jest.fn(async () => {}),
+        deleteValueByPath: jest.fn(),
+        equalsIgnoreCaseAndAccents: jest.fn((a, b) => String(a).toLowerCase() === String(b).toLowerCase()),
+        escapeHtml: jest.fn(value => String(value ?? '')),
+        isSubsetOf: jest.fn((values, required) => required.every(value => values.includes(value))),
+        sanitizeSelector: jest.fn(value => String(value ?? '').replace(/[^a-z0-9_-]/gi, '_')),
+        setValueByPath: jest.fn(),
+        versionCompare: jest.fn(() => true),
+    }));
+
+    jest.unstable_mockModule('../public/scripts/user.js', () => ({
+        isAdmin: jest.fn(() => false),
+    }));
+
+    jest.unstable_mockModule('../public/scripts/i18n.js', () => ({
+        addLocaleData: jest.fn(),
+        getCurrentLocale: jest.fn(() => 'en'),
+        t: jest.fn(strings => Array.isArray(strings) ? strings.join('') : String(strings ?? '')),
+    }));
+
+    jest.unstable_mockModule('../public/scripts/constants.js', () => ({
+        debounce_timeout: { relaxed: 1 },
+    }));
+
+    jest.unstable_mockModule('../public/scripts/util/AccountStorage.js', () => ({
+        accountStorage: { getItem: jest.fn(() => null), setItem: jest.fn() },
+    }));
+
+    jest.unstable_mockModule('../public/scripts/util/SimpleMutex.js', () => ({
+        SimpleMutex: class SimpleMutex {},
+    }));
+
+    jest.unstable_mockModule('../public/scripts/dynamic-styles.js', () => ({
+        loadStylesheetAsync: jest.fn(async () => {}),
+        prefetchAsset: jest.fn(),
+    }));
+}
+
+describe('disabled extensions', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        globalThis.toastr = { clear: jest.fn(), error: jest.fn(), info: jest.fn(), success: jest.fn(), warning: jest.fn() };
+        globalThis.$ = jest.fn(() => createJqueryMock());
+        globalThis.setInterval = jest.fn(() => 0);
+        globalThis.clearInterval = jest.fn();
+        globalThis.window = {
+            setTimeout: jest.fn((callback) => {
+                if (typeof callback === 'function') callback();
+                return 0;
+            }),
+            clearTimeout: jest.fn(),
+        };
+        globalThis.navigator = { connection: {} };
+        globalThis.location = { reload: jest.fn() };
+        globalThis.document = {
+            body: { appendChild: jest.fn() },
+            createElement: jest.fn(() => ({ addEventListener: jest.fn(), append: jest.fn(), classList: { add: jest.fn(), remove: jest.fn() }, style: {}, dataset: {} })),
+            getElementById: jest.fn(() => null),
+            querySelector: jest.fn(() => null),
+        };
+    });
+
+    test('does not run generate interceptors for disabled extensions', async () => {
+        installExtensionModuleMocks();
+
+        globalThis.fetch = jest.fn(async (url) => {
+            const text = String(url);
+            if (text.endsWith('/api/extensions/discover')) {
+                return { ok: true, json: async () => [{ name: 'vectors', type: 'system' }] };
+            }
+            if (text.includes('/scripts/extensions/vectors/manifest.json')) {
+                return { ok: true, json: async () => ({ display_name: 'Vector Storage', loading_order: 100, generate_interceptor: 'vectors_rearrangeChat' }) };
+            }
+            return { ok: false, json: async () => ({}) };
+        });
+
+        const { loadExtensionSettings, runGenerationInterceptors } = await import('../public/scripts/extensions.js');
+        await loadExtensionSettings({ extension_settings: { disabledExtensions: ['vectors'] } }, false, false);
+
+        globalThis.vectors_rearrangeChat = jest.fn();
+        await runGenerationInterceptors([], 4096, 'normal');
+
+        expect(globalThis.vectors_rearrangeChat).not.toHaveBeenCalled();
+    });
+
+    test('Summarize exposes a disable hook that clears the memory prompt', async () => {
+        const manifest = JSON.parse(await readFile(new URL('../public/scripts/extensions/memory/manifest.json', import.meta.url), 'utf8'));
+        const source = await readFile(new URL('../public/scripts/extensions/memory/index.js', import.meta.url), 'utf8');
+
+        expect(manifest.hooks.disable).toBe('deactivate');
+        expect(source).toContain('export function deactivate()');
+        expect(source).toContain('setExtensionPrompt(MODULE_NAME, \'\',');
+    });
+});


### PR DESCRIPTION
## What?
Prevent disabled extensions from continuing to affect prompt generation after their settings state changes. This normalizes extension IDs for enable/disable state, removes disabled extensions from the active registry, skips disabled/inactive generate interceptors, and adds a Summarize disable hook that clears the `1_memory` prompt and detaches its event listeners.

## Why?
Users could see extensions marked disabled in the UI while extension behavior still affected outgoing prompts. The clearest repro was Summarize continuing to inject `[Summary: ...]`, which changed prompts turn-to-turn and could force full prompt reprocessing even when the user believed the extension was off.

## How?
Extension enable/disable now resolves canonical extension names and de-dupes disabled entries by normalized ID. Disabling an extension also marks it inactive in the live extension registries. Generation interceptors are gated on both enabled state and active registration. The Summarize extension now exposes a `disable` hook that clears its extension prompt and prevents inactive or in-flight summary work from re-inserting content.

## Testing?
- `npm run test:unit --prefix tests -- extensions-disable.test.js --runInBand`
- `npx eslint public/scripts/extensions.js public/scripts/extensions/memory/index.js`
- `npx eslint extensions-disable.test.js` from `tests/`
- `graphify update .` completed locally; it rebuilt the graph after falling back around large vendored files, and graph artifacts were not included in this PR diff.

## Screenshots (optional)
Not applicable; this is prompt-generation state handling covered by unit tests.

## Anything Else?
This intentionally does not add disable hooks for every extension. Extensions without their own cleanup may still require reload for UI/event cleanup, but disabled generate interceptors and the Summarize prompt-injection path are now guarded.