### PR TITLE
Refactor redisplay chat batching through lifecycle

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -312,6 +312,7 @@ import {
     CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY,
     CHAT_SCROLL_INTENT,
     captureVisibleMessageAnchor,
+    renderMessagesInBatches,
     resolveChatBottomScrollAction,
     resolveChatRenderLifecycleRollout,
     resolveChatScrollAction,
@@ -2144,6 +2145,63 @@ function scrollLoadedChatToBottom() {
     }
 }
 
+async function renderRedisplayChatMessagesLegacy({ messages, startIndex, batchSize }) {
+    const renderedMessageIds = lodash.range(startIndex, startIndex + messages.length, 1);
+    const shouldYieldBetweenBatches = batchSize < messages.length;
+
+    for (let offset = 0; offset < messages.length; offset += batchSize) {
+        const batchMessages = messages.slice(offset, offset + batchSize);
+        const fragment = document.createDocumentFragment();
+        const newMessageElements = batchMessages.map((message, batchOffset) => {
+            const messageId = startIndex + offset + batchOffset;
+            const messageElement = updateMessageElement(message, { messageId });
+
+            return messageElement[0];
+        });
+
+        if (offset + batchSize >= messages.length) {
+            //The last_mes has been removed, add it to the new last message.
+            newMessageElements.at(-1).classList.add('last_mes');
+        }
+
+        //Append each batch in one DOM update.
+        for (const messageElement of newMessageElements) {
+            fragment.appendChild(messageElement);
+        }
+        chatElement[0].appendChild(fragment);
+
+        if (shouldYieldBetweenBatches && offset + batchSize < messages.length) {
+            await waitForNextFrame();
+        }
+    }
+
+    return renderedMessageIds;
+}
+
+async function renderRedisplayChatMessagesThroughLifecycle({ messages, startIndex, batchSize }) {
+    const { renderedMessageIds } = await renderMessagesInBatches({
+        messages,
+        firstMessageId: startIndex,
+        batchSize,
+        renderMessageElement: (message, messageId) => updateMessageElement(message, { messageId }),
+        insertFragment: fragment => chatElement[0].appendChild(fragment),
+        waitForNextFrame,
+        markLastMessage: true,
+    });
+
+    return renderedMessageIds;
+}
+
+async function renderRedisplayChatMessages({ messages, startIndex }) {
+    const batchSize = getMobileChatRenderBatchSize(messages.length);
+
+    if (isChatRenderLifecycleRolloutEnabled()) {
+        return renderRedisplayChatMessagesThroughLifecycle({ messages, startIndex, batchSize });
+    }
+
+    return renderRedisplayChatMessagesLegacy({ messages, startIndex, batchSize });
+}
+
 /**
  * Visually updates all chat messages including and after index by removing them, then adding them.
  * @param {object} [options] Options
@@ -2163,35 +2221,7 @@ export async function redisplayChat({ targetChat = chat, startIndex = 0, fade = 
     const messages = targetChat.slice(startIndex);
 
     if (messages.length > 0) {
-        const renderedMessageIds = lodash.range(startIndex, targetChat.length, 1);
-        const batchSize = getMobileChatRenderBatchSize(messages.length);
-        const shouldYieldBetweenBatches = batchSize < messages.length;
-
-        for (let offset = 0; offset < messages.length; offset += batchSize) {
-            const batchMessages = messages.slice(offset, offset + batchSize);
-            const fragment = document.createDocumentFragment();
-            const newMessageElements = batchMessages.map((message, batchOffset) => {
-                const i = startIndex + offset + batchOffset;
-                const messageElement = updateMessageElement(message, { messageId: i });
-
-                return messageElement[0];
-            });
-
-            if (offset + batchSize >= messages.length) {
-                //The last_mes has been removed, add it to the new last message.
-                newMessageElements.at(-1).classList.add('last_mes');
-            }
-
-            //Append each batch in one DOM update.
-            for (const messageElement of newMessageElements) {
-                fragment.appendChild(messageElement);
-            }
-            chatElement[0].appendChild(fragment);
-
-            if (shouldYieldBetweenBatches && offset + batchSize < messages.length) {
-                await waitForNextFrame();
-            }
-        }
+        const renderedMessageIds = await renderRedisplayChatMessages({ messages, startIndex });
 
         applyCharacterTagsToMessageDivs({ mesIds: renderedMessageIds });
     }

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -93,6 +93,56 @@ describe('chat render lifecycle script wiring', () => {
         expect(lifecycleGateSource).toContain('scrollLoadedChatToBottom();');
     });
 
+    test('redisplayChat delegates selected messages to the guarded redisplay renderer', () => {
+        const redisplayChat = findExportedFunction('redisplayChat');
+        const source = getSource(redisplayChat);
+
+        expect(source).toContain('const messages = targetChat.slice(startIndex);');
+        expect(source).toContain('const renderedMessageIds = await renderRedisplayChatMessages({ messages, startIndex });');
+        expect(source).toContain('applyCharacterTagsToMessageDivs({ mesIds: renderedMessageIds });');
+        expect(source).toContain('refreshSwipeButtons(false, fade);');
+        expect(source).toContain('applyStylePins();');
+        expect(source).toContain('updateEditArrowClasses();');
+    });
+
+    test('redisplayChat keeps render-batch routing behind the lifecycle rollout guard', () => {
+        const renderRedisplayChatMessages = findFunctionDeclaration('renderRedisplayChatMessages');
+        const source = getSource(renderRedisplayChatMessages);
+
+        expect(source).toContain('const batchSize = getMobileChatRenderBatchSize(messages.length);');
+        expect(source).toContain('if (isChatRenderLifecycleRolloutEnabled())');
+        expect(source).toContain('return renderRedisplayChatMessagesThroughLifecycle({ messages, startIndex, batchSize });');
+        expect(source).toContain('return renderRedisplayChatMessagesLegacy({ messages, startIndex, batchSize });');
+    });
+
+    test('guard-on redisplayChat delegates batch mechanics to the lifecycle render batch helper', () => {
+        const renderRedisplayChatMessagesThroughLifecycle = findFunctionDeclaration('renderRedisplayChatMessagesThroughLifecycle');
+        const source = getSource(renderRedisplayChatMessagesThroughLifecycle);
+
+        expect(source).toContain('renderMessagesInBatches({');
+        expect(source).toContain('messages,');
+        expect(source).toContain('firstMessageId: startIndex');
+        expect(source).toContain('batchSize,');
+        expect(source).toContain('renderMessageElement: (message, messageId) => updateMessageElement(message, { messageId })');
+        expect(source).toContain('insertFragment: fragment => chatElement[0].appendChild(fragment)');
+        expect(source).toContain('waitForNextFrame,');
+        expect(source).toContain('markLastMessage: true');
+    });
+
+    test('guard-off redisplayChat keeps legacy inline batching', () => {
+        const renderRedisplayChatMessagesLegacy = findFunctionDeclaration('renderRedisplayChatMessagesLegacy');
+        const source = getSource(renderRedisplayChatMessagesLegacy);
+
+        expect(source).not.toContain('renderMessagesInBatches');
+        expect(source).toContain('const renderedMessageIds = lodash.range(startIndex, startIndex + messages.length, 1);');
+        expect(source).toContain('const fragment = document.createDocumentFragment();');
+        expect(source).toContain('const messageElement = updateMessageElement(message, { messageId });');
+        expect(source).toContain('newMessageElements.at(-1).classList.add(\'last_mes\');');
+        expect(source).toContain('chatElement[0].appendChild(fragment);');
+        expect(source).toContain('await waitForNextFrame();');
+        expect(source).toContain('return renderedMessageIds;');
+    });
+
     test('addOneMessage passes pre-mutation bottom state into lifecycle bottom scroll', () => {
         const addOneMessage = findExportedFunction('addOneMessage');
         expect(addOneMessage).toBeTruthy();

--- a/tests/chat-scroll-regression-helpers.js
+++ b/tests/chat-scroll-regression-helpers.js
@@ -297,6 +297,34 @@ export async function getRenderedMessageIds(page) {
         .filter(Boolean));
 }
 
+export async function markFirstRenderedMessageEditing(page) {
+    const firstEditButton = page.locator('#chat .mes[mesid] .mes_edit').first();
+
+    await firstEditButton.waitFor({ state: 'visible', timeout: 5000 });
+    await firstEditButton.click();
+    await page.locator('#chat .mes[mesid] .mes_edit_buttons:visible').first().waitFor({ state: 'visible', timeout: 5000 });
+    await waitForAnimationFrames(page, 2);
+}
+
+export async function getRedisplayCompatibilitySnapshot(page) {
+    return page.evaluate(() => {
+        const chat = document.querySelector('#chat');
+        const messages = Array.from(chat.querySelectorAll('.mes[mesid]'));
+        const firstMessage = messages.at(0);
+        const lastMessage = messages.at(-1);
+
+        return {
+            renderedMessageIds: messages.map(message => message.getAttribute('mesid')),
+            lastMessageId: lastMessage?.getAttribute('mesid') ?? null,
+            lastMessageClassCount: chat.querySelectorAll('.mes.last_mes').length,
+            fadeClassCount: chat.querySelectorAll('.mes.fade').length,
+            stylePinsCount: chat.querySelectorAll(':scope > .style-pins').length,
+            firstEditUpDisabled: firstMessage?.querySelector('.mes_edit_up')?.classList.contains('disabled') ?? false,
+            firstEditDownDisabled: firstMessage?.querySelector('.mes_edit_down')?.classList.contains('disabled') ?? false,
+        };
+    });
+}
+
 export async function scrollMessageNearTop(page, messageId, offsetTop = 24) {
     await page.waitForFunction((targetMessageId) => {
         return document.querySelector(`#chat .mes[mesid="${targetMessageId}"]`) !== null;

--- a/tests/chat-scroll-regressions.e2e.js
+++ b/tests/chat-scroll-regressions.e2e.js
@@ -2,9 +2,11 @@
 import { expect, test } from '@playwright/test';
 import {
     getChatScrollSnapshot,
+    getRedisplayCompatibilitySnapshot,
     getRenderedMessageIds,
     installSwipeCandidate,
     installSyntheticLongChat,
+    markFirstRenderedMessageEditing,
     markManualMobileScroll,
     openReadyChat,
     scrollMessageNearTop,
@@ -26,6 +28,22 @@ test.describe('issue 167 chat scroll regressions', () => {
         expect(snapshot.lastMesId).toBe('95');
         expect(snapshot.lastVisibleMesId).toBe('95');
         expect(snapshot.bottomDelta).toBeLessThanOrEqual(16);
+    });
+
+    test('redisplay keeps render follow-up hooks applied after batched render', async ({ page }) => {
+        await installSyntheticLongChat(page, { messageCount: 36, visibleCount: 12 });
+        await markFirstRenderedMessageEditing(page);
+        await page.evaluate(async () => window.SillyTavern.getContext().redisplayChat({ startIndex: 24, fade: false }));
+
+        const snapshot = await getRedisplayCompatibilitySnapshot(page);
+
+        expect(snapshot.renderedMessageIds).toEqual(Array.from({ length: 12 }, (_, index) => String(24 + index)));
+        expect(snapshot.lastMessageId).toBe('35');
+        expect(snapshot.lastMessageClassCount).toBe(1);
+        expect(snapshot.fadeClassCount).toBe(0);
+        expect(snapshot.stylePinsCount).toBe(0);
+        expect(snapshot.firstEditUpDisabled).toBe(true);
+        expect(snapshot.firstEditDownDisabled).toBe(false);
     });
 
     test('show more preserves the first visible message anchor', async ({ page }) => {


### PR DESCRIPTION
## What?
Routes `redisplayChat()` message batch rendering through the chat render lifecycle seam when the lifecycle rollout guard is enabled.

## Why?
`redisplayChat()` still owned its own fragment, batch, yield, and rendered-id mechanics. Moving the guard-on path through `renderMessagesInBatches()` keeps render batching in the lifecycle module while preserving legacy behavior for default and explicit guard-off users.

## How?
Adds a small guarded redisplay renderer split:
- default/guard-off uses the existing inline batching logic
- guard-on uses `renderMessagesInBatches()` with the same selected messages, `startIndex`, batch size, append target, frame yield, and `.last_mes` marking
- `redisplayChat()` keeps its compatibility follow-up hooks for character tags, swipe buttons, style pins, edit arrow classes, fade behavior, and timing logs

Adds static wiring assertions for the guard split and an e2e regression check for redisplay follow-up hooks after batched render.

## Testing?
- `npm run test:unit --prefix tests -- script-export-surface.test.js chat-render-lifecycle-index.test.js chat-render-lifecycle-render-batch.test.js chat-render-lifecycle-rollout-guard.test.js chat-render-lifecycle-script-wiring.test.js chat-render-lifecycle-bottom-scroll.test.js chat-render-lifecycle-scroll-intent.test.js chat-render-lifecycle-anchor.test.js chat-render-lifecycle-scheduler.test.js chat-scroll-edges.test.js mobile-streaming.test.js`
- `npm run lint`
- `npm run check:frontend-budgets`
- `npm run lint --prefix tests -- chat-scroll-regression-helpers.js chat-scroll-regressions.e2e.js chat-render-lifecycle-script-wiring.test.js`
- `SILLYBUNNY_TEST_BASE_URL=http://127.0.0.1:4567/ npm run test:e2e --prefix tests -- chat-send-scroll.e2e.js chat-scroll-regressions.e2e.js`
- `SILLYBUNNY_TEST_BASE_URL=http://127.0.0.1:4567/?sillybunny.chatRenderLifecycle.enabled=false npm run test:e2e --prefix tests -- chat-send-scroll.e2e.js chat-scroll-regressions.e2e.js`
- `SILLYBUNNY_TEST_BASE_URL=http://127.0.0.1:4567/?sillybunny.chatRenderLifecycle.enabled=true npm run test:e2e --prefix tests -- chat-send-scroll.e2e.js chat-scroll-regressions.e2e.js`

## Screenshots (optional)
Not applicable; this is a guarded render-path refactor with no intended visual change.

## Anything Else?
Stacked on `refactor/chat-lifecycle-scroll-function` after the initial-load lifecycle route.