### PR TITLE
Style boolean radio choices as segmented toggles

### DIFF
--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -592,6 +592,66 @@ h3:not(.popup h3):not(#chat h3) {
     transform: none;
 }
 
+.sb-boolean-radio-group {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 180px), 1fr));
+    gap: 6px;
+    width: 100%;
+    padding: 4px;
+    border: 1px solid color-mix(in srgb, var(--sb-shell-border) 74%, transparent);
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--SmartThemeBodyColor) 4%, transparent);
+    box-sizing: border-box;
+}
+
+.sb-boolean-radio-option {
+    position: relative;
+    min-height: var(--sb-control-min-height);
+    padding: 0;
+    cursor: pointer;
+}
+
+.sb-boolean-radio-option > input[type="radio"] {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+    cursor: pointer;
+}
+
+.sb-boolean-radio-option > span {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    min-height: var(--sb-control-min-height);
+    padding: 7px 10px;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    text-align: center;
+    background: transparent;
+    color: var(--SmartThemeBodyColor);
+    transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease;
+    box-sizing: border-box;
+}
+
+.sb-boolean-radio-option > input[type="radio"]:checked + span {
+    border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent, var(--SmartThemeQuoteColor))) 46%, transparent);
+    background: color-mix(in srgb, var(--color-primary, var(--sb-accent, var(--SmartThemeQuoteColor))) 20%, transparent);
+    color: var(--SmartThemeQuoteColor);
+}
+
+.sb-boolean-radio-option > input[type="radio"]:focus-visible + span {
+    outline: 2px solid var(--sb-focus-ring);
+    outline-offset: 2px;
+}
+
+.sb-boolean-radio-option:hover > input[type="radio"]:not(:checked) + span {
+    border-color: color-mix(in srgb, var(--sb-shell-border) 88%, transparent);
+    background: var(--sb-button-hover);
+}
+
 .floating_prompt_radio_group label {
     min-height: var(--sb-control-min-height);
     font-size: var(--sb-type-control);

--- a/public/scripts/templates/exportPreset.html
+++ b/public/scripts/templates/exportPreset.html
@@ -1,5 +1,5 @@
 <div class="flex-container flexFlowColumn marginBot10">
-    <h3 data-i18n="Do you want to export connection data with the preset?">
+    <h3 id="export_connection_data_prompt" data-i18n="Do you want to export connection data with the preset?">
         Do you want to export connection data with the preset?
     </h3>
 
@@ -11,14 +11,14 @@
         Your stored API keys are never exported.
     </strong>
 </div>
-<div class="flex-container flexFlowColumn">
-    <label class="checkbox_label" for="export_connection_data_yes">
+<div class="sb-boolean-radio-group" role="radiogroup" aria-labelledby="export_connection_data_prompt">
+    <label class="checkbox_label sb-boolean-radio-option" for="export_connection_data_yes">
         <input type="radio" id="export_connection_data_yes" name="export_connection_data" value="true">
         <span data-i18n="Export connection data">
             Export connection data
         </span>
     </label>
-    <label class="checkbox_label" for="export_connection_data_no">
+    <label class="checkbox_label sb-boolean-radio-option" for="export_connection_data_no">
         <input type="radio" id="export_connection_data_no" name="export_connection_data" value="false" checked>
         <span data-i18n="Do not export connection data">
             Do not export connection data

--- a/public/scripts/templates/globalStylesPreference.html
+++ b/public/scripts/templates/globalStylesPreference.html
@@ -1,16 +1,18 @@
 <div class="flex-container flexFlowColumn">
-    <h3 data-i18n="Choose how to apply CSS style tags if they are defined in Creator's Notes of this character:" class="margin0">
+    <h3 id="global_styles_preference_prompt" data-i18n="Choose how to apply CSS style tags if they are defined in Creator's Notes of this character:" class="margin0">
         Choose how to apply CSS style tags if they are defined in Creator's Notes of this character:
     </h3>
     <h4 data-i18n="CAUTION: Malformed styles may cause issues." class="neutral_warning">
         CAUTION: Malformed styles may cause issues.
     </h4>
-    <label class="checkbox_label" for="global_styles_forbidden">
-        <input type="radio" id="global_styles_forbidden" name="global_styles_preference" />
-        <span data-i18n="Just to Creator's Notes">Just to Creator's Notes</span>
-    </label>
-    <label class="checkbox_label" for="global_styles_allowed">
-        <input type="radio" id="global_styles_allowed" name="global_styles_preference" />
-        <span data-i18n="Apply to the entire app">Apply to the entire app</span>
-    </label>
+    <div class="sb-boolean-radio-group" role="radiogroup" aria-labelledby="global_styles_preference_prompt">
+        <label class="checkbox_label sb-boolean-radio-option" for="global_styles_forbidden">
+            <input type="radio" id="global_styles_forbidden" name="global_styles_preference" />
+            <span data-i18n="Just to Creator's Notes">Just to Creator's Notes</span>
+        </label>
+        <label class="checkbox_label sb-boolean-radio-option" for="global_styles_allowed">
+            <input type="radio" id="global_styles_allowed" name="global_styles_preference" />
+            <span data-i18n="Apply to the entire app">Apply to the entire app</span>
+        </label>
+    </div>
 </div>


### PR DESCRIPTION
## What?
Styles the two known boolean radio-choice dialogs as compact segmented choices while keeping their existing radio inputs and values.

## Why?
Issue #180 asks for clearer toggle controls where binary radio buttons are visually ambiguous. This narrows the first slice to boolean-backed pairs that already map directly to true/false preferences.

## How?
- Adds a scoped `sb-boolean-radio-group` wrapper to the preset connection-data export dialog and Creator's Notes global styles preference dialog.
- Keeps the existing radio names, checked state, and calling code unchanged.
- Adds keyboard-visible focus, checked, and hover states in the SillyBunny theme CSS without affecting unrelated radio groups.

## Testing?
- `git diff --check -- public/css/sillybunny-theme.css public/scripts/templates/exportPreset.html public/scripts/templates/globalStylesPreference.html`
- `node --check public/scripts/chats.js`
- `node --check public/scripts/openai.js`
- Parsed `public/css/sillybunny-theme.css` with `@adobe/css-tools` from the installed runtime dependencies.
- `eslint --resolve-plugins-relative-to <runtime checkout> public/scripts/chats.js public/scripts/openai.js`
- Ran `graphify update .` and removed generated graph output from the PR scope.

## Screenshots (optional)
Not included; this is a small scoped dialog style change. Browser QA can verify the two dialogs during the shared UI pass.

## Anything Else?
Closes #180.
