### PR TITLE
refactor: add chat render batch helper

### DIFF
--- a/public/scripts/chat-render-lifecycle/index.js
+++ b/public/scripts/chat-render-lifecycle/index.js
@@ -20,6 +20,9 @@ import {
     CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY,
     resolveChatRenderLifecycleRollout,
 } from './rollout-guard.js';
+import {
+    renderMessagesInBatches,
+} from './render-batch.js';
 
 export {
     CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY,
@@ -30,6 +33,7 @@ export {
     resolveChatBottomScrollAction,
     resolveChatScrollAction,
     restoreVisibleMessageAnchor,
+    renderMessagesInBatches,
     resolveChatRenderLifecycleRollout,
     runSettledFrames,
     settleVisibleMessageAnchor,
@@ -63,6 +67,9 @@ export function createChatRenderLifecycle() {
         rollout: {
             key: CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY,
             resolve: resolveChatRenderLifecycleRollout,
+        },
+        renderBatch: {
+            render: renderMessagesInBatches,
         },
     };
 }

--- a/public/scripts/chat-render-lifecycle/render-batch.js
+++ b/public/scripts/chat-render-lifecycle/render-batch.js
@@ -1,0 +1,178 @@
+function isPositiveInteger(value) {
+    return Number.isInteger(value) && value > 0;
+}
+
+function assertRenderBatchOptions({
+    messages,
+    firstMessageId,
+    batchSize,
+    documentRef,
+    renderMessageElement,
+    insertFragment,
+    waitForNextFrame,
+    afterBatch,
+}) {
+    if (!Array.isArray(messages)) {
+        throw new TypeError('renderMessagesInBatches requires messages to be an array.');
+    }
+
+    if (!Number.isInteger(firstMessageId)) {
+        throw new TypeError('renderMessagesInBatches requires firstMessageId to be an integer.');
+    }
+
+    if (!isPositiveInteger(batchSize)) {
+        throw new TypeError('renderMessagesInBatches requires batchSize to be a positive integer.');
+    }
+
+    if (!documentRef || typeof documentRef.createDocumentFragment !== 'function') {
+        throw new TypeError('renderMessagesInBatches requires documentRef.createDocumentFragment.');
+    }
+
+    if (typeof renderMessageElement !== 'function') {
+        throw new TypeError('renderMessagesInBatches requires renderMessageElement.');
+    }
+
+    if (typeof insertFragment !== 'function') {
+        throw new TypeError('renderMessagesInBatches requires insertFragment.');
+    }
+
+    if (typeof waitForNextFrame !== 'function') {
+        throw new TypeError('renderMessagesInBatches requires waitForNextFrame.');
+    }
+
+    if (afterBatch !== undefined && typeof afterBatch !== 'function') {
+        throw new TypeError('renderMessagesInBatches afterBatch must be a function when provided.');
+    }
+}
+
+function unwrapRenderedElement(renderedMessageElement) {
+    if (renderedMessageElement && typeof renderedMessageElement === 'object' && '0' in renderedMessageElement) {
+        return renderedMessageElement[0];
+    }
+
+    return renderedMessageElement;
+}
+
+function assertRenderedElement(renderedMessageElement, messageId) {
+    if (!renderedMessageElement || typeof renderedMessageElement !== 'object') {
+        throw new TypeError(`renderMessageElement must return an element for message ${messageId}.`);
+    }
+}
+
+function createBatchMeta({
+    batchIndex,
+    startOffset,
+    endOffset,
+    firstMessageId,
+    renderedMessageIds,
+    renderedMessageElements,
+    fragment,
+    isFinalBatch,
+}) {
+    return {
+        batchIndex,
+        startOffset,
+        endOffset,
+        firstMessageId: firstMessageId + startOffset,
+        lastMessageId: firstMessageId + endOffset - 1,
+        renderedMessageIds,
+        renderedMessageElements,
+        fragment,
+        isFinalBatch,
+    };
+}
+
+/**
+ * Renders caller-selected chat messages into deterministic DOM batches.
+ * @param {object} options Options.
+ * @param {Array} options.messages Messages already selected by the caller.
+ * @param {number} options.firstMessageId Numeric id for the first selected message.
+ * @param {number} options.batchSize Positive number of messages per fragment.
+ * @param {{createDocumentFragment: () => DocumentFragment}} [options.documentRef=globalThis.document] Fragment factory.
+ * @param {(message: object, messageId: number) => Element|Array<Element>} options.renderMessageElement Injected renderer.
+ * @param {(fragment: DocumentFragment, batchMeta: object) => void} options.insertFragment Injected insertion target.
+ * @param {() => Promise<void>|void} options.waitForNextFrame Injected frame yield.
+ * @param {boolean} [options.markLastMessage=false] Add `.last_mes` to the final rendered element.
+ * @param {(batchMeta: object) => Promise<void>|void} [options.afterBatch] Optional post-insert callback.
+ * @returns {Promise<{renderedMessageIds: number[], renderedMessageElements: Element[]}>}
+ */
+export async function renderMessagesInBatches({
+    messages,
+    firstMessageId,
+    batchSize,
+    documentRef = globalThis.document,
+    renderMessageElement,
+    insertFragment,
+    waitForNextFrame,
+    markLastMessage = false,
+    afterBatch,
+} = {}) {
+    assertRenderBatchOptions({
+        messages,
+        firstMessageId,
+        batchSize,
+        documentRef,
+        renderMessageElement,
+        insertFragment,
+        waitForNextFrame,
+        afterBatch,
+    });
+
+    const renderedMessageIds = [];
+    const renderedMessageElements = [];
+    const shouldYieldBetweenBatches = batchSize < messages.length;
+    let batchIndex = 0;
+
+    for (let startOffset = 0; startOffset < messages.length; startOffset += batchSize) {
+        const endOffset = Math.min(startOffset + batchSize, messages.length);
+        const fragment = documentRef.createDocumentFragment();
+        const batchRenderedMessageIds = [];
+        const batchRenderedMessageElements = [];
+        const isFinalBatch = endOffset >= messages.length;
+
+        for (let offset = startOffset; offset < endOffset; offset++) {
+            const messageId = firstMessageId + offset;
+            const renderedMessageElement = unwrapRenderedElement(renderMessageElement(messages[offset], messageId));
+
+            assertRenderedElement(renderedMessageElement, messageId);
+
+            batchRenderedMessageIds.push(messageId);
+            batchRenderedMessageElements.push(renderedMessageElement);
+            renderedMessageIds.push(messageId);
+            renderedMessageElements.push(renderedMessageElement);
+        }
+
+        if (markLastMessage && isFinalBatch) {
+            batchRenderedMessageElements.at(-1)?.classList?.add('last_mes');
+        }
+
+        for (const renderedMessageElement of batchRenderedMessageElements) {
+            fragment.appendChild(renderedMessageElement);
+        }
+
+        const batchMeta = createBatchMeta({
+            batchIndex,
+            startOffset,
+            endOffset,
+            firstMessageId,
+            renderedMessageIds: batchRenderedMessageIds,
+            renderedMessageElements: batchRenderedMessageElements,
+            fragment,
+            isFinalBatch,
+        });
+
+        insertFragment(fragment, batchMeta);
+        await afterBatch?.(batchMeta);
+
+        if (shouldYieldBetweenBatches && !isFinalBatch) {
+            await waitForNextFrame();
+        }
+
+        batchIndex++;
+    }
+
+    return {
+        renderedMessageIds,
+        renderedMessageElements,
+    };
+}

--- a/tests/chat-render-lifecycle-index.test.js
+++ b/tests/chat-render-lifecycle-index.test.js
@@ -10,6 +10,7 @@ import {
     resolveChatBottomScrollAction,
     resolveChatRenderLifecycleRollout,
     resolveChatScrollAction,
+    renderMessagesInBatches,
     restoreVisibleMessageAnchor,
     runSettledFrames,
     settleVisibleMessageAnchor,
@@ -27,6 +28,7 @@ describe('chat render lifecycle index seam', () => {
         expect(typeof shouldApplyChatBottomScrollAction).toBe('function');
         expect(typeof resolveChatScrollAction).toBe('function');
         expect(typeof resolveChatRenderLifecycleRollout).toBe('function');
+        expect(typeof renderMessagesInBatches).toBe('function');
         expect(CHAT_SCROLL_INTENT.TAIL_APPEND).toBe('tail-append');
         expect(CHAT_SCROLL_ACTION.PIN_BOTTOM).toBe('pin-bottom');
         expect(CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY).toBe('sillybunny.chatRenderLifecycle.enabled');
@@ -47,5 +49,6 @@ describe('chat render lifecycle index seam', () => {
         expect(lifecycle.scrollIntent.action).toBe(CHAT_SCROLL_ACTION);
         expect(lifecycle.rollout.key).toBe(CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY);
         expect(lifecycle.rollout.resolve).toBe(resolveChatRenderLifecycleRollout);
+        expect(lifecycle.renderBatch.render).toBe(renderMessagesInBatches);
     });
 });

--- a/tests/chat-render-lifecycle-render-batch.test.js
+++ b/tests/chat-render-lifecycle-render-batch.test.js
@@ -1,0 +1,183 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { renderMessagesInBatches } from '../public/scripts/chat-render-lifecycle/render-batch.js';
+
+class FakeElement {
+    constructor(messageId) {
+        this.messageId = messageId;
+        this.children = [];
+        this.classList = {
+            classes: [],
+            add: className => this.classList.classes.push(className),
+        };
+    }
+
+    appendChild(child) {
+        this.children.push(child);
+        return child;
+    }
+}
+
+class FakeDocument {
+    constructor() {
+        this.fragments = [];
+    }
+
+    createDocumentFragment() {
+        const fragment = new FakeElement('fragment');
+        this.fragments.push(fragment);
+        return fragment;
+    }
+}
+
+function pickBatchMeta(batchMeta) {
+    return {
+        batchIndex: batchMeta.batchIndex,
+        startOffset: batchMeta.startOffset,
+        endOffset: batchMeta.endOffset,
+        firstMessageId: batchMeta.firstMessageId,
+        lastMessageId: batchMeta.lastMessageId,
+        renderedMessageIds: batchMeta.renderedMessageIds,
+        isFinalBatch: batchMeta.isFinalBatch,
+    };
+}
+
+describe('chat render lifecycle render batch helper', () => {
+    test('renders caller-selected messages in deterministic yielded fragments', async () => {
+        const documentRef = new FakeDocument();
+        const messages = [{ text: 'first' }, { text: 'second' }, { text: 'third' }];
+        const rendered = [];
+        const inserted = [];
+        const waits = [];
+        const afterBatches = [];
+
+        const result = await renderMessagesInBatches({
+            messages,
+            firstMessageId: 10,
+            batchSize: 2,
+            documentRef,
+            renderMessageElement: (message, messageId) => {
+                rendered.push({ message, messageId });
+                return new FakeElement(messageId);
+            },
+            insertFragment: (fragment, batchMeta) => inserted.push({ fragment, batchMeta }),
+            waitForNextFrame: async () => waits.push('frame'),
+            afterBatch: batchMeta => afterBatches.push(batchMeta),
+        });
+
+        expect(rendered).toEqual([
+            { message: messages[0], messageId: 10 },
+            { message: messages[1], messageId: 11 },
+            { message: messages[2], messageId: 12 },
+        ]);
+        expect(inserted.map(item => item.fragment.children.map(child => child.messageId))).toEqual([[10, 11], [12]]);
+        expect(waits).toEqual(['frame']);
+        expect(afterBatches.map(pickBatchMeta)).toEqual([
+            {
+                batchIndex: 0,
+                startOffset: 0,
+                endOffset: 2,
+                firstMessageId: 10,
+                lastMessageId: 11,
+                renderedMessageIds: [10, 11],
+                isFinalBatch: false,
+            },
+            {
+                batchIndex: 1,
+                startOffset: 2,
+                endOffset: 3,
+                firstMessageId: 12,
+                lastMessageId: 12,
+                renderedMessageIds: [12],
+                isFinalBatch: true,
+            },
+        ]);
+        expect(result.renderedMessageIds).toEqual([10, 11, 12]);
+        expect(result.renderedMessageElements.map(element => element.messageId)).toEqual([10, 11, 12]);
+    });
+
+    test('marks only the final rendered element when requested', async () => {
+        const documentRef = new FakeDocument();
+        const elements = [];
+
+        await renderMessagesInBatches({
+            messages: ['first', 'second', 'third'],
+            firstMessageId: 4,
+            batchSize: 2,
+            documentRef,
+            renderMessageElement: (message, messageId) => {
+                const element = new FakeElement(messageId);
+                elements.push(element);
+                return [element];
+            },
+            insertFragment: () => {},
+            waitForNextFrame: async () => {},
+            markLastMessage: true,
+        });
+
+        expect(elements.map(element => element.classList.classes)).toEqual([[], [], ['last_mes']]);
+    });
+
+    test('does not yield when all messages fit in one batch', async () => {
+        const waits = [];
+
+        await renderMessagesInBatches({
+            messages: ['first', 'second'],
+            firstMessageId: 0,
+            batchSize: 10,
+            documentRef: new FakeDocument(),
+            renderMessageElement: (message, messageId) => new FakeElement(messageId),
+            insertFragment: () => {},
+            waitForNextFrame: async () => waits.push('frame'),
+        });
+
+        expect(waits).toEqual([]);
+    });
+
+    test('returns an empty result without inserting or yielding when there are no messages', async () => {
+        const inserted = [];
+        const waits = [];
+
+        const result = await renderMessagesInBatches({
+            messages: [],
+            firstMessageId: 0,
+            batchSize: 1,
+            documentRef: new FakeDocument(),
+            renderMessageElement: () => new FakeElement(0),
+            insertFragment: fragment => inserted.push(fragment),
+            waitForNextFrame: async () => waits.push('frame'),
+        });
+
+        expect(inserted).toEqual([]);
+        expect(waits).toEqual([]);
+        expect(result).toEqual({
+            renderedMessageIds: [],
+            renderedMessageElements: [],
+        });
+    });
+
+    test('fails fast for invalid boundary options', async () => {
+        const validOptions = {
+            messages: ['message'],
+            firstMessageId: 0,
+            batchSize: 1,
+            documentRef: new FakeDocument(),
+            renderMessageElement: (message, messageId) => new FakeElement(messageId),
+            insertFragment: () => {},
+            waitForNextFrame: async () => {},
+        };
+
+        await expect(renderMessagesInBatches({ ...validOptions, messages: null })).rejects.toThrow('messages');
+        await expect(renderMessagesInBatches({ ...validOptions, firstMessageId: 0.5 })).rejects.toThrow('firstMessageId');
+        await expect(renderMessagesInBatches({ ...validOptions, batchSize: 0 })).rejects.toThrow('batchSize');
+        await expect(renderMessagesInBatches({ ...validOptions, documentRef: null })).rejects.toThrow('documentRef');
+        await expect(renderMessagesInBatches({ ...validOptions, renderMessageElement: null })).rejects.toThrow('renderMessageElement');
+        await expect(renderMessagesInBatches({ ...validOptions, insertFragment: null })).rejects.toThrow('insertFragment');
+        await expect(renderMessagesInBatches({ ...validOptions, waitForNextFrame: null })).rejects.toThrow('waitForNextFrame');
+        await expect(renderMessagesInBatches({ ...validOptions, afterBatch: true })).rejects.toThrow('afterBatch');
+        await expect(renderMessagesInBatches({
+            ...validOptions,
+            renderMessageElement: () => null,
+        })).rejects.toThrow('message 0');
+    });
+});


### PR DESCRIPTION
## What?
Adds `renderMessagesInBatches()` under `public/scripts/chat-render-lifecycle/` and exports it through the lifecycle index seam. The helper renders caller-selected messages into deterministic `DocumentFragment` batches, computes message ids by offset from `firstMessageId`, supports direct or jQuery-like rendered elements, optionally marks only the final rendered element with `.last_mes`, and returns rendered ids/elements.

## Why?
This is the Phase 5 helper-first slice for moving chat render batching behind a small compatibility adapter before routing `redisplayChat()` or `showMoreMessages()`. Keeping it unused by runtime call sites lets reviewers validate the batching contract without changing default or guard-on behavior.

## How?
The helper uses injected render, insertion, frame-yield, and document-fragment dependencies so it stays independent of `public/script.js` and browser globals in unit tests. It validates boundary options up front, inserts one fragment per batch, runs optional per-batch callbacks after insertion, and yields only between batches.

## Testing?
- `npm run test:unit --prefix tests -- script-export-surface.test.js chat-render-lifecycle-index.test.js chat-render-lifecycle-render-batch.test.js chat-render-lifecycle-rollout-guard.test.js chat-render-lifecycle-script-wiring.test.js chat-render-lifecycle-bottom-scroll.test.js chat-render-lifecycle-scroll-intent.test.js chat-render-lifecycle-anchor.test.js chat-render-lifecycle-scheduler.test.js chat-scroll-edges.test.js mobile-streaming.test.js`
- `npm run lint`
- `npm run check:frontend-budgets`
- `npm run lint --prefix tests -- chat-scroll-regression-helpers.js chat-send-scroll.e2e.js chat-scroll-regressions.e2e.js chat-render-lifecycle-render-batch.test.js chat-render-lifecycle-index.test.js`
- GitHub checks passed.

## Screenshots (optional)
Not applicable; this is a helper-only refactor with no rendered UI or runtime route change.

## Anything Else?
Stacked on #208 / `refactor/chat-lifecycle-scroll-function`. No `public/script.js` runtime caller is routed in this PR.