### PR TITLE
Fix character lorebook focus routing

### DIFF
--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -2164,7 +2164,9 @@ function openWorldInfoCharacterPanelTab() {
         return;
     }
 
-    $('#WIDrawerIcon').trigger('click');
+    if (!$('#WorldInfo').is(':visible')) {
+        $('#WIDrawerIcon').trigger('click');
+    }
 }
 
 function bindWorldInfoDesktopEditorPopoutShellSync() {
@@ -6134,9 +6136,7 @@ export async function importWorldInfo(file) {
  */
 export function openWorldInfoEditor(worldName) {
     console.log(`Opening lorebook for ${worldName}`);
-    if (!$('#WorldInfo').is(':visible')) {
-        openWorldInfoCharacterPanelTab();
-    }
+    openWorldInfoCharacterPanelTab();
     const index = world_names.indexOf(worldName);
     $('#world_editor_select').val(index).trigger('change');
 }


### PR DESCRIPTION
## What?
Fixes the character lorebook button so opening a specific character lorebook always focuses the Characters drawer's World Info tab before selecting the lorebook.

## Why?
When the World Info drawer was already visible, the old path skipped the SillyBunny shell tab routing. That could leave the character editor tab focused over the lorebook until the user manually closed or changed panels.

## How?
`openWorldInfoEditor` now always routes through the shared World Info tab helper. The legacy drawer fallback only clicks the old drawer icon when World Info is not already visible, preserving the existing open/close behavior outside the shell.

## Testing?
- `npm run lint`
- `bun node_modules/eslint/bin/eslint.js public/scripts/world-info.js`
- `node --check public/scripts/world-info.js`
- Targeted Jest: `world-info-character-book.test.js`
- `git diff --check -- public/scripts/world-info.js`

## Screenshots (optional)
Not included; this is a focus/routing behavior change with no visual styling changes.

## Anything Else?
Targets `staging`.
Closes #174.
