### PR TITLE
Refactor chat lifecycle update queue helper

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -312,6 +312,7 @@ import {
     CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY,
     CHAT_SCROLL_INTENT,
     captureVisibleMessageAnchor,
+    renderMessagesInBatches,
     resolveChatBottomScrollAction,
     resolveChatRenderLifecycleRollout,
     resolveChatScrollAction,
@@ -2144,6 +2145,63 @@ function scrollLoadedChatToBottom() {
     }
 }
 
+async function renderRedisplayChatMessagesLegacy({ messages, startIndex, batchSize }) {
+    const renderedMessageIds = lodash.range(startIndex, startIndex + messages.length, 1);
+    const shouldYieldBetweenBatches = batchSize < messages.length;
+
+    for (let offset = 0; offset < messages.length; offset += batchSize) {
+        const batchMessages = messages.slice(offset, offset + batchSize);
+        const fragment = document.createDocumentFragment();
+        const newMessageElements = batchMessages.map((message, batchOffset) => {
+            const messageId = startIndex + offset + batchOffset;
+            const messageElement = updateMessageElement(message, { messageId });
+
+            return messageElement[0];
+        });
+
+        if (offset + batchSize >= messages.length) {
+            //The last_mes has been removed, add it to the new last message.
+            newMessageElements.at(-1).classList.add('last_mes');
+        }
+
+        //Append each batch in one DOM update.
+        for (const messageElement of newMessageElements) {
+            fragment.appendChild(messageElement);
+        }
+        chatElement[0].appendChild(fragment);
+
+        if (shouldYieldBetweenBatches && offset + batchSize < messages.length) {
+            await waitForNextFrame();
+        }
+    }
+
+    return renderedMessageIds;
+}
+
+async function renderRedisplayChatMessagesThroughLifecycle({ messages, startIndex, batchSize }) {
+    const { renderedMessageIds } = await renderMessagesInBatches({
+        messages,
+        firstMessageId: startIndex,
+        batchSize,
+        renderMessageElement: (message, messageId) => updateMessageElement(message, { messageId }),
+        insertFragment: fragment => chatElement[0].appendChild(fragment),
+        waitForNextFrame,
+        markLastMessage: true,
+    });
+
+    return renderedMessageIds;
+}
+
+async function renderRedisplayChatMessages({ messages, startIndex }) {
+    const batchSize = getMobileChatRenderBatchSize(messages.length);
+
+    if (isChatRenderLifecycleRolloutEnabled()) {
+        return renderRedisplayChatMessagesThroughLifecycle({ messages, startIndex, batchSize });
+    }
+
+    return renderRedisplayChatMessagesLegacy({ messages, startIndex, batchSize });
+}
+
 /**
  * Visually updates all chat messages including and after index by removing them, then adding them.
  * @param {object} [options] Options
@@ -2163,35 +2221,7 @@ export async function redisplayChat({ targetChat = chat, startIndex = 0, fade = 
     const messages = targetChat.slice(startIndex);
 
     if (messages.length > 0) {
-        const renderedMessageIds = lodash.range(startIndex, targetChat.length, 1);
-        const batchSize = getMobileChatRenderBatchSize(messages.length);
-        const shouldYieldBetweenBatches = batchSize < messages.length;
-
-        for (let offset = 0; offset < messages.length; offset += batchSize) {
-            const batchMessages = messages.slice(offset, offset + batchSize);
-            const fragment = document.createDocumentFragment();
-            const newMessageElements = batchMessages.map((message, batchOffset) => {
-                const i = startIndex + offset + batchOffset;
-                const messageElement = updateMessageElement(message, { messageId: i });
-
-                return messageElement[0];
-            });
-
-            if (offset + batchSize >= messages.length) {
-                //The last_mes has been removed, add it to the new last message.
-                newMessageElements.at(-1).classList.add('last_mes');
-            }
-
-            //Append each batch in one DOM update.
-            for (const messageElement of newMessageElements) {
-                fragment.appendChild(messageElement);
-            }
-            chatElement[0].appendChild(fragment);
-
-            if (shouldYieldBetweenBatches && offset + batchSize < messages.length) {
-                await waitForNextFrame();
-            }
-        }
+        const renderedMessageIds = await renderRedisplayChatMessages({ messages, startIndex });
 
         applyCharacterTagsToMessageDivs({ mesIds: renderedMessageIds });
     }

--- a/public/script.js
+++ b/public/script.js
@@ -2016,6 +2016,96 @@ function insertShowMoreFragment(referenceNode, fragment) {
     }
 }
 
+async function renderShowMoreMessagesLegacy({
+    messages,
+    firstId,
+    batchSize,
+    insertionReference,
+    anchor,
+    shouldPreserveScroll,
+}) {
+    const shouldYieldBetweenBatches = batchSize < messages.length;
+
+    for (let offset = 0; offset < messages.length; offset += batchSize) {
+        const fragment = document.createDocumentFragment();
+        const batch = messages.slice(offset, offset + batchSize);
+
+        batch.forEach((message, id) => {
+            const messageElement = updateMessageElement(message, { messageId: firstId + offset + id });
+            if (messageElement[0]) {
+                fragment.appendChild(messageElement[0]);
+            }
+        });
+
+        // Fallback to chatElement if the button isn't where it's expected to be.
+        insertShowMoreFragment(insertionReference, fragment);
+
+        if (shouldPreserveScroll) {
+            restoreVisibleChatMessageAnchor(anchor);
+        }
+
+        if (shouldYieldBetweenBatches && offset + batchSize < messages.length) {
+            await waitForNextFrame();
+            if (shouldPreserveScroll) {
+                restoreVisibleChatMessageAnchor(anchor);
+            }
+        }
+    }
+}
+
+async function renderShowMoreMessagesThroughLifecycle({
+    messages,
+    firstId,
+    batchSize,
+    insertionReference,
+    anchor,
+    shouldPreserveScroll,
+}) {
+    const restoreAnchorIfNeeded = () => {
+        if (shouldPreserveScroll) {
+            restoreVisibleChatMessageAnchor(anchor);
+        }
+    };
+
+    await renderMessagesInBatches({
+        messages,
+        firstMessageId: firstId,
+        batchSize,
+        renderMessageElement: (message, messageId) => updateMessageElement(message, { messageId }),
+        insertFragment: fragment => insertShowMoreFragment(insertionReference, fragment),
+        waitForNextFrame: async () => {
+            await waitForNextFrame();
+            restoreAnchorIfNeeded();
+        },
+        afterBatch: restoreAnchorIfNeeded,
+    });
+}
+
+async function renderShowMoreMessages({
+    messages,
+    firstId,
+    insertionReference,
+    anchor,
+    shouldPreserveScroll,
+}) {
+    const batchSize = getMobileChatRenderBatchSize(messages.length);
+    const renderOptions = {
+        messages,
+        firstId,
+        batchSize,
+        insertionReference,
+        anchor,
+        shouldPreserveScroll,
+    };
+
+    if (isChatRenderLifecycleRolloutEnabled()) {
+        await renderShowMoreMessagesThroughLifecycle(renderOptions);
+        return;
+    }
+
+    await renderShowMoreMessagesLegacy(renderOptions);
+}
+
 export async function showMoreMessages(messagesToLoad = null) {
     if (isLoadingMoreMessages) {
         return;
@@ -2040,8 +2130,6 @@ export async function showMoreMessages(messagesToLoad = null) {
 
         const firstId = clamp(messageId - count, 0, Infinity);
         const messages = chat.slice(firstId, messageId);
-        const batchSize = getMobileChatRenderBatchSize(messages.length);
-        const shouldYieldBetweenBatches = batchSize < messages.length;
         const insertionReference = showMoreButtonElement instanceof HTMLElement
             ? showMoreButtonElement.nextSibling
             : chatElement[0]?.firstChild ?? null;
@@ -2052,31 +2140,13 @@ export async function showMoreMessages(messagesToLoad = null) {
             showMoreButtonElement.setAttribute('aria-busy', 'true');
         }
 
-        for (let offset = 0; offset < messages.length; offset += batchSize) {
-            const fragment = document.createDocumentFragment();
-            const batch = messages.slice(offset, offset + batchSize);
-
-            batch.forEach((message, id) => {
-                const messageElement = updateMessageElement(message, { messageId: firstId + offset + id });
-                if (messageElement[0]) {
-                    fragment.appendChild(messageElement[0]);
-                }
-            });
-
-            // Fallback to chatElement if the button isn't where it's expected to be.
-            insertShowMoreFragment(insertionReference, fragment);
-
-            if (shouldPreserveScroll) {
-                restoreVisibleChatMessageAnchor(anchor);
-            }
-
-            if (shouldYieldBetweenBatches && offset + batchSize < messages.length) {
-                await waitForNextFrame();
-                if (shouldPreserveScroll) {
-                    restoreVisibleChatMessageAnchor(anchor);
-                }
-            }
-        }
+        await renderShowMoreMessages({
+            messages,
+            firstId,
+            insertionReference,
+            anchor,
+            shouldPreserveScroll,
+        });
 
         refreshSwipeButtons();
 

--- a/public/scripts/chat-render-lifecycle/index.js
+++ b/public/scripts/chat-render-lifecycle/index.js
@@ -23,12 +23,16 @@ import {
 import {
     renderMessagesInBatches,
 } from './render-batch.js';
+import {
+    createMessageUpdateQueue,
+} from './update-queue.js';
 
 export {
     CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY,
     CHAT_SCROLL_ACTION,
     CHAT_SCROLL_INTENT,
     captureVisibleMessageAnchor,
+    createMessageUpdateQueue,
     createFrameWriteScheduler,
     resolveChatBottomScrollAction,
     resolveChatScrollAction,
@@ -70,6 +74,9 @@ export function createChatRenderLifecycle() {
         },
         renderBatch: {
             render: renderMessagesInBatches,
+        },
+        updateQueue: {
+            create: createMessageUpdateQueue,
         },
     };
 }

--- a/public/scripts/chat-render-lifecycle/update-queue.js
+++ b/public/scripts/chat-render-lifecycle/update-queue.js
@@ -1,0 +1,62 @@
+function assertApplyUpdate(applyUpdate) {
+    if (typeof applyUpdate !== 'function') {
+        throw new TypeError('createMessageUpdateQueue requires applyUpdate to be a function.');
+    }
+}
+
+function normalizeQueueOptions({ rerenderMessage = true, ...restOptions } = {}) {
+    return {
+        ...restOptions,
+        rerenderMessage: Boolean(rerenderMessage),
+    };
+}
+
+/**
+ * Creates a coalescing queue for already-decided message-block update requests.
+ * The injected apply function remains the only message-block mutation surface.
+ * @param {object} options Options.
+ * @param {(messageId: number|string, message: object, options: object) => void} options.applyUpdate Message update applier.
+ * @returns {{queue: (messageId: number|string, message: object, options?: object) => number, flush: () => number, clear: () => void, size: () => number}}
+ */
+export function createMessageUpdateQueue({ applyUpdate } = {}) {
+    assertApplyUpdate(applyUpdate);
+
+    const pendingUpdates = new Map();
+
+    const queue = (messageId, message, options = {}) => {
+        const normalizedOptions = normalizeQueueOptions(options);
+        const previousUpdate = pendingUpdates.get(messageId);
+
+        pendingUpdates.set(messageId, {
+            message,
+            options: {
+                ...previousUpdate?.options,
+                ...normalizedOptions,
+                rerenderMessage: Boolean(previousUpdate?.options?.rerenderMessage || normalizedOptions.rerenderMessage),
+            },
+        });
+
+        return pendingUpdates.size;
+    };
+
+    const flush = () => {
+        const updates = [...pendingUpdates.entries()];
+        pendingUpdates.clear();
+
+        for (const [messageId, { message, options }] of updates) {
+            applyUpdate(messageId, message, options);
+        }
+
+        return updates.length;
+    };
+
+    const clear = () => pendingUpdates.clear();
+    const size = () => pendingUpdates.size;
+
+    return {
+        queue,
+        flush,
+        clear,
+        size,
+    };
+}

--- a/tests/chat-render-lifecycle-index.test.js
+++ b/tests/chat-render-lifecycle-index.test.js
@@ -6,6 +6,7 @@ import {
     CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY,
     captureVisibleMessageAnchor,
     createChatRenderLifecycle,
+    createMessageUpdateQueue,
     createFrameWriteScheduler,
     resolveChatBottomScrollAction,
     resolveChatRenderLifecycleRollout,
@@ -29,6 +30,7 @@ describe('chat render lifecycle index seam', () => {
         expect(typeof resolveChatScrollAction).toBe('function');
         expect(typeof resolveChatRenderLifecycleRollout).toBe('function');
         expect(typeof renderMessagesInBatches).toBe('function');
+        expect(typeof createMessageUpdateQueue).toBe('function');
         expect(CHAT_SCROLL_INTENT.TAIL_APPEND).toBe('tail-append');
         expect(CHAT_SCROLL_ACTION.PIN_BOTTOM).toBe('pin-bottom');
         expect(CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY).toBe('sillybunny.chatRenderLifecycle.enabled');
@@ -50,5 +52,6 @@ describe('chat render lifecycle index seam', () => {
         expect(lifecycle.rollout.key).toBe(CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY);
         expect(lifecycle.rollout.resolve).toBe(resolveChatRenderLifecycleRollout);
         expect(lifecycle.renderBatch.render).toBe(renderMessagesInBatches);
+        expect(lifecycle.updateQueue.create).toBe(createMessageUpdateQueue);
     });
 });

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -93,6 +93,56 @@ describe('chat render lifecycle script wiring', () => {
         expect(lifecycleGateSource).toContain('scrollLoadedChatToBottom();');
     });
 
+    test('redisplayChat delegates selected messages to the guarded redisplay renderer', () => {
+        const redisplayChat = findExportedFunction('redisplayChat');
+        const source = getSource(redisplayChat);
+
+        expect(source).toContain('const messages = targetChat.slice(startIndex);');
+        expect(source).toContain('const renderedMessageIds = await renderRedisplayChatMessages({ messages, startIndex });');
+        expect(source).toContain('applyCharacterTagsToMessageDivs({ mesIds: renderedMessageIds });');
+        expect(source).toContain('refreshSwipeButtons(false, fade);');
+        expect(source).toContain('applyStylePins();');
+        expect(source).toContain('updateEditArrowClasses();');
+    });
+
+    test('redisplayChat keeps render-batch routing behind the lifecycle rollout guard', () => {
+        const renderRedisplayChatMessages = findFunctionDeclaration('renderRedisplayChatMessages');
+        const source = getSource(renderRedisplayChatMessages);
+
+        expect(source).toContain('const batchSize = getMobileChatRenderBatchSize(messages.length);');
+        expect(source).toContain('if (isChatRenderLifecycleRolloutEnabled())');
+        expect(source).toContain('return renderRedisplayChatMessagesThroughLifecycle({ messages, startIndex, batchSize });');
+        expect(source).toContain('return renderRedisplayChatMessagesLegacy({ messages, startIndex, batchSize });');
+    });
+
+    test('guard-on redisplayChat delegates batch mechanics to the lifecycle render batch helper', () => {
+        const renderRedisplayChatMessagesThroughLifecycle = findFunctionDeclaration('renderRedisplayChatMessagesThroughLifecycle');
+        const source = getSource(renderRedisplayChatMessagesThroughLifecycle);
+
+        expect(source).toContain('renderMessagesInBatches({');
+        expect(source).toContain('messages,');
+        expect(source).toContain('firstMessageId: startIndex');
+        expect(source).toContain('batchSize,');
+        expect(source).toContain('renderMessageElement: (message, messageId) => updateMessageElement(message, { messageId })');
+        expect(source).toContain('insertFragment: fragment => chatElement[0].appendChild(fragment)');
+        expect(source).toContain('waitForNextFrame,');
+        expect(source).toContain('markLastMessage: true');
+    });
+
+    test('guard-off redisplayChat keeps legacy inline batching', () => {
+        const renderRedisplayChatMessagesLegacy = findFunctionDeclaration('renderRedisplayChatMessagesLegacy');
+        const source = getSource(renderRedisplayChatMessagesLegacy);
+
+        expect(source).not.toContain('renderMessagesInBatches');
+        expect(source).toContain('const renderedMessageIds = lodash.range(startIndex, startIndex + messages.length, 1);');
+        expect(source).toContain('const fragment = document.createDocumentFragment();');
+        expect(source).toContain('const messageElement = updateMessageElement(message, { messageId });');
+        expect(source).toContain('newMessageElements.at(-1).classList.add(\'last_mes\');');
+        expect(source).toContain('chatElement[0].appendChild(fragment);');
+        expect(source).toContain('await waitForNextFrame();');
+        expect(source).toContain('return renderedMessageIds;');
+    });
+
     test('addOneMessage passes pre-mutation bottom state into lifecycle bottom scroll', () => {
         const addOneMessage = findExportedFunction('addOneMessage');
         expect(addOneMessage).toBeTruthy();

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -143,6 +143,59 @@ describe('chat render lifecycle script wiring', () => {
         expect(source).toContain('return renderedMessageIds;');
     });
 
+    test('showMoreMessages delegates selected history messages to the guarded show-more renderer', () => {
+        const showMoreMessages = findExportedFunction('showMoreMessages');
+        const source = getSource(showMoreMessages);
+
+        expect(source).toContain('const firstId = clamp(messageId - count, 0, Infinity);');
+        expect(source).toContain('const messages = chat.slice(firstId, messageId);');
+        expect(source).toContain('const anchor = captureVisibleChatMessageAnchor();');
+        expect(source).toContain('await renderShowMoreMessages({');
+        expect(source).toContain('refreshSwipeButtons();');
+        expect(source).toContain('showMoreButton.remove();');
+        expect(source).toContain('applyStylePins();');
+        expect(source).toContain('await settleVisibleChatMessageAnchor(anchor);');
+        expect(source).toContain('await eventSource.emit(event_types.MORE_MESSAGES_LOADED);');
+    });
+
+    test('showMoreMessages keeps render-batch routing behind the lifecycle rollout guard', () => {
+        const renderShowMoreMessages = findFunctionDeclaration('renderShowMoreMessages');
+        const source = getSource(renderShowMoreMessages);
+
+        expect(source).toContain('const batchSize = getMobileChatRenderBatchSize(messages.length);');
+        expect(source).toContain('if (isChatRenderLifecycleRolloutEnabled())');
+        expect(source).toContain('await renderShowMoreMessagesThroughLifecycle(renderOptions);');
+        expect(source).toContain('await renderShowMoreMessagesLegacy(renderOptions);');
+    });
+
+    test('guard-on showMoreMessages delegates batch insertion to the lifecycle render batch helper', () => {
+        const renderShowMoreMessagesThroughLifecycle = findFunctionDeclaration('renderShowMoreMessagesThroughLifecycle');
+        const source = getSource(renderShowMoreMessagesThroughLifecycle);
+
+        expect(source).toContain('renderMessagesInBatches({');
+        expect(source).toContain('messages,');
+        expect(source).toContain('firstMessageId: firstId');
+        expect(source).toContain('batchSize,');
+        expect(source).toContain('renderMessageElement: (message, messageId) => updateMessageElement(message, { messageId })');
+        expect(source).toContain('insertFragment: fragment => insertShowMoreFragment(insertionReference, fragment)');
+        expect(source).toContain('waitForNextFrame: async () =>');
+        expect(source).toContain('await waitForNextFrame();');
+        expect(source).toContain('afterBatch: restoreAnchorIfNeeded');
+    });
+
+    test('guard-off showMoreMessages keeps legacy inline batching and anchor restores', () => {
+        const renderShowMoreMessagesLegacy = findFunctionDeclaration('renderShowMoreMessagesLegacy');
+        const source = getSource(renderShowMoreMessagesLegacy);
+
+        expect(source).not.toContain('renderMessagesInBatches');
+        expect(source).toContain('const fragment = document.createDocumentFragment();');
+        expect(source).toContain('const batch = messages.slice(offset, offset + batchSize);');
+        expect(source).toContain('const messageElement = updateMessageElement(message, { messageId: firstId + offset + id });');
+        expect(source).toContain('insertShowMoreFragment(insertionReference, fragment);');
+        expect(source).toContain('restoreVisibleChatMessageAnchor(anchor);');
+        expect(source).toContain('await waitForNextFrame();');
+    });
+
     test('addOneMessage passes pre-mutation bottom state into lifecycle bottom scroll', () => {
         const addOneMessage = findExportedFunction('addOneMessage');
         expect(addOneMessage).toBeTruthy();

--- a/tests/chat-render-lifecycle-update-queue.test.js
+++ b/tests/chat-render-lifecycle-update-queue.test.js
@@ -1,0 +1,95 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { createMessageUpdateQueue } from '../public/scripts/chat-render-lifecycle/update-queue.js';
+
+describe('chat render lifecycle update queue helper', () => {
+    test('queues and flushes message updates through the injected apply function in order', () => {
+        const applied = [];
+        const queue = createMessageUpdateQueue({
+            applyUpdate: (messageId, message, options) => applied.push({ messageId, message, options }),
+        });
+
+        expect(queue.queue(3, { mes: 'first' }, { rerenderMessage: true })).toBe(1);
+        expect(queue.queue(4, { mes: 'second' }, { rerenderMessage: false })).toBe(2);
+
+        expect(queue.size()).toBe(2);
+        expect(queue.flush()).toBe(2);
+        expect(queue.size()).toBe(0);
+        expect(applied).toEqual([
+            { messageId: 3, message: { mes: 'first' }, options: { rerenderMessage: true } },
+            { messageId: 4, message: { mes: 'second' }, options: { rerenderMessage: false } },
+        ]);
+    });
+
+    test('coalesces duplicate message ids with the latest message and any rerender request', () => {
+        const applied = [];
+        const queue = createMessageUpdateQueue({
+            applyUpdate: (messageId, message, options) => applied.push({ messageId, message, options }),
+        });
+
+        queue.queue(5, { mes: 'old' }, { rerenderMessage: true });
+        queue.queue(5, { mes: 'new' }, { rerenderMessage: false });
+
+        expect(queue.size()).toBe(1);
+        expect(queue.flush()).toBe(1);
+        expect(applied).toEqual([
+            { messageId: 5, message: { mes: 'new' }, options: { rerenderMessage: true } },
+        ]);
+    });
+
+    test('defaults rerenderMessage to true when callers omit options', () => {
+        const applied = [];
+        const queue = createMessageUpdateQueue({
+            applyUpdate: (messageId, message, options) => applied.push({ messageId, message, options }),
+        });
+
+        queue.queue(6, { mes: 'default' });
+        queue.flush();
+
+        expect(applied).toEqual([
+            { messageId: 6, message: { mes: 'default' }, options: { rerenderMessage: true } },
+        ]);
+    });
+
+    test('clears pending updates before applying so nested queue work survives for the next flush', () => {
+        const applied = [];
+        const queue = createMessageUpdateQueue({
+            applyUpdate: (messageId, message, options) => {
+                applied.push({ messageId, message, options });
+
+                if (messageId === 1) {
+                    queue.queue(2, { mes: 'nested' }, { rerenderMessage: false });
+                }
+            },
+        });
+
+        queue.queue(1, { mes: 'outer' }, { rerenderMessage: false });
+
+        expect(queue.flush()).toBe(1);
+        expect(queue.size()).toBe(1);
+        expect(queue.flush()).toBe(1);
+        expect(applied).toEqual([
+            { messageId: 1, message: { mes: 'outer' }, options: { rerenderMessage: false } },
+            { messageId: 2, message: { mes: 'nested' }, options: { rerenderMessage: false } },
+        ]);
+    });
+
+    test('clear drops pending updates without applying them', () => {
+        const applied = [];
+        const queue = createMessageUpdateQueue({
+            applyUpdate: (messageId, message, options) => applied.push({ messageId, message, options }),
+        });
+
+        queue.queue(1, { mes: 'drop' });
+        queue.clear();
+
+        expect(queue.size()).toBe(0);
+        expect(queue.flush()).toBe(0);
+        expect(applied).toEqual([]);
+    });
+
+    test('fails fast for invalid apply function', () => {
+        expect(() => createMessageUpdateQueue()).toThrow('applyUpdate');
+        expect(() => createMessageUpdateQueue({ applyUpdate: null })).toThrow('applyUpdate');
+    });
+});

--- a/tests/chat-scroll-regression-helpers.js
+++ b/tests/chat-scroll-regression-helpers.js
@@ -297,6 +297,34 @@ export async function getRenderedMessageIds(page) {
         .filter(Boolean));
 }
 
+export async function markFirstRenderedMessageEditing(page) {
+    const firstEditButton = page.locator('#chat .mes[mesid] .mes_edit').first();
+
+    await firstEditButton.waitFor({ state: 'visible', timeout: 5000 });
+    await firstEditButton.click();
+    await page.locator('#chat .mes[mesid] .mes_edit_buttons:visible').first().waitFor({ state: 'visible', timeout: 5000 });
+    await waitForAnimationFrames(page, 2);
+}
+
+export async function getRedisplayCompatibilitySnapshot(page) {
+    return page.evaluate(() => {
+        const chat = document.querySelector('#chat');
+        const messages = Array.from(chat.querySelectorAll('.mes[mesid]'));
+        const firstMessage = messages.at(0);
+        const lastMessage = messages.at(-1);
+
+        return {
+            renderedMessageIds: messages.map(message => message.getAttribute('mesid')),
+            lastMessageId: lastMessage?.getAttribute('mesid') ?? null,
+            lastMessageClassCount: chat.querySelectorAll('.mes.last_mes').length,
+            fadeClassCount: chat.querySelectorAll('.mes.fade').length,
+            stylePinsCount: chat.querySelectorAll(':scope > .style-pins').length,
+            firstEditUpDisabled: firstMessage?.querySelector('.mes_edit_up')?.classList.contains('disabled') ?? false,
+            firstEditDownDisabled: firstMessage?.querySelector('.mes_edit_down')?.classList.contains('disabled') ?? false,
+        };
+    });
+}
+
 export async function scrollMessageNearTop(page, messageId, offsetTop = 24) {
     await page.waitForFunction((targetMessageId) => {
         return document.querySelector(`#chat .mes[mesid="${targetMessageId}"]`) !== null;

--- a/tests/chat-scroll-regressions.e2e.js
+++ b/tests/chat-scroll-regressions.e2e.js
@@ -2,9 +2,11 @@
 import { expect, test } from '@playwright/test';
 import {
     getChatScrollSnapshot,
+    getRedisplayCompatibilitySnapshot,
     getRenderedMessageIds,
     installSwipeCandidate,
     installSyntheticLongChat,
+    markFirstRenderedMessageEditing,
     markManualMobileScroll,
     openReadyChat,
     scrollMessageNearTop,
@@ -26,6 +28,22 @@ test.describe('issue 167 chat scroll regressions', () => {
         expect(snapshot.lastMesId).toBe('95');
         expect(snapshot.lastVisibleMesId).toBe('95');
         expect(snapshot.bottomDelta).toBeLessThanOrEqual(16);
+    });
+
+    test('redisplay keeps render follow-up hooks applied after batched render', async ({ page }) => {
+        await installSyntheticLongChat(page, { messageCount: 36, visibleCount: 12 });
+        await markFirstRenderedMessageEditing(page);
+        await page.evaluate(async () => window.SillyTavern.getContext().redisplayChat({ startIndex: 24, fade: false }));
+
+        const snapshot = await getRedisplayCompatibilitySnapshot(page);
+
+        expect(snapshot.renderedMessageIds).toEqual(Array.from({ length: 12 }, (_, index) => String(24 + index)));
+        expect(snapshot.lastMessageId).toBe('35');
+        expect(snapshot.lastMessageClassCount).toBe(1);
+        expect(snapshot.fadeClassCount).toBe(0);
+        expect(snapshot.stylePinsCount).toBe(0);
+        expect(snapshot.firstEditUpDisabled).toBe(true);
+        expect(snapshot.firstEditDownDisabled).toBe(false);
     });
 
     test('show more preserves the first visible message anchor', async ({ page }) => {


### PR DESCRIPTION
## What?
Adds `createMessageUpdateQueue()` to the chat render lifecycle module and exports it through the lifecycle index seam.

## Why?
Message-block update coalescing needs a small tested adapter before `updateMessageBlock()` or the mobile pending-update map can route through lifecycle code.

## How?
The helper keeps a `Map` of pending updates keyed by message id, preserves the latest message payload, ORs `rerenderMessage` across duplicate requests, clears before applying, and flushes through an injected `applyUpdate` function so DOM mutation ownership stays with the existing caller.

## Testing?
- `npm run test:unit --prefix tests -- chat-render-lifecycle-update-queue.test.js chat-render-lifecycle-index.test.js`
- `npm run test:unit --prefix tests -- script-export-surface.test.js chat-render-lifecycle-index.test.js chat-render-lifecycle-render-batch.test.js chat-render-lifecycle-rollout-guard.test.js chat-render-lifecycle-script-wiring.test.js chat-render-lifecycle-bottom-scroll.test.js chat-render-lifecycle-scroll-intent.test.js chat-render-lifecycle-anchor.test.js chat-render-lifecycle-scheduler.test.js chat-scroll-edges.test.js mobile-streaming.test.js chat-render-lifecycle-update-queue.test.js`
- `npm run lint`
- `npm run check:frontend-budgets`
- `npm run lint --prefix tests -- chat-render-lifecycle-update-queue.test.js chat-render-lifecycle-index.test.js`
- `graphify update . --force`

## Screenshots (optional)
Not applicable; helper-only change with no UI route.

## Anything Else?
Stacked on `refactor/chat-lifecycle-show-more-batch`.