### PR TITLE
Fix Workspace Select2 dropdown geometry

### DIFF
--- a/public/css/promptmanager.css
+++ b/public/css/promptmanager.css
@@ -839,6 +839,7 @@
         max-height: 100%;
         overflow: auto;
         overscroll-behavior: contain;
+        scrollbar-gutter: stable;
         padding-right: 4px;
     }
 

--- a/public/css/select2-overrides.css
+++ b/public/css/select2-overrides.css
@@ -1,6 +1,7 @@
 /* Customize the Select2 container */
 .select2-container {
     color: var(--SmartThemeBodyColor);
+    max-width: 100%;
 }
 
 /* Customize the dropdown */
@@ -52,6 +53,7 @@
 
 .select2-container .select2-results>.select2-results__options {
     max-height: 300px;
+    overflow-x: hidden;
 }
 
 .select2-container .select2-selection--multiple .select2-selection__choice__remove {
@@ -92,6 +94,10 @@
 .select2-results__option {
     color: var(--SmartThemeBodyColor);
     background-color: var(--SmartThemeBodyColor);
+    box-sizing: border-box;
+    max-width: 100%;
+    min-width: 0;
+    overflow-wrap: anywhere;
 }
 
 .select2-container .select2-selection--multiple,

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -2086,11 +2086,13 @@ input[type='range']::-moz-range-thumb {
     border-radius: var(--sb-radius-button);
     border: 1px solid color-mix(in srgb, var(--sb-shell-border) 88%, transparent);
     box-shadow: 0 18px 32px color-mix(in srgb, var(--SmartThemeShadowColor) 18%, transparent);
-    overflow: visible;
+    max-width: 100%;
+    overflow: hidden;
 }
 
 .select2-container--default .select2-results {
     max-height: 300px;
+    overflow-x: hidden;
     overflow-y: auto;
 }
 

--- a/public/scripts/horde.js
+++ b/public/scripts/horde.js
@@ -463,7 +463,9 @@ export function initHorde() {
 
     // Not needed on mobile
     if (!isMobile()) {
+        const apiDropdownParent = $('#rm_api_block');
         $('#horde_model').select2({
+            dropdownParent: apiDropdownParent.length ? apiDropdownParent : $(document.body),
             width: '100%',
             placeholder: t`Select Horde models`,
             allowClear: true,

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -2156,6 +2156,16 @@ function appendOpenAIModelEntry($container, entry, favoriteValues = new Set()) {
     }
 }
 
+function getApiSelect2DropdownParent() {
+    const apiDropdownParent = $('#rm_api_block');
+    return apiDropdownParent.length ? apiDropdownParent : $(document.body);
+}
+
+function getPromptManagerSelect2DropdownParent() {
+    const promptManagerPopup = $('#completion_prompt_manager_popup');
+    return promptManagerPopup.length ? promptManagerPopup : getApiSelect2DropdownParent();
+}
+
 function initOpenAIModelSearch() {
     const $modelSelect = $('#model_openai_select');
 
@@ -2168,6 +2178,7 @@ function initOpenAIModelSearch() {
     }
 
     $modelSelect.select2({
+        dropdownParent: getApiSelect2DropdownParent(),
         placeholder: t`Select a model`,
         searchInputPlaceholder: t`Search models...`,
         searchInputCssClass: 'text_pole',
@@ -9397,6 +9408,7 @@ export function initOpenAI() {
 
     if (!isMobile()) {
         $('#model_openai_select').select2({
+            dropdownParent: getApiSelect2DropdownParent(),
             placeholder: t`Select a model`,
             searchInputPlaceholder: t`Search models...`,
             searchInputCssClass: 'text_pole',
@@ -9404,6 +9416,7 @@ export function initOpenAI() {
             matcher: textValueMatcher,
         });
         $('#model_openrouter_select').select2({
+            dropdownParent: getApiSelect2DropdownParent(),
             placeholder: t`Select a model`,
             searchInputPlaceholder: t`Search models...`,
             searchInputCssClass: 'text_pole',
@@ -9412,6 +9425,7 @@ export function initOpenAI() {
             matcher: textValueMatcher,
         });
         $('#model_aimlapi_select').select2({
+            dropdownParent: getApiSelect2DropdownParent(),
             placeholder: t`Select a model`,
             searchInputPlaceholder: t`Search models...`,
             searchInputCssClass: 'text_pole',
@@ -9419,6 +9433,7 @@ export function initOpenAI() {
             templateResult: getAimlapiModelTemplate,
         });
         $('#model_electronhub_select').select2({
+            dropdownParent: getApiSelect2DropdownParent(),
             placeholder: t`Select a model`,
             searchInputPlaceholder: t`Search models...`,
             searchInputCssClass: 'text_pole',
@@ -9427,6 +9442,7 @@ export function initOpenAI() {
             matcher: textValueMatcher,
         });
         $('#model_chutes_select').select2({
+            dropdownParent: getApiSelect2DropdownParent(),
             placeholder: t`Select a model`,
             searchInputPlaceholder: t`Search models...`,
             searchInputCssClass: 'text_pole',
@@ -9435,6 +9451,7 @@ export function initOpenAI() {
             matcher: textValueMatcher,
         });
         $('#model_nanogpt_select').select2({
+            dropdownParent: getApiSelect2DropdownParent(),
             placeholder: t`Select a model`,
             searchInputPlaceholder: t`Search models...`,
             searchInputCssClass: 'text_pole',
@@ -9443,6 +9460,7 @@ export function initOpenAI() {
             matcher: textValueMatcher,
         });
         $('#model_workers_ai_select').select2({
+            dropdownParent: getApiSelect2DropdownParent(),
             placeholder: t`Select a model`,
             searchInputPlaceholder: t`Search models...`,
             searchInputCssClass: 'text_pole',
@@ -9450,6 +9468,7 @@ export function initOpenAI() {
             matcher: textValueMatcher,
         });
         $('#completion_prompt_manager_popup_entry_form_injection_trigger').select2({
+            dropdownParent: getPromptManagerSelect2DropdownParent(),
             placeholder: t`All types (default)`,
             width: '100%',
             closeOnSelect: false,

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -13040,7 +13040,11 @@ function reinitSelect2AfterShell() {
         }
     } else {
         // On desktop, reinitialize Select2 after DOM reparenting
-        const select2Defaults = { dropdownParent: $(document.body), minimumResultsForSearch: 0 };
+        const apiDropdownParent = $('#rm_api_block');
+        const select2Defaults = {
+            dropdownParent: apiDropdownParent.length ? apiDropdownParent : $(document.body),
+            minimumResultsForSearch: 0,
+        };
         const allSelectors = [...modelSelectors, '.openrouter_quantizations', '.openrouter_providers'];
         for (const selector of allSelectors) {
             const $el = $(selector);

--- a/public/scripts/textgen-models.js
+++ b/public/scripts/textgen-models.js
@@ -1365,8 +1365,12 @@ export function initTextGenModels() {
         }));
     }
 
-    // SillyBunny keeps searchable Select2 controls available on mobile too.
-    const select2Defaults = { dropdownParent: $(document.body), minimumResultsForSearch: 0 };
+    // Keep API Select2 dropdowns inside the scrolling API drawer so they move with the control.
+    const apiDropdownParent = $('#rm_api_block');
+    const select2Defaults = {
+        dropdownParent: apiDropdownParent.length ? apiDropdownParent : $(document.body),
+        minimumResultsForSearch: 0,
+    };
     $('#mancer_model').select2({
         ...select2Defaults,
         placeholder: t`Select a model`,


### PR DESCRIPTION
## What?
Fixes Workspace/API Select2 dropdown geometry so searchable model/provider dropdowns stay anchored inside the scrolling API drawer and their rows do not paint wider than the dropdown.

## Why?
Issue #173 reports that Workspace form dropdown highlights and popup geometry drift while the drawer scrolls. Keeping the dropdown parent inside the drawer makes the popup move with the control instead of floating against the page body.

## How?
- Adds shared dropdown-parent helpers for OpenAI/API Select2 controls.
- Reinitializes TextGen, Horde, OpenAI, and shell-restored Select2 controls against the API drawer when present.
- Anchors the prompt manager injection-trigger Select2 to its popup.
- Clamps Select2 dropdown/result overflow and reserves prompt manager scrollbar gutter space.

## Testing?
- `node --check` for touched JavaScript files.
- Targeted ESLint for touched JavaScript files with installed repo dependencies.
- Parsed touched CSS files with `@adobe/css-tools`.
- `git diff --check` for touched files.
- Ran `graphify update .` and removed generated graph output from the PR scope.

## Screenshots (optional)
Not included. Browser QA should verify the Workspace dropdown scroll behavior during the shared UI pass.

## Anything Else?
Closes #173.
