### PR TITLE
Fix first-launch topbar scale default

### DIFF
--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -1173,6 +1173,10 @@ function resetMobileQuickActions() {
 }
 
 function normalizeTopbarScale(value) {
+    if (value === null || value === undefined || value === '') {
+        return SB_TOPBAR_SCALE.defaultValue;
+    }
+
     const numericValue = Number(value);
 
     if (!Number.isFinite(numericValue)) {


### PR DESCRIPTION
## What?
Fixes first-launch topbar sizing so missing saved scale values default to the normal `100%` topbar size instead of the compact minimum.

## Why?
`Number(null)` evaluates to `0`, so a fresh profile with no stored topbar scale normalized to the minimum `70%` size before defaults were seeded. After refresh, the seeded `100%` value was read, causing inconsistent first-load versus refreshed behavior.

## How?
`normalizeTopbarScale` now treats `null`, `undefined`, and blank values as the configured default before numeric coercion. Explicit saved numeric values are still clamped and snapped through the existing scale rules.

## Testing?
- `npm run lint`
- `node --check public/scripts/sillybunny-tabs.js`
- `git diff --check -- public/scripts/sillybunny-tabs.js`

## Screenshots (optional)
Not included; this is startup state normalization with no visual styling change.

## Anything Else?
Targets `staging`.
Closes #178.
