### PR TITLE
Fix bulk preset deletion tooltip copy

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -158,7 +158,7 @@
                                             <div id="delete_oai_preset" class="margin0 menu_button menu_button_icon" title="Delete the preset" data-i18n="[title]Delete the preset">
                                                 <i class="fa-fw fa-solid fa-trash-can"></i>
                                             </div>
-                                            <div data-preset-manager-delete-all="openai" class="margin0 menu_button menu_button_icon" title="Delete all saved presets" data-i18n="[title]Delete all saved presets">
+                                            <div data-preset-manager-delete-all="openai" class="margin0 menu_button menu_button_icon" title="Delete presets in bulk" data-i18n="[title]Delete presets in bulk">
                                                 <i class="fa-fw fa-solid fa-trash-arrow-up"></i>
                                             </div>
                                         </div>
@@ -223,7 +223,7 @@
                                             <div data-preset-manager-delete="textgenerationwebui" class="margin0 menu_button menu_button_icon" title="Delete the preset" data-i18n="[title]Delete the preset">
                                                 <i class="fa-fw fa-solid fa-trash-can"></i>
                                             </div>
-                                            <div data-preset-manager-delete-all="textgenerationwebui" class="margin0 menu_button menu_button_icon" title="Delete all saved presets" data-i18n="[title]Delete all saved presets">
+                                            <div data-preset-manager-delete-all="textgenerationwebui" class="margin0 menu_button menu_button_icon" title="Delete presets in bulk" data-i18n="[title]Delete presets in bulk">
                                                 <i class="fa-fw fa-solid fa-trash-arrow-up"></i>
                                             </div>
                                         </div>


### PR DESCRIPTION
## What?
Updates the OpenAI and Text Completion bulk preset delete tooltips from `Delete all saved presets` to `Delete presets in bulk`.

## Why?
The old copy sounded broader and more alarming than the action itself. The new tooltip better communicates that this opens the bulk preset deletion flow.

## How?
Changed the two bulk-delete preset button `title` and i18n title keys in the preset toolbar markup. No delete behavior changed.

## Testing?
- Ran `git diff --check`.
- Verified the old tooltip string no longer appears in `public/index.html`.

## Screenshots (optional)
Not included; this is a tooltip copy-only change.

## Anything Else?
Fixes #187.