### PR TITLE
Fix Guided Generations GGSystemPrompt cleanup

### DIFF
--- a/public/scripts/extensions/guided-generations/index.js
+++ b/public/scripts/extensions/guided-generations/index.js
@@ -13,6 +13,7 @@ import { simpleSend } from './scripts/simpleSend.js';
 
 const oldExtensionKey = 'GuidedGenerations-Extension';
 const oldExtensionName = 'third-party/GuidedGenerations-Extension';
+const legacySystemPromptPresetNames = new Set(['GGSystemPrompt', 'GGSytemPrompt']);
 
 const defaultSettings = {
     showGuidedResponse: true,
@@ -38,6 +39,34 @@ const defaultSettings = {
 let qrObserver;
 let qrPollTimer;
 
+function isLegacySystemPromptPreset(value) {
+    return typeof value === 'string' && legacySystemPromptPresetNames.has(value.trim());
+}
+
+function sanitizeLegacySettings(settings) {
+    let changed = false;
+
+    for (const key of Object.keys(settings)) {
+        if (key.startsWith('preset') && isLegacySystemPromptPreset(settings[key])) {
+            if (Object.hasOwn(defaultSettings, key)) {
+                settings[key] = defaultSettings[key];
+            } else {
+                delete settings[key];
+            }
+            changed = true;
+        }
+    }
+
+    for (const key of ['promptGuidedResponse', 'promptGuidedSwipe', 'promptGuidedCorrection', 'promptImpersonate1st']) {
+        if (isLegacySystemPromptPreset(settings[key])) {
+            settings[key] = defaultSettings[key];
+            changed = true;
+        }
+    }
+
+    return changed;
+}
+
 function getSettings() {
     return extension_settings[extensionName] ?? defaultSettings;
 }
@@ -45,6 +74,7 @@ function getSettings() {
 function loadSettings() {
     const existing = extension_settings[extensionName] ?? {};
     const settings = Object.assign({}, defaultSettings, existing);
+    let changed = false;
 
     if (extension_settings[oldExtensionKey] && !settings._migrated) {
         const old = extension_settings[oldExtensionKey];
@@ -55,10 +85,20 @@ function loadSettings() {
         }
 
         settings._migrated = true;
+        changed = true;
     }
 
-    delete settings.showRecoverInputButton;
+    if (Object.hasOwn(settings, 'showRecoverInputButton')) {
+        delete settings.showRecoverInputButton;
+        changed = true;
+    }
+
+    changed = sanitizeLegacySettings(settings) || changed;
     extension_settings[extensionName] = settings;
+
+    if (changed) {
+        saveSettingsDebounced();
+    }
 }
 
 function maybeWarnOldExtensionDeprecated() {

--- a/public/scripts/extensions/guided-generations/scripts/guidedResponse.js
+++ b/public/scripts/extensions/guided-generations/scripts/guidedResponse.js
@@ -76,6 +76,12 @@ async function guidedResponse() {
     } finally {
         textarea.value = getPreviousImpersonateInput();
         textarea.dispatchEvent(new Event('input', { bubbles: true }));
+
+        try {
+            await getContext().executeSlashCommandsWithOptions('/flushinject instruct');
+        } catch (error) {
+            console.warn('[GuidedGenerations][Response] Could not flush guided response injection:', error);
+        }
     }
 }
 

--- a/tests/guided-generations-settings.test.js
+++ b/tests/guided-generations-settings.test.js
@@ -1,0 +1,104 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+
+describe('Guided Generations settings migration', () => {
+    let extensionSettings;
+    let saveSettingsDebounced;
+
+    beforeEach(async () => {
+        jest.resetModules();
+
+        extensionSettings = {};
+        saveSettingsDebounced = jest.fn();
+
+        await jest.unstable_mockModule('../public/script.js', () => ({
+            saveSettingsDebounced,
+        }));
+        await jest.unstable_mockModule('../public/scripts/extensions.js', () => ({
+            extensionNames: [],
+            extension_settings: extensionSettings,
+            renderExtensionTemplateAsync: jest.fn(async () => ''),
+        }));
+        await jest.unstable_mockModule('../public/scripts/extensions/guided-generations/scripts/shared.js', () => ({
+            extensionName: 'guided-generations',
+            getPresetsForApiType: jest.fn(async () => []),
+            getProfileApiType: jest.fn(async () => ''),
+            getProfileList: jest.fn(async () => []),
+        }));
+        await jest.unstable_mockModule('../public/scripts/extensions/guided-generations/scripts/guidedCorrection.js', () => ({
+            guidedCorrection: jest.fn(),
+        }));
+        await jest.unstable_mockModule('../public/scripts/extensions/guided-generations/scripts/guidedImpersonate.js', () => ({
+            guidedImpersonate: jest.fn(),
+        }));
+        await jest.unstable_mockModule('../public/scripts/extensions/guided-generations/scripts/guidedResponse.js', () => ({
+            guidedResponse: jest.fn(),
+        }));
+        await jest.unstable_mockModule('../public/scripts/extensions/guided-generations/scripts/guidedSwipe.js', () => ({
+            guidedSwipe: jest.fn(),
+        }));
+        await jest.unstable_mockModule('../public/scripts/extensions/guided-generations/scripts/legacyForkWarning.js', () => ({
+            markOldExtensionWarningDismissed: jest.fn(),
+            shouldWarnOldExtensionDeprecated: jest.fn(() => false),
+        }));
+        await jest.unstable_mockModule('../public/scripts/extensions/guided-generations/scripts/simpleSend.js', () => ({
+            simpleSend: jest.fn(),
+        }));
+    });
+
+    test('removes legacy GGSystemPrompt values migrated into native settings', async () => {
+        extensionSettings['GuidedGenerations-Extension'] = {
+            promptGuidedResponse: 'GGSystemPrompt',
+            promptGuidedSwipe: 'GGSytemPrompt',
+            promptGuidedCorrection: 'custom correction: {{input}}',
+            promptImpersonate1st: 'GGSytemPrompt',
+            presetImpersonate1st: 'GGSytemPrompt',
+        };
+
+        const { defaultSettings, loadSettings } = await import('../public/scripts/extensions/guided-generations/index.js');
+
+        loadSettings();
+
+        expect(extensionSettings['guided-generations']).toMatchObject({
+            _migrated: true,
+            promptGuidedResponse: defaultSettings.promptGuidedResponse,
+            promptGuidedSwipe: defaultSettings.promptGuidedSwipe,
+            promptGuidedCorrection: 'custom correction: {{input}}',
+            promptImpersonate1st: defaultSettings.promptImpersonate1st,
+            presetImpersonate1st: '',
+        });
+        expect(saveSettingsDebounced).toHaveBeenCalledTimes(1);
+    });
+
+    test('cleans stale legacy preset references after the migration marker already exists', async () => {
+        extensionSettings['guided-generations'] = {
+            _migrated: true,
+            promptGuidedResponse: 'keep this custom prompt: {{input}}',
+            presetImpersonate1st: 'GGSystemPrompt',
+            presetGuidedSwipe: 'GGSytemPrompt',
+        };
+
+        const { loadSettings } = await import('../public/scripts/extensions/guided-generations/index.js');
+
+        loadSettings();
+
+        expect(extensionSettings['guided-generations'].promptGuidedResponse).toBe('keep this custom prompt: {{input}}');
+        expect(extensionSettings['guided-generations'].presetImpersonate1st).toBe('');
+        expect(extensionSettings['guided-generations'].presetGuidedSwipe).toBeUndefined();
+        expect(saveSettingsDebounced).toHaveBeenCalledTimes(1);
+    });
+
+    test('keeps valid custom presets and prompts unchanged', async () => {
+        extensionSettings['guided-generations'] = {
+            promptGuidedResponse: 'use my custom guide: {{input}}',
+            presetImpersonate1st: 'My Custom Preset',
+        };
+
+        const { loadSettings } = await import('../public/scripts/extensions/guided-generations/index.js');
+
+        loadSettings();
+
+        expect(extensionSettings['guided-generations'].promptGuidedResponse).toBe('use my custom guide: {{input}}');
+        expect(extensionSettings['guided-generations'].presetImpersonate1st).toBe('My Custom Preset');
+        expect(saveSettingsDebounced).not.toHaveBeenCalled();
+    });
+});

--- a/tests/guided-generations-steering.test.js
+++ b/tests/guided-generations-steering.test.js
@@ -109,17 +109,31 @@ describe('Guided Generations steering commands', () => {
         }));
     });
 
-    test('guided response injects guidance before triggering generation', async () => {
+    test('guided response injects guidance only for the awaited generation', async () => {
         const { guidedResponse } = await import('../public/scripts/extensions/guided-generations/scripts/guidedResponse.js');
 
         await guidedResponse();
 
-        expect(context.executeSlashCommandsWithOptions).toHaveBeenCalledTimes(1);
+        expect(context.executeSlashCommandsWithOptions).toHaveBeenCalledTimes(2);
         const command = context.executeSlashCommandsWithOptions.mock.calls[0][0];
         expect(command).toContain('/inject id=instruct position=chat ephemeral=true scan=true depth=2 role=assistant GUIDE: aim for a colder, suspicious reply|');
         expect(command).toContain('/trigger await=true|');
+        expect(context.executeSlashCommandsWithOptions).toHaveBeenLastCalledWith('/flushinject instruct');
+        expect(context.chatMetadata.script_injects.instruct).toBeUndefined();
         expect(textarea.value).toBe('aim for a colder, suspicious reply');
         expect(textarea.dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'input' }));
+    });
+
+    test('guided response clears legacy GGSystemPrompt guidance after use', async () => {
+        extensionSettings['guided-generations'].promptGuidedResponse = 'GGSystemPrompt {{input}}';
+        const { guidedResponse } = await import('../public/scripts/extensions/guided-generations/scripts/guidedResponse.js');
+
+        await guidedResponse();
+
+        const command = context.executeSlashCommandsWithOptions.mock.calls[0][0];
+        expect(command).toContain('GGSystemPrompt aim for a colder, suspicious reply');
+        expect(context.executeSlashCommandsWithOptions).toHaveBeenLastCalledWith('/flushinject instruct');
+        expect(context.chatMetadata.script_injects.instruct).toBeUndefined();
     });
 
     test('guided swipe keeps guidance injected until the swipe generation starts', async () => {

--- a/tests/guided-generations-steering.test.js
+++ b/tests/guided-generations-steering.test.js
@@ -124,18 +124,6 @@ describe('Guided Generations steering commands', () => {
         expect(textarea.dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'input' }));
     });
 
-    test('guided response clears legacy GGSystemPrompt guidance after use', async () => {
-        extensionSettings['guided-generations'].promptGuidedResponse = 'GGSystemPrompt {{input}}';
-        const { guidedResponse } = await import('../public/scripts/extensions/guided-generations/scripts/guidedResponse.js');
-
-        await guidedResponse();
-
-        const command = context.executeSlashCommandsWithOptions.mock.calls[0][0];
-        expect(command).toContain('GGSystemPrompt aim for a colder, suspicious reply');
-        expect(context.executeSlashCommandsWithOptions).toHaveBeenLastCalledWith('/flushinject instruct');
-        expect(context.chatMetadata.script_injects.instruct).toBeUndefined();
-    });
-
     test('guided swipe keeps guidance injected until the swipe generation starts', async () => {
         const { guidedSwipe } = await import('../public/scripts/extensions/guided-generations/scripts/guidedSwipe.js');
 


### PR DESCRIPTION
## What?
Fixes Guided Generations so stale legacy `GGSystemPrompt` / `GGSytemPrompt` settings are removed when native settings load, and Guided Response clears its temporary `instruct` injection after use.

## Why?
The legacy Guided Generations fork used `GGSytemPrompt` as a preset/function-style setting. The native port does not use that preset, so migrated or already-migrated values could keep surfacing as unwanted guidance instead of behaving like a valid native setting.

## How?
`loadSettings()` now sanitizes exact legacy sentinel values from preset fields and the native prompt fields they could be migrated into. Known native fields fall back to their native defaults, unknown legacy preset fields are removed, and changed settings are persisted. Guided Response still flushes its temporary `instruct` injection in `finally` after the awaited generation.

## Testing?
- `node --experimental-vm-modules tests/node_modules/jest/bin/jest.js --config tests/jest.config.json guided-generations-settings.test.js guided-generations-steering.test.js --runInBand`
- `node --check public/scripts/extensions/guided-generations/index.js`
- `node --check tests/guided-generations-settings.test.js`
- `node --check tests/guided-generations-steering.test.js`

## Screenshots (optional)
Not applicable; this is settings migration and prompt-injection lifecycle behavior covered by unit tests.

## Anything Else?
Closes #23.