### PR TITLE
Add compact Pathfinder mode selector

### DIFF
--- a/public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js
@@ -527,6 +527,46 @@ function readPromptMaxTokens() {
     return Math.min(200000, Math.max(100, value));
 }
 
+const PATHFINDER_MODE_LABELS = {
+    off: 'Off',
+    tool: 'Tool',
+    pipeline: 'Pipeline',
+    both: 'Both',
+};
+
+function normalizePathfinderModeValue(value) {
+    const mode = String(value || '').trim().toLowerCase();
+    return Object.hasOwn(PATHFINDER_MODE_LABELS, mode) ? mode : 'off';
+}
+
+function getPathfinderModeValue(settings = getPathfinderSettings()) {
+    const toolEnabled = Boolean(settings?.sidecarEnabled);
+    const pipelineEnabled = Boolean(settings?.pipelineEnabled);
+
+    if (toolEnabled && pipelineEnabled) {
+        return 'both';
+    }
+
+    if (toolEnabled) {
+        return 'tool';
+    }
+
+    if (pipelineEnabled) {
+        return 'pipeline';
+    }
+
+    return 'off';
+}
+
+function applyPathfinderModeValue(settings, value) {
+    const mode = normalizePathfinderModeValue(value);
+
+    settings.sidecarEnabled = mode === 'tool' || mode === 'both';
+    settings.pipelineEnabled = mode === 'pipeline' || mode === 'both';
+
+    return mode;
+}
+
 /**
  * Load current settings into UI elements
  */
@@ -551,6 +591,7 @@ function loadSettingsIntoUI() {
     settingsEl.find('#pf--dedupe-natural-activation').prop('checked', s.dedupeNaturalActivation !== false);
     settingsEl.find('#pf--auto-summary').prop('checked', s.autoSummary || false);
     settingsEl.find('#pf--auto-summary-interval').val(s.autoSummaryInterval ?? 20);
+    settingsEl.find('#pf--mode-selector').val(getPathfinderModeValue(s));
 
     settingsEl.find('#pf--enable-summarize-tool').prop('checked', isPathfinderToolEnabled('Pathfinder_Summarize'));
 
@@ -794,6 +835,21 @@ function bindEvents() {
     });
 
     // Mode toggles
+    settingsEl.find('#pf--mode-selector').on('change', function () {
+        const s = getPathfinderSettings();
+        const previousToolEnabled = Boolean(s.sidecarEnabled);
+        const mode = applyPathfinderModeValue(s, $(this).val());
+        setPathfinderSettings(s);
+        logPathfinder(`Pathfinder mode set to ${PATHFINDER_MODE_LABELS[mode]}.`);
+        updateModeCardStates();
+        updateStatusBanner();
+        updateAgentSettings();
+
+        if (previousToolEnabled !== Boolean(s.sidecarEnabled)) {
+            syncToolAgentRegistrations();
+        }
+    });
+
     settingsEl.find('#pf--enable-tools').on('change', function () {
         const enabled = $(this).prop('checked');
         const s = getPathfinderSettings();
@@ -802,6 +858,7 @@ function bindEvents() {
         logPathfinder(`Tool Mode ${enabled ? 'enabled' : 'disabled'}.`);
         updateModeCardStates();
         updateDualModeWarning();
+        updateStatusBanner();
         updateAgentSettings();
         syncToolAgentRegistrations();
     });
@@ -814,6 +871,7 @@ function bindEvents() {
         setPathfinderSettings(s);
         logPathfinder(`Predictive Pipeline ${enabled ? 'enabled' : 'disabled'}.`);
         updateModeCardStates();
+        updateStatusBanner();
         updateAgentSettings();
     });
 
@@ -1442,16 +1500,22 @@ function formatRetrievalLogItem(item) {
 function updateModeCardStates() {
     const s = getPathfinderSettings();
 
+    const toolEnabled = Boolean(s.sidecarEnabled);
+    const pipelineEnabled = Boolean(s.pipelineEnabled);
     const toolCard = settingsEl.find('.pf--mode-card[data-mode="tools"]');
     const pipelineCard = settingsEl.find('.pf--mode-card[data-mode="pipeline"]');
 
-    toolCard.toggleClass('active', s.sidecarEnabled || false);
-    pipelineCard.toggleClass('active', s.pipelineEnabled || false);
+    settingsEl.find('#pf--mode-selector').val(getPathfinderModeValue(s));
+    settingsEl.find('#pf--enable-tools').prop('checked', toolEnabled);
+    settingsEl.find('#pf--enable-pipeline').prop('checked', pipelineEnabled);
+
+    toolCard.toggleClass('active', toolEnabled);
+    pipelineCard.toggleClass('active', pipelineEnabled);
 
     // Show/hide settings sections
-    settingsEl.find('#pf--tool-settings').toggle(s.sidecarEnabled || false);
-    settingsEl.find('#pf--pipeline-settings').toggle(s.pipelineEnabled || false);
-    settingsEl.find('#pf--prompt-editor-section').toggle(s.pipelineEnabled || false);
+    settingsEl.find('#pf--tool-settings').toggle(toolEnabled);
+    settingsEl.find('#pf--pipeline-settings').toggle(pipelineEnabled);
+    settingsEl.find('#pf--prompt-editor-section').toggle(pipelineEnabled);
 
     // Update dual-mode warning
     updateDualModeWarning();

--- a/public/scripts/extensions/in-chat-agents/pathfinder-settings.html
+++ b/public/scripts/extensions/in-chat-agents/pathfinder-settings.html
@@ -79,6 +79,19 @@
             <strong>Choose How Pathfinder Works</strong>
         </div>
 
+        <div class="pf--mode-selector-row">
+            <label class="pf--setting-label" for="pf--mode-selector">
+                <i class="fa-solid fa-route"></i>
+                <span>Mode</span>
+            </label>
+            <select id="pf--mode-selector" class="text_pole" aria-label="Pathfinder mode">
+                <option value="off">Off</option>
+                <option value="tool">Tool</option>
+                <option value="pipeline">Pipeline</option>
+                <option value="both">Both</option>
+            </select>
+        </div>
+
         <!-- Warning banner when both modes enabled -->
         <div id="pf--dual-mode-warning" class="pf--dual-mode-warning" style="display: none;">
             <i class="fa-solid fa-triangle-exclamation"></i>
@@ -792,6 +805,37 @@
 }
 
 /* Mode Cards */
+.pf--mode-selector-row {
+    display: grid;
+    grid-template-columns: max-content minmax(160px, 260px);
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 12px;
+    padding: 10px 12px;
+    background: color-mix(in srgb, var(--pf-surface-strong) 90%, var(--pf-accent) 6%);
+    border: 1px solid color-mix(in srgb, var(--pf-border) 80%, transparent);
+    border-radius: var(--pf-radius-md);
+}
+
+.pf--mode-selector-row .pf--setting-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin: 0;
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--pf-text);
+}
+
+.pf--mode-selector-row .pf--setting-label i {
+    color: var(--pf-accent);
+}
+
+#pf--mode-selector {
+    width: 100%;
+    min-width: 0;
+}
+
 .pf--mode-cards {
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -1153,6 +1197,11 @@
 @media (max-width: 600px) {
     .pf--settings {
         max-height: calc(100dvh - 120px);
+    }
+
+    .pf--mode-selector-row {
+        grid-template-columns: 1fr;
+        align-items: stretch;
     }
 
     .pf--mode-cards {


### PR DESCRIPTION
## What?
Adds a compact Pathfinder Mode selector with `Off`, `Tool`, `Pipeline`, and `Both` options above the existing detailed mode controls.

## Why?
Users should be able to switch Pathfinder's common operating mode without scrolling through the full settings panel, while still keeping the detailed Tool and Pipeline controls available.

## How?
The selector maps directly to the existing persisted `sidecarEnabled` and `pipelineEnabled` booleans. It syncs both directions with the existing checkboxes, refreshes mode card state and status messaging, and resyncs tool registrations when Tool mode changes.

## Testing?
- `npm run lint`
- `bun node_modules/eslint/bin/eslint.js public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js`
- `node --check public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js`
- Targeted Jest: `pathfinder-settings-utils.test.js`, `pathfinder-tool-bridge.test.js`
- `git diff --check -- public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js public/scripts/extensions/in-chat-agents/pathfinder-settings.html`

## Screenshots (optional)
Not included; this is a small settings control addition and the branch was validated with lint, syntax, and targeted Pathfinder unit coverage.

## Anything Else?
Targets `staging`.
Closes #222.
