### PR TITLE
Test replace-message anchor positions

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -312,6 +312,7 @@ import {
     CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY,
     CHAT_SCROLL_INTENT,
     captureVisibleMessageAnchor,
+    createMessageUpdateQueue,
     renderMessagesInBatches,
     resolveChatBottomScrollAction,
     resolveChatRenderLifecycleRollout,
@@ -598,6 +599,7 @@ let pendingMobileMessageUpdateFrame = 0;
 let pendingMobileMessageUpdateTimer = 0;
 /** @type {Map<number, { message: object, rerenderMessage: boolean }>} */
 const pendingMobileMessageUpdates = new Map();
+let messageUpdateQueue = null;
 
 let dialogueResolve = null;
 let dialogueCloseStop = false;
@@ -1983,6 +1985,22 @@ async function settleVisibleChatMessageAnchor(anchor, frames = 8) {
     });
 }
 
+function getMessageUpdateQueue() {
+    if (!messageUpdateQueue) {
+        messageUpdateQueue = createMessageUpdateQueue({
+            applyUpdate: applyMessageBlockUpdate,
+        });
+    }
+
+    return messageUpdateQueue;
+}
+
+function updateMessageBlockThroughLifecycle(messageId, message, { rerenderMessage }) {
+    const queue = getMessageUpdateQueue();
+    queue.queue(messageId, message, { rerenderMessage });
+    queue.flush();
+}
+
 function flushPendingMobileMessageUpdates() {
     pendingMobileMessageUpdateFrame = 0;
     pendingMobileMessageUpdateTimer = 0;
@@ -2926,6 +2944,11 @@ function applyMessageBlockUpdate(messageId, message, { rerenderMessage = true } 
 export function updateMessageBlock(messageId, message, { rerenderMessage = true } = {}) {
     if (shouldDeferMobileMessageUpdates()) {
         queueMobileMessageBlockUpdate(messageId, message, { rerenderMessage });
+        return;
+    }
+
+    if (isChatRenderLifecycleRolloutEnabled()) {
+        updateMessageBlockThroughLifecycle(messageId, message, { rerenderMessage });
         return;
     }
 

--- a/public/script.js
+++ b/public/script.js
@@ -597,9 +597,8 @@ let entitySelectionPulseId = 0;
 let showMoreTouchMoved = false;
 let pendingMobileMessageUpdateFrame = 0;
 let pendingMobileMessageUpdateTimer = 0;
-/** @type {Map<number, { message: object, rerenderMessage: boolean }>} */
-const pendingMobileMessageUpdates = new Map();
 let messageUpdateQueue = null;
+let mobileMessageUpdateQueue = null;
 
 let dialogueResolve = null;
 let dialogueCloseStop = false;
@@ -1995,6 +1994,16 @@ function getMessageUpdateQueue() {
     return messageUpdateQueue;
 }
 
+function getMobileMessageUpdateQueue() {
+    if (!mobileMessageUpdateQueue) {
+        mobileMessageUpdateQueue = createMessageUpdateQueue({
+            applyUpdate: applyMessageBlockUpdate,
+        });
+    }
+
+    return mobileMessageUpdateQueue;
+}
+
 function updateMessageBlockThroughLifecycle(messageId, message, { rerenderMessage }) {
     const queue = getMessageUpdateQueue();
     queue.queue(messageId, message, { rerenderMessage });
@@ -2004,19 +2013,11 @@ function updateMessageBlockThroughLifecycle(messageId, message, { rerenderMessag
 function flushPendingMobileMessageUpdates() {
     pendingMobileMessageUpdateFrame = 0;
     pendingMobileMessageUpdateTimer = 0;
-    const updates = [...pendingMobileMessageUpdates.entries()];
-    pendingMobileMessageUpdates.clear();
-
-    for (const [messageId, { message, rerenderMessage }] of updates) {
-        applyMessageBlockUpdate(messageId, message, { rerenderMessage });
-    }
+    getMobileMessageUpdateQueue().flush();
 }
 
 function queueMobileMessageBlockUpdate(messageId, message, { rerenderMessage }) {
-    pendingMobileMessageUpdates.set(messageId, {
-        message,
-        rerenderMessage: pendingMobileMessageUpdates.get(messageId)?.rerenderMessage || rerenderMessage,
-    });
+    getMobileMessageUpdateQueue().queue(messageId, message, { rerenderMessage });
 
     if (pendingMobileMessageUpdateFrame || pendingMobileMessageUpdateTimer) {
         return;

--- a/public/script.js
+++ b/public/script.js
@@ -312,6 +312,7 @@ import {
     CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY,
     CHAT_SCROLL_INTENT,
     captureVisibleMessageAnchor,
+    renderMessagesInBatches,
     resolveChatBottomScrollAction,
     resolveChatRenderLifecycleRollout,
     resolveChatScrollAction,
@@ -2144,6 +2145,63 @@ function scrollLoadedChatToBottom() {
     }
 }
 
+async function renderRedisplayChatMessagesLegacy({ messages, startIndex, batchSize }) {
+    const renderedMessageIds = lodash.range(startIndex, startIndex + messages.length, 1);
+    const shouldYieldBetweenBatches = batchSize < messages.length;
+
+    for (let offset = 0; offset < messages.length; offset += batchSize) {
+        const batchMessages = messages.slice(offset, offset + batchSize);
+        const fragment = document.createDocumentFragment();
+        const newMessageElements = batchMessages.map((message, batchOffset) => {
+            const messageId = startIndex + offset + batchOffset;
+            const messageElement = updateMessageElement(message, { messageId });
+
+            return messageElement[0];
+        });
+
+        if (offset + batchSize >= messages.length) {
+            //The last_mes has been removed, add it to the new last message.
+            newMessageElements.at(-1).classList.add('last_mes');
+        }
+
+        //Append each batch in one DOM update.
+        for (const messageElement of newMessageElements) {
+            fragment.appendChild(messageElement);
+        }
+        chatElement[0].appendChild(fragment);
+
+        if (shouldYieldBetweenBatches && offset + batchSize < messages.length) {
+            await waitForNextFrame();
+        }
+    }
+
+    return renderedMessageIds;
+}
+
+async function renderRedisplayChatMessagesThroughLifecycle({ messages, startIndex, batchSize }) {
+    const { renderedMessageIds } = await renderMessagesInBatches({
+        messages,
+        firstMessageId: startIndex,
+        batchSize,
+        renderMessageElement: (message, messageId) => updateMessageElement(message, { messageId }),
+        insertFragment: fragment => chatElement[0].appendChild(fragment),
+        waitForNextFrame,
+        markLastMessage: true,
+    });
+
+    return renderedMessageIds;
+}
+
+async function renderRedisplayChatMessages({ messages, startIndex }) {
+    const batchSize = getMobileChatRenderBatchSize(messages.length);
+
+    if (isChatRenderLifecycleRolloutEnabled()) {
+        return renderRedisplayChatMessagesThroughLifecycle({ messages, startIndex, batchSize });
+    }
+
+    return renderRedisplayChatMessagesLegacy({ messages, startIndex, batchSize });
+}
+
 /**
  * Visually updates all chat messages including and after index by removing them, then adding them.
  * @param {object} [options] Options
@@ -2163,35 +2221,7 @@ export async function redisplayChat({ targetChat = chat, startIndex = 0, fade = 
     const messages = targetChat.slice(startIndex);
 
     if (messages.length > 0) {
-        const renderedMessageIds = lodash.range(startIndex, targetChat.length, 1);
-        const batchSize = getMobileChatRenderBatchSize(messages.length);
-        const shouldYieldBetweenBatches = batchSize < messages.length;
-
-        for (let offset = 0; offset < messages.length; offset += batchSize) {
-            const batchMessages = messages.slice(offset, offset + batchSize);
-            const fragment = document.createDocumentFragment();
-            const newMessageElements = batchMessages.map((message, batchOffset) => {
-                const i = startIndex + offset + batchOffset;
-                const messageElement = updateMessageElement(message, { messageId: i });
-
-                return messageElement[0];
-            });
-
-            if (offset + batchSize >= messages.length) {
-                //The last_mes has been removed, add it to the new last message.
-                newMessageElements.at(-1).classList.add('last_mes');
-            }
-
-            //Append each batch in one DOM update.
-            for (const messageElement of newMessageElements) {
-                fragment.appendChild(messageElement);
-            }
-            chatElement[0].appendChild(fragment);
-
-            if (shouldYieldBetweenBatches && offset + batchSize < messages.length) {
-                await waitForNextFrame();
-            }
-        }
+        const renderedMessageIds = await renderRedisplayChatMessages({ messages, startIndex });
 
         applyCharacterTagsToMessageDivs({ mesIds: renderedMessageIds });
     }

--- a/public/script.js
+++ b/public/script.js
@@ -313,6 +313,7 @@ import {
     CHAT_SCROLL_INTENT,
     captureVisibleMessageAnchor,
     createMessageUpdateQueue,
+    createStreamWriteBuffer,
     renderMessagesInBatches,
     resolveChatBottomScrollAction,
     resolveChatRenderLifecycleRollout,
@@ -599,6 +600,7 @@ let pendingMobileMessageUpdateFrame = 0;
 let pendingMobileMessageUpdateTimer = 0;
 let messageUpdateQueue = null;
 let mobileMessageUpdateQueue = null;
+let streamingVisibleWriteBuffer = null;
 
 let dialogueResolve = null;
 let dialogueCloseStop = false;
@@ -2002,6 +2004,54 @@ function getMobileMessageUpdateQueue() {
     }
 
     return mobileMessageUpdateQueue;
+}
+
+function applyStreamingVisibleWrite(messageId, {
+    messageTextDom,
+    messageTimerDom,
+    messageTokenCounterDom,
+    messageDom,
+    message,
+    formattedText,
+    timePassed,
+    currentTokenCount,
+    shouldRefreshTokenCount,
+    shouldUpdateMetaBadges,
+    shouldUseStreamFadeIn,
+    bypassFadeIn,
+}, { isFinal = false } = {}) {
+    if (shouldRefreshTokenCount && messageTokenCounterDom instanceof HTMLElement) {
+        messageTokenCounterDom.textContent = `${currentTokenCount}t`;
+    }
+
+    if (shouldUpdateMetaBadges) {
+        updateMessageMetaBadges(messageDom, message);
+    }
+
+    if (messageTextDom instanceof HTMLElement) {
+        if (shouldUseStreamFadeIn) {
+            applyStreamFadeIn(messageTextDom, formattedText, { bypassFadeIn });
+        } else {
+            messageTextDom.innerHTML = formattedText;
+        }
+    }
+
+    if (messageTimerDom instanceof HTMLElement) {
+        messageTimerDom.textContent = timePassed.timerValue;
+        messageTimerDom.title = timePassed.timerTitle;
+    }
+
+    return isFinal;
+}
+
+function getStreamingVisibleWriteBuffer() {
+    if (!streamingVisibleWriteBuffer) {
+        streamingVisibleWriteBuffer = createStreamWriteBuffer({
+            applyWrite: applyStreamingVisibleWrite,
+        });
+    }
+
+    return streamingVisibleWriteBuffer;
 }
 
 function updateMessageBlockThroughLifecycle(messageId, message, { rerenderMessage }) {
@@ -4779,6 +4829,15 @@ class StreamingProcessor {
         }
     }
 
+    #queueStreamingVisibleWrite({ messageId, write, isFinal }) {
+        if (!isChatRenderLifecycleRolloutEnabled()) {
+            applyStreamingVisibleWrite(messageId, write, { isFinal });
+            return;
+        }
+
+        getStreamingVisibleWriteBuffer().queue(messageId, write, { isFinal });
+    }
+
     markUIGenStarted() {
         deactivateSendButtons();
     }
@@ -4883,16 +4942,6 @@ class StreamingProcessor {
                 });
                 currentTokenCount = outputTokens;
             }
-            if (shouldRefreshTokenCount) {
-                if (this.messageTokenCounterDom instanceof HTMLElement) {
-                    this.messageTokenCounterDom.textContent = `${currentTokenCount}t`;
-                }
-            }
-
-            if (!shouldReduceIntermediateStreamingWork) {
-                updateMessageMetaBadges(this.messageDom, chat[messageId]);
-            }
-
             if ((this.type == 'swipe' || this.type === 'continue') && Array.isArray(chat[messageId].swipes)) {
                 chat[messageId].swipes[chat[messageId].swipe_id] = processedText;
                 if (!shouldReduceIntermediateStreamingWork) {
@@ -4914,21 +4963,25 @@ class StreamingProcessor {
                 {},
                 false,
             );
-            if (this.messageTextDom instanceof HTMLElement) {
-                if (power_user.stream_fade_in) {
-                    applyStreamFadeIn(this.messageTextDom, formattedText, {
-                        bypassFadeIn: isIOSWebKit && power_user.ios_webkit_disable_stream_fade_in,
-                    });
-                } else {
-                    this.messageTextDom.innerHTML = formattedText;
-                }
-            }
-
             const timePassed = formatGenerationTimer(this.timeStarted, currentTime, currentTokenCount, this.reasoningHandler.getDuration(), this.timeToFirstToken);
-            if (this.messageTimerDom instanceof HTMLElement) {
-                this.messageTimerDom.textContent = timePassed.timerValue;
-                this.messageTimerDom.title = timePassed.timerTitle;
-            }
+            this.#queueStreamingVisibleWrite({
+                messageId,
+                write: {
+                    messageTextDom: this.messageTextDom,
+                    messageTimerDom: this.messageTimerDom,
+                    messageTokenCounterDom: this.messageTokenCounterDom,
+                    messageDom: this.messageDom,
+                    message: chat[messageId],
+                    formattedText,
+                    timePassed,
+                    currentTokenCount,
+                    shouldRefreshTokenCount,
+                    shouldUpdateMetaBadges: !shouldReduceIntermediateStreamingWork,
+                    shouldUseStreamFadeIn: power_user.stream_fade_in,
+                    bypassFadeIn: isIOSWebKit && power_user.ios_webkit_disable_stream_fade_in,
+                },
+                isFinal,
+            });
 
             if (!shouldReduceIntermediateStreamingWork) {
                 this.setFirstSwipe(messageId);

--- a/public/script.js
+++ b/public/script.js
@@ -2010,6 +2010,26 @@ function updateMessageBlockThroughLifecycle(messageId, message, { rerenderMessag
     queue.flush();
 }
 
+function scrollStartedStreamingMessageThroughLifecycle() {
+    if (!isChatRenderLifecycleRolloutEnabled()) {
+        scrollChatToBottom({ waitForFrame: true });
+        return;
+    }
+
+    const action = resolveChatScrollAction({
+        intent: CHAT_SCROLL_INTENT.STREAM_PROGRESS,
+        autoScrollEnabled: power_user.auto_scroll_chat_to_bottom,
+        isNearBottom: isChatScrolledNearBottom(),
+        isManualScrollSuppressed: shouldSuppressMobileChatAutoScroll(),
+    });
+
+    if (shouldApplyChatBottomScrollAction(action)) {
+        requestAnimationFrame(() => {
+            scrollChatElementToBottom();
+        });
+    }
+}
+
 function flushPendingMobileMessageUpdates() {
     pendingMobileMessageUpdateFrame = 0;
     pendingMobileMessageUpdateTimer = 0;
@@ -4787,7 +4807,7 @@ class StreamingProcessor {
         hideSwipeButtons({ hideCounters: true });
         scrollLock = false;
         scrollLockImmunityUntil = Date.now() + 500;
-        scrollChatToBottom({ waitForFrame: true });
+        scrollStartedStreamingMessageThroughLifecycle();
         return messageId;
     }
 

--- a/public/script.js
+++ b/public/script.js
@@ -2016,6 +2016,96 @@ function insertShowMoreFragment(referenceNode, fragment) {
     }
 }
 
+async function renderShowMoreMessagesLegacy({
+    messages,
+    firstId,
+    batchSize,
+    insertionReference,
+    anchor,
+    shouldPreserveScroll,
+}) {
+    const shouldYieldBetweenBatches = batchSize < messages.length;
+
+    for (let offset = 0; offset < messages.length; offset += batchSize) {
+        const fragment = document.createDocumentFragment();
+        const batch = messages.slice(offset, offset + batchSize);
+
+        batch.forEach((message, id) => {
+            const messageElement = updateMessageElement(message, { messageId: firstId + offset + id });
+            if (messageElement[0]) {
+                fragment.appendChild(messageElement[0]);
+            }
+        });
+
+        // Fallback to chatElement if the button isn't where it's expected to be.
+        insertShowMoreFragment(insertionReference, fragment);
+
+        if (shouldPreserveScroll) {
+            restoreVisibleChatMessageAnchor(anchor);
+        }
+
+        if (shouldYieldBetweenBatches && offset + batchSize < messages.length) {
+            await waitForNextFrame();
+            if (shouldPreserveScroll) {
+                restoreVisibleChatMessageAnchor(anchor);
+            }
+        }
+    }
+}
+
+async function renderShowMoreMessagesThroughLifecycle({
+    messages,
+    firstId,
+    batchSize,
+    insertionReference,
+    anchor,
+    shouldPreserveScroll,
+}) {
+    const restoreAnchorIfNeeded = () => {
+        if (shouldPreserveScroll) {
+            restoreVisibleChatMessageAnchor(anchor);
+        }
+    };
+
+    await renderMessagesInBatches({
+        messages,
+        firstMessageId: firstId,
+        batchSize,
+        renderMessageElement: (message, messageId) => updateMessageElement(message, { messageId }),
+        insertFragment: fragment => insertShowMoreFragment(insertionReference, fragment),
+        waitForNextFrame: async () => {
+            await waitForNextFrame();
+            restoreAnchorIfNeeded();
+        },
+        afterBatch: restoreAnchorIfNeeded,
+    });
+}
+
+async function renderShowMoreMessages({
+    messages,
+    firstId,
+    insertionReference,
+    anchor,
+    shouldPreserveScroll,
+}) {
+    const batchSize = getMobileChatRenderBatchSize(messages.length);
+    const renderOptions = {
+        messages,
+        firstId,
+        batchSize,
+        insertionReference,
+        anchor,
+        shouldPreserveScroll,
+    };
+
+    if (isChatRenderLifecycleRolloutEnabled()) {
+        await renderShowMoreMessagesThroughLifecycle(renderOptions);
+        return;
+    }
+
+    await renderShowMoreMessagesLegacy(renderOptions);
+}
+
 export async function showMoreMessages(messagesToLoad = null) {
     if (isLoadingMoreMessages) {
         return;
@@ -2040,8 +2130,6 @@ export async function showMoreMessages(messagesToLoad = null) {
 
         const firstId = clamp(messageId - count, 0, Infinity);
         const messages = chat.slice(firstId, messageId);
-        const batchSize = getMobileChatRenderBatchSize(messages.length);
-        const shouldYieldBetweenBatches = batchSize < messages.length;
         const insertionReference = showMoreButtonElement instanceof HTMLElement
             ? showMoreButtonElement.nextSibling
             : chatElement[0]?.firstChild ?? null;
@@ -2052,31 +2140,13 @@ export async function showMoreMessages(messagesToLoad = null) {
             showMoreButtonElement.setAttribute('aria-busy', 'true');
         }
 
-        for (let offset = 0; offset < messages.length; offset += batchSize) {
-            const fragment = document.createDocumentFragment();
-            const batch = messages.slice(offset, offset + batchSize);
-
-            batch.forEach((message, id) => {
-                const messageElement = updateMessageElement(message, { messageId: firstId + offset + id });
-                if (messageElement[0]) {
-                    fragment.appendChild(messageElement[0]);
-                }
-            });
-
-            // Fallback to chatElement if the button isn't where it's expected to be.
-            insertShowMoreFragment(insertionReference, fragment);
-
-            if (shouldPreserveScroll) {
-                restoreVisibleChatMessageAnchor(anchor);
-            }
-
-            if (shouldYieldBetweenBatches && offset + batchSize < messages.length) {
-                await waitForNextFrame();
-                if (shouldPreserveScroll) {
-                    restoreVisibleChatMessageAnchor(anchor);
-                }
-            }
-        }
+        await renderShowMoreMessages({
+            messages,
+            firstId,
+            insertionReference,
+            anchor,
+            shouldPreserveScroll,
+        });
 
         refreshSwipeButtons();
 

--- a/public/scripts/chat-render-lifecycle/index.js
+++ b/public/scripts/chat-render-lifecycle/index.js
@@ -23,12 +23,16 @@ import {
 import {
     renderMessagesInBatches,
 } from './render-batch.js';
+import {
+    createMessageUpdateQueue,
+} from './update-queue.js';
 
 export {
     CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY,
     CHAT_SCROLL_ACTION,
     CHAT_SCROLL_INTENT,
     captureVisibleMessageAnchor,
+    createMessageUpdateQueue,
     createFrameWriteScheduler,
     resolveChatBottomScrollAction,
     resolveChatScrollAction,
@@ -70,6 +74,9 @@ export function createChatRenderLifecycle() {
         },
         renderBatch: {
             render: renderMessagesInBatches,
+        },
+        updateQueue: {
+            create: createMessageUpdateQueue,
         },
     };
 }

--- a/public/scripts/chat-render-lifecycle/index.js
+++ b/public/scripts/chat-render-lifecycle/index.js
@@ -24,6 +24,9 @@ import {
     renderMessagesInBatches,
 } from './render-batch.js';
 import {
+    createStreamWriteBuffer,
+} from './stream-buffer.js';
+import {
     createMessageUpdateQueue,
 } from './update-queue.js';
 
@@ -34,6 +37,7 @@ export {
     captureVisibleMessageAnchor,
     createMessageUpdateQueue,
     createFrameWriteScheduler,
+    createStreamWriteBuffer,
     resolveChatBottomScrollAction,
     resolveChatScrollAction,
     restoreVisibleMessageAnchor,
@@ -74,6 +78,9 @@ export function createChatRenderLifecycle() {
         },
         renderBatch: {
             render: renderMessagesInBatches,
+        },
+        streamBuffer: {
+            create: createStreamWriteBuffer,
         },
         updateQueue: {
             create: createMessageUpdateQueue,

--- a/public/scripts/chat-render-lifecycle/stream-buffer.js
+++ b/public/scripts/chat-render-lifecycle/stream-buffer.js
@@ -1,0 +1,90 @@
+import { createFrameWriteScheduler } from './scheduler.js';
+
+function assertStreamBufferOptions({ applyWrite, scheduler }) {
+    if (typeof applyWrite !== 'function') {
+        throw new TypeError('createStreamWriteBuffer requires applyWrite to be a function.');
+    }
+
+    if (!scheduler || typeof scheduler.request !== 'function' || typeof scheduler.cancel !== 'function') {
+        throw new TypeError('createStreamWriteBuffer requires scheduler.request and scheduler.cancel.');
+    }
+}
+
+function normalizeWriteOptions({ isFinal = false, ...restOptions } = {}) {
+    return {
+        ...restOptions,
+        isFinal: Boolean(isFinal),
+    };
+}
+
+/**
+ * Coalesces already-decided streaming visible writes through one scheduler lane.
+ * Provider state, token events, and persistence stay with the caller.
+ * @param {object} options Options.
+ * @param {{request: (callback: () => void) => void, cancel: () => void}} [options.scheduler] Write scheduler.
+ * @param {(messageId: number|string, write: object, options: object) => void} options.applyWrite Visible write applier.
+ * @returns {{queue: (messageId: number|string, write: object, options?: object) => number, flush: () => number, clear: () => void, size: () => number}}
+ */
+export function createStreamWriteBuffer({
+    scheduler = createFrameWriteScheduler(),
+    applyWrite,
+} = {}) {
+    assertStreamBufferOptions({ applyWrite, scheduler });
+
+    const pendingWrites = new Map();
+    let hasScheduledFlush = false;
+
+    const flush = () => {
+        hasScheduledFlush = false;
+        const writes = [...pendingWrites.entries()];
+        pendingWrites.clear();
+
+        for (const [messageId, { write, options }] of writes) {
+            applyWrite(messageId, write, options);
+        }
+
+        return writes.length;
+    };
+
+    const scheduleFlush = () => {
+        if (hasScheduledFlush) {
+            return;
+        }
+
+        hasScheduledFlush = true;
+        scheduler.request(flush);
+    };
+
+    const queue = (messageId, write, options = {}) => {
+        const normalizedOptions = normalizeWriteOptions(options);
+
+        pendingWrites.set(messageId, {
+            write,
+            options: normalizedOptions,
+        });
+
+        if (normalizedOptions.isFinal) {
+            scheduler.cancel();
+            flush();
+            return pendingWrites.size;
+        }
+
+        scheduleFlush();
+        return pendingWrites.size;
+    };
+
+    const clear = () => {
+        pendingWrites.clear();
+        hasScheduledFlush = false;
+        scheduler.cancel();
+    };
+
+    const size = () => pendingWrites.size;
+
+    return {
+        queue,
+        flush,
+        clear,
+        size,
+    };
+}

--- a/public/scripts/chat-render-lifecycle/update-queue.js
+++ b/public/scripts/chat-render-lifecycle/update-queue.js
@@ -1,0 +1,62 @@
+function assertApplyUpdate(applyUpdate) {
+    if (typeof applyUpdate !== 'function') {
+        throw new TypeError('createMessageUpdateQueue requires applyUpdate to be a function.');
+    }
+}
+
+function normalizeQueueOptions({ rerenderMessage = true, ...restOptions } = {}) {
+    return {
+        ...restOptions,
+        rerenderMessage: Boolean(rerenderMessage),
+    };
+}
+
+/**
+ * Creates a coalescing queue for already-decided message-block update requests.
+ * The injected apply function remains the only message-block mutation surface.
+ * @param {object} options Options.
+ * @param {(messageId: number|string, message: object, options: object) => void} options.applyUpdate Message update applier.
+ * @returns {{queue: (messageId: number|string, message: object, options?: object) => number, flush: () => number, clear: () => void, size: () => number}}
+ */
+export function createMessageUpdateQueue({ applyUpdate } = {}) {
+    assertApplyUpdate(applyUpdate);
+
+    const pendingUpdates = new Map();
+
+    const queue = (messageId, message, options = {}) => {
+        const normalizedOptions = normalizeQueueOptions(options);
+        const previousUpdate = pendingUpdates.get(messageId);
+
+        pendingUpdates.set(messageId, {
+            message,
+            options: {
+                ...previousUpdate?.options,
+                ...normalizedOptions,
+                rerenderMessage: Boolean(previousUpdate?.options?.rerenderMessage || normalizedOptions.rerenderMessage),
+            },
+        });
+
+        return pendingUpdates.size;
+    };
+
+    const flush = () => {
+        const updates = [...pendingUpdates.entries()];
+        pendingUpdates.clear();
+
+        for (const [messageId, { message, options }] of updates) {
+            applyUpdate(messageId, message, options);
+        }
+
+        return updates.length;
+    };
+
+    const clear = () => pendingUpdates.clear();
+    const size = () => pendingUpdates.size;
+
+    return {
+        queue,
+        flush,
+        clear,
+        size,
+    };
+}

--- a/tests/chat-render-lifecycle-anchor.test.js
+++ b/tests/chat-render-lifecycle-anchor.test.js
@@ -62,6 +62,54 @@ describe('chat render lifecycle anchor helpers', () => {
         expect(scrollElement.scrollTop).toBe(72);
     });
 
+    test('preserves viewport-relative anchors during top, middle, and tail replacements', () => {
+        const cases = [
+            {
+                messages: [
+                    new FakeMessageElement(10, { top: 12, bottom: 68 }),
+                    new FakeMessageElement(11, { top: 76, bottom: 132 }),
+                    new FakeMessageElement(12, { top: 140, bottom: 196 }),
+                ],
+                mutate(messages) {
+                    messages[0].rect = { top: 42, bottom: 118 };
+                },
+                expectedScrollTop: 30,
+            },
+            {
+                messages: [
+                    new FakeMessageElement(20, { top: -92, bottom: -24 }),
+                    new FakeMessageElement(21, { top: 18, bottom: 82 }),
+                    new FakeMessageElement(22, { top: 90, bottom: 160 }),
+                ],
+                mutate(messages) {
+                    messages[1].rect = { top: -14, bottom: 106 };
+                },
+                expectedScrollTop: -32,
+            },
+            {
+                messages: [
+                    new FakeMessageElement(30, { top: -150, bottom: -80 }),
+                    new FakeMessageElement(31, { top: -72, bottom: -8 }),
+                    new FakeMessageElement(32, { top: 28, bottom: 94 }),
+                ],
+                mutate(messages) {
+                    messages[2].rect = { top: 64, bottom: 156 };
+                },
+                expectedScrollTop: 36,
+            },
+        ];
+
+        for (const { messages, mutate, expectedScrollTop } of cases) {
+            const scrollElement = new FakeScrollElement(messages);
+            const anchor = captureVisibleMessageAnchor(scrollElement);
+
+            mutate(messages);
+            restoreVisibleMessageAnchor(scrollElement, anchor);
+
+            expect(scrollElement.scrollTop).toBe(expectedScrollTop);
+        }
+    });
+
     test('settles the anchor across multiple animation frames', async () => {
         const anchorMessage = new FakeMessageElement(5, { top: 10, bottom: 60 });
         const scrollElement = new FakeScrollElement([anchorMessage]);

--- a/tests/chat-render-lifecycle-index.test.js
+++ b/tests/chat-render-lifecycle-index.test.js
@@ -8,6 +8,7 @@ import {
     createChatRenderLifecycle,
     createMessageUpdateQueue,
     createFrameWriteScheduler,
+    createStreamWriteBuffer,
     resolveChatBottomScrollAction,
     resolveChatRenderLifecycleRollout,
     resolveChatScrollAction,
@@ -31,6 +32,7 @@ describe('chat render lifecycle index seam', () => {
         expect(typeof resolveChatRenderLifecycleRollout).toBe('function');
         expect(typeof renderMessagesInBatches).toBe('function');
         expect(typeof createMessageUpdateQueue).toBe('function');
+        expect(typeof createStreamWriteBuffer).toBe('function');
         expect(CHAT_SCROLL_INTENT.TAIL_APPEND).toBe('tail-append');
         expect(CHAT_SCROLL_ACTION.PIN_BOTTOM).toBe('pin-bottom');
         expect(CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY).toBe('sillybunny.chatRenderLifecycle.enabled');
@@ -52,6 +54,7 @@ describe('chat render lifecycle index seam', () => {
         expect(lifecycle.rollout.key).toBe(CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY);
         expect(lifecycle.rollout.resolve).toBe(resolveChatRenderLifecycleRollout);
         expect(lifecycle.renderBatch.render).toBe(renderMessagesInBatches);
+        expect(lifecycle.streamBuffer.create).toBe(createStreamWriteBuffer);
         expect(lifecycle.updateQueue.create).toBe(createMessageUpdateQueue);
     });
 });

--- a/tests/chat-render-lifecycle-index.test.js
+++ b/tests/chat-render-lifecycle-index.test.js
@@ -6,6 +6,7 @@ import {
     CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY,
     captureVisibleMessageAnchor,
     createChatRenderLifecycle,
+    createMessageUpdateQueue,
     createFrameWriteScheduler,
     resolveChatBottomScrollAction,
     resolveChatRenderLifecycleRollout,
@@ -29,6 +30,7 @@ describe('chat render lifecycle index seam', () => {
         expect(typeof resolveChatScrollAction).toBe('function');
         expect(typeof resolveChatRenderLifecycleRollout).toBe('function');
         expect(typeof renderMessagesInBatches).toBe('function');
+        expect(typeof createMessageUpdateQueue).toBe('function');
         expect(CHAT_SCROLL_INTENT.TAIL_APPEND).toBe('tail-append');
         expect(CHAT_SCROLL_ACTION.PIN_BOTTOM).toBe('pin-bottom');
         expect(CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY).toBe('sillybunny.chatRenderLifecycle.enabled');
@@ -50,5 +52,6 @@ describe('chat render lifecycle index seam', () => {
         expect(lifecycle.rollout.key).toBe(CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY);
         expect(lifecycle.rollout.resolve).toBe(resolveChatRenderLifecycleRollout);
         expect(lifecycle.renderBatch.render).toBe(renderMessagesInBatches);
+        expect(lifecycle.updateQueue.create).toBe(createMessageUpdateQueue);
     });
 });

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -93,6 +93,56 @@ describe('chat render lifecycle script wiring', () => {
         expect(lifecycleGateSource).toContain('scrollLoadedChatToBottom();');
     });
 
+    test('redisplayChat delegates selected messages to the guarded redisplay renderer', () => {
+        const redisplayChat = findExportedFunction('redisplayChat');
+        const source = getSource(redisplayChat);
+
+        expect(source).toContain('const messages = targetChat.slice(startIndex);');
+        expect(source).toContain('const renderedMessageIds = await renderRedisplayChatMessages({ messages, startIndex });');
+        expect(source).toContain('applyCharacterTagsToMessageDivs({ mesIds: renderedMessageIds });');
+        expect(source).toContain('refreshSwipeButtons(false, fade);');
+        expect(source).toContain('applyStylePins();');
+        expect(source).toContain('updateEditArrowClasses();');
+    });
+
+    test('redisplayChat keeps render-batch routing behind the lifecycle rollout guard', () => {
+        const renderRedisplayChatMessages = findFunctionDeclaration('renderRedisplayChatMessages');
+        const source = getSource(renderRedisplayChatMessages);
+
+        expect(source).toContain('const batchSize = getMobileChatRenderBatchSize(messages.length);');
+        expect(source).toContain('if (isChatRenderLifecycleRolloutEnabled())');
+        expect(source).toContain('return renderRedisplayChatMessagesThroughLifecycle({ messages, startIndex, batchSize });');
+        expect(source).toContain('return renderRedisplayChatMessagesLegacy({ messages, startIndex, batchSize });');
+    });
+
+    test('guard-on redisplayChat delegates batch mechanics to the lifecycle render batch helper', () => {
+        const renderRedisplayChatMessagesThroughLifecycle = findFunctionDeclaration('renderRedisplayChatMessagesThroughLifecycle');
+        const source = getSource(renderRedisplayChatMessagesThroughLifecycle);
+
+        expect(source).toContain('renderMessagesInBatches({');
+        expect(source).toContain('messages,');
+        expect(source).toContain('firstMessageId: startIndex');
+        expect(source).toContain('batchSize,');
+        expect(source).toContain('renderMessageElement: (message, messageId) => updateMessageElement(message, { messageId })');
+        expect(source).toContain('insertFragment: fragment => chatElement[0].appendChild(fragment)');
+        expect(source).toContain('waitForNextFrame,');
+        expect(source).toContain('markLastMessage: true');
+    });
+
+    test('guard-off redisplayChat keeps legacy inline batching', () => {
+        const renderRedisplayChatMessagesLegacy = findFunctionDeclaration('renderRedisplayChatMessagesLegacy');
+        const source = getSource(renderRedisplayChatMessagesLegacy);
+
+        expect(source).not.toContain('renderMessagesInBatches');
+        expect(source).toContain('const renderedMessageIds = lodash.range(startIndex, startIndex + messages.length, 1);');
+        expect(source).toContain('const fragment = document.createDocumentFragment();');
+        expect(source).toContain('const messageElement = updateMessageElement(message, { messageId });');
+        expect(source).toContain('newMessageElements.at(-1).classList.add(\'last_mes\');');
+        expect(source).toContain('chatElement[0].appendChild(fragment);');
+        expect(source).toContain('await waitForNextFrame();');
+        expect(source).toContain('return renderedMessageIds;');
+    });
+
     test('addOneMessage passes pre-mutation bottom state into lifecycle bottom scroll', () => {
         const addOneMessage = findExportedFunction('addOneMessage');
         expect(addOneMessage).toBeTruthy();

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -143,6 +143,59 @@ describe('chat render lifecycle script wiring', () => {
         expect(source).toContain('return renderedMessageIds;');
     });
 
+    test('showMoreMessages delegates selected history messages to the guarded show-more renderer', () => {
+        const showMoreMessages = findExportedFunction('showMoreMessages');
+        const source = getSource(showMoreMessages);
+
+        expect(source).toContain('const firstId = clamp(messageId - count, 0, Infinity);');
+        expect(source).toContain('const messages = chat.slice(firstId, messageId);');
+        expect(source).toContain('const anchor = captureVisibleChatMessageAnchor();');
+        expect(source).toContain('await renderShowMoreMessages({');
+        expect(source).toContain('refreshSwipeButtons();');
+        expect(source).toContain('showMoreButton.remove();');
+        expect(source).toContain('applyStylePins();');
+        expect(source).toContain('await settleVisibleChatMessageAnchor(anchor);');
+        expect(source).toContain('await eventSource.emit(event_types.MORE_MESSAGES_LOADED);');
+    });
+
+    test('showMoreMessages keeps render-batch routing behind the lifecycle rollout guard', () => {
+        const renderShowMoreMessages = findFunctionDeclaration('renderShowMoreMessages');
+        const source = getSource(renderShowMoreMessages);
+
+        expect(source).toContain('const batchSize = getMobileChatRenderBatchSize(messages.length);');
+        expect(source).toContain('if (isChatRenderLifecycleRolloutEnabled())');
+        expect(source).toContain('await renderShowMoreMessagesThroughLifecycle(renderOptions);');
+        expect(source).toContain('await renderShowMoreMessagesLegacy(renderOptions);');
+    });
+
+    test('guard-on showMoreMessages delegates batch insertion to the lifecycle render batch helper', () => {
+        const renderShowMoreMessagesThroughLifecycle = findFunctionDeclaration('renderShowMoreMessagesThroughLifecycle');
+        const source = getSource(renderShowMoreMessagesThroughLifecycle);
+
+        expect(source).toContain('renderMessagesInBatches({');
+        expect(source).toContain('messages,');
+        expect(source).toContain('firstMessageId: firstId');
+        expect(source).toContain('batchSize,');
+        expect(source).toContain('renderMessageElement: (message, messageId) => updateMessageElement(message, { messageId })');
+        expect(source).toContain('insertFragment: fragment => insertShowMoreFragment(insertionReference, fragment)');
+        expect(source).toContain('waitForNextFrame: async () =>');
+        expect(source).toContain('await waitForNextFrame();');
+        expect(source).toContain('afterBatch: restoreAnchorIfNeeded');
+    });
+
+    test('guard-off showMoreMessages keeps legacy inline batching and anchor restores', () => {
+        const renderShowMoreMessagesLegacy = findFunctionDeclaration('renderShowMoreMessagesLegacy');
+        const source = getSource(renderShowMoreMessagesLegacy);
+
+        expect(source).not.toContain('renderMessagesInBatches');
+        expect(source).toContain('const fragment = document.createDocumentFragment();');
+        expect(source).toContain('const batch = messages.slice(offset, offset + batchSize);');
+        expect(source).toContain('const messageElement = updateMessageElement(message, { messageId: firstId + offset + id });');
+        expect(source).toContain('insertShowMoreFragment(insertionReference, fragment);');
+        expect(source).toContain('restoreVisibleChatMessageAnchor(anchor);');
+        expect(source).toContain('await waitForNextFrame();');
+    });
+
     test('addOneMessage passes pre-mutation bottom state into lifecycle bottom scroll', () => {
         const addOneMessage = findExportedFunction('addOneMessage');
         expect(addOneMessage).toBeTruthy();

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -263,4 +263,32 @@ describe('chat render lifecycle script wiring', () => {
             name: 'messageElement',
         }));
     });
+
+    test('updateMessageBlock keeps lifecycle update routing behind the rollout guard', () => {
+        const updateMessageBlock = findExportedFunction('updateMessageBlock');
+        const source = getSource(updateMessageBlock);
+
+        expect(source).toContain('if (shouldDeferMobileMessageUpdates())');
+        expect(source).toContain('queueMobileMessageBlockUpdate(messageId, message, { rerenderMessage });');
+        expect(source).toContain('if (isChatRenderLifecycleRolloutEnabled())');
+        expect(source).toContain('updateMessageBlockThroughLifecycle(messageId, message, { rerenderMessage });');
+        expect(source).toContain('applyMessageBlockUpdate(messageId, message, { rerenderMessage });');
+    });
+
+    test('guard-on updateMessageBlock delegates queue mechanics to the lifecycle update queue helper', () => {
+        expect(scriptSource).toContain('createMessageUpdateQueue,');
+
+        const getMessageUpdateQueue = findFunctionDeclaration('getMessageUpdateQueue');
+        const getQueueSource = getSource(getMessageUpdateQueue);
+
+        expect(getQueueSource).toContain('createMessageUpdateQueue({');
+        expect(getQueueSource).toContain('applyUpdate: applyMessageBlockUpdate');
+
+        const updateMessageBlockThroughLifecycle = findFunctionDeclaration('updateMessageBlockThroughLifecycle');
+        const lifecycleSource = getSource(updateMessageBlockThroughLifecycle);
+
+        expect(lifecycleSource).toContain('const queue = getMessageUpdateQueue();');
+        expect(lifecycleSource).toContain('queue.queue(messageId, message, { rerenderMessage });');
+        expect(lifecycleSource).toContain('queue.flush();');
+    });
 });

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -317,4 +317,31 @@ describe('chat render lifecycle script wiring', () => {
         expect(queueSource).toContain('pendingMobileMessageUpdateTimer = window.setTimeout(() =>');
         expect(queueSource).toContain('pendingMobileMessageUpdateFrame = requestAnimationFrame(flushPendingMobileMessageUpdates);');
     });
+
+    test('streaming start keeps viewport routing behind the lifecycle rollout guard', () => {
+        const onStartStreaming = findNode(scriptAst, node => node.type === 'MethodDefinition'
+            && node.key?.name === 'onStartStreaming');
+        const source = getSource(onStartStreaming.value);
+
+        expect(source).toContain('hideSwipeButtons({ hideCounters: true });');
+        expect(source).toContain('scrollLock = false;');
+        expect(source).toContain('scrollLockImmunityUntil = Date.now() + 500;');
+        expect(source).toContain('scrollStartedStreamingMessageThroughLifecycle();');
+        expect(source).not.toContain('scrollChatToBottom({ waitForFrame: true });');
+    });
+
+    test('guard-on streaming start resolves viewport intent through lifecycle scroll rules', () => {
+        const scrollStartedStreamingMessageThroughLifecycle = findFunctionDeclaration('scrollStartedStreamingMessageThroughLifecycle');
+        const source = getSource(scrollStartedStreamingMessageThroughLifecycle);
+
+        expect(source).toContain('if (!isChatRenderLifecycleRolloutEnabled())');
+        expect(source).toContain('scrollChatToBottom({ waitForFrame: true });');
+        expect(source).toContain('resolveChatScrollAction({');
+        expect(source).toContain('intent: CHAT_SCROLL_INTENT.STREAM_PROGRESS');
+        expect(source).toContain('autoScrollEnabled: power_user.auto_scroll_chat_to_bottom');
+        expect(source).toContain('isNearBottom: isChatScrolledNearBottom()');
+        expect(source).toContain('isManualScrollSuppressed: shouldSuppressMobileChatAutoScroll()');
+        expect(source).toContain('shouldApplyChatBottomScrollAction(action)');
+        expect(source).toContain('scrollChatElementToBottom();');
+    });
 });

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -291,4 +291,30 @@ describe('chat render lifecycle script wiring', () => {
         expect(lifecycleSource).toContain('queue.queue(messageId, message, { rerenderMessage });');
         expect(lifecycleSource).toContain('queue.flush();');
     });
+
+    test('mobile-deferred message updates use the lifecycle update queue without changing scheduling policy', () => {
+        expect(scriptSource).not.toContain('pendingMobileMessageUpdates = new Map');
+        expect(scriptSource).not.toContain('pendingMobileMessageUpdates.set');
+
+        const getMobileMessageUpdateQueue = findFunctionDeclaration('getMobileMessageUpdateQueue');
+        const getMobileQueueSource = getSource(getMobileMessageUpdateQueue);
+
+        expect(getMobileQueueSource).toContain('createMessageUpdateQueue({');
+        expect(getMobileQueueSource).toContain('applyUpdate: applyMessageBlockUpdate');
+
+        const flushPendingMobileMessageUpdates = findFunctionDeclaration('flushPendingMobileMessageUpdates');
+        const flushSource = getSource(flushPendingMobileMessageUpdates);
+
+        expect(flushSource).toContain('pendingMobileMessageUpdateFrame = 0;');
+        expect(flushSource).toContain('pendingMobileMessageUpdateTimer = 0;');
+        expect(flushSource).toContain('getMobileMessageUpdateQueue().flush();');
+
+        const queueMobileMessageBlockUpdate = findFunctionDeclaration('queueMobileMessageBlockUpdate');
+        const queueSource = getSource(queueMobileMessageBlockUpdate);
+
+        expect(queueSource).toContain('getMobileMessageUpdateQueue().queue(messageId, message, { rerenderMessage });');
+        expect(queueSource).toContain('if (pendingMobileMessageUpdateFrame || pendingMobileMessageUpdateTimer)');
+        expect(queueSource).toContain('pendingMobileMessageUpdateTimer = window.setTimeout(() =>');
+        expect(queueSource).toContain('pendingMobileMessageUpdateFrame = requestAnimationFrame(flushPendingMobileMessageUpdates);');
+    });
 });

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -344,4 +344,47 @@ describe('chat render lifecycle script wiring', () => {
         expect(source).toContain('shouldApplyChatBottomScrollAction(action)');
         expect(source).toContain('scrollChatElementToBottom();');
     });
+
+    test('streaming progress keeps visible DOM write routing behind the lifecycle rollout guard', () => {
+        const onProgressStreaming = findNode(scriptAst, node => node.type === 'MethodDefinition'
+            && node.key?.name === 'onProgressStreaming');
+        const source = getSource(onProgressStreaming.value);
+
+        expect(source).toContain('await this.#checkDomElements(messageId);');
+        expect(source).toContain('await updateMessageTokenAccounting(chat[messageId],');
+        expect(source).toContain('shouldUpdateMetaBadges: !shouldReduceIntermediateStreamingWork');
+        expect(source).toContain('this.setFirstSwipe(messageId);');
+        expect(source).toContain('this.#queueStreamingVisibleWrite({');
+        expect(source).toContain('formattedText,');
+        expect(source).toContain('timePassed,');
+        expect(source).toContain('currentTokenCount,');
+        expect(source).toContain('isFinal,');
+    });
+
+    test('guard-on streaming progress delegates visible DOM writes to the lifecycle stream buffer', () => {
+        expect(scriptSource).toContain('createStreamWriteBuffer,');
+
+        const getStreamingVisibleWriteBuffer = findFunctionDeclaration('getStreamingVisibleWriteBuffer');
+        const getBufferSource = getSource(getStreamingVisibleWriteBuffer);
+
+        expect(getBufferSource).toContain('createStreamWriteBuffer({');
+        expect(getBufferSource).toContain('applyWrite: applyStreamingVisibleWrite');
+
+        const applyStreamingVisibleWrite = findFunctionDeclaration('applyStreamingVisibleWrite');
+        const applySource = getSource(applyStreamingVisibleWrite);
+
+        expect(applySource).toContain('applyStreamFadeIn(messageTextDom, formattedText,');
+        expect(applySource).toContain('messageTextDom.innerHTML = formattedText;');
+        expect(applySource).toContain('messageTokenCounterDom.textContent = `${currentTokenCount}t`;');
+        expect(applySource).toContain('messageTimerDom.textContent = timePassed.timerValue;');
+        expect(applySource).toContain('messageTimerDom.title = timePassed.timerTitle;');
+
+        const queueStreamingVisibleWrite = findNode(scriptAst, node => node.type === 'MethodDefinition'
+            && node.key?.name === 'queueStreamingVisibleWrite');
+        const queueSource = getSource(queueStreamingVisibleWrite.value);
+
+        expect(queueSource).toContain('if (!isChatRenderLifecycleRolloutEnabled())');
+        expect(queueSource).toContain('applyStreamingVisibleWrite(messageId, write, { isFinal });');
+        expect(queueSource).toContain('getStreamingVisibleWriteBuffer().queue(messageId, write, { isFinal });');
+    });
 });

--- a/tests/chat-render-lifecycle-stream-buffer.test.js
+++ b/tests/chat-render-lifecycle-stream-buffer.test.js
@@ -1,0 +1,146 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { createStreamWriteBuffer } from '../public/scripts/chat-render-lifecycle/stream-buffer.js';
+
+function createFakeScheduler() {
+    let scheduledCallback = null;
+
+    return {
+        get hasScheduledCallback() {
+            return typeof scheduledCallback === 'function';
+        },
+        requestCount: 0,
+        cancelCount: 0,
+        request(callback) {
+            this.requestCount++;
+            scheduledCallback = callback;
+        },
+        cancel() {
+            this.cancelCount++;
+            scheduledCallback = null;
+        },
+        run() {
+            const callback = scheduledCallback;
+            scheduledCallback = null;
+            callback?.();
+        },
+    };
+}
+
+describe('chat render lifecycle stream buffer helper', () => {
+    test('coalesces visible stream writes into one scheduled frame lane', () => {
+        const scheduler = createFakeScheduler();
+        const applied = [];
+        const buffer = createStreamWriteBuffer({
+            scheduler,
+            applyWrite: (messageId, write, options) => applied.push({ messageId, write, options }),
+        });
+
+        expect(buffer.queue(1, { text: 'first' }, { isFinal: false })).toBe(1);
+        expect(buffer.queue(1, { text: 'latest' }, { isFinal: false })).toBe(1);
+
+        expect(scheduler.requestCount).toBe(1);
+        expect(buffer.size()).toBe(1);
+        expect(applied).toEqual([]);
+
+        scheduler.run();
+
+        expect(buffer.size()).toBe(0);
+        expect(applied).toEqual([
+            { messageId: 1, write: { text: 'latest' }, options: { isFinal: false } },
+        ]);
+    });
+
+    test('keeps distinct message writes in insertion order', () => {
+        const scheduler = createFakeScheduler();
+        const applied = [];
+        const buffer = createStreamWriteBuffer({
+            scheduler,
+            applyWrite: (messageId, write, options) => applied.push({ messageId, write, options }),
+        });
+
+        buffer.queue(2, { text: 'second' }, { isFinal: false });
+        buffer.queue(3, { text: 'third' }, { isFinal: false });
+        scheduler.run();
+
+        expect(applied).toEqual([
+            { messageId: 2, write: { text: 'second' }, options: { isFinal: false } },
+            { messageId: 3, write: { text: 'third' }, options: { isFinal: false } },
+        ]);
+    });
+
+    test('final writes flush immediately and cancel a pending scheduled frame', () => {
+        const scheduler = createFakeScheduler();
+        const applied = [];
+        const buffer = createStreamWriteBuffer({
+            scheduler,
+            applyWrite: (messageId, write, options) => applied.push({ messageId, write, options }),
+        });
+
+        buffer.queue(4, { text: 'draft' }, { isFinal: false });
+
+        expect(scheduler.hasScheduledCallback).toBe(true);
+        expect(buffer.queue(4, { text: 'final' }, { isFinal: true })).toBe(0);
+
+        expect(scheduler.cancelCount).toBe(1);
+        expect(scheduler.hasScheduledCallback).toBe(false);
+        expect(applied).toEqual([
+            { messageId: 4, write: { text: 'final' }, options: { isFinal: true } },
+        ]);
+    });
+
+    test('clears before applying so nested writes survive for the next flush', () => {
+        const scheduler = createFakeScheduler();
+        const applied = [];
+        const buffer = createStreamWriteBuffer({
+            scheduler,
+            applyWrite: (messageId, write, options) => {
+                applied.push({ messageId, write, options });
+
+                if (messageId === 5) {
+                    buffer.queue(6, { text: 'nested' }, { isFinal: false });
+                }
+            },
+        });
+
+        buffer.queue(5, { text: 'outer' }, { isFinal: true });
+
+        expect(buffer.size()).toBe(1);
+        expect(applied).toEqual([
+            { messageId: 5, write: { text: 'outer' }, options: { isFinal: true } },
+        ]);
+
+        scheduler.run();
+
+        expect(applied).toEqual([
+            { messageId: 5, write: { text: 'outer' }, options: { isFinal: true } },
+            { messageId: 6, write: { text: 'nested' }, options: { isFinal: false } },
+        ]);
+    });
+
+    test('clear drops pending writes and cancels the scheduled frame', () => {
+        const scheduler = createFakeScheduler();
+        const applied = [];
+        const buffer = createStreamWriteBuffer({
+            scheduler,
+            applyWrite: (messageId, write, options) => applied.push({ messageId, write, options }),
+        });
+
+        buffer.queue(7, { text: 'drop' }, { isFinal: false });
+        buffer.clear();
+        scheduler.run();
+
+        expect(buffer.size()).toBe(0);
+        expect(scheduler.cancelCount).toBe(1);
+        expect(applied).toEqual([]);
+    });
+
+    test('fails fast for invalid boundary options', () => {
+        expect(() => createStreamWriteBuffer()).toThrow('applyWrite');
+        expect(() => createStreamWriteBuffer({ applyWrite: null })).toThrow('applyWrite');
+        expect(() => createStreamWriteBuffer({
+            applyWrite: () => {},
+            scheduler: null,
+        })).toThrow('scheduler');
+    });
+});

--- a/tests/chat-render-lifecycle-update-queue.test.js
+++ b/tests/chat-render-lifecycle-update-queue.test.js
@@ -1,0 +1,95 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { createMessageUpdateQueue } from '../public/scripts/chat-render-lifecycle/update-queue.js';
+
+describe('chat render lifecycle update queue helper', () => {
+    test('queues and flushes message updates through the injected apply function in order', () => {
+        const applied = [];
+        const queue = createMessageUpdateQueue({
+            applyUpdate: (messageId, message, options) => applied.push({ messageId, message, options }),
+        });
+
+        expect(queue.queue(3, { mes: 'first' }, { rerenderMessage: true })).toBe(1);
+        expect(queue.queue(4, { mes: 'second' }, { rerenderMessage: false })).toBe(2);
+
+        expect(queue.size()).toBe(2);
+        expect(queue.flush()).toBe(2);
+        expect(queue.size()).toBe(0);
+        expect(applied).toEqual([
+            { messageId: 3, message: { mes: 'first' }, options: { rerenderMessage: true } },
+            { messageId: 4, message: { mes: 'second' }, options: { rerenderMessage: false } },
+        ]);
+    });
+
+    test('coalesces duplicate message ids with the latest message and any rerender request', () => {
+        const applied = [];
+        const queue = createMessageUpdateQueue({
+            applyUpdate: (messageId, message, options) => applied.push({ messageId, message, options }),
+        });
+
+        queue.queue(5, { mes: 'old' }, { rerenderMessage: true });
+        queue.queue(5, { mes: 'new' }, { rerenderMessage: false });
+
+        expect(queue.size()).toBe(1);
+        expect(queue.flush()).toBe(1);
+        expect(applied).toEqual([
+            { messageId: 5, message: { mes: 'new' }, options: { rerenderMessage: true } },
+        ]);
+    });
+
+    test('defaults rerenderMessage to true when callers omit options', () => {
+        const applied = [];
+        const queue = createMessageUpdateQueue({
+            applyUpdate: (messageId, message, options) => applied.push({ messageId, message, options }),
+        });
+
+        queue.queue(6, { mes: 'default' });
+        queue.flush();
+
+        expect(applied).toEqual([
+            { messageId: 6, message: { mes: 'default' }, options: { rerenderMessage: true } },
+        ]);
+    });
+
+    test('clears pending updates before applying so nested queue work survives for the next flush', () => {
+        const applied = [];
+        const queue = createMessageUpdateQueue({
+            applyUpdate: (messageId, message, options) => {
+                applied.push({ messageId, message, options });
+
+                if (messageId === 1) {
+                    queue.queue(2, { mes: 'nested' }, { rerenderMessage: false });
+                }
+            },
+        });
+
+        queue.queue(1, { mes: 'outer' }, { rerenderMessage: false });
+
+        expect(queue.flush()).toBe(1);
+        expect(queue.size()).toBe(1);
+        expect(queue.flush()).toBe(1);
+        expect(applied).toEqual([
+            { messageId: 1, message: { mes: 'outer' }, options: { rerenderMessage: false } },
+            { messageId: 2, message: { mes: 'nested' }, options: { rerenderMessage: false } },
+        ]);
+    });
+
+    test('clear drops pending updates without applying them', () => {
+        const applied = [];
+        const queue = createMessageUpdateQueue({
+            applyUpdate: (messageId, message, options) => applied.push({ messageId, message, options }),
+        });
+
+        queue.queue(1, { mes: 'drop' });
+        queue.clear();
+
+        expect(queue.size()).toBe(0);
+        expect(queue.flush()).toBe(0);
+        expect(applied).toEqual([]);
+    });
+
+    test('fails fast for invalid apply function', () => {
+        expect(() => createMessageUpdateQueue()).toThrow('applyUpdate');
+        expect(() => createMessageUpdateQueue({ applyUpdate: null })).toThrow('applyUpdate');
+    });
+});

--- a/tests/chat-scroll-regression-helpers.js
+++ b/tests/chat-scroll-regression-helpers.js
@@ -297,6 +297,34 @@ export async function getRenderedMessageIds(page) {
         .filter(Boolean));
 }
 
+export async function markFirstRenderedMessageEditing(page) {
+    const firstEditButton = page.locator('#chat .mes[mesid] .mes_edit').first();
+
+    await firstEditButton.waitFor({ state: 'visible', timeout: 5000 });
+    await firstEditButton.click();
+    await page.locator('#chat .mes[mesid] .mes_edit_buttons:visible').first().waitFor({ state: 'visible', timeout: 5000 });
+    await waitForAnimationFrames(page, 2);
+}
+
+export async function getRedisplayCompatibilitySnapshot(page) {
+    return page.evaluate(() => {
+        const chat = document.querySelector('#chat');
+        const messages = Array.from(chat.querySelectorAll('.mes[mesid]'));
+        const firstMessage = messages.at(0);
+        const lastMessage = messages.at(-1);
+
+        return {
+            renderedMessageIds: messages.map(message => message.getAttribute('mesid')),
+            lastMessageId: lastMessage?.getAttribute('mesid') ?? null,
+            lastMessageClassCount: chat.querySelectorAll('.mes.last_mes').length,
+            fadeClassCount: chat.querySelectorAll('.mes.fade').length,
+            stylePinsCount: chat.querySelectorAll(':scope > .style-pins').length,
+            firstEditUpDisabled: firstMessage?.querySelector('.mes_edit_up')?.classList.contains('disabled') ?? false,
+            firstEditDownDisabled: firstMessage?.querySelector('.mes_edit_down')?.classList.contains('disabled') ?? false,
+        };
+    });
+}
+
 export async function scrollMessageNearTop(page, messageId, offsetTop = 24) {
     await page.waitForFunction((targetMessageId) => {
         return document.querySelector(`#chat .mes[mesid="${targetMessageId}"]`) !== null;

--- a/tests/chat-scroll-regressions.e2e.js
+++ b/tests/chat-scroll-regressions.e2e.js
@@ -2,9 +2,11 @@
 import { expect, test } from '@playwright/test';
 import {
     getChatScrollSnapshot,
+    getRedisplayCompatibilitySnapshot,
     getRenderedMessageIds,
     installSwipeCandidate,
     installSyntheticLongChat,
+    markFirstRenderedMessageEditing,
     markManualMobileScroll,
     openReadyChat,
     scrollMessageNearTop,
@@ -26,6 +28,22 @@ test.describe('issue 167 chat scroll regressions', () => {
         expect(snapshot.lastMesId).toBe('95');
         expect(snapshot.lastVisibleMesId).toBe('95');
         expect(snapshot.bottomDelta).toBeLessThanOrEqual(16);
+    });
+
+    test('redisplay keeps render follow-up hooks applied after batched render', async ({ page }) => {
+        await installSyntheticLongChat(page, { messageCount: 36, visibleCount: 12 });
+        await markFirstRenderedMessageEditing(page);
+        await page.evaluate(async () => window.SillyTavern.getContext().redisplayChat({ startIndex: 24, fade: false }));
+
+        const snapshot = await getRedisplayCompatibilitySnapshot(page);
+
+        expect(snapshot.renderedMessageIds).toEqual(Array.from({ length: 12 }, (_, index) => String(24 + index)));
+        expect(snapshot.lastMessageId).toBe('35');
+        expect(snapshot.lastMessageClassCount).toBe(1);
+        expect(snapshot.fadeClassCount).toBe(0);
+        expect(snapshot.stylePinsCount).toBe(0);
+        expect(snapshot.firstEditUpDisabled).toBe(true);
+        expect(snapshot.firstEditDownDisabled).toBe(false);
     });
 
     test('show more preserves the first visible message anchor', async ({ page }) => {


### PR DESCRIPTION
## What?
Adds unit coverage for chat render lifecycle anchor restoration across top, middle, and tail message replacement positions.

## Why?
The next lifecycle route treats swipe display changes as message replacement rather than append. The anchor helper needs explicit coverage that replacement geometry preserves viewport-relative position no matter where the replaced message sits in the visible set.

## How?
Adds a focused anchor-helper test that captures the first visible message, mutates replacement geometry for top, middle, and tail cases, then verifies the resulting scroll adjustment.

## Testing?
- `npm run test:unit --prefix tests -- script-export-surface.test.js chat-render-lifecycle-index.test.js chat-render-lifecycle-render-batch.test.js chat-render-lifecycle-rollout-guard.test.js chat-render-lifecycle-script-wiring.test.js chat-render-lifecycle-bottom-scroll.test.js chat-render-lifecycle-scroll-intent.test.js chat-render-lifecycle-anchor.test.js chat-render-lifecycle-scheduler.test.js chat-scroll-edges.test.js mobile-streaming.test.js chat-render-lifecycle-update-queue.test.js chat-render-lifecycle-stream-buffer.test.js`
- `npm run lint`
- `npm run check:frontend-budgets`
- `graphify update . --force`

## Screenshots (optional)
Not applicable; this is unit coverage only.

## Anything Else?
Stacked on `refactor/chat-lifecycle-stream-progress-route`.
