### PR TITLE
test: add chat render performance baseline

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -312,6 +312,7 @@ import {
     CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY,
     CHAT_SCROLL_INTENT,
     captureVisibleMessageAnchor,
+    createMessageUpdateQueue,
     renderMessagesInBatches,
     resolveChatBottomScrollAction,
     resolveChatRenderLifecycleRollout,
@@ -598,6 +599,7 @@ let pendingMobileMessageUpdateFrame = 0;
 let pendingMobileMessageUpdateTimer = 0;
 /** @type {Map<number, { message: object, rerenderMessage: boolean }>} */
 const pendingMobileMessageUpdates = new Map();
+let messageUpdateQueue = null;
 
 let dialogueResolve = null;
 let dialogueCloseStop = false;
@@ -1983,6 +1985,22 @@ async function settleVisibleChatMessageAnchor(anchor, frames = 8) {
     });
 }
 
+function getMessageUpdateQueue() {
+    if (!messageUpdateQueue) {
+        messageUpdateQueue = createMessageUpdateQueue({
+            applyUpdate: applyMessageBlockUpdate,
+        });
+    }
+
+    return messageUpdateQueue;
+}
+
+function updateMessageBlockThroughLifecycle(messageId, message, { rerenderMessage }) {
+    const queue = getMessageUpdateQueue();
+    queue.queue(messageId, message, { rerenderMessage });
+    queue.flush();
+}
+
 function flushPendingMobileMessageUpdates() {
     pendingMobileMessageUpdateFrame = 0;
     pendingMobileMessageUpdateTimer = 0;
@@ -2926,6 +2944,11 @@ function applyMessageBlockUpdate(messageId, message, { rerenderMessage = true } 
 export function updateMessageBlock(messageId, message, { rerenderMessage = true } = {}) {
     if (shouldDeferMobileMessageUpdates()) {
         queueMobileMessageBlockUpdate(messageId, message, { rerenderMessage });
+        return;
+    }
+
+    if (isChatRenderLifecycleRolloutEnabled()) {
+        updateMessageBlockThroughLifecycle(messageId, message, { rerenderMessage });
         return;
     }
 

--- a/public/script.js
+++ b/public/script.js
@@ -597,9 +597,8 @@ let entitySelectionPulseId = 0;
 let showMoreTouchMoved = false;
 let pendingMobileMessageUpdateFrame = 0;
 let pendingMobileMessageUpdateTimer = 0;
-/** @type {Map<number, { message: object, rerenderMessage: boolean }>} */
-const pendingMobileMessageUpdates = new Map();
 let messageUpdateQueue = null;
+let mobileMessageUpdateQueue = null;
 
 let dialogueResolve = null;
 let dialogueCloseStop = false;
@@ -1995,6 +1994,16 @@ function getMessageUpdateQueue() {
     return messageUpdateQueue;
 }
 
+function getMobileMessageUpdateQueue() {
+    if (!mobileMessageUpdateQueue) {
+        mobileMessageUpdateQueue = createMessageUpdateQueue({
+            applyUpdate: applyMessageBlockUpdate,
+        });
+    }
+
+    return mobileMessageUpdateQueue;
+}
+
 function updateMessageBlockThroughLifecycle(messageId, message, { rerenderMessage }) {
     const queue = getMessageUpdateQueue();
     queue.queue(messageId, message, { rerenderMessage });
@@ -2004,19 +2013,11 @@ function updateMessageBlockThroughLifecycle(messageId, message, { rerenderMessag
 function flushPendingMobileMessageUpdates() {
     pendingMobileMessageUpdateFrame = 0;
     pendingMobileMessageUpdateTimer = 0;
-    const updates = [...pendingMobileMessageUpdates.entries()];
-    pendingMobileMessageUpdates.clear();
-
-    for (const [messageId, { message, rerenderMessage }] of updates) {
-        applyMessageBlockUpdate(messageId, message, { rerenderMessage });
-    }
+    getMobileMessageUpdateQueue().flush();
 }
 
 function queueMobileMessageBlockUpdate(messageId, message, { rerenderMessage }) {
-    pendingMobileMessageUpdates.set(messageId, {
-        message,
-        rerenderMessage: pendingMobileMessageUpdates.get(messageId)?.rerenderMessage || rerenderMessage,
-    });
+    getMobileMessageUpdateQueue().queue(messageId, message, { rerenderMessage });
 
     if (pendingMobileMessageUpdateFrame || pendingMobileMessageUpdateTimer) {
         return;

--- a/public/script.js
+++ b/public/script.js
@@ -312,6 +312,7 @@ import {
     CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY,
     CHAT_SCROLL_INTENT,
     captureVisibleMessageAnchor,
+    renderMessagesInBatches,
     resolveChatBottomScrollAction,
     resolveChatRenderLifecycleRollout,
     resolveChatScrollAction,
@@ -2144,6 +2145,63 @@ function scrollLoadedChatToBottom() {
     }
 }
 
+async function renderRedisplayChatMessagesLegacy({ messages, startIndex, batchSize }) {
+    const renderedMessageIds = lodash.range(startIndex, startIndex + messages.length, 1);
+    const shouldYieldBetweenBatches = batchSize < messages.length;
+
+    for (let offset = 0; offset < messages.length; offset += batchSize) {
+        const batchMessages = messages.slice(offset, offset + batchSize);
+        const fragment = document.createDocumentFragment();
+        const newMessageElements = batchMessages.map((message, batchOffset) => {
+            const messageId = startIndex + offset + batchOffset;
+            const messageElement = updateMessageElement(message, { messageId });
+
+            return messageElement[0];
+        });
+
+        if (offset + batchSize >= messages.length) {
+            //The last_mes has been removed, add it to the new last message.
+            newMessageElements.at(-1).classList.add('last_mes');
+        }
+
+        //Append each batch in one DOM update.
+        for (const messageElement of newMessageElements) {
+            fragment.appendChild(messageElement);
+        }
+        chatElement[0].appendChild(fragment);
+
+        if (shouldYieldBetweenBatches && offset + batchSize < messages.length) {
+            await waitForNextFrame();
+        }
+    }
+
+    return renderedMessageIds;
+}
+
+async function renderRedisplayChatMessagesThroughLifecycle({ messages, startIndex, batchSize }) {
+    const { renderedMessageIds } = await renderMessagesInBatches({
+        messages,
+        firstMessageId: startIndex,
+        batchSize,
+        renderMessageElement: (message, messageId) => updateMessageElement(message, { messageId }),
+        insertFragment: fragment => chatElement[0].appendChild(fragment),
+        waitForNextFrame,
+        markLastMessage: true,
+    });
+
+    return renderedMessageIds;
+}
+
+async function renderRedisplayChatMessages({ messages, startIndex }) {
+    const batchSize = getMobileChatRenderBatchSize(messages.length);
+
+    if (isChatRenderLifecycleRolloutEnabled()) {
+        return renderRedisplayChatMessagesThroughLifecycle({ messages, startIndex, batchSize });
+    }
+
+    return renderRedisplayChatMessagesLegacy({ messages, startIndex, batchSize });
+}
+
 /**
  * Visually updates all chat messages including and after index by removing them, then adding them.
  * @param {object} [options] Options
@@ -2163,35 +2221,7 @@ export async function redisplayChat({ targetChat = chat, startIndex = 0, fade = 
     const messages = targetChat.slice(startIndex);
 
     if (messages.length > 0) {
-        const renderedMessageIds = lodash.range(startIndex, targetChat.length, 1);
-        const batchSize = getMobileChatRenderBatchSize(messages.length);
-        const shouldYieldBetweenBatches = batchSize < messages.length;
-
-        for (let offset = 0; offset < messages.length; offset += batchSize) {
-            const batchMessages = messages.slice(offset, offset + batchSize);
-            const fragment = document.createDocumentFragment();
-            const newMessageElements = batchMessages.map((message, batchOffset) => {
-                const i = startIndex + offset + batchOffset;
-                const messageElement = updateMessageElement(message, { messageId: i });
-
-                return messageElement[0];
-            });
-
-            if (offset + batchSize >= messages.length) {
-                //The last_mes has been removed, add it to the new last message.
-                newMessageElements.at(-1).classList.add('last_mes');
-            }
-
-            //Append each batch in one DOM update.
-            for (const messageElement of newMessageElements) {
-                fragment.appendChild(messageElement);
-            }
-            chatElement[0].appendChild(fragment);
-
-            if (shouldYieldBetweenBatches && offset + batchSize < messages.length) {
-                await waitForNextFrame();
-            }
-        }
+        const renderedMessageIds = await renderRedisplayChatMessages({ messages, startIndex });
 
         applyCharacterTagsToMessageDivs({ mesIds: renderedMessageIds });
     }

--- a/public/script.js
+++ b/public/script.js
@@ -313,6 +313,7 @@ import {
     CHAT_SCROLL_INTENT,
     captureVisibleMessageAnchor,
     createMessageUpdateQueue,
+    createStreamWriteBuffer,
     renderMessagesInBatches,
     resolveChatBottomScrollAction,
     resolveChatRenderLifecycleRollout,
@@ -599,6 +600,7 @@ let pendingMobileMessageUpdateFrame = 0;
 let pendingMobileMessageUpdateTimer = 0;
 let messageUpdateQueue = null;
 let mobileMessageUpdateQueue = null;
+let streamingVisibleWriteBuffer = null;
 
 let dialogueResolve = null;
 let dialogueCloseStop = false;
@@ -2002,6 +2004,54 @@ function getMobileMessageUpdateQueue() {
     }
 
     return mobileMessageUpdateQueue;
+}
+
+function applyStreamingVisibleWrite(messageId, {
+    messageTextDom,
+    messageTimerDom,
+    messageTokenCounterDom,
+    messageDom,
+    message,
+    formattedText,
+    timePassed,
+    currentTokenCount,
+    shouldRefreshTokenCount,
+    shouldUpdateMetaBadges,
+    shouldUseStreamFadeIn,
+    bypassFadeIn,
+}, { isFinal = false } = {}) {
+    if (shouldRefreshTokenCount && messageTokenCounterDom instanceof HTMLElement) {
+        messageTokenCounterDom.textContent = `${currentTokenCount}t`;
+    }
+
+    if (shouldUpdateMetaBadges) {
+        updateMessageMetaBadges(messageDom, message);
+    }
+
+    if (messageTextDom instanceof HTMLElement) {
+        if (shouldUseStreamFadeIn) {
+            applyStreamFadeIn(messageTextDom, formattedText, { bypassFadeIn });
+        } else {
+            messageTextDom.innerHTML = formattedText;
+        }
+    }
+
+    if (messageTimerDom instanceof HTMLElement) {
+        messageTimerDom.textContent = timePassed.timerValue;
+        messageTimerDom.title = timePassed.timerTitle;
+    }
+
+    return isFinal;
+}
+
+function getStreamingVisibleWriteBuffer() {
+    if (!streamingVisibleWriteBuffer) {
+        streamingVisibleWriteBuffer = createStreamWriteBuffer({
+            applyWrite: applyStreamingVisibleWrite,
+        });
+    }
+
+    return streamingVisibleWriteBuffer;
 }
 
 function updateMessageBlockThroughLifecycle(messageId, message, { rerenderMessage }) {
@@ -4779,6 +4829,15 @@ class StreamingProcessor {
         }
     }
 
+    #queueStreamingVisibleWrite({ messageId, write, isFinal }) {
+        if (!isChatRenderLifecycleRolloutEnabled()) {
+            applyStreamingVisibleWrite(messageId, write, { isFinal });
+            return;
+        }
+
+        getStreamingVisibleWriteBuffer().queue(messageId, write, { isFinal });
+    }
+
     markUIGenStarted() {
         deactivateSendButtons();
     }
@@ -4883,16 +4942,6 @@ class StreamingProcessor {
                 });
                 currentTokenCount = outputTokens;
             }
-            if (shouldRefreshTokenCount) {
-                if (this.messageTokenCounterDom instanceof HTMLElement) {
-                    this.messageTokenCounterDom.textContent = `${currentTokenCount}t`;
-                }
-            }
-
-            if (!shouldReduceIntermediateStreamingWork) {
-                updateMessageMetaBadges(this.messageDom, chat[messageId]);
-            }
-
             if ((this.type == 'swipe' || this.type === 'continue') && Array.isArray(chat[messageId].swipes)) {
                 chat[messageId].swipes[chat[messageId].swipe_id] = processedText;
                 if (!shouldReduceIntermediateStreamingWork) {
@@ -4914,21 +4963,25 @@ class StreamingProcessor {
                 {},
                 false,
             );
-            if (this.messageTextDom instanceof HTMLElement) {
-                if (power_user.stream_fade_in) {
-                    applyStreamFadeIn(this.messageTextDom, formattedText, {
-                        bypassFadeIn: isIOSWebKit && power_user.ios_webkit_disable_stream_fade_in,
-                    });
-                } else {
-                    this.messageTextDom.innerHTML = formattedText;
-                }
-            }
-
             const timePassed = formatGenerationTimer(this.timeStarted, currentTime, currentTokenCount, this.reasoningHandler.getDuration(), this.timeToFirstToken);
-            if (this.messageTimerDom instanceof HTMLElement) {
-                this.messageTimerDom.textContent = timePassed.timerValue;
-                this.messageTimerDom.title = timePassed.timerTitle;
-            }
+            this.#queueStreamingVisibleWrite({
+                messageId,
+                write: {
+                    messageTextDom: this.messageTextDom,
+                    messageTimerDom: this.messageTimerDom,
+                    messageTokenCounterDom: this.messageTokenCounterDom,
+                    messageDom: this.messageDom,
+                    message: chat[messageId],
+                    formattedText,
+                    timePassed,
+                    currentTokenCount,
+                    shouldRefreshTokenCount,
+                    shouldUpdateMetaBadges: !shouldReduceIntermediateStreamingWork,
+                    shouldUseStreamFadeIn: power_user.stream_fade_in,
+                    bypassFadeIn: isIOSWebKit && power_user.ios_webkit_disable_stream_fade_in,
+                },
+                isFinal,
+            });
 
             if (!shouldReduceIntermediateStreamingWork) {
                 this.setFirstSwipe(messageId);

--- a/public/script.js
+++ b/public/script.js
@@ -313,6 +313,7 @@ import {
     CHAT_SCROLL_ACTION,
     CHAT_SCROLL_INTENT,
     captureVisibleMessageAnchor,
+    createDelegatedResizeObserver,
     createMessageUpdateQueue,
     createStreamWriteBuffer,
     renderMessagesInBatches,
@@ -602,6 +603,8 @@ let pendingMobileMessageUpdateTimer = 0;
 let messageUpdateQueue = null;
 let mobileMessageUpdateQueue = null;
 let streamingVisibleWriteBuffer = null;
+let chatMessageResizeObserver = null;
+const chatMessageResizeStates = new Map();
 
 let dialogueResolve = null;
 let dialogueCloseStop = false;
@@ -2055,6 +2058,169 @@ function getStreamingVisibleWriteBuffer() {
     return streamingVisibleWriteBuffer;
 }
 
+function getObservedElementHeight(element, entry = null) {
+    return Number(entry?.contentRect?.height ?? element?.getBoundingClientRect?.().height ?? 0);
+}
+
+function captureChatMessageResizeViewportState() {
+    return {
+        anchor: captureVisibleChatMessageAnchor(),
+        isNearBottom: isChatScrolledNearBottom(),
+    };
+}
+
+function captureChatMessageResizeState(element, entry = null) {
+    return {
+        ...captureChatMessageResizeViewportState(),
+        blockHeight: getObservedElementHeight(element, entry),
+    };
+}
+
+function refreshChatMessageResizeState(element, metadata, entry = null) {
+    if (!metadata) {
+        return;
+    }
+
+    Object.assign(metadata, captureChatMessageResizeState(element, entry));
+}
+
+function refreshObservedChatMessageResizeViewportStates() {
+    if (chatMessageResizeStates.size === 0) {
+        return;
+    }
+
+    const viewportState = captureChatMessageResizeViewportState();
+
+    for (const [element, metadata] of chatMessageResizeStates) {
+        if (!element.isConnected) {
+            unobserveChatMessageResizeBlock(element);
+            continue;
+        }
+
+        Object.assign(metadata, viewportState);
+    }
+}
+
+async function applyChatMessageResizeAction(element, entry, metadata) {
+    if (!isChatRenderLifecycleRolloutEnabled()) {
+        return;
+    }
+
+    const nextHeight = getObservedElementHeight(element, entry);
+    const resizeState = metadata ?? captureChatMessageResizeState(element, entry);
+    const previousHeight = Number(resizeState.blockHeight ?? nextHeight);
+
+    if (Math.abs(nextHeight - previousHeight) < 1) {
+        refreshChatMessageResizeState(element, metadata, entry);
+        return;
+    }
+
+    const action = resolveChatScrollAction({
+        intent: CHAT_SCROLL_INTENT.MEDIA_RESIZE,
+        autoScrollEnabled: power_user.auto_scroll_chat_to_bottom,
+        isNearBottom: Boolean(resizeState.isNearBottom),
+        hasAnchor: Boolean(resizeState.anchor),
+        isManualScrollSuppressed: shouldSuppressMobileChatAutoScroll(),
+    });
+
+    if (shouldApplyChatBottomScrollAction(action)) {
+        requestAnimationFrame(() => {
+            scrollChatElementToBottom();
+            refreshChatMessageResizeState(element, metadata, entry);
+        });
+        return;
+    }
+
+    if (action.action === CHAT_SCROLL_ACTION.PRESERVE_ANCHOR) {
+        await settleVisibleChatMessageAnchor(resizeState.anchor);
+    }
+
+    refreshChatMessageResizeState(element, metadata, entry);
+}
+
+function onChatMessageResize(element, entry, metadata) {
+    if (!element?.isConnected) {
+        unobserveChatMessageResizeBlock(element);
+        return;
+    }
+
+    void applyChatMessageResizeAction(element, entry, metadata);
+}
+
+function getChatMessageResizeObserver() {
+    if (!chatMessageResizeObserver) {
+        chatMessageResizeObserver = createDelegatedResizeObserver({
+            onResize: onChatMessageResize,
+        });
+    }
+
+    return chatMessageResizeObserver;
+}
+
+function canObserveChatMessageResize() {
+    return typeof globalThis.ResizeObserver === 'function';
+}
+
+function getMessageBlockElement(messageElement) {
+    const element = messageElement?.jquery ? messageElement[0] : messageElement;
+
+    if (!(element instanceof HTMLElement)) {
+        return null;
+    }
+
+    return element.matches('.mes_block') ? element : element.querySelector('.mes_block');
+}
+
+function unobserveChatMessageResizeBlock(messageBlock) {
+    if (messageBlock instanceof HTMLElement) {
+        chatMessageResizeObserver?.unobserve(messageBlock);
+        chatMessageResizeStates.delete(messageBlock);
+    }
+}
+
+function observeChatMessageResize(messageElement) {
+    if (!isChatRenderLifecycleRolloutEnabled() || !canObserveChatMessageResize()) {
+        return;
+    }
+
+    const messageBlock = getMessageBlockElement(messageElement);
+
+    if (!(messageBlock instanceof HTMLElement)) {
+        return;
+    }
+
+    requestAnimationFrame(() => {
+        if (!isChatRenderLifecycleRolloutEnabled() || !messageBlock.isConnected) {
+            return;
+        }
+
+        const observer = getChatMessageResizeObserver();
+        unobserveChatMessageResizeBlock(messageBlock);
+
+        const metadata = captureChatMessageResizeState(messageBlock);
+        if (observer.observe(messageBlock, metadata)) {
+            chatMessageResizeStates.set(messageBlock, metadata);
+        }
+    });
+}
+
+function unobserveChatMessageResize(messageElement) {
+    if (messageElement?.jquery && typeof messageElement.toArray === 'function') {
+        messageElement.toArray().forEach(unobserveChatMessageResize);
+        return;
+    }
+
+    const messageBlock = getMessageBlockElement(messageElement);
+
+    unobserveChatMessageResizeBlock(messageBlock);
+}
+
+function disposeChatMessageResizeObserver() {
+    chatMessageResizeObserver?.dispose();
+    chatMessageResizeObserver = null;
+    chatMessageResizeStates.clear();
+}
+
 function updateMessageBlockThroughLifecycle(messageId, message, { rerenderMessage }) {
     const queue = getMessageUpdateQueue();
     queue.queue(messageId, message, { rerenderMessage });
@@ -2426,7 +2592,9 @@ export async function redisplayChat({ targetChat = chat, startIndex = 0, fade = 
     messageElements.removeClass('last_mes');
 
     //Remove messages after index.
-    messageElements.filter(`.mes[mesid="${startIndex}"]`).nextAll('.mes').addBack().remove();
+    const removedMessageElements = messageElements.filter(`.mes[mesid="${startIndex}"]`).nextAll('.mes').addBack();
+    unobserveChatMessageResize(removedMessageElements);
+    removedMessageElements.remove();
 
     const t1 = performance.now();
 
@@ -2505,6 +2673,7 @@ export async function clearChat({ clearData = false } = {}) {
     cancelDebouncedChatSave();
     cancelDebouncedMetadataSave();
     closeMessageEditor();
+    disposeChatMessageResizeObserver();
     extension_prompts = {};
     if (is_delete_mode) {
         $('#dialogue_del_mes_cancel').trigger('click');
@@ -2525,7 +2694,9 @@ export async function clearChat({ clearData = false } = {}) {
 export async function deleteLastMessage() {
     deleteItemizedPromptForMessage(chat.length - 1);
     chat.length = chat.length - 1;
-    chatElement.children('.mes').last().remove();
+    const messageElement = chatElement.children('.mes').last();
+    unobserveChatMessageResize(messageElement);
+    messageElement.remove();
     await eventSource.emit(event_types.MESSAGE_DELETED, chat.length);
 }
 
@@ -2574,6 +2745,7 @@ export async function deleteMessage(id, swipeDeletionIndex = undefined, askConfi
     }
 
     chat.splice(id, 1);
+    unobserveChatMessageResize(messageElement);
     messageElement.remove();
 
     chat_metadata.tainted = true;
@@ -3783,6 +3955,7 @@ export function updateMessageElement(mes, { messageId = chat.length - 1, message
         updateSwipeCounter(messageId, { message: mes, messageElement });
     }
 
+    observeChatMessageResize(messageElement);
     return messageElement;
 }
 
@@ -14478,6 +14651,8 @@ jQuery(async function () {
     window.visualViewport?.addEventListener('resize', markMobileViewportScroll, { passive: true });
 
     const chatScrollHandler = function () {
+        refreshObservedChatMessageResizeViewportStates();
+
         if (power_user.waifuMode) {
             scrollLock = true;
             return;
@@ -15747,6 +15922,7 @@ jQuery(async function () {
     });
 
     $(window).on('beforeunload', () => {
+        disposeChatMessageResizeObserver();
         cancelTtsPlay();
         if (streamingProcessor) {
             console.log('Page reloaded. Aborting streaming...');

--- a/public/script.js
+++ b/public/script.js
@@ -315,6 +315,7 @@ import {
     captureVisibleMessageAnchor,
     createDelegatedResizeObserver,
     createMessageUpdateQueue,
+    createMobileViewportObserver,
     createStreamWriteBuffer,
     renderMessagesInBatches,
     resolveChatBottomScrollAction,
@@ -604,6 +605,7 @@ let messageUpdateQueue = null;
 let mobileMessageUpdateQueue = null;
 let streamingVisibleWriteBuffer = null;
 let chatMessageResizeObserver = null;
+let mobileChatViewportObserver = null;
 const chatMessageResizeStates = new Map();
 
 let dialogueResolve = null;
@@ -1935,6 +1937,52 @@ function pinMobileChatToBottom({ waitForFrame = true, settle = false } = {}) {
     }
 }
 
+function resetMobileViewportScrollState() {
+    mobileChatTouchScrolling = false;
+    mobileChatManualScrollSuppressedUntil = 0;
+    mobileChatBottomPinUntil = 0;
+}
+
+function getMobileViewportScrollHandler() {
+    return () => {
+        if (mobileChatTouchScrolling || Date.now() < mobileChatManualScrollSuppressedUntil) {
+            markMobileChatManualScroll({ suppressMs: MOBILE_CHAT_VIEWPORT_SCROLL_SUPPRESS_MS });
+        }
+    };
+}
+
+function disposeMobileChatViewportObserver() {
+    mobileChatViewportObserver?.dispose();
+    mobileChatViewportObserver = null;
+}
+
+function resetMobileChatViewportLifecycle() {
+    if (!isChatRenderLifecycleRolloutEnabled()) {
+        return;
+    }
+
+    resetMobileViewportScrollState();
+
+    if (mobileChatViewportObserver) {
+        setupMobileChatViewportObserver(getMobileViewportScrollHandler());
+    }
+}
+
+function setupMobileChatViewportObserver(onViewportChange) {
+    if (!isChatRenderLifecycleRolloutEnabled()) {
+        window.visualViewport?.addEventListener('scroll', onViewportChange, { passive: true });
+        window.visualViewport?.addEventListener('resize', onViewportChange, { passive: true });
+        return;
+    }
+
+    disposeMobileChatViewportObserver();
+    mobileChatViewportObserver = createMobileViewportObserver({
+        onViewportChange,
+        onViewportSettle: onViewportChange,
+    });
+    mobileChatViewportObserver.start();
+}
+
 function shouldDeferMobileMessageUpdates() {
     return Boolean(shouldBatchMobileChatRendering() && !is_send_press);
 }
@@ -2674,6 +2722,7 @@ export async function clearChat({ clearData = false } = {}) {
     cancelDebouncedMetadataSave();
     closeMessageEditor();
     disposeChatMessageResizeObserver();
+    resetMobileChatViewportLifecycle();
     extension_prompts = {};
     if (is_delete_mode) {
         $('#dialogue_del_mes_cancel').trigger('click');
@@ -14636,19 +14685,14 @@ jQuery(async function () {
     const markMobileChatTouchScrollStart = () => markMobileChatManualScroll({ touchActive: true });
     const markMobileChatTouchScrollMove = () => markMobileChatManualScroll();
     const markMobileChatWheelScroll = () => markMobileChatManualScroll();
-    const markMobileViewportScroll = () => {
-        if (mobileChatTouchScrolling || Date.now() < mobileChatManualScrollSuppressedUntil) {
-            markMobileChatManualScroll({ suppressMs: MOBILE_CHAT_VIEWPORT_SCROLL_SUPPRESS_MS });
-        }
-    };
+    const markMobileViewportScroll = getMobileViewportScrollHandler();
 
     chatElementScroll.addEventListener('touchstart', markMobileChatTouchScrollStart, { passive: true });
     chatElementScroll.addEventListener('touchmove', markMobileChatTouchScrollMove, { passive: true });
     chatElementScroll.addEventListener('touchend', releaseMobileChatTouchScroll, { passive: true });
     chatElementScroll.addEventListener('touchcancel', releaseMobileChatTouchScroll, { passive: true });
     chatElementScroll.addEventListener('wheel', markMobileChatWheelScroll, { passive: true });
-    window.visualViewport?.addEventListener('scroll', markMobileViewportScroll, { passive: true });
-    window.visualViewport?.addEventListener('resize', markMobileViewportScroll, { passive: true });
+    setupMobileChatViewportObserver(markMobileViewportScroll);
 
     const chatScrollHandler = function () {
         refreshObservedChatMessageResizeViewportStates();
@@ -15923,6 +15967,7 @@ jQuery(async function () {
 
     $(window).on('beforeunload', () => {
         disposeChatMessageResizeObserver();
+        disposeMobileChatViewportObserver();
         cancelTtsPlay();
         if (streamingProcessor) {
             console.log('Page reloaded. Aborting streaming...');

--- a/public/script.js
+++ b/public/script.js
@@ -310,6 +310,7 @@ import { bindIOSFastTapSendButton, isIOSWebKitPlatform } from './scripts/mobile-
 import { getStreamingUpdateInterval } from './scripts/mobile-streaming.js';
 import {
     CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY,
+    CHAT_SCROLL_ACTION,
     CHAT_SCROLL_INTENT,
     captureVisibleMessageAnchor,
     createMessageUpdateQueue,
@@ -2078,6 +2079,58 @@ function scrollStartedStreamingMessageThroughLifecycle() {
             scrollChatElementToBottom();
         });
     }
+}
+
+function getSwipeReplacementViewportUpdate({ isLastMessageSwipe, useLifecycleRoute }) {
+    if (!useLifecycleRoute || !isChatRenderLifecycleRolloutEnabled()) {
+        const anchor = isLastMessageSwipe && !isChatScrolledNearBottom()
+            ? captureVisibleChatMessageAnchor()
+            : null;
+
+        return {
+            action: null,
+            anchor,
+            scrollWithAddOneMessage: isLastMessageSwipe && !anchor,
+        };
+    }
+
+    const isNearBottom = isChatScrolledNearBottom();
+    const anchor = !isNearBottom ? captureVisibleChatMessageAnchor() : null;
+    const action = resolveChatScrollAction({
+        intent: CHAT_SCROLL_INTENT.REPLACE_MESSAGE,
+        autoScrollEnabled: power_user.auto_scroll_chat_to_bottom,
+        isNearBottom,
+        hasAnchor: Boolean(anchor),
+        isManualScrollSuppressed: shouldSuppressMobileChatAutoScroll(),
+    });
+
+    return {
+        action,
+        anchor,
+        scrollWithAddOneMessage: false,
+    };
+}
+
+function shouldSettleSwipeReplacementAnchor(viewportUpdate) {
+    return Boolean(viewportUpdate?.anchor)
+        && (!viewportUpdate.action || viewportUpdate.action.action === CHAT_SCROLL_ACTION.PRESERVE_ANCHOR);
+}
+
+async function settleSwipeReplacementAnchor(viewportUpdate) {
+    if (shouldSettleSwipeReplacementAnchor(viewportUpdate)) {
+        await settleVisibleChatMessageAnchor(viewportUpdate.anchor);
+    }
+}
+
+async function applySwipeReplacementViewportUpdate(viewportUpdate) {
+    if (shouldApplyChatBottomScrollAction(viewportUpdate?.action)) {
+        requestAnimationFrame(() => {
+            scrollChatElementToBottom();
+        });
+        return;
+    }
+
+    await settleSwipeReplacementAnchor(viewportUpdate);
 }
 
 function flushPendingMobileMessageUpdates() {
@@ -13119,6 +13172,7 @@ export async function swipe(event, direction, { source, repeated, message = chat
 
     swipeState = SWIPE_STATE.SWIPING;
     let generation;
+    let isOverswipeReplacement = false;
 
     const thisMesDiv = chatElement.children('.mes').filter(`[mesid="${mesId}"]`);
     const thisMesText = thisMesDiv.find('.mes_block .mes_text');
@@ -13395,7 +13449,7 @@ export async function swipe(event, direction, { source, repeated, message = chat
      * @param {boolean} [skipSwipeOut=false]
      */
     async function animateSwipe(run_generate = false, skipSwipeOut = false) {
-        let swipeAnchor = null;
+        let swipeViewportUpdate = null;
 
         if (!skipSwipeOut) {
             //Swipe out.
@@ -13415,17 +13469,13 @@ export async function swipe(event, direction, { source, repeated, message = chat
             //console.log('showing previously generated swipe candidate, or "..."');
             //console.log('onclick right swipe calling addOneMessage');
 
-            // SillyBunny: preserve a manual viewport position when replacing the last message via swipe.
+            // SillyBunny: route display-only swipe replacement scroll handling through the guarded lifecycle seam.
             const isLastMessageSwipe = (mesId == chat.length - 1);
-            swipeAnchor = isLastMessageSwipe && !isChatScrolledNearBottom()
-                ? captureVisibleChatMessageAnchor()
-                : null;
+            const useLifecycleRoute = source !== SWIPE_SOURCE.DELETE && source !== SWIPE_SOURCE.BACK && !isOverswipeReplacement;
+            swipeViewportUpdate = getSwipeReplacementViewportUpdate({ isLastMessageSwipe, useLifecycleRoute });
             //The swipe buttons will be refreshed in endSwipe(), refreshing them now will cause flickering.
-            addOneMessage(chat[mesId], { type: 'swipe', forceId: mesId, scroll: isLastMessageSwipe && !swipeAnchor, showSwipes: false });
-
-            if (swipeAnchor) {
-                await settleVisibleChatMessageAnchor(swipeAnchor);
-            }
+            addOneMessage(chat[mesId], { type: 'swipe', forceId: mesId, scroll: swipeViewportUpdate.scrollWithAddOneMessage, showSwipes: false });
+            await applySwipeReplacementViewportUpdate(swipeViewportUpdate);
 
             if (power_user.message_token_count_enabled) {
                 if (!chat[mesId].extra) {
@@ -13455,9 +13505,7 @@ export async function swipe(event, direction, { source, repeated, message = chat
         //Swipe in from the opposite side.
         await animateSwipeTransition(mesId, { xStart: `${-swipeRange}px`, xEnd: `${0}px`, duration: swipeDuration });
 
-        if (swipeAnchor) {
-            await settleVisibleChatMessageAnchor(swipeAnchor);
-        }
+        await settleSwipeReplacementAnchor(swipeViewportUpdate);
     }
 
     if (mesId === Number(this_edit_mes_id)) {
@@ -13554,6 +13602,7 @@ export async function swipe(event, direction, { source, repeated, message = chat
                 return;
             } else if (overswipe == OVERSWIPE_BEHAVIOR.LOOP || overswipe == OVERSWIPE_BEHAVIOR.PRISTINE_GREETING) {
                 // Loop to the first swipe.
+                isOverswipeReplacement = true;
                 newSwipeId = 0;
             }
         }

--- a/public/script.js
+++ b/public/script.js
@@ -2010,6 +2010,26 @@ function updateMessageBlockThroughLifecycle(messageId, message, { rerenderMessag
     queue.flush();
 }
 
+function scrollStartedStreamingMessageThroughLifecycle() {
+    if (!isChatRenderLifecycleRolloutEnabled()) {
+        scrollChatToBottom({ waitForFrame: true });
+        return;
+    }
+
+    const action = resolveChatScrollAction({
+        intent: CHAT_SCROLL_INTENT.STREAM_PROGRESS,
+        autoScrollEnabled: power_user.auto_scroll_chat_to_bottom,
+        isNearBottom: isChatScrolledNearBottom(),
+        isManualScrollSuppressed: shouldSuppressMobileChatAutoScroll(),
+    });
+
+    if (shouldApplyChatBottomScrollAction(action)) {
+        requestAnimationFrame(() => {
+            scrollChatElementToBottom();
+        });
+    }
+}
+
 function flushPendingMobileMessageUpdates() {
     pendingMobileMessageUpdateFrame = 0;
     pendingMobileMessageUpdateTimer = 0;
@@ -4787,7 +4807,7 @@ class StreamingProcessor {
         hideSwipeButtons({ hideCounters: true });
         scrollLock = false;
         scrollLockImmunityUntil = Date.now() + 500;
-        scrollChatToBottom({ waitForFrame: true });
+        scrollStartedStreamingMessageThroughLifecycle();
         return messageId;
     }
 

--- a/public/script.js
+++ b/public/script.js
@@ -2016,6 +2016,96 @@ function insertShowMoreFragment(referenceNode, fragment) {
     }
 }
 
+async function renderShowMoreMessagesLegacy({
+    messages,
+    firstId,
+    batchSize,
+    insertionReference,
+    anchor,
+    shouldPreserveScroll,
+}) {
+    const shouldYieldBetweenBatches = batchSize < messages.length;
+
+    for (let offset = 0; offset < messages.length; offset += batchSize) {
+        const fragment = document.createDocumentFragment();
+        const batch = messages.slice(offset, offset + batchSize);
+
+        batch.forEach((message, id) => {
+            const messageElement = updateMessageElement(message, { messageId: firstId + offset + id });
+            if (messageElement[0]) {
+                fragment.appendChild(messageElement[0]);
+            }
+        });
+
+        // Fallback to chatElement if the button isn't where it's expected to be.
+        insertShowMoreFragment(insertionReference, fragment);
+
+        if (shouldPreserveScroll) {
+            restoreVisibleChatMessageAnchor(anchor);
+        }
+
+        if (shouldYieldBetweenBatches && offset + batchSize < messages.length) {
+            await waitForNextFrame();
+            if (shouldPreserveScroll) {
+                restoreVisibleChatMessageAnchor(anchor);
+            }
+        }
+    }
+}
+
+async function renderShowMoreMessagesThroughLifecycle({
+    messages,
+    firstId,
+    batchSize,
+    insertionReference,
+    anchor,
+    shouldPreserveScroll,
+}) {
+    const restoreAnchorIfNeeded = () => {
+        if (shouldPreserveScroll) {
+            restoreVisibleChatMessageAnchor(anchor);
+        }
+    };
+
+    await renderMessagesInBatches({
+        messages,
+        firstMessageId: firstId,
+        batchSize,
+        renderMessageElement: (message, messageId) => updateMessageElement(message, { messageId }),
+        insertFragment: fragment => insertShowMoreFragment(insertionReference, fragment),
+        waitForNextFrame: async () => {
+            await waitForNextFrame();
+            restoreAnchorIfNeeded();
+        },
+        afterBatch: restoreAnchorIfNeeded,
+    });
+}
+
+async function renderShowMoreMessages({
+    messages,
+    firstId,
+    insertionReference,
+    anchor,
+    shouldPreserveScroll,
+}) {
+    const batchSize = getMobileChatRenderBatchSize(messages.length);
+    const renderOptions = {
+        messages,
+        firstId,
+        batchSize,
+        insertionReference,
+        anchor,
+        shouldPreserveScroll,
+    };
+
+    if (isChatRenderLifecycleRolloutEnabled()) {
+        await renderShowMoreMessagesThroughLifecycle(renderOptions);
+        return;
+    }
+
+    await renderShowMoreMessagesLegacy(renderOptions);
+}
+
 export async function showMoreMessages(messagesToLoad = null) {
     if (isLoadingMoreMessages) {
         return;
@@ -2040,8 +2130,6 @@ export async function showMoreMessages(messagesToLoad = null) {
 
         const firstId = clamp(messageId - count, 0, Infinity);
         const messages = chat.slice(firstId, messageId);
-        const batchSize = getMobileChatRenderBatchSize(messages.length);
-        const shouldYieldBetweenBatches = batchSize < messages.length;
         const insertionReference = showMoreButtonElement instanceof HTMLElement
             ? showMoreButtonElement.nextSibling
             : chatElement[0]?.firstChild ?? null;
@@ -2052,31 +2140,13 @@ export async function showMoreMessages(messagesToLoad = null) {
             showMoreButtonElement.setAttribute('aria-busy', 'true');
         }
 
-        for (let offset = 0; offset < messages.length; offset += batchSize) {
-            const fragment = document.createDocumentFragment();
-            const batch = messages.slice(offset, offset + batchSize);
-
-            batch.forEach((message, id) => {
-                const messageElement = updateMessageElement(message, { messageId: firstId + offset + id });
-                if (messageElement[0]) {
-                    fragment.appendChild(messageElement[0]);
-                }
-            });
-
-            // Fallback to chatElement if the button isn't where it's expected to be.
-            insertShowMoreFragment(insertionReference, fragment);
-
-            if (shouldPreserveScroll) {
-                restoreVisibleChatMessageAnchor(anchor);
-            }
-
-            if (shouldYieldBetweenBatches && offset + batchSize < messages.length) {
-                await waitForNextFrame();
-                if (shouldPreserveScroll) {
-                    restoreVisibleChatMessageAnchor(anchor);
-                }
-            }
-        }
+        await renderShowMoreMessages({
+            messages,
+            firstId,
+            insertionReference,
+            anchor,
+            shouldPreserveScroll,
+        });
 
         refreshSwipeButtons();
 

--- a/public/scripts/chat-render-lifecycle/index.js
+++ b/public/scripts/chat-render-lifecycle/index.js
@@ -23,12 +23,16 @@ import {
 import {
     renderMessagesInBatches,
 } from './render-batch.js';
+import {
+    createMessageUpdateQueue,
+} from './update-queue.js';
 
 export {
     CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY,
     CHAT_SCROLL_ACTION,
     CHAT_SCROLL_INTENT,
     captureVisibleMessageAnchor,
+    createMessageUpdateQueue,
     createFrameWriteScheduler,
     resolveChatBottomScrollAction,
     resolveChatScrollAction,
@@ -70,6 +74,9 @@ export function createChatRenderLifecycle() {
         },
         renderBatch: {
             render: renderMessagesInBatches,
+        },
+        updateQueue: {
+            create: createMessageUpdateQueue,
         },
     };
 }

--- a/public/scripts/chat-render-lifecycle/index.js
+++ b/public/scripts/chat-render-lifecycle/index.js
@@ -24,6 +24,9 @@ import {
     renderMessagesInBatches,
 } from './render-batch.js';
 import {
+    createStreamWriteBuffer,
+} from './stream-buffer.js';
+import {
     createMessageUpdateQueue,
 } from './update-queue.js';
 
@@ -34,6 +37,7 @@ export {
     captureVisibleMessageAnchor,
     createMessageUpdateQueue,
     createFrameWriteScheduler,
+    createStreamWriteBuffer,
     resolveChatBottomScrollAction,
     resolveChatScrollAction,
     restoreVisibleMessageAnchor,
@@ -74,6 +78,9 @@ export function createChatRenderLifecycle() {
         },
         renderBatch: {
             render: renderMessagesInBatches,
+        },
+        streamBuffer: {
+            create: createStreamWriteBuffer,
         },
         updateQueue: {
             create: createMessageUpdateQueue,

--- a/public/scripts/chat-render-lifecycle/index.js
+++ b/public/scripts/chat-render-lifecycle/index.js
@@ -29,6 +29,9 @@ import {
 import {
     createMessageUpdateQueue,
 } from './update-queue.js';
+import {
+    createDelegatedResizeObserver,
+} from './resize-observer.js';
 
 export {
     CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY,
@@ -36,6 +39,7 @@ export {
     CHAT_SCROLL_INTENT,
     captureVisibleMessageAnchor,
     createMessageUpdateQueue,
+    createDelegatedResizeObserver,
     createFrameWriteScheduler,
     createStreamWriteBuffer,
     resolveChatBottomScrollAction,
@@ -84,6 +88,9 @@ export function createChatRenderLifecycle() {
         },
         updateQueue: {
             create: createMessageUpdateQueue,
+        },
+        resizeObserver: {
+            create: createDelegatedResizeObserver,
         },
     };
 }

--- a/public/scripts/chat-render-lifecycle/index.js
+++ b/public/scripts/chat-render-lifecycle/index.js
@@ -32,6 +32,10 @@ import {
 import {
     createDelegatedResizeObserver,
 } from './resize-observer.js';
+import {
+    createMobileViewportObserver,
+    MOBILE_VIEWPORT_SETTLE_DELAY_MS,
+} from './mobile-viewport.js';
 
 export {
     CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY,
@@ -41,7 +45,9 @@ export {
     createMessageUpdateQueue,
     createDelegatedResizeObserver,
     createFrameWriteScheduler,
+    createMobileViewportObserver,
     createStreamWriteBuffer,
+    MOBILE_VIEWPORT_SETTLE_DELAY_MS,
     resolveChatBottomScrollAction,
     resolveChatScrollAction,
     restoreVisibleMessageAnchor,
@@ -91,6 +97,10 @@ export function createChatRenderLifecycle() {
         },
         resizeObserver: {
             create: createDelegatedResizeObserver,
+        },
+        mobileViewport: {
+            create: createMobileViewportObserver,
+            settleDelayMs: MOBILE_VIEWPORT_SETTLE_DELAY_MS,
         },
     };
 }

--- a/public/scripts/chat-render-lifecycle/mobile-viewport.js
+++ b/public/scripts/chat-render-lifecycle/mobile-viewport.js
@@ -1,0 +1,126 @@
+export const MOBILE_VIEWPORT_SETTLE_DELAY_MS = 180;
+
+function isViewportLike(viewport) {
+    return Boolean(viewport
+        && typeof viewport.addEventListener === 'function'
+        && typeof viewport.removeEventListener === 'function');
+}
+
+function assertMobileViewportOptions({
+    onViewportChange,
+    onViewportSettle,
+    setTimeoutRef,
+    clearTimeoutRef,
+}) {
+    if (typeof onViewportChange !== 'function') {
+        throw new TypeError('createMobileViewportObserver requires onViewportChange to be a function.');
+    }
+
+    if (onViewportSettle !== null && typeof onViewportSettle !== 'function') {
+        throw new TypeError('createMobileViewportObserver requires onViewportSettle to be a function when provided.');
+    }
+
+    if (typeof setTimeoutRef !== 'function') {
+        throw new TypeError('createMobileViewportObserver requires setTimeoutRef to be a function.');
+    }
+
+    if (typeof clearTimeoutRef !== 'function') {
+        throw new TypeError('createMobileViewportObserver requires clearTimeoutRef to be a function.');
+    }
+}
+
+/**
+ * Creates lifecycle-owned visual viewport listener setup with cancellable settle detection.
+ * Runtime policy still belongs to the injected callbacks.
+ * @param {object} options Options.
+ * @param {VisualViewport|null} [options.viewport=globalThis.visualViewport] Viewport-like event target.
+ * @param {(event: Event) => void} options.onViewportChange Immediate viewport movement handler.
+ * @param {(event: Event) => void|null} [options.onViewportSettle=null] Settled viewport handler.
+ * @param {number} [options.settleDelayMs=MOBILE_VIEWPORT_SETTLE_DELAY_MS] Settle debounce delay.
+ * @param {(callback: () => void, delay: number) => number|object} [options.setTimeoutRef=globalThis.setTimeout] Timer function.
+ * @param {(handle: number|object) => void} [options.clearTimeoutRef=globalThis.clearTimeout] Timer clear function.
+ * @returns {{start: () => boolean, dispose: () => void, isStarted: () => boolean}}
+ */
+export function createMobileViewportObserver({
+    viewport = globalThis.visualViewport ?? null,
+    onViewportChange,
+    onViewportSettle = null,
+    settleDelayMs = MOBILE_VIEWPORT_SETTLE_DELAY_MS,
+    setTimeoutRef = globalThis.setTimeout,
+    clearTimeoutRef = globalThis.clearTimeout,
+} = {}) {
+    assertMobileViewportOptions({
+        onViewportChange,
+        onViewportSettle,
+        setTimeoutRef,
+        clearTimeoutRef,
+    });
+
+    let isStarted = false;
+    let settleTimer = null;
+    let lastEvent = null;
+
+    const cancelSettleTimer = () => {
+        if (settleTimer === null) {
+            return;
+        }
+
+        clearTimeoutRef(settleTimer);
+        settleTimer = null;
+    };
+
+    const scheduleSettle = () => {
+        cancelSettleTimer();
+
+        if (typeof onViewportSettle !== 'function') {
+            return;
+        }
+
+        let timerHandle = null;
+        timerHandle = setTimeoutRef(() => {
+            if (settleTimer !== timerHandle) {
+                return;
+            }
+
+            settleTimer = null;
+            onViewportSettle(lastEvent);
+        }, settleDelayMs);
+        settleTimer = timerHandle;
+    };
+
+    const handleViewportChange = (event) => {
+        lastEvent = event;
+        onViewportChange(event);
+        scheduleSettle();
+    };
+
+    const start = () => {
+        if (isStarted || !isViewportLike(viewport)) {
+            return false;
+        }
+
+        viewport.addEventListener('scroll', handleViewportChange, { passive: true });
+        viewport.addEventListener('resize', handleViewportChange, { passive: true });
+        isStarted = true;
+        return true;
+    };
+
+    const dispose = () => {
+        cancelSettleTimer();
+
+        if (!isStarted || !isViewportLike(viewport)) {
+            isStarted = false;
+            return;
+        }
+
+        viewport.removeEventListener('scroll', handleViewportChange, { passive: true });
+        viewport.removeEventListener('resize', handleViewportChange, { passive: true });
+        isStarted = false;
+    };
+
+    return {
+        start,
+        dispose,
+        isStarted: () => isStarted,
+    };
+}

--- a/public/scripts/chat-render-lifecycle/resize-observer.js
+++ b/public/scripts/chat-render-lifecycle/resize-observer.js
@@ -1,0 +1,66 @@
+function assertResizeObserverOptions({ ResizeObserverImpl, onResize }) {
+    if (typeof ResizeObserverImpl !== 'function') {
+        throw new TypeError('createDelegatedResizeObserver requires ResizeObserverImpl to be a constructor.');
+    }
+
+    if (typeof onResize !== 'function') {
+        throw new TypeError('createDelegatedResizeObserver requires onResize to be a function.');
+    }
+}
+
+/**
+ * Creates one delegated resize observer for late-growing chat message surfaces.
+ * Scroll policy and anchor restoration stay with the runtime route that handles callbacks.
+ * @param {object} options Options.
+ * @param {ResizeObserver} [options.ResizeObserverImpl=globalThis.ResizeObserver] ResizeObserver constructor.
+ * @param {(element: Element, entry: ResizeObserverEntry, metadata: object) => void} options.onResize Resize callback.
+ * @returns {{observe: (element: Element, metadata?: object) => boolean, unobserve: (element: Element) => boolean, dispose: () => void}}
+ */
+export function createDelegatedResizeObserver({
+    ResizeObserverImpl = globalThis.ResizeObserver,
+    onResize,
+} = {}) {
+    assertResizeObserverOptions({ ResizeObserverImpl, onResize });
+
+    const observedElements = new Map();
+    const observer = new ResizeObserverImpl(entries => {
+        for (const entry of entries) {
+            if (!observedElements.has(entry.target)) {
+                continue;
+            }
+
+            onResize(entry.target, entry, observedElements.get(entry.target));
+        }
+    });
+
+    const observe = (element, metadata = {}) => {
+        if (!element || observedElements.has(element)) {
+            return false;
+        }
+
+        observedElements.set(element, metadata);
+        observer.observe(element);
+        return true;
+    };
+
+    const unobserve = (element) => {
+        if (!observedElements.has(element)) {
+            return false;
+        }
+
+        observedElements.delete(element);
+        observer.unobserve(element);
+        return true;
+    };
+
+    const dispose = () => {
+        observedElements.clear();
+        observer.disconnect();
+    };
+
+    return {
+        observe,
+        unobserve,
+        dispose,
+    };
+}

--- a/public/scripts/chat-render-lifecycle/stream-buffer.js
+++ b/public/scripts/chat-render-lifecycle/stream-buffer.js
@@ -1,0 +1,90 @@
+import { createFrameWriteScheduler } from './scheduler.js';
+
+function assertStreamBufferOptions({ applyWrite, scheduler }) {
+    if (typeof applyWrite !== 'function') {
+        throw new TypeError('createStreamWriteBuffer requires applyWrite to be a function.');
+    }
+
+    if (!scheduler || typeof scheduler.request !== 'function' || typeof scheduler.cancel !== 'function') {
+        throw new TypeError('createStreamWriteBuffer requires scheduler.request and scheduler.cancel.');
+    }
+}
+
+function normalizeWriteOptions({ isFinal = false, ...restOptions } = {}) {
+    return {
+        ...restOptions,
+        isFinal: Boolean(isFinal),
+    };
+}
+
+/**
+ * Coalesces already-decided streaming visible writes through one scheduler lane.
+ * Provider state, token events, and persistence stay with the caller.
+ * @param {object} options Options.
+ * @param {{request: (callback: () => void) => void, cancel: () => void}} [options.scheduler] Write scheduler.
+ * @param {(messageId: number|string, write: object, options: object) => void} options.applyWrite Visible write applier.
+ * @returns {{queue: (messageId: number|string, write: object, options?: object) => number, flush: () => number, clear: () => void, size: () => number}}
+ */
+export function createStreamWriteBuffer({
+    scheduler = createFrameWriteScheduler(),
+    applyWrite,
+} = {}) {
+    assertStreamBufferOptions({ applyWrite, scheduler });
+
+    const pendingWrites = new Map();
+    let hasScheduledFlush = false;
+
+    const flush = () => {
+        hasScheduledFlush = false;
+        const writes = [...pendingWrites.entries()];
+        pendingWrites.clear();
+
+        for (const [messageId, { write, options }] of writes) {
+            applyWrite(messageId, write, options);
+        }
+
+        return writes.length;
+    };
+
+    const scheduleFlush = () => {
+        if (hasScheduledFlush) {
+            return;
+        }
+
+        hasScheduledFlush = true;
+        scheduler.request(flush);
+    };
+
+    const queue = (messageId, write, options = {}) => {
+        const normalizedOptions = normalizeWriteOptions(options);
+
+        pendingWrites.set(messageId, {
+            write,
+            options: normalizedOptions,
+        });
+
+        if (normalizedOptions.isFinal) {
+            scheduler.cancel();
+            flush();
+            return pendingWrites.size;
+        }
+
+        scheduleFlush();
+        return pendingWrites.size;
+    };
+
+    const clear = () => {
+        pendingWrites.clear();
+        hasScheduledFlush = false;
+        scheduler.cancel();
+    };
+
+    const size = () => pendingWrites.size;
+
+    return {
+        queue,
+        flush,
+        clear,
+        size,
+    };
+}

--- a/public/scripts/chat-render-lifecycle/update-queue.js
+++ b/public/scripts/chat-render-lifecycle/update-queue.js
@@ -1,0 +1,62 @@
+function assertApplyUpdate(applyUpdate) {
+    if (typeof applyUpdate !== 'function') {
+        throw new TypeError('createMessageUpdateQueue requires applyUpdate to be a function.');
+    }
+}
+
+function normalizeQueueOptions({ rerenderMessage = true, ...restOptions } = {}) {
+    return {
+        ...restOptions,
+        rerenderMessage: Boolean(rerenderMessage),
+    };
+}
+
+/**
+ * Creates a coalescing queue for already-decided message-block update requests.
+ * The injected apply function remains the only message-block mutation surface.
+ * @param {object} options Options.
+ * @param {(messageId: number|string, message: object, options: object) => void} options.applyUpdate Message update applier.
+ * @returns {{queue: (messageId: number|string, message: object, options?: object) => number, flush: () => number, clear: () => void, size: () => number}}
+ */
+export function createMessageUpdateQueue({ applyUpdate } = {}) {
+    assertApplyUpdate(applyUpdate);
+
+    const pendingUpdates = new Map();
+
+    const queue = (messageId, message, options = {}) => {
+        const normalizedOptions = normalizeQueueOptions(options);
+        const previousUpdate = pendingUpdates.get(messageId);
+
+        pendingUpdates.set(messageId, {
+            message,
+            options: {
+                ...previousUpdate?.options,
+                ...normalizedOptions,
+                rerenderMessage: Boolean(previousUpdate?.options?.rerenderMessage || normalizedOptions.rerenderMessage),
+            },
+        });
+
+        return pendingUpdates.size;
+    };
+
+    const flush = () => {
+        const updates = [...pendingUpdates.entries()];
+        pendingUpdates.clear();
+
+        for (const [messageId, { message, options }] of updates) {
+            applyUpdate(messageId, message, options);
+        }
+
+        return updates.length;
+    };
+
+    const clear = () => pendingUpdates.clear();
+    const size = () => pendingUpdates.size;
+
+    return {
+        queue,
+        flush,
+        clear,
+        size,
+    };
+}

--- a/scripts/measure-frontend-performance.js
+++ b/scripts/measure-frontend-performance.js
@@ -12,8 +12,11 @@ const outputDir = path.join(repoRoot, 'output', 'performance');
 const baseUrl = process.env.SILLYBUNNY_PERF_URL || 'http://127.0.0.1:4444';
 const outputPath = process.env.SILLYBUNNY_PERF_OUTPUT || path.join(outputDir, `frontend-${Date.now()}.json`);
 const mobileProfile = devices['Pixel 5'];
+export const LONG_CHAT_RENDER_MESSAGE_COUNT = 96;
+export const LONG_CHAT_RENDER_VISIBLE_COUNT = 24;
+export const LONG_CHAT_RENDER_FILLER_REPEAT = 36;
 
-function summarizeRequests(requests) {
+export function summarizeRequests(requests) {
     const totals = {
         count: requests.length,
         js: 0,
@@ -38,6 +41,82 @@ function summarizeRequests(requests) {
     }
 
     return totals;
+}
+
+export function createLongChatRenderFixture({
+    messageCount = LONG_CHAT_RENDER_MESSAGE_COUNT,
+    visibleCount = LONG_CHAT_RENDER_VISIBLE_COUNT,
+    fillerRepeat = LONG_CHAT_RENDER_FILLER_REPEAT,
+} = {}) {
+    const messages = [];
+
+    for (let index = 0; index < messageCount; index++) {
+        const isUser = index % 2 === 0;
+        const baseText = `performance synthetic message ${index}`;
+        messages.push({
+            name: isUser ? 'Scroll Tester' : 'Bunny Guide',
+            is_user: isUser,
+            is_system: false,
+            send_date: new Date(Date.UTC(2024, 0, 1, 0, index)).toISOString(),
+            mes: `${baseText}\n${'long chat filler '.repeat(fillerRepeat)}`,
+            extra: {},
+        });
+    }
+
+    return {
+        messageCount,
+        visibleCount,
+        fillerRepeat,
+        messages,
+    };
+}
+
+export async function measureLongChatRender(page, fixture = createLongChatRenderFixture()) {
+    const renderResult = await page.evaluate(async ({ messages, messageCount, visibleCount, fillerRepeat }) => {
+        const browserGlobal = globalThis;
+        const context = browserGlobal.SillyTavern?.getContext?.();
+        const chatElement = browserGlobal.document.querySelector('#chat');
+
+        if (!context || !(chatElement instanceof browserGlobal.HTMLElement) || typeof context.printMessages !== 'function') {
+            return {
+                available: false,
+                reason: 'chat-context-unavailable',
+            };
+        }
+
+        context.powerUserSettings.auto_scroll_chat_to_bottom = true;
+        context.powerUserSettings.chat_truncation = visibleCount;
+        context.chat.length = 0;
+        chatElement.replaceChildren();
+        context.chat.push(...messages);
+
+        const start = browserGlobal.performance.now();
+        await context.printMessages();
+        await new Promise(resolve => browserGlobal.requestAnimationFrame(() => browserGlobal.requestAnimationFrame(resolve)));
+        const durationMs = browserGlobal.performance.now() - start;
+        const renderedMessages = Array.from(chatElement.querySelectorAll('.mes[mesid]'));
+
+        return {
+            available: true,
+            durationMs,
+            messageCount: context.chat.length,
+            visibleCount,
+            fillerRepeat,
+            renderedCount: renderedMessages.length,
+            firstRenderedMesId: renderedMessages.at(0)?.getAttribute('mesid') ?? null,
+            lastRenderedMesId: renderedMessages.at(-1)?.getAttribute('mesid') ?? null,
+            bottomDelta: chatElement.scrollHeight - chatElement.clientHeight - chatElement.scrollTop,
+        };
+    }, fixture);
+
+    return {
+        fixture: {
+            messageCount: fixture.messageCount,
+            visibleCount: fixture.visibleCount,
+            fillerRepeat: fixture.fillerRepeat,
+        },
+        ...renderResult,
+    };
 }
 
 async function measurePage(page) {
@@ -107,10 +186,13 @@ async function measurePage(page) {
     return {
         ...metrics,
         scrollFps,
+        chatRender: {
+            longChat: await measureLongChatRender(page),
+        },
     };
 }
 
-async function run() {
+export async function run() {
     await fs.mkdir(path.dirname(outputPath), { recursive: true });
 
     const browser = await chromium.launch();
@@ -136,6 +218,11 @@ async function run() {
 
     await page.goto(baseUrl, { waitUntil: 'networkidle' });
     await page.waitForFunction('document.getElementById("preloader") === null', { timeout: 60000 }).catch(() => {});
+    await page.waitForFunction(() => {
+        const browserGlobal = globalThis;
+        return typeof browserGlobal.SillyTavern?.getContext === 'function'
+            && browserGlobal.document.querySelector('#chat') instanceof browserGlobal.HTMLElement;
+    }, { timeout: 60000 }).catch(() => {});
 
     const result = {
         url: baseUrl,
@@ -151,7 +238,13 @@ async function run() {
     await browser.close();
 }
 
-run().catch((error) => {
-    console.error(error);
-    process.exitCode = 1;
-});
+function isDirectRun() {
+    return Boolean(process.argv[1]) && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+}
+
+if (isDirectRun()) {
+    run().catch((error) => {
+        console.error(error);
+        process.exitCode = 1;
+    });
+}

--- a/tests/chat-render-lifecycle-anchor.test.js
+++ b/tests/chat-render-lifecycle-anchor.test.js
@@ -62,6 +62,54 @@ describe('chat render lifecycle anchor helpers', () => {
         expect(scrollElement.scrollTop).toBe(72);
     });
 
+    test('preserves viewport-relative anchors during top, middle, and tail replacements', () => {
+        const cases = [
+            {
+                messages: [
+                    new FakeMessageElement(10, { top: 12, bottom: 68 }),
+                    new FakeMessageElement(11, { top: 76, bottom: 132 }),
+                    new FakeMessageElement(12, { top: 140, bottom: 196 }),
+                ],
+                mutate(messages) {
+                    messages[0].rect = { top: 42, bottom: 118 };
+                },
+                expectedScrollTop: 30,
+            },
+            {
+                messages: [
+                    new FakeMessageElement(20, { top: -92, bottom: -24 }),
+                    new FakeMessageElement(21, { top: 18, bottom: 82 }),
+                    new FakeMessageElement(22, { top: 90, bottom: 160 }),
+                ],
+                mutate(messages) {
+                    messages[1].rect = { top: -14, bottom: 106 };
+                },
+                expectedScrollTop: -32,
+            },
+            {
+                messages: [
+                    new FakeMessageElement(30, { top: -150, bottom: -80 }),
+                    new FakeMessageElement(31, { top: -72, bottom: -8 }),
+                    new FakeMessageElement(32, { top: 28, bottom: 94 }),
+                ],
+                mutate(messages) {
+                    messages[2].rect = { top: 64, bottom: 156 };
+                },
+                expectedScrollTop: 36,
+            },
+        ];
+
+        for (const { messages, mutate, expectedScrollTop } of cases) {
+            const scrollElement = new FakeScrollElement(messages);
+            const anchor = captureVisibleMessageAnchor(scrollElement);
+
+            mutate(messages);
+            restoreVisibleMessageAnchor(scrollElement, anchor);
+
+            expect(scrollElement.scrollTop).toBe(expectedScrollTop);
+        }
+    });
+
     test('settles the anchor across multiple animation frames', async () => {
         const anchorMessage = new FakeMessageElement(5, { top: 10, bottom: 60 });
         const scrollElement = new FakeScrollElement([anchorMessage]);

--- a/tests/chat-render-lifecycle-index.test.js
+++ b/tests/chat-render-lifecycle-index.test.js
@@ -8,6 +8,7 @@ import {
     createChatRenderLifecycle,
     createMessageUpdateQueue,
     createFrameWriteScheduler,
+    createStreamWriteBuffer,
     resolveChatBottomScrollAction,
     resolveChatRenderLifecycleRollout,
     resolveChatScrollAction,
@@ -31,6 +32,7 @@ describe('chat render lifecycle index seam', () => {
         expect(typeof resolveChatRenderLifecycleRollout).toBe('function');
         expect(typeof renderMessagesInBatches).toBe('function');
         expect(typeof createMessageUpdateQueue).toBe('function');
+        expect(typeof createStreamWriteBuffer).toBe('function');
         expect(CHAT_SCROLL_INTENT.TAIL_APPEND).toBe('tail-append');
         expect(CHAT_SCROLL_ACTION.PIN_BOTTOM).toBe('pin-bottom');
         expect(CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY).toBe('sillybunny.chatRenderLifecycle.enabled');
@@ -52,6 +54,7 @@ describe('chat render lifecycle index seam', () => {
         expect(lifecycle.rollout.key).toBe(CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY);
         expect(lifecycle.rollout.resolve).toBe(resolveChatRenderLifecycleRollout);
         expect(lifecycle.renderBatch.render).toBe(renderMessagesInBatches);
+        expect(lifecycle.streamBuffer.create).toBe(createStreamWriteBuffer);
         expect(lifecycle.updateQueue.create).toBe(createMessageUpdateQueue);
     });
 });

--- a/tests/chat-render-lifecycle-index.test.js
+++ b/tests/chat-render-lifecycle-index.test.js
@@ -6,6 +6,7 @@ import {
     CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY,
     captureVisibleMessageAnchor,
     createChatRenderLifecycle,
+    createMessageUpdateQueue,
     createFrameWriteScheduler,
     resolveChatBottomScrollAction,
     resolveChatRenderLifecycleRollout,
@@ -29,6 +30,7 @@ describe('chat render lifecycle index seam', () => {
         expect(typeof resolveChatScrollAction).toBe('function');
         expect(typeof resolveChatRenderLifecycleRollout).toBe('function');
         expect(typeof renderMessagesInBatches).toBe('function');
+        expect(typeof createMessageUpdateQueue).toBe('function');
         expect(CHAT_SCROLL_INTENT.TAIL_APPEND).toBe('tail-append');
         expect(CHAT_SCROLL_ACTION.PIN_BOTTOM).toBe('pin-bottom');
         expect(CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY).toBe('sillybunny.chatRenderLifecycle.enabled');
@@ -50,5 +52,6 @@ describe('chat render lifecycle index seam', () => {
         expect(lifecycle.rollout.key).toBe(CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY);
         expect(lifecycle.rollout.resolve).toBe(resolveChatRenderLifecycleRollout);
         expect(lifecycle.renderBatch.render).toBe(renderMessagesInBatches);
+        expect(lifecycle.updateQueue.create).toBe(createMessageUpdateQueue);
     });
 });

--- a/tests/chat-render-lifecycle-index.test.js
+++ b/tests/chat-render-lifecycle-index.test.js
@@ -6,6 +6,7 @@ import {
     CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY,
     captureVisibleMessageAnchor,
     createChatRenderLifecycle,
+    createDelegatedResizeObserver,
     createMessageUpdateQueue,
     createFrameWriteScheduler,
     createStreamWriteBuffer,
@@ -33,6 +34,7 @@ describe('chat render lifecycle index seam', () => {
         expect(typeof renderMessagesInBatches).toBe('function');
         expect(typeof createMessageUpdateQueue).toBe('function');
         expect(typeof createStreamWriteBuffer).toBe('function');
+        expect(typeof createDelegatedResizeObserver).toBe('function');
         expect(CHAT_SCROLL_INTENT.TAIL_APPEND).toBe('tail-append');
         expect(CHAT_SCROLL_ACTION.PIN_BOTTOM).toBe('pin-bottom');
         expect(CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY).toBe('sillybunny.chatRenderLifecycle.enabled');
@@ -56,5 +58,6 @@ describe('chat render lifecycle index seam', () => {
         expect(lifecycle.renderBatch.render).toBe(renderMessagesInBatches);
         expect(lifecycle.streamBuffer.create).toBe(createStreamWriteBuffer);
         expect(lifecycle.updateQueue.create).toBe(createMessageUpdateQueue);
+        expect(lifecycle.resizeObserver.create).toBe(createDelegatedResizeObserver);
     });
 });

--- a/tests/chat-render-lifecycle-index.test.js
+++ b/tests/chat-render-lifecycle-index.test.js
@@ -9,7 +9,9 @@ import {
     createDelegatedResizeObserver,
     createMessageUpdateQueue,
     createFrameWriteScheduler,
+    createMobileViewportObserver,
     createStreamWriteBuffer,
+    MOBILE_VIEWPORT_SETTLE_DELAY_MS,
     resolveChatBottomScrollAction,
     resolveChatRenderLifecycleRollout,
     resolveChatScrollAction,
@@ -35,9 +37,11 @@ describe('chat render lifecycle index seam', () => {
         expect(typeof createMessageUpdateQueue).toBe('function');
         expect(typeof createStreamWriteBuffer).toBe('function');
         expect(typeof createDelegatedResizeObserver).toBe('function');
+        expect(typeof createMobileViewportObserver).toBe('function');
         expect(CHAT_SCROLL_INTENT.TAIL_APPEND).toBe('tail-append');
         expect(CHAT_SCROLL_ACTION.PIN_BOTTOM).toBe('pin-bottom');
         expect(CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY).toBe('sillybunny.chatRenderLifecycle.enabled');
+        expect(MOBILE_VIEWPORT_SETTLE_DELAY_MS).toBe(180);
     });
 
     test('creates a pass-through lifecycle adapter without mutating runtime behavior', () => {
@@ -59,5 +63,7 @@ describe('chat render lifecycle index seam', () => {
         expect(lifecycle.streamBuffer.create).toBe(createStreamWriteBuffer);
         expect(lifecycle.updateQueue.create).toBe(createMessageUpdateQueue);
         expect(lifecycle.resizeObserver.create).toBe(createDelegatedResizeObserver);
+        expect(lifecycle.mobileViewport.create).toBe(createMobileViewportObserver);
+        expect(lifecycle.mobileViewport.settleDelayMs).toBe(MOBILE_VIEWPORT_SETTLE_DELAY_MS);
     });
 });

--- a/tests/chat-render-lifecycle-mobile-viewport.test.js
+++ b/tests/chat-render-lifecycle-mobile-viewport.test.js
@@ -1,0 +1,193 @@
+import { describe, expect, test } from '@jest/globals';
+
+import {
+    createMobileViewportObserver,
+    MOBILE_VIEWPORT_SETTLE_DELAY_MS,
+} from '../public/scripts/chat-render-lifecycle/mobile-viewport.js';
+
+function createViewportHarness() {
+    const listeners = new Map();
+
+    return {
+        addedListeners: [],
+        removedListeners: [],
+        viewport: {
+            addEventListener(type, listener, options) {
+                listeners.set(type, listener);
+                this.addedListeners.push({ type, listener, options });
+            },
+            removeEventListener(type, listener, options) {
+                if (listeners.get(type) === listener) {
+                    listeners.delete(type);
+                }
+
+                this.removedListeners.push({ type, listener, options });
+            },
+            get addedListeners() {
+                return this._addedListeners;
+            },
+            set addedListeners(value) {
+                this._addedListeners = value;
+            },
+            get removedListeners() {
+                return this._removedListeners;
+            },
+            set removedListeners(value) {
+                this._removedListeners = value;
+            },
+            trigger(type, event = { type }) {
+                listeners.get(type)?.(event);
+            },
+        },
+        listeners,
+    };
+}
+
+function createTimerHarness() {
+    let nextTimerId = 1;
+    const timers = [];
+    const clearedTimers = [];
+
+    return {
+        timers,
+        clearedTimers,
+        setTimeoutRef(callback, delay) {
+            const timerId = nextTimerId++;
+            timers.push({ timerId, callback, delay });
+            return timerId;
+        },
+        clearTimeoutRef(timerId) {
+            clearedTimers.push(timerId);
+        },
+    };
+}
+
+describe('chat render lifecycle mobile viewport observer', () => {
+    test('uses a conservative visual viewport settle delay', () => {
+        expect(MOBILE_VIEWPORT_SETTLE_DELAY_MS).toBe(180);
+    });
+
+    test('subscribes visual viewport scroll and resize through one disposable adapter', () => {
+        const { viewport } = createViewportHarness();
+        viewport.addedListeners = [];
+        viewport.removedListeners = [];
+        const observer = createMobileViewportObserver({
+            viewport,
+            onViewportChange: () => {},
+        });
+
+        expect(observer.start()).toBe(true);
+        expect(observer.start()).toBe(false);
+        expect(observer.isStarted()).toBe(true);
+        expect(viewport.addedListeners.map(listener => listener.type)).toEqual(['scroll', 'resize']);
+        expect(viewport.addedListeners.every(listener => listener.options.passive === true)).toBe(true);
+
+        observer.dispose();
+
+        expect(observer.isStarted()).toBe(false);
+        expect(viewport.removedListeners.map(listener => listener.type)).toEqual(['scroll', 'resize']);
+        expect(viewport.removedListeners.every(listener => listener.options.passive === true)).toBe(true);
+    });
+
+    test('forwards viewport movement events immediately', () => {
+        const { viewport } = createViewportHarness();
+        viewport.addedListeners = [];
+        viewport.removedListeners = [];
+        const changes = [];
+        const observer = createMobileViewportObserver({
+            viewport,
+            onViewportChange: event => changes.push(event.type),
+        });
+
+        observer.start();
+        viewport.trigger('scroll', { type: 'scroll' });
+        viewport.trigger('resize', { type: 'resize' });
+
+        expect(changes).toEqual(['scroll', 'resize']);
+    });
+
+    test('debounces cancellable settle detection for momentum-style viewport movement', () => {
+        const { viewport } = createViewportHarness();
+        viewport.addedListeners = [];
+        viewport.removedListeners = [];
+        const timers = createTimerHarness();
+        const settledEvents = [];
+        const observer = createMobileViewportObserver({
+            viewport,
+            onViewportChange: () => {},
+            onViewportSettle: event => settledEvents.push(event.type),
+            setTimeoutRef: timers.setTimeoutRef,
+            clearTimeoutRef: timers.clearTimeoutRef,
+        });
+
+        observer.start();
+        viewport.trigger('scroll', { type: 'scroll' });
+        viewport.trigger('resize', { type: 'resize' });
+
+        expect(timers.timers).toHaveLength(2);
+        expect(timers.timers.map(timer => timer.delay)).toEqual([
+            MOBILE_VIEWPORT_SETTLE_DELAY_MS,
+            MOBILE_VIEWPORT_SETTLE_DELAY_MS,
+        ]);
+        expect(timers.clearedTimers).toEqual([1]);
+
+        timers.timers.at(-1).callback();
+
+        expect(settledEvents).toEqual(['resize']);
+    });
+
+    test('dispose cancels pending settle callbacks', () => {
+        const { viewport } = createViewportHarness();
+        viewport.addedListeners = [];
+        viewport.removedListeners = [];
+        const timers = createTimerHarness();
+        const settledEvents = [];
+        const observer = createMobileViewportObserver({
+            viewport,
+            onViewportChange: () => {},
+            onViewportSettle: event => settledEvents.push(event.type),
+            setTimeoutRef: timers.setTimeoutRef,
+            clearTimeoutRef: timers.clearTimeoutRef,
+        });
+
+        observer.start();
+        viewport.trigger('scroll', { type: 'scroll' });
+        observer.dispose();
+
+        expect(timers.clearedTimers).toEqual([1]);
+        timers.timers[0].callback();
+        expect(settledEvents).toEqual([]);
+    });
+
+    test('does not subscribe when visualViewport is unavailable', () => {
+        const observer = createMobileViewportObserver({
+            viewport: null,
+            onViewportChange: () => {},
+        });
+
+        expect(observer.start()).toBe(false);
+        expect(observer.isStarted()).toBe(false);
+
+        observer.dispose();
+        expect(observer.isStarted()).toBe(false);
+    });
+
+    test('fails fast for invalid boundary options', () => {
+        expect(() => createMobileViewportObserver()).toThrow('onViewportChange');
+        expect(() => createMobileViewportObserver({
+            onViewportChange: null,
+        })).toThrow('onViewportChange');
+        expect(() => createMobileViewportObserver({
+            onViewportChange: () => {},
+            onViewportSettle: 'settle',
+        })).toThrow('onViewportSettle');
+        expect(() => createMobileViewportObserver({
+            onViewportChange: () => {},
+            setTimeoutRef: null,
+        })).toThrow('setTimeoutRef');
+        expect(() => createMobileViewportObserver({
+            onViewportChange: () => {},
+            clearTimeoutRef: null,
+        })).toThrow('clearTimeoutRef');
+    });
+});

--- a/tests/chat-render-lifecycle-resize-observer.test.js
+++ b/tests/chat-render-lifecycle-resize-observer.test.js
@@ -1,0 +1,134 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { createDelegatedResizeObserver } from '../public/scripts/chat-render-lifecycle/resize-observer.js';
+
+function createFakeResizeObserverConstructor() {
+    const instances = [];
+
+    class FakeResizeObserver {
+        constructor(callback) {
+            this.callback = callback;
+            this.observed = [];
+            this.unobserved = [];
+            this.disconnectCount = 0;
+            instances.push(this);
+        }
+
+        observe(element) {
+            this.observed.push(element);
+        }
+
+        unobserve(element) {
+            this.unobserved.push(element);
+        }
+
+        disconnect() {
+            this.disconnectCount++;
+        }
+
+        trigger(entries) {
+            this.callback(entries);
+        }
+    }
+
+    return {
+        ResizeObserverImpl: FakeResizeObserver,
+        instances,
+    };
+}
+
+describe('chat render lifecycle resize observer helper', () => {
+    test('delegates multiple observed elements through one observer instance', () => {
+        const { ResizeObserverImpl, instances } = createFakeResizeObserverConstructor();
+        const firstElement = { id: 'first' };
+        const secondElement = { id: 'second' };
+        const callbacks = [];
+        const resizeObserver = createDelegatedResizeObserver({
+            ResizeObserverImpl,
+            onResize: (element, entry, metadata) => callbacks.push({ element, entry, metadata }),
+        });
+
+        expect(resizeObserver.observe(firstElement, { messageId: 1 })).toBe(true);
+        expect(resizeObserver.observe(secondElement, { messageId: 2 })).toBe(true);
+
+        expect(instances).toHaveLength(1);
+        expect(instances[0].observed).toEqual([firstElement, secondElement]);
+
+        const firstEntry = { target: firstElement, contentRect: { height: 120 } };
+        const secondEntry = { target: secondElement, contentRect: { height: 180 } };
+        instances[0].trigger([firstEntry, secondEntry]);
+
+        expect(callbacks).toEqual([
+            { element: firstElement, entry: firstEntry, metadata: { messageId: 1 } },
+            { element: secondElement, entry: secondEntry, metadata: { messageId: 2 } },
+        ]);
+    });
+
+    test('does not observe the same element twice', () => {
+        const { ResizeObserverImpl, instances } = createFakeResizeObserverConstructor();
+        const element = { id: 'message' };
+        const resizeObserver = createDelegatedResizeObserver({
+            ResizeObserverImpl,
+            onResize: () => {},
+        });
+
+        expect(resizeObserver.observe(element, { first: true })).toBe(true);
+        expect(resizeObserver.observe(element, { second: true })).toBe(false);
+
+        expect(instances[0].observed).toEqual([element]);
+    });
+
+    test('unobserve removes callbacks for one element without disconnecting the delegate', () => {
+        const { ResizeObserverImpl, instances } = createFakeResizeObserverConstructor();
+        const activeElement = { id: 'active' };
+        const removedElement = { id: 'removed' };
+        const callbacks = [];
+        const resizeObserver = createDelegatedResizeObserver({
+            ResizeObserverImpl,
+            onResize: (element) => callbacks.push(element),
+        });
+
+        resizeObserver.observe(activeElement);
+        resizeObserver.observe(removedElement);
+
+        expect(resizeObserver.unobserve(removedElement)).toBe(true);
+        expect(resizeObserver.unobserve(removedElement)).toBe(false);
+        instances[0].trigger([
+            { target: activeElement },
+            { target: removedElement },
+        ]);
+
+        expect(instances[0].unobserved).toEqual([removedElement]);
+        expect(instances[0].disconnectCount).toBe(0);
+        expect(callbacks).toEqual([activeElement]);
+    });
+
+    test('dispose disconnects the observer and suppresses later callbacks', () => {
+        const { ResizeObserverImpl, instances } = createFakeResizeObserverConstructor();
+        const element = { id: 'message' };
+        const callbacks = [];
+        const resizeObserver = createDelegatedResizeObserver({
+            ResizeObserverImpl,
+            onResize: (target) => callbacks.push(target),
+        });
+
+        resizeObserver.observe(element);
+        resizeObserver.dispose();
+        instances[0].trigger([{ target: element }]);
+
+        expect(instances[0].disconnectCount).toBe(1);
+        expect(callbacks).toEqual([]);
+    });
+
+    test('fails fast for invalid boundary options', () => {
+        expect(() => createDelegatedResizeObserver()).toThrow('ResizeObserverImpl');
+        expect(() => createDelegatedResizeObserver({
+            ResizeObserverImpl: null,
+            onResize: () => {},
+        })).toThrow('ResizeObserverImpl');
+        expect(() => createDelegatedResizeObserver({
+            ResizeObserverImpl: createFakeResizeObserverConstructor().ResizeObserverImpl,
+            onResize: null,
+        })).toThrow('onResize');
+    });
+});

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -93,6 +93,56 @@ describe('chat render lifecycle script wiring', () => {
         expect(lifecycleGateSource).toContain('scrollLoadedChatToBottom();');
     });
 
+    test('redisplayChat delegates selected messages to the guarded redisplay renderer', () => {
+        const redisplayChat = findExportedFunction('redisplayChat');
+        const source = getSource(redisplayChat);
+
+        expect(source).toContain('const messages = targetChat.slice(startIndex);');
+        expect(source).toContain('const renderedMessageIds = await renderRedisplayChatMessages({ messages, startIndex });');
+        expect(source).toContain('applyCharacterTagsToMessageDivs({ mesIds: renderedMessageIds });');
+        expect(source).toContain('refreshSwipeButtons(false, fade);');
+        expect(source).toContain('applyStylePins();');
+        expect(source).toContain('updateEditArrowClasses();');
+    });
+
+    test('redisplayChat keeps render-batch routing behind the lifecycle rollout guard', () => {
+        const renderRedisplayChatMessages = findFunctionDeclaration('renderRedisplayChatMessages');
+        const source = getSource(renderRedisplayChatMessages);
+
+        expect(source).toContain('const batchSize = getMobileChatRenderBatchSize(messages.length);');
+        expect(source).toContain('if (isChatRenderLifecycleRolloutEnabled())');
+        expect(source).toContain('return renderRedisplayChatMessagesThroughLifecycle({ messages, startIndex, batchSize });');
+        expect(source).toContain('return renderRedisplayChatMessagesLegacy({ messages, startIndex, batchSize });');
+    });
+
+    test('guard-on redisplayChat delegates batch mechanics to the lifecycle render batch helper', () => {
+        const renderRedisplayChatMessagesThroughLifecycle = findFunctionDeclaration('renderRedisplayChatMessagesThroughLifecycle');
+        const source = getSource(renderRedisplayChatMessagesThroughLifecycle);
+
+        expect(source).toContain('renderMessagesInBatches({');
+        expect(source).toContain('messages,');
+        expect(source).toContain('firstMessageId: startIndex');
+        expect(source).toContain('batchSize,');
+        expect(source).toContain('renderMessageElement: (message, messageId) => updateMessageElement(message, { messageId })');
+        expect(source).toContain('insertFragment: fragment => chatElement[0].appendChild(fragment)');
+        expect(source).toContain('waitForNextFrame,');
+        expect(source).toContain('markLastMessage: true');
+    });
+
+    test('guard-off redisplayChat keeps legacy inline batching', () => {
+        const renderRedisplayChatMessagesLegacy = findFunctionDeclaration('renderRedisplayChatMessagesLegacy');
+        const source = getSource(renderRedisplayChatMessagesLegacy);
+
+        expect(source).not.toContain('renderMessagesInBatches');
+        expect(source).toContain('const renderedMessageIds = lodash.range(startIndex, startIndex + messages.length, 1);');
+        expect(source).toContain('const fragment = document.createDocumentFragment();');
+        expect(source).toContain('const messageElement = updateMessageElement(message, { messageId });');
+        expect(source).toContain('newMessageElements.at(-1).classList.add(\'last_mes\');');
+        expect(source).toContain('chatElement[0].appendChild(fragment);');
+        expect(source).toContain('await waitForNextFrame();');
+        expect(source).toContain('return renderedMessageIds;');
+    });
+
     test('addOneMessage passes pre-mutation bottom state into lifecycle bottom scroll', () => {
         const addOneMessage = findExportedFunction('addOneMessage');
         expect(addOneMessage).toBeTruthy();

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -143,6 +143,59 @@ describe('chat render lifecycle script wiring', () => {
         expect(source).toContain('return renderedMessageIds;');
     });
 
+    test('showMoreMessages delegates selected history messages to the guarded show-more renderer', () => {
+        const showMoreMessages = findExportedFunction('showMoreMessages');
+        const source = getSource(showMoreMessages);
+
+        expect(source).toContain('const firstId = clamp(messageId - count, 0, Infinity);');
+        expect(source).toContain('const messages = chat.slice(firstId, messageId);');
+        expect(source).toContain('const anchor = captureVisibleChatMessageAnchor();');
+        expect(source).toContain('await renderShowMoreMessages({');
+        expect(source).toContain('refreshSwipeButtons();');
+        expect(source).toContain('showMoreButton.remove();');
+        expect(source).toContain('applyStylePins();');
+        expect(source).toContain('await settleVisibleChatMessageAnchor(anchor);');
+        expect(source).toContain('await eventSource.emit(event_types.MORE_MESSAGES_LOADED);');
+    });
+
+    test('showMoreMessages keeps render-batch routing behind the lifecycle rollout guard', () => {
+        const renderShowMoreMessages = findFunctionDeclaration('renderShowMoreMessages');
+        const source = getSource(renderShowMoreMessages);
+
+        expect(source).toContain('const batchSize = getMobileChatRenderBatchSize(messages.length);');
+        expect(source).toContain('if (isChatRenderLifecycleRolloutEnabled())');
+        expect(source).toContain('await renderShowMoreMessagesThroughLifecycle(renderOptions);');
+        expect(source).toContain('await renderShowMoreMessagesLegacy(renderOptions);');
+    });
+
+    test('guard-on showMoreMessages delegates batch insertion to the lifecycle render batch helper', () => {
+        const renderShowMoreMessagesThroughLifecycle = findFunctionDeclaration('renderShowMoreMessagesThroughLifecycle');
+        const source = getSource(renderShowMoreMessagesThroughLifecycle);
+
+        expect(source).toContain('renderMessagesInBatches({');
+        expect(source).toContain('messages,');
+        expect(source).toContain('firstMessageId: firstId');
+        expect(source).toContain('batchSize,');
+        expect(source).toContain('renderMessageElement: (message, messageId) => updateMessageElement(message, { messageId })');
+        expect(source).toContain('insertFragment: fragment => insertShowMoreFragment(insertionReference, fragment)');
+        expect(source).toContain('waitForNextFrame: async () =>');
+        expect(source).toContain('await waitForNextFrame();');
+        expect(source).toContain('afterBatch: restoreAnchorIfNeeded');
+    });
+
+    test('guard-off showMoreMessages keeps legacy inline batching and anchor restores', () => {
+        const renderShowMoreMessagesLegacy = findFunctionDeclaration('renderShowMoreMessagesLegacy');
+        const source = getSource(renderShowMoreMessagesLegacy);
+
+        expect(source).not.toContain('renderMessagesInBatches');
+        expect(source).toContain('const fragment = document.createDocumentFragment();');
+        expect(source).toContain('const batch = messages.slice(offset, offset + batchSize);');
+        expect(source).toContain('const messageElement = updateMessageElement(message, { messageId: firstId + offset + id });');
+        expect(source).toContain('insertShowMoreFragment(insertionReference, fragment);');
+        expect(source).toContain('restoreVisibleChatMessageAnchor(anchor);');
+        expect(source).toContain('await waitForNextFrame();');
+    });
+
     test('addOneMessage passes pre-mutation bottom state into lifecycle bottom scroll', () => {
         const addOneMessage = findExportedFunction('addOneMessage');
         expect(addOneMessage).toBeTruthy();

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -263,4 +263,32 @@ describe('chat render lifecycle script wiring', () => {
             name: 'messageElement',
         }));
     });
+
+    test('updateMessageBlock keeps lifecycle update routing behind the rollout guard', () => {
+        const updateMessageBlock = findExportedFunction('updateMessageBlock');
+        const source = getSource(updateMessageBlock);
+
+        expect(source).toContain('if (shouldDeferMobileMessageUpdates())');
+        expect(source).toContain('queueMobileMessageBlockUpdate(messageId, message, { rerenderMessage });');
+        expect(source).toContain('if (isChatRenderLifecycleRolloutEnabled())');
+        expect(source).toContain('updateMessageBlockThroughLifecycle(messageId, message, { rerenderMessage });');
+        expect(source).toContain('applyMessageBlockUpdate(messageId, message, { rerenderMessage });');
+    });
+
+    test('guard-on updateMessageBlock delegates queue mechanics to the lifecycle update queue helper', () => {
+        expect(scriptSource).toContain('createMessageUpdateQueue,');
+
+        const getMessageUpdateQueue = findFunctionDeclaration('getMessageUpdateQueue');
+        const getQueueSource = getSource(getMessageUpdateQueue);
+
+        expect(getQueueSource).toContain('createMessageUpdateQueue({');
+        expect(getQueueSource).toContain('applyUpdate: applyMessageBlockUpdate');
+
+        const updateMessageBlockThroughLifecycle = findFunctionDeclaration('updateMessageBlockThroughLifecycle');
+        const lifecycleSource = getSource(updateMessageBlockThroughLifecycle);
+
+        expect(lifecycleSource).toContain('const queue = getMessageUpdateQueue();');
+        expect(lifecycleSource).toContain('queue.queue(messageId, message, { rerenderMessage });');
+        expect(lifecycleSource).toContain('queue.flush();');
+    });
 });

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -317,4 +317,31 @@ describe('chat render lifecycle script wiring', () => {
         expect(queueSource).toContain('pendingMobileMessageUpdateTimer = window.setTimeout(() =>');
         expect(queueSource).toContain('pendingMobileMessageUpdateFrame = requestAnimationFrame(flushPendingMobileMessageUpdates);');
     });
+
+    test('streaming start keeps viewport routing behind the lifecycle rollout guard', () => {
+        const onStartStreaming = findNode(scriptAst, node => node.type === 'MethodDefinition'
+            && node.key?.name === 'onStartStreaming');
+        const source = getSource(onStartStreaming.value);
+
+        expect(source).toContain('hideSwipeButtons({ hideCounters: true });');
+        expect(source).toContain('scrollLock = false;');
+        expect(source).toContain('scrollLockImmunityUntil = Date.now() + 500;');
+        expect(source).toContain('scrollStartedStreamingMessageThroughLifecycle();');
+        expect(source).not.toContain('scrollChatToBottom({ waitForFrame: true });');
+    });
+
+    test('guard-on streaming start resolves viewport intent through lifecycle scroll rules', () => {
+        const scrollStartedStreamingMessageThroughLifecycle = findFunctionDeclaration('scrollStartedStreamingMessageThroughLifecycle');
+        const source = getSource(scrollStartedStreamingMessageThroughLifecycle);
+
+        expect(source).toContain('if (!isChatRenderLifecycleRolloutEnabled())');
+        expect(source).toContain('scrollChatToBottom({ waitForFrame: true });');
+        expect(source).toContain('resolveChatScrollAction({');
+        expect(source).toContain('intent: CHAT_SCROLL_INTENT.STREAM_PROGRESS');
+        expect(source).toContain('autoScrollEnabled: power_user.auto_scroll_chat_to_bottom');
+        expect(source).toContain('isNearBottom: isChatScrolledNearBottom()');
+        expect(source).toContain('isManualScrollSuppressed: shouldSuppressMobileChatAutoScroll()');
+        expect(source).toContain('shouldApplyChatBottomScrollAction(action)');
+        expect(source).toContain('scrollChatElementToBottom();');
+    });
 });

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -437,4 +437,89 @@ describe('chat render lifecycle script wiring', () => {
         expect(runGenerateBlock).not.toContain('getSwipeReplacementViewportUpdate');
         expect(runGenerateBlock).not.toContain('addOneMessage');
     });
+
+    test('guard-on message rendering registers delegated resize observation', () => {
+        expect(scriptSource).toContain('createDelegatedResizeObserver,');
+        expect(scriptSource).toContain('let chatMessageResizeObserver = null;');
+        expect(scriptSource).toContain('const chatMessageResizeStates = new Map();');
+
+        const updateMessageElement = findExportedFunction('updateMessageElement');
+        expect(getSource(updateMessageElement)).toContain('observeChatMessageResize(messageElement);');
+
+        const observeChatMessageResize = findFunctionDeclaration('observeChatMessageResize');
+        const observeSource = getSource(observeChatMessageResize);
+
+        expect(observeSource).toContain('if (!isChatRenderLifecycleRolloutEnabled() || !canObserveChatMessageResize())');
+        expect(observeSource).toContain('const messageBlock = getMessageBlockElement(messageElement);');
+        expect(observeSource).toContain('requestAnimationFrame(() =>');
+        expect(observeSource).toContain('const observer = getChatMessageResizeObserver();');
+        expect(observeSource).toContain('unobserveChatMessageResizeBlock(messageBlock);');
+        expect(observeSource).toContain('const metadata = captureChatMessageResizeState(messageBlock);');
+        expect(observeSource).toContain('observer.observe(messageBlock, metadata)');
+        expect(observeSource).toContain('chatMessageResizeStates.set(messageBlock, metadata);');
+
+        const getMessageBlockElement = findFunctionDeclaration('getMessageBlockElement');
+        expect(getSource(getMessageBlockElement)).toContain('element.matches(\'.mes_block\') ? element : element.querySelector(\'.mes_block\')');
+
+        const getChatMessageResizeObserver = findFunctionDeclaration('getChatMessageResizeObserver');
+        expect(getSource(getChatMessageResizeObserver)).toContain('createDelegatedResizeObserver({');
+        expect(getSource(getChatMessageResizeObserver)).toContain('onResize: onChatMessageResize');
+    });
+
+    test('guard-on message resize resolves media-resize intent through lifecycle scroll rules', () => {
+        const applyChatMessageResizeAction = findFunctionDeclaration('applyChatMessageResizeAction');
+        const source = getSource(applyChatMessageResizeAction);
+
+        expect(source).toContain('if (!isChatRenderLifecycleRolloutEnabled())');
+        expect(source).toContain('const resizeState = metadata ?? captureChatMessageResizeState(element, entry);');
+        expect(source).toContain('intent: CHAT_SCROLL_INTENT.MEDIA_RESIZE');
+        expect(source).toContain('autoScrollEnabled: power_user.auto_scroll_chat_to_bottom');
+        expect(source).toContain('isNearBottom: Boolean(resizeState.isNearBottom)');
+        expect(source).toContain('hasAnchor: Boolean(resizeState.anchor)');
+        expect(source).toContain('isManualScrollSuppressed: shouldSuppressMobileChatAutoScroll()');
+        expect(source).toContain('shouldApplyChatBottomScrollAction(action)');
+        expect(source).toContain('scrollChatElementToBottom();');
+        expect(source).toContain('action.action === CHAT_SCROLL_ACTION.PRESERVE_ANCHOR');
+        expect(source).toContain('await settleVisibleChatMessageAnchor(resizeState.anchor);');
+        expect(source).toContain('refreshChatMessageResizeState(element, metadata, entry);');
+    });
+
+    test('message resize metadata refreshes viewport anchors on chat scroll', () => {
+        const refreshObservedChatMessageResizeViewportStates = findFunctionDeclaration('refreshObservedChatMessageResizeViewportStates');
+        const source = getSource(refreshObservedChatMessageResizeViewportStates);
+
+        expect(source).toContain('if (chatMessageResizeStates.size === 0)');
+        expect(source).toContain('const viewportState = captureChatMessageResizeViewportState();');
+        expect(source).toContain('for (const [element, metadata] of chatMessageResizeStates)');
+        expect(source).toContain('unobserveChatMessageResizeBlock(element);');
+        expect(source).toContain('Object.assign(metadata, viewportState);');
+
+        expect(scriptSource).toContain('const chatScrollHandler = function () {');
+        expect(scriptSource).toContain('refreshObservedChatMessageResizeViewportStates();');
+    });
+
+    test('message resize observer cleans up on chat removal paths', () => {
+        const unobserveChatMessageResize = findFunctionDeclaration('unobserveChatMessageResize');
+        const unobserveSource = getSource(unobserveChatMessageResize);
+
+        expect(unobserveSource).toContain('messageElement.toArray().forEach(unobserveChatMessageResize);');
+        expect(unobserveSource).toContain('unobserveChatMessageResizeBlock(messageBlock);');
+
+        const disposeChatMessageResizeObserver = findFunctionDeclaration('disposeChatMessageResizeObserver');
+        const disposeSource = getSource(disposeChatMessageResizeObserver);
+
+        expect(disposeSource).toContain('chatMessageResizeObserver?.dispose();');
+        expect(disposeSource).toContain('chatMessageResizeObserver = null;');
+        expect(disposeSource).toContain('chatMessageResizeStates.clear();');
+
+        expect(getSource(findExportedFunction('redisplayChat'))).toContain('unobserveChatMessageResize(removedMessageElements);');
+        expect(getSource(findExportedFunction('clearChat'))).toContain('disposeChatMessageResizeObserver();');
+        expect(getSource(findExportedFunction('deleteLastMessage'))).toContain('unobserveChatMessageResize(messageElement);');
+        expect(getSource(findExportedFunction('deleteMessage'))).toContain('unobserveChatMessageResize(messageElement);');
+        expect(scriptSource).toContain('$(window).on(\'beforeunload\', () => {');
+        expect(scriptSource).toContain('disposeChatMessageResizeObserver();');
+
+        const onChatMessageResize = findFunctionDeclaration('onChatMessageResize');
+        expect(getSource(onChatMessageResize)).toContain('unobserveChatMessageResizeBlock(element);');
+    });
 });

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -387,4 +387,54 @@ describe('chat render lifecycle script wiring', () => {
         expect(queueSource).toContain('applyStreamingVisibleWrite(messageId, write, { isFinal });');
         expect(queueSource).toContain('getStreamingVisibleWriteBuffer().queue(messageId, write, { isFinal });');
     });
+
+    test('swipe replacement keeps viewport routing behind the lifecycle rollout guard', () => {
+        const getSwipeReplacementViewportUpdate = findFunctionDeclaration('getSwipeReplacementViewportUpdate');
+        const source = getSource(getSwipeReplacementViewportUpdate);
+
+        expect(source).toContain('if (!useLifecycleRoute || !isChatRenderLifecycleRolloutEnabled())');
+        expect(source).toContain('const anchor = isLastMessageSwipe && !isChatScrolledNearBottom()');
+        expect(source).toContain('captureVisibleChatMessageAnchor()');
+        expect(source).toContain('scrollWithAddOneMessage: isLastMessageSwipe && !anchor');
+        expect(source).toContain('intent: CHAT_SCROLL_INTENT.REPLACE_MESSAGE');
+        expect(source).toContain('autoScrollEnabled: power_user.auto_scroll_chat_to_bottom');
+        expect(source).toContain('isNearBottom,');
+        expect(source).toContain('hasAnchor: Boolean(anchor)');
+        expect(source).toContain('isManualScrollSuppressed: shouldSuppressMobileChatAutoScroll()');
+        expect(source).toContain('scrollWithAddOneMessage: false');
+    });
+
+    test('guard-on swipe replacement applies bottom or anchor lifecycle actions', () => {
+        const applySwipeReplacementViewportUpdate = findFunctionDeclaration('applySwipeReplacementViewportUpdate');
+        const applySource = getSource(applySwipeReplacementViewportUpdate);
+
+        expect(applySource).toContain('shouldApplyChatBottomScrollAction(viewportUpdate?.action)');
+        expect(applySource).toContain('requestAnimationFrame(() =>');
+        expect(applySource).toContain('scrollChatElementToBottom();');
+        expect(applySource).toContain('await settleSwipeReplacementAnchor(viewportUpdate);');
+
+        const shouldSettleSwipeReplacementAnchor = findFunctionDeclaration('shouldSettleSwipeReplacementAnchor');
+        const settleSource = getSource(shouldSettleSwipeReplacementAnchor);
+
+        expect(settleSource).toContain('Boolean(viewportUpdate?.anchor)');
+        expect(settleSource).toContain('viewportUpdate.action.action === CHAT_SCROLL_ACTION.PRESERVE_ANCHOR');
+    });
+
+    test('display-only swipe replacement delegates viewport handling without touching generation flow', () => {
+        const swipe = findExportedFunction('swipe');
+        const source = getSource(swipe);
+
+        expect(source).toContain('let swipeViewportUpdate = null;');
+        expect(source).toContain('let isOverswipeReplacement = false;');
+        expect(source).toContain('const useLifecycleRoute = source !== SWIPE_SOURCE.DELETE && source !== SWIPE_SOURCE.BACK && !isOverswipeReplacement;');
+        expect(source).toContain('swipeViewportUpdate = getSwipeReplacementViewportUpdate({ isLastMessageSwipe, useLifecycleRoute });');
+        expect(source).toContain('isOverswipeReplacement = true;');
+        expect(source).toContain('addOneMessage(chat[mesId], { type: \'swipe\', forceId: mesId, scroll: swipeViewportUpdate.scrollWithAddOneMessage, showSwipes: false });');
+        expect(source).toContain('await applySwipeReplacementViewportUpdate(swipeViewportUpdate);');
+        expect(source).toContain('await settleSwipeReplacementAnchor(swipeViewportUpdate);');
+
+        const runGenerateBlock = source.slice(source.indexOf('if (run_generate) {'), source.indexOf('} else {', source.indexOf('if (run_generate) {')));
+        expect(runGenerateBlock).not.toContain('getSwipeReplacementViewportUpdate');
+        expect(runGenerateBlock).not.toContain('addOneMessage');
+    });
 });

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -291,4 +291,30 @@ describe('chat render lifecycle script wiring', () => {
         expect(lifecycleSource).toContain('queue.queue(messageId, message, { rerenderMessage });');
         expect(lifecycleSource).toContain('queue.flush();');
     });
+
+    test('mobile-deferred message updates use the lifecycle update queue without changing scheduling policy', () => {
+        expect(scriptSource).not.toContain('pendingMobileMessageUpdates = new Map');
+        expect(scriptSource).not.toContain('pendingMobileMessageUpdates.set');
+
+        const getMobileMessageUpdateQueue = findFunctionDeclaration('getMobileMessageUpdateQueue');
+        const getMobileQueueSource = getSource(getMobileMessageUpdateQueue);
+
+        expect(getMobileQueueSource).toContain('createMessageUpdateQueue({');
+        expect(getMobileQueueSource).toContain('applyUpdate: applyMessageBlockUpdate');
+
+        const flushPendingMobileMessageUpdates = findFunctionDeclaration('flushPendingMobileMessageUpdates');
+        const flushSource = getSource(flushPendingMobileMessageUpdates);
+
+        expect(flushSource).toContain('pendingMobileMessageUpdateFrame = 0;');
+        expect(flushSource).toContain('pendingMobileMessageUpdateTimer = 0;');
+        expect(flushSource).toContain('getMobileMessageUpdateQueue().flush();');
+
+        const queueMobileMessageBlockUpdate = findFunctionDeclaration('queueMobileMessageBlockUpdate');
+        const queueSource = getSource(queueMobileMessageBlockUpdate);
+
+        expect(queueSource).toContain('getMobileMessageUpdateQueue().queue(messageId, message, { rerenderMessage });');
+        expect(queueSource).toContain('if (pendingMobileMessageUpdateFrame || pendingMobileMessageUpdateTimer)');
+        expect(queueSource).toContain('pendingMobileMessageUpdateTimer = window.setTimeout(() =>');
+        expect(queueSource).toContain('pendingMobileMessageUpdateFrame = requestAnimationFrame(flushPendingMobileMessageUpdates);');
+    });
 });

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -522,4 +522,59 @@ describe('chat render lifecycle script wiring', () => {
         const onChatMessageResize = findFunctionDeclaration('onChatMessageResize');
         expect(getSource(onChatMessageResize)).toContain('unobserveChatMessageResizeBlock(element);');
     });
+
+    test('guard-on mobile viewport events route through the lifecycle observer helper', () => {
+        expect(scriptSource).toContain('createMobileViewportObserver,');
+        expect(scriptSource).toContain('let mobileChatViewportObserver = null;');
+
+        const setupMobileChatViewportObserver = findFunctionDeclaration('setupMobileChatViewportObserver');
+        const setupSource = getSource(setupMobileChatViewportObserver);
+
+        expect(setupSource).toContain('if (!isChatRenderLifecycleRolloutEnabled())');
+        expect(setupSource).toContain('window.visualViewport?.addEventListener(\'scroll\', onViewportChange, { passive: true });');
+        expect(setupSource).toContain('window.visualViewport?.addEventListener(\'resize\', onViewportChange, { passive: true });');
+        expect(setupSource).toContain('disposeMobileChatViewportObserver();');
+        expect(setupSource).toContain('mobileChatViewportObserver = createMobileViewportObserver({');
+        expect(setupSource).toContain('onViewportChange,');
+        expect(setupSource).toContain('onViewportSettle: onViewportChange');
+        expect(setupSource).toContain('mobileChatViewportObserver.start();');
+
+        const initSource = scriptSource.slice(scriptSource.indexOf('const chatElementScroll = document.getElementById(\'chat\');'));
+        expect(initSource).toContain('const markMobileViewportScroll = getMobileViewportScrollHandler();');
+        expect(initSource).toContain('setupMobileChatViewportObserver(markMobileViewportScroll);');
+    });
+
+    test('mobile viewport lifecycle route preserves existing scroll suppression policy', () => {
+        const getMobileViewportScrollHandler = findFunctionDeclaration('getMobileViewportScrollHandler');
+        const handlerSource = getSource(getMobileViewportScrollHandler);
+
+        expect(handlerSource).toContain('if (mobileChatTouchScrolling || Date.now() < mobileChatManualScrollSuppressedUntil)');
+        expect(handlerSource).toContain('markMobileChatManualScroll({ suppressMs: MOBILE_CHAT_VIEWPORT_SCROLL_SUPPRESS_MS });');
+
+        const resetMobileViewportScrollState = findFunctionDeclaration('resetMobileViewportScrollState');
+        const resetSource = getSource(resetMobileViewportScrollState);
+
+        expect(resetSource).toContain('mobileChatTouchScrolling = false;');
+        expect(resetSource).toContain('mobileChatManualScrollSuppressedUntil = 0;');
+        expect(resetSource).toContain('mobileChatBottomPinUntil = 0;');
+    });
+
+    test('mobile viewport lifecycle observer resets on chat clear and disposes on unload', () => {
+        const disposeMobileChatViewportObserver = findFunctionDeclaration('disposeMobileChatViewportObserver');
+        const disposeSource = getSource(disposeMobileChatViewportObserver);
+
+        expect(disposeSource).toContain('mobileChatViewportObserver?.dispose();');
+        expect(disposeSource).toContain('mobileChatViewportObserver = null;');
+
+        const resetMobileChatViewportLifecycle = findFunctionDeclaration('resetMobileChatViewportLifecycle');
+        const resetSource = getSource(resetMobileChatViewportLifecycle);
+
+        expect(resetSource).toContain('if (!isChatRenderLifecycleRolloutEnabled())');
+        expect(resetSource).toContain('resetMobileViewportScrollState();');
+        expect(resetSource).toContain('setupMobileChatViewportObserver(getMobileViewportScrollHandler());');
+
+        expect(getSource(findExportedFunction('clearChat'))).toContain('resetMobileChatViewportLifecycle();');
+        expect(scriptSource).toContain('$(window).on(\'beforeunload\', () => {');
+        expect(scriptSource).toContain('disposeMobileChatViewportObserver();');
+    });
 });

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -344,4 +344,47 @@ describe('chat render lifecycle script wiring', () => {
         expect(source).toContain('shouldApplyChatBottomScrollAction(action)');
         expect(source).toContain('scrollChatElementToBottom();');
     });
+
+    test('streaming progress keeps visible DOM write routing behind the lifecycle rollout guard', () => {
+        const onProgressStreaming = findNode(scriptAst, node => node.type === 'MethodDefinition'
+            && node.key?.name === 'onProgressStreaming');
+        const source = getSource(onProgressStreaming.value);
+
+        expect(source).toContain('await this.#checkDomElements(messageId);');
+        expect(source).toContain('await updateMessageTokenAccounting(chat[messageId],');
+        expect(source).toContain('shouldUpdateMetaBadges: !shouldReduceIntermediateStreamingWork');
+        expect(source).toContain('this.setFirstSwipe(messageId);');
+        expect(source).toContain('this.#queueStreamingVisibleWrite({');
+        expect(source).toContain('formattedText,');
+        expect(source).toContain('timePassed,');
+        expect(source).toContain('currentTokenCount,');
+        expect(source).toContain('isFinal,');
+    });
+
+    test('guard-on streaming progress delegates visible DOM writes to the lifecycle stream buffer', () => {
+        expect(scriptSource).toContain('createStreamWriteBuffer,');
+
+        const getStreamingVisibleWriteBuffer = findFunctionDeclaration('getStreamingVisibleWriteBuffer');
+        const getBufferSource = getSource(getStreamingVisibleWriteBuffer);
+
+        expect(getBufferSource).toContain('createStreamWriteBuffer({');
+        expect(getBufferSource).toContain('applyWrite: applyStreamingVisibleWrite');
+
+        const applyStreamingVisibleWrite = findFunctionDeclaration('applyStreamingVisibleWrite');
+        const applySource = getSource(applyStreamingVisibleWrite);
+
+        expect(applySource).toContain('applyStreamFadeIn(messageTextDom, formattedText,');
+        expect(applySource).toContain('messageTextDom.innerHTML = formattedText;');
+        expect(applySource).toContain('messageTokenCounterDom.textContent = `${currentTokenCount}t`;');
+        expect(applySource).toContain('messageTimerDom.textContent = timePassed.timerValue;');
+        expect(applySource).toContain('messageTimerDom.title = timePassed.timerTitle;');
+
+        const queueStreamingVisibleWrite = findNode(scriptAst, node => node.type === 'MethodDefinition'
+            && node.key?.name === 'queueStreamingVisibleWrite');
+        const queueSource = getSource(queueStreamingVisibleWrite.value);
+
+        expect(queueSource).toContain('if (!isChatRenderLifecycleRolloutEnabled())');
+        expect(queueSource).toContain('applyStreamingVisibleWrite(messageId, write, { isFinal });');
+        expect(queueSource).toContain('getStreamingVisibleWriteBuffer().queue(messageId, write, { isFinal });');
+    });
 });

--- a/tests/chat-render-lifecycle-stream-buffer.test.js
+++ b/tests/chat-render-lifecycle-stream-buffer.test.js
@@ -1,0 +1,146 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { createStreamWriteBuffer } from '../public/scripts/chat-render-lifecycle/stream-buffer.js';
+
+function createFakeScheduler() {
+    let scheduledCallback = null;
+
+    return {
+        get hasScheduledCallback() {
+            return typeof scheduledCallback === 'function';
+        },
+        requestCount: 0,
+        cancelCount: 0,
+        request(callback) {
+            this.requestCount++;
+            scheduledCallback = callback;
+        },
+        cancel() {
+            this.cancelCount++;
+            scheduledCallback = null;
+        },
+        run() {
+            const callback = scheduledCallback;
+            scheduledCallback = null;
+            callback?.();
+        },
+    };
+}
+
+describe('chat render lifecycle stream buffer helper', () => {
+    test('coalesces visible stream writes into one scheduled frame lane', () => {
+        const scheduler = createFakeScheduler();
+        const applied = [];
+        const buffer = createStreamWriteBuffer({
+            scheduler,
+            applyWrite: (messageId, write, options) => applied.push({ messageId, write, options }),
+        });
+
+        expect(buffer.queue(1, { text: 'first' }, { isFinal: false })).toBe(1);
+        expect(buffer.queue(1, { text: 'latest' }, { isFinal: false })).toBe(1);
+
+        expect(scheduler.requestCount).toBe(1);
+        expect(buffer.size()).toBe(1);
+        expect(applied).toEqual([]);
+
+        scheduler.run();
+
+        expect(buffer.size()).toBe(0);
+        expect(applied).toEqual([
+            { messageId: 1, write: { text: 'latest' }, options: { isFinal: false } },
+        ]);
+    });
+
+    test('keeps distinct message writes in insertion order', () => {
+        const scheduler = createFakeScheduler();
+        const applied = [];
+        const buffer = createStreamWriteBuffer({
+            scheduler,
+            applyWrite: (messageId, write, options) => applied.push({ messageId, write, options }),
+        });
+
+        buffer.queue(2, { text: 'second' }, { isFinal: false });
+        buffer.queue(3, { text: 'third' }, { isFinal: false });
+        scheduler.run();
+
+        expect(applied).toEqual([
+            { messageId: 2, write: { text: 'second' }, options: { isFinal: false } },
+            { messageId: 3, write: { text: 'third' }, options: { isFinal: false } },
+        ]);
+    });
+
+    test('final writes flush immediately and cancel a pending scheduled frame', () => {
+        const scheduler = createFakeScheduler();
+        const applied = [];
+        const buffer = createStreamWriteBuffer({
+            scheduler,
+            applyWrite: (messageId, write, options) => applied.push({ messageId, write, options }),
+        });
+
+        buffer.queue(4, { text: 'draft' }, { isFinal: false });
+
+        expect(scheduler.hasScheduledCallback).toBe(true);
+        expect(buffer.queue(4, { text: 'final' }, { isFinal: true })).toBe(0);
+
+        expect(scheduler.cancelCount).toBe(1);
+        expect(scheduler.hasScheduledCallback).toBe(false);
+        expect(applied).toEqual([
+            { messageId: 4, write: { text: 'final' }, options: { isFinal: true } },
+        ]);
+    });
+
+    test('clears before applying so nested writes survive for the next flush', () => {
+        const scheduler = createFakeScheduler();
+        const applied = [];
+        const buffer = createStreamWriteBuffer({
+            scheduler,
+            applyWrite: (messageId, write, options) => {
+                applied.push({ messageId, write, options });
+
+                if (messageId === 5) {
+                    buffer.queue(6, { text: 'nested' }, { isFinal: false });
+                }
+            },
+        });
+
+        buffer.queue(5, { text: 'outer' }, { isFinal: true });
+
+        expect(buffer.size()).toBe(1);
+        expect(applied).toEqual([
+            { messageId: 5, write: { text: 'outer' }, options: { isFinal: true } },
+        ]);
+
+        scheduler.run();
+
+        expect(applied).toEqual([
+            { messageId: 5, write: { text: 'outer' }, options: { isFinal: true } },
+            { messageId: 6, write: { text: 'nested' }, options: { isFinal: false } },
+        ]);
+    });
+
+    test('clear drops pending writes and cancels the scheduled frame', () => {
+        const scheduler = createFakeScheduler();
+        const applied = [];
+        const buffer = createStreamWriteBuffer({
+            scheduler,
+            applyWrite: (messageId, write, options) => applied.push({ messageId, write, options }),
+        });
+
+        buffer.queue(7, { text: 'drop' }, { isFinal: false });
+        buffer.clear();
+        scheduler.run();
+
+        expect(buffer.size()).toBe(0);
+        expect(scheduler.cancelCount).toBe(1);
+        expect(applied).toEqual([]);
+    });
+
+    test('fails fast for invalid boundary options', () => {
+        expect(() => createStreamWriteBuffer()).toThrow('applyWrite');
+        expect(() => createStreamWriteBuffer({ applyWrite: null })).toThrow('applyWrite');
+        expect(() => createStreamWriteBuffer({
+            applyWrite: () => {},
+            scheduler: null,
+        })).toThrow('scheduler');
+    });
+});

--- a/tests/chat-render-lifecycle-update-queue.test.js
+++ b/tests/chat-render-lifecycle-update-queue.test.js
@@ -1,0 +1,95 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { createMessageUpdateQueue } from '../public/scripts/chat-render-lifecycle/update-queue.js';
+
+describe('chat render lifecycle update queue helper', () => {
+    test('queues and flushes message updates through the injected apply function in order', () => {
+        const applied = [];
+        const queue = createMessageUpdateQueue({
+            applyUpdate: (messageId, message, options) => applied.push({ messageId, message, options }),
+        });
+
+        expect(queue.queue(3, { mes: 'first' }, { rerenderMessage: true })).toBe(1);
+        expect(queue.queue(4, { mes: 'second' }, { rerenderMessage: false })).toBe(2);
+
+        expect(queue.size()).toBe(2);
+        expect(queue.flush()).toBe(2);
+        expect(queue.size()).toBe(0);
+        expect(applied).toEqual([
+            { messageId: 3, message: { mes: 'first' }, options: { rerenderMessage: true } },
+            { messageId: 4, message: { mes: 'second' }, options: { rerenderMessage: false } },
+        ]);
+    });
+
+    test('coalesces duplicate message ids with the latest message and any rerender request', () => {
+        const applied = [];
+        const queue = createMessageUpdateQueue({
+            applyUpdate: (messageId, message, options) => applied.push({ messageId, message, options }),
+        });
+
+        queue.queue(5, { mes: 'old' }, { rerenderMessage: true });
+        queue.queue(5, { mes: 'new' }, { rerenderMessage: false });
+
+        expect(queue.size()).toBe(1);
+        expect(queue.flush()).toBe(1);
+        expect(applied).toEqual([
+            { messageId: 5, message: { mes: 'new' }, options: { rerenderMessage: true } },
+        ]);
+    });
+
+    test('defaults rerenderMessage to true when callers omit options', () => {
+        const applied = [];
+        const queue = createMessageUpdateQueue({
+            applyUpdate: (messageId, message, options) => applied.push({ messageId, message, options }),
+        });
+
+        queue.queue(6, { mes: 'default' });
+        queue.flush();
+
+        expect(applied).toEqual([
+            { messageId: 6, message: { mes: 'default' }, options: { rerenderMessage: true } },
+        ]);
+    });
+
+    test('clears pending updates before applying so nested queue work survives for the next flush', () => {
+        const applied = [];
+        const queue = createMessageUpdateQueue({
+            applyUpdate: (messageId, message, options) => {
+                applied.push({ messageId, message, options });
+
+                if (messageId === 1) {
+                    queue.queue(2, { mes: 'nested' }, { rerenderMessage: false });
+                }
+            },
+        });
+
+        queue.queue(1, { mes: 'outer' }, { rerenderMessage: false });
+
+        expect(queue.flush()).toBe(1);
+        expect(queue.size()).toBe(1);
+        expect(queue.flush()).toBe(1);
+        expect(applied).toEqual([
+            { messageId: 1, message: { mes: 'outer' }, options: { rerenderMessage: false } },
+            { messageId: 2, message: { mes: 'nested' }, options: { rerenderMessage: false } },
+        ]);
+    });
+
+    test('clear drops pending updates without applying them', () => {
+        const applied = [];
+        const queue = createMessageUpdateQueue({
+            applyUpdate: (messageId, message, options) => applied.push({ messageId, message, options }),
+        });
+
+        queue.queue(1, { mes: 'drop' });
+        queue.clear();
+
+        expect(queue.size()).toBe(0);
+        expect(queue.flush()).toBe(0);
+        expect(applied).toEqual([]);
+    });
+
+    test('fails fast for invalid apply function', () => {
+        expect(() => createMessageUpdateQueue()).toThrow('applyUpdate');
+        expect(() => createMessageUpdateQueue({ applyUpdate: null })).toThrow('applyUpdate');
+    });
+});

--- a/tests/chat-scroll-regression-helpers.js
+++ b/tests/chat-scroll-regression-helpers.js
@@ -297,6 +297,34 @@ export async function getRenderedMessageIds(page) {
         .filter(Boolean));
 }
 
+export async function markFirstRenderedMessageEditing(page) {
+    const firstEditButton = page.locator('#chat .mes[mesid] .mes_edit').first();
+
+    await firstEditButton.waitFor({ state: 'visible', timeout: 5000 });
+    await firstEditButton.click();
+    await page.locator('#chat .mes[mesid] .mes_edit_buttons:visible').first().waitFor({ state: 'visible', timeout: 5000 });
+    await waitForAnimationFrames(page, 2);
+}
+
+export async function getRedisplayCompatibilitySnapshot(page) {
+    return page.evaluate(() => {
+        const chat = document.querySelector('#chat');
+        const messages = Array.from(chat.querySelectorAll('.mes[mesid]'));
+        const firstMessage = messages.at(0);
+        const lastMessage = messages.at(-1);
+
+        return {
+            renderedMessageIds: messages.map(message => message.getAttribute('mesid')),
+            lastMessageId: lastMessage?.getAttribute('mesid') ?? null,
+            lastMessageClassCount: chat.querySelectorAll('.mes.last_mes').length,
+            fadeClassCount: chat.querySelectorAll('.mes.fade').length,
+            stylePinsCount: chat.querySelectorAll(':scope > .style-pins').length,
+            firstEditUpDisabled: firstMessage?.querySelector('.mes_edit_up')?.classList.contains('disabled') ?? false,
+            firstEditDownDisabled: firstMessage?.querySelector('.mes_edit_down')?.classList.contains('disabled') ?? false,
+        };
+    });
+}
+
 export async function scrollMessageNearTop(page, messageId, offsetTop = 24) {
     await page.waitForFunction((targetMessageId) => {
         return document.querySelector(`#chat .mes[mesid="${targetMessageId}"]`) !== null;

--- a/tests/chat-scroll-regression-helpers.js
+++ b/tests/chat-scroll-regression-helpers.js
@@ -352,3 +352,24 @@ export async function markManualMobileScroll(page, scrollTop) {
     }, scrollTop);
     await waitForAnimationFrames(page, 2);
 }
+
+export async function growMessageBlockAboveViewport(page, messageId, { height = 420 } = {}) {
+    await page.evaluate(({ targetMessageId, nextHeight }) => {
+        const chat = document.querySelector('#chat');
+        const message = chat.querySelector(`.mes[mesid="${targetMessageId}"]`);
+        const messageText = message?.querySelector('.mes_text');
+
+        if (!(messageText instanceof HTMLElement)) {
+            throw new Error(`Could not find message text for message ${targetMessageId}.`);
+        }
+
+        const lateMedia = document.createElement('div');
+        lateMedia.className = 'issue-167-late-media';
+        lateMedia.style.height = `${nextHeight}px`;
+        lateMedia.style.margin = '8px 0';
+        lateMedia.style.width = '100%';
+
+        messageText.prepend(lateMedia);
+    }, { targetMessageId: String(messageId), nextHeight: height });
+    await waitForAnimationFrames(page, 10);
+}

--- a/tests/chat-scroll-regressions.e2e.js
+++ b/tests/chat-scroll-regressions.e2e.js
@@ -4,6 +4,7 @@ import {
     getChatScrollSnapshot,
     getRedisplayCompatibilitySnapshot,
     getRenderedMessageIds,
+    growMessageBlockAboveViewport,
     installSwipeCandidate,
     installSyntheticLongChat,
     markFirstRenderedMessageEditing,
@@ -87,6 +88,20 @@ test.describe('issue 167 chat scroll regressions', () => {
         expect(after.firstVisibleMesId).toBe(before.firstVisibleMesId);
         expect(Math.abs(after.firstVisibleOffsetTop - before.firstVisibleOffsetTop)).toBeLessThanOrEqual(8);
         await expect(page.locator(`.mes[mesid="${swipeMessageId}"] .mes_text`)).toContainText(`issue 167 replacement swipe ${swipeMessageId}`);
+    });
+
+    test('late media resize above the viewport keeps the current message anchored', async ({ page }) => {
+        await installSyntheticLongChat(page, { messageCount: 72, visibleCount: 72 });
+
+        await scrollMessageNearTop(page, 48, 24);
+
+        const before = await getChatScrollSnapshot(page);
+        await growMessageBlockAboveViewport(page, 12, { height: 460 });
+        const after = await getChatScrollSnapshot(page);
+
+        expect(after.firstVisibleMesId).toBe(before.firstVisibleMesId);
+        expect(Math.abs(after.firstVisibleOffsetTop - before.firstVisibleOffsetTop)).toBeLessThanOrEqual(8);
+        expect(after.scrollTop).toBeGreaterThan(before.scrollTop + 300);
     });
 });
 

--- a/tests/chat-scroll-regressions.e2e.js
+++ b/tests/chat-scroll-regressions.e2e.js
@@ -2,9 +2,11 @@
 import { expect, test } from '@playwright/test';
 import {
     getChatScrollSnapshot,
+    getRedisplayCompatibilitySnapshot,
     getRenderedMessageIds,
     installSwipeCandidate,
     installSyntheticLongChat,
+    markFirstRenderedMessageEditing,
     markManualMobileScroll,
     openReadyChat,
     scrollMessageNearTop,
@@ -26,6 +28,22 @@ test.describe('issue 167 chat scroll regressions', () => {
         expect(snapshot.lastMesId).toBe('95');
         expect(snapshot.lastVisibleMesId).toBe('95');
         expect(snapshot.bottomDelta).toBeLessThanOrEqual(16);
+    });
+
+    test('redisplay keeps render follow-up hooks applied after batched render', async ({ page }) => {
+        await installSyntheticLongChat(page, { messageCount: 36, visibleCount: 12 });
+        await markFirstRenderedMessageEditing(page);
+        await page.evaluate(async () => window.SillyTavern.getContext().redisplayChat({ startIndex: 24, fade: false }));
+
+        const snapshot = await getRedisplayCompatibilitySnapshot(page);
+
+        expect(snapshot.renderedMessageIds).toEqual(Array.from({ length: 12 }, (_, index) => String(24 + index)));
+        expect(snapshot.lastMessageId).toBe('35');
+        expect(snapshot.lastMessageClassCount).toBe(1);
+        expect(snapshot.fadeClassCount).toBe(0);
+        expect(snapshot.stylePinsCount).toBe(0);
+        expect(snapshot.firstEditUpDisabled).toBe(true);
+        expect(snapshot.firstEditDownDisabled).toBe(false);
     });
 
     test('show more preserves the first visible message anchor', async ({ page }) => {

--- a/tests/measure-frontend-performance.test.js
+++ b/tests/measure-frontend-performance.test.js
@@ -1,0 +1,128 @@
+/* global globalThis */
+import { describe, expect, test } from '@jest/globals';
+
+import {
+    createLongChatRenderFixture,
+    LONG_CHAT_RENDER_FILLER_REPEAT,
+    LONG_CHAT_RENDER_MESSAGE_COUNT,
+    LONG_CHAT_RENDER_VISIBLE_COUNT,
+    measureLongChatRender,
+    summarizeRequests,
+} from '../scripts/measure-frontend-performance.js';
+
+describe('frontend performance measurement helpers', () => {
+    test('records the long-chat render fixture size used for baseline measurements', () => {
+        const fixture = createLongChatRenderFixture();
+
+        expect(fixture.messageCount).toBe(LONG_CHAT_RENDER_MESSAGE_COUNT);
+        expect(fixture.visibleCount).toBe(LONG_CHAT_RENDER_VISIBLE_COUNT);
+        expect(fixture.fillerRepeat).toBe(LONG_CHAT_RENDER_FILLER_REPEAT);
+        expect(fixture.messages).toHaveLength(96);
+        expect(fixture.messages.at(0)).toEqual(expect.objectContaining({
+            name: 'Scroll Tester',
+            is_user: true,
+            is_system: false,
+        }));
+        expect(fixture.messages.at(1)).toEqual(expect.objectContaining({
+            name: 'Bunny Guide',
+            is_user: false,
+            is_system: false,
+        }));
+        expect(fixture.messages.at(-1).mes).toContain('performance synthetic message 95');
+    });
+
+    test('summarizes request bytes by asset type', () => {
+        expect(summarizeRequests([
+            { url: 'http://example.test/script.js', bytes: 12 },
+            { url: 'http://example.test/styles.css?v=1', bytes: 20 },
+            { url: 'http://example.test/font.woff2', bytes: 30 },
+            { url: 'http://example.test/image.webp', bytes: 40 },
+            { url: 'http://example.test/api/status', bytes: 50 },
+        ])).toEqual({
+            count: 5,
+            js: 12,
+            css: 20,
+            font: 30,
+            image: 40,
+            other: 50,
+        });
+    });
+
+    test('measures long-chat render timing through the browser page contract', async () => {
+        const page = {
+            evaluate: async (callback, fixture) => {
+                const previousGlobal = globalThis.SillyTavern;
+                const previousDocument = globalThis.document;
+                const previousHTMLElement = globalThis.HTMLElement;
+                const previousPerformance = globalThis.performance;
+                const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+                const renderedMessages = [];
+                const chatElement = {
+                    scrollHeight: 1200,
+                    clientHeight: 500,
+                    scrollTop: 700,
+                    replaceChildren: () => renderedMessages.splice(0),
+                    querySelectorAll: () => renderedMessages,
+                };
+                const context = {
+                    powerUserSettings: {},
+                    chat: [],
+                    printMessages: async () => {
+                        renderedMessages.push(...fixture.messages.slice(-fixture.visibleCount).map((message, offset) => ({
+                            getAttribute: attributeName => attributeName === 'mesid'
+                                ? String(fixture.messageCount - fixture.visibleCount + offset)
+                                : null,
+                        })));
+                    },
+                };
+
+                try {
+                    globalThis.HTMLElement = Object;
+                    globalThis.document = {
+                        querySelector: () => chatElement,
+                    };
+                    globalThis.SillyTavern = {
+                        getContext: () => context,
+                    };
+                    globalThis.performance = {
+                        now: (() => {
+                            let now = 100;
+                            return () => {
+                                now += 25;
+                                return now;
+                            };
+                        })(),
+                    };
+                    globalThis.requestAnimationFrame = callbackRef => callbackRef();
+
+                    return await callback(fixture);
+                } finally {
+                    globalThis.SillyTavern = previousGlobal;
+                    globalThis.document = previousDocument;
+                    globalThis.HTMLElement = previousHTMLElement;
+                    globalThis.performance = previousPerformance;
+                    globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+                }
+            },
+        };
+
+        const result = await measureLongChatRender(page, createLongChatRenderFixture());
+
+        expect(result).toEqual(expect.objectContaining({
+            available: true,
+            durationMs: 25,
+            messageCount: 96,
+            visibleCount: 24,
+            fillerRepeat: 36,
+            renderedCount: 24,
+            firstRenderedMesId: '72',
+            lastRenderedMesId: '95',
+            bottomDelta: 0,
+        }));
+        expect(result.fixture).toEqual({
+            messageCount: 96,
+            visibleCount: 24,
+            fillerRepeat: 36,
+        });
+    });
+});


### PR DESCRIPTION
## What?
Adds a chat render timing sample to the frontend performance harness and unit coverage for the new measurement helpers.

## Why?
The lifecycle stack needs recorded long-chat render evidence before adding regression thresholds. This captures an observational baseline without changing runtime behavior or enforcing pass/fail timing budgets.

## How?
The harness now builds a synthetic 96-message chat fixture, renders the latest 24 visible messages through `printMessages()`, and reports duration, rendered message IDs, rendered count, fixture size, and bottom drift under `metrics.chatRender.longChat`. The script is import-safe so unit tests can exercise helper behavior without launching Playwright.

## Testing?
- `npm run test:unit --prefix tests -- measure-frontend-performance.test.js`
- `npm run lint --prefix tests -- measure-frontend-performance.test.js`
- `npm run lint -- --quiet`
- `npm run test:unit --prefix tests -- script-export-surface.test.js chat-render-lifecycle-index.test.js chat-render-lifecycle-render-batch.test.js chat-render-lifecycle-rollout-guard.test.js chat-render-lifecycle-script-wiring.test.js chat-render-lifecycle-bottom-scroll.test.js chat-render-lifecycle-scroll-intent.test.js chat-render-lifecycle-anchor.test.js chat-render-lifecycle-scheduler.test.js chat-render-lifecycle-mobile-viewport.test.js chat-scroll-edges.test.js mobile-streaming.test.js chat-render-lifecycle-update-queue.test.js chat-render-lifecycle-stream-buffer.test.js chat-render-lifecycle-resize-observer.test.js measure-frontend-performance.test.js`
- `npm run lint`
- `npm run check:frontend-budgets`
- `npm run perf:frontend` against `http://127.0.0.1:4567/?sillybunny.chatRenderLifecycle.enabled=true`: long-chat fixture available, 96 messages, 24 rendered, bottom drift `0`

## Screenshots (optional)
Not applicable; this is a measurement harness change.

## Anything Else?
Stacked on `refactor/chat-lifecycle-mobile-viewport-route`. This PR records baseline data only; it does not add regression thresholds.