### PR TITLE
Add Pathfinder submodule toggle

### DIFF
--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -27,6 +27,7 @@ import {
     getEnabledToolAgents,
     getGlobalSettings,
     getPromptTransformMode,
+    isPathfinderSubmoduleEnabled,
     saveAgent,
     isToolAgent,
     normalizePreProcessMaxTokens,
@@ -355,6 +356,10 @@ function isPathfinderToolAgent(agent) {
 }
 
 export function getPathfinderRuntimeAgent(agents = getEnabledToolAgents()) {
+    if (!isPathfinderSubmoduleEnabled()) {
+        return null;
+    }
+
     return agents.find(isPathfinderToolAgent) ?? null;
 }
 
@@ -399,6 +404,10 @@ function syncPathfinderRuntimeSettings(agent = getPathfinderRuntimeAgent()) {
 
 function getRegisterableAgentTools(agent) {
     if (isPathfinderToolAgent(agent)) {
+        if (!isPathfinderSubmoduleEnabled()) {
+            return [];
+        }
+
         const enabledTools = getPathfinderToolDefinitions()
             .filter(tool => isPathfinderToolEnabledForAgent(agent, tool.name));
 
@@ -425,6 +434,10 @@ export function getToolRecursionState() {
 }
 
 export async function syncPathfinderAgentLorebooksForCurrentChat(agent = getPathfinderRuntimeAgent(), { persist = false } = {}) {
+    if (!isPathfinderSubmoduleEnabled()) {
+        return false;
+    }
+
     if (!agent || !isPathfinderToolAgent(agent)) {
         return false;
     }
@@ -2746,10 +2759,27 @@ function scheduleMessageRefresh(messageIndex, expectedMessage) {
 
 function clearInChatAgentExtensionPrompts() {
     for (const key of Object.keys(extension_prompts)) {
-        if (key.startsWith(PROMPT_KEY_PREFIX) || PATHFINDER_RETRIEVAL_PROMPT_KEYS.includes(key) || key === PATHFINDER_AUTO_SUMMARY_PROMPT_KEY) {
+        if (key.startsWith(PROMPT_KEY_PREFIX)) {
             delete extension_prompts[key];
         }
     }
+    clearPathfinderExtensionPrompts();
+}
+
+function clearPathfinderExtensionPrompts() {
+    for (const key of Object.keys(extension_prompts)) {
+        if (PATHFINDER_RETRIEVAL_PROMPT_KEYS.includes(key) || key === PATHFINDER_AUTO_SUMMARY_PROMPT_KEY) {
+            delete extension_prompts[key];
+        }
+    }
+}
+
+export function deactivatePathfinderRuntime() {
+    clearPathfinderRetrievalToast();
+    abortActivePathfinderRetrieval('Pathfinder disabled.');
+    clearPathfinderExtensionPrompts();
+    toolRecursionDepth = 0;
+    syncToolAgentRegistrations();
 }
 
 function injectPreGenerationAgentPrompts(activeAgents, generationType) {

--- a/public/scripts/extensions/in-chat-agents/agent-store.js
+++ b/public/scripts/extensions/in-chat-agents/agent-store.js
@@ -122,6 +122,7 @@ function createDefaultScopedEnabledAgentIds() {
 /** Global settings for the In-Chat Agents extension. */
 let globalSettings = {
     enabled: true,
+    pathfinderEnabled: true,
     separateRecentChats: false,
     enabledAgentIdsByChatType: createDefaultScopedEnabledAgentIds(),
     scopedEnabledAgentIdsInitialized: false,
@@ -132,7 +133,7 @@ let globalSettings = {
 
 /**
  * Returns the global settings.
- * @returns {{ enabled: boolean, separateRecentChats: boolean, enabledAgentIdsByChatType: Record<string, string[]>, scopedEnabledAgentIdsInitialized: boolean, connectionProfile: string, promptTransformShowNotifications: boolean, appendAgentsExecutionMode: 'parallel'|'sequential' }}
+ * @returns {{ enabled: boolean, pathfinderEnabled: boolean, separateRecentChats: boolean, enabledAgentIdsByChatType: Record<string, string[]>, scopedEnabledAgentIdsInitialized: boolean, connectionProfile: string, promptTransformShowNotifications: boolean, appendAgentsExecutionMode: 'parallel'|'sequential' }}
  */
 export function getGlobalSettings() {
     return globalSettings;
@@ -148,6 +149,7 @@ export function setGlobalSettings(update) {
     }
 
     Object.assign(globalSettings, update);
+    globalSettings.pathfinderEnabled = globalSettings.pathfinderEnabled !== false;
     globalSettings.enabledAgentIdsByChatType = normalizeScopedEnabledAgentIds(globalSettings.enabledAgentIdsByChatType);
 
     if (!globalSettings.scopedEnabledAgentIdsInitialized) {
@@ -428,6 +430,14 @@ export const PATHFINDER_TEMPLATE_ID = 'tpl-pathfinder';
 
 export function areAgentsGloballyEnabled() {
     return globalSettings.enabled !== false;
+}
+
+export function isPathfinderSubmoduleEnabled() {
+    return globalSettings.pathfinderEnabled !== false;
+}
+
+export function setPathfinderSubmoduleEnabled(enabled) {
+    setGlobalSettings({ pathfinderEnabled: enabled !== false });
 }
 
 function getAgentTemplateName(value) {

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -27,12 +27,14 @@ import {
     normalizeAgentCategory,
     getAgentChatScopeLabel,
     getPromptTransformMode,
+    isPathfinderSubmoduleEnabled,
     findTemplateForAgentSnapshot,
     getRedundantBundledAgentDuplicateIds,
     reconcileScopedEnabledAgentIdsFromLegacyFlags,
     resolveConnectionProfile,
     setAgentEnabledForCurrentScope,
     setGlobalSettings,
+    setPathfinderSubmoduleEnabled,
     getGroups,
     getCustomGroups,
     loadBuiltinGroups,
@@ -44,6 +46,7 @@ import {
 import {
     cancelAgentGeneration,
     buildPromptDynamicMacros,
+    deactivatePathfinderRuntime,
     initAgentRunner,
     isAgentGenerationActive,
     onAgentGenerationStateChanged,
@@ -60,7 +63,7 @@ import {
     createDefaultRegexScript,
     normalizeRegexScript,
 } from './regex-scripts.js';
-import { initPathfinder } from './pathfinder-init.js';
+import { initPathfinder, teardownPathfinder } from './pathfinder-init.js';
 import { openPathfinderSettings, isPathfinderAgent } from './pathfinder-settings-ui.js';
 import { getPathfinderToolDefinitions } from './pathfinder/tool-definitions.js';
 import { buildFallbackPromptText, extractProfileResponseText } from './llm-utils.js';
@@ -3314,6 +3317,11 @@ function getPathfinderSettingsAgent() {
     return getAgents().find(isPathfinderAgent) ?? null;
 }
 
+function removePathfinderExtensionsHost() {
+    document.getElementById(PATHFINDER_EXTENSIONS_HOST_ID)?.remove();
+    pathfinderExtensionsMountPromise = null;
+}
+
 function ensurePathfinderExtensionsHost() {
     const parent = document.getElementById('extensions_settings2') ?? document.getElementById('extensions_settings');
     if (!parent) {
@@ -3341,6 +3349,11 @@ function ensurePathfinderExtensionsHost() {
 }
 
 async function mountPathfinderSettingsInExtensions() {
+    if (!isPathfinderSubmoduleEnabled()) {
+        removePathfinderExtensionsHost();
+        return null;
+    }
+
     const host = ensurePathfinderExtensionsHost();
     if (!host) {
         console.warn('[Pathfinder] Could not mount settings in Extensions drawer because #extensions_settings was not found.');
@@ -3361,6 +3374,11 @@ async function mountPathfinderSettingsInExtensions() {
     }
 
     const settingsPanel = await openPathfinderSettings(agent);
+    if (!isPathfinderSubmoduleEnabled()) {
+        removePathfinderExtensionsHost();
+        return null;
+    }
+
     if (!settingsPanel) {
         body.innerHTML = '<div class="pf--extensions-empty">Could not load Pathfinder settings.</div>';
         return host;
@@ -3374,6 +3392,11 @@ async function mountPathfinderSettingsInExtensions() {
 }
 
 function schedulePathfinderExtensionsMount() {
+    if (!isPathfinderSubmoduleEnabled()) {
+        removePathfinderExtensionsHost();
+        return Promise.resolve(null);
+    }
+
     pathfinderExtensionsMountPromise = mountPathfinderSettingsInExtensions()
         .catch(error => {
             console.warn('[Pathfinder] Failed to mount settings in Extensions drawer:', error);
@@ -3409,6 +3432,11 @@ function openPathfinderExtensionsDrawer(host) {
  * @param {Object} agent - The Pathfinder agent
  */
 async function openPathfinderEditor(agent) {
+    if (!isPathfinderSubmoduleEnabled()) {
+        toastr.warning('Pathfinder is disabled in In-Chat Agents settings.');
+        return;
+    }
+
     const existingHost = document.getElementById(PATHFINDER_EXTENSIONS_HOST_ID);
     if (existingHost) {
         const host = await (pathfinderExtensionsMountPromise ?? schedulePathfinderExtensionsMount());
@@ -3491,10 +3519,15 @@ function refreshConnectionProfileUi() {
 function populateGlobalNotificationToggle() {
     updateGlobalAgentToggle();
     populateSeparateRecentChatsToggle();
+    populatePathfinderSubmoduleToggle();
     $('#ica--promptTransformShowNotifications').prop(
         'checked',
         Boolean(getGlobalSettings().promptTransformShowNotifications),
     );
+}
+
+function populatePathfinderSubmoduleToggle() {
+    $('#ica--pathfinderSubmoduleEnabled').prop('checked', isPathfinderSubmoduleEnabled());
 }
 
 function populateGlobalExecutionModeDropdown() {
@@ -3836,9 +3869,11 @@ async function refinePromptWithAI(currentPrompt, category, phase, connectionProf
         toastr.success(`Updated ${migratedRegexPostDefaultsCount} bundled regex agent(s) to post-generation defaults.`);
     }
 
-    const migratedPathfinderToolCount = await migratePathfinderAgentToolsFromTemplate();
-    if (migratedPathfinderToolCount > 0) {
-        toastr.success(`Updated ${migratedPathfinderToolCount} Pathfinder agent(s) with default tool toggles.`);
+    if (isPathfinderSubmoduleEnabled()) {
+        const migratedPathfinderToolCount = await migratePathfinderAgentToolsFromTemplate();
+        if (migratedPathfinderToolCount > 0) {
+            toastr.success(`Updated ${migratedPathfinderToolCount} Pathfinder agent(s) with default tool toggles.`);
+        }
     }
 
     const migratedPromptTransformImpersonateCount = await migrateBundledPromptTransformImpersonateToSavedAgents();
@@ -3876,11 +3911,12 @@ async function refinePromptWithAI(currentPrompt, category, phase, connectionProf
         console.error('[InChatAgents] Agent runner initialization failed:', err);
     }
 
-    // Initialize Pathfinder (tool agent core)
-    try {
-        initPathfinder(getContext());
-    } catch (err) {
-        console.warn('[InChatAgents] Pathfinder initialization failed:', err);
+    if (isPathfinderSubmoduleEnabled()) {
+        try {
+            initPathfinder(getContext());
+        } catch (err) {
+            console.warn('[InChatAgents] Pathfinder initialization failed:', err);
+        }
     }
 
     // Sync any existing tool agents' tools with ToolManager
@@ -4049,6 +4085,34 @@ async function refinePromptWithAI(currentPrompt, category, phase, connectionProf
     $('#ica--promptTransformShowNotifications').on('change', function () {
         setGlobalSettings({ promptTransformShowNotifications: $(this).prop('checked') });
         persistExtensionState();
+    });
+    $('#ica--pathfinderSubmoduleEnabled').on('change', async function () {
+        const enabled = $(this).prop('checked');
+        setPathfinderSubmoduleEnabled(enabled);
+        persistExtensionState();
+        populatePathfinderSubmoduleToggle();
+
+        if (enabled) {
+            try {
+                const migratedPathfinderToolCount = await migratePathfinderAgentToolsFromTemplate();
+                if (migratedPathfinderToolCount > 0) {
+                    toastr.success(`Updated ${migratedPathfinderToolCount} Pathfinder agent(s) with default tool toggles.`);
+                }
+                initPathfinder(getContext());
+                schedulePathfinderExtensionsMount();
+                syncToolAgentRegistrations();
+                toastr.info('Pathfinder submodule enabled.');
+            } catch (err) {
+                console.warn('[InChatAgents] Failed to enable Pathfinder submodule:', err);
+                toastr.error('Could not enable Pathfinder.');
+            }
+            return;
+        }
+
+        teardownPathfinder();
+        deactivatePathfinderRuntime();
+        removePathfinderExtensionsHost();
+        toastr.info('Pathfinder submodule disabled.');
     });
     $('#ica--appendAgentsExecutionMode').on('change', function () {
         setGlobalSettings({ appendAgentsExecutionMode: this.value });

--- a/public/scripts/extensions/in-chat-agents/pathfinder-init.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder-init.js
@@ -1,8 +1,10 @@
 import { getSettings, setSettings, isLorebookEnabled, setLorebookEnabled } from './pathfinder/tree-store.js';
 import { initEntryManagerAPIs } from './pathfinder/entry-manager.js';
 import { initActivityFeed } from './pathfinder/activity-feed.js';
-import { initAutoSummary } from './pathfinder/auto-summary.js';
-import { initCommands } from './pathfinder/commands.js';
+import { isPathfinderSubmoduleEnabled } from './agent-store.js';
+import { unregisterToolAction, unregisterToolFormatter } from './tool-action-registry.js';
+import { deinitAutoSummary, initAutoSummary } from './pathfinder/auto-summary.js';
+import { initCommands, removeCommands } from './pathfinder/commands.js';
 import { getPathfinderToolDefinitions } from './pathfinder/tool-definitions.js';
 
 import { registerActions as registerSearchActions } from './pathfinder/tools/search.js';
@@ -23,10 +25,7 @@ import { getDefaultPrompts, getDefaultPipelines } from './pathfinder/prompts/def
 
 let initialized = false;
 
-export function initPathfinder(context) {
-    if (initialized) return;
-    initialized = true;
-
+function registerPathfinderToolActions() {
     registerSearchActions();
     registerRememberActions();
     registerUpdateActions();
@@ -35,6 +34,29 @@ export function initPathfinder(context) {
     registerReorganizeActions();
     registerMergeSplitActions();
     registerNotebookActions();
+}
+
+function unregisterPathfinderToolActions() {
+    for (const tool of getPathfinderToolDefinitions()) {
+        if (tool?.actionKey) {
+            unregisterToolAction(tool.actionKey);
+        }
+        if (tool?.formatMessageKey) {
+            unregisterToolFormatter(tool.formatMessageKey);
+        }
+    }
+}
+
+export function initPathfinder(context) {
+    if (!isPathfinderSubmoduleEnabled()) {
+        teardownPathfinder();
+        return;
+    }
+
+    if (initialized) return;
+    initialized = true;
+
+    registerPathfinderToolActions();
 
     initActivityFeed();
 
@@ -58,6 +80,18 @@ export function initPathfinder(context) {
     }
 
     console.info('[Pathfinder] Initialized with 8 tools and predictive pipeline system.');
+}
+
+export function teardownPathfinder() {
+    if (!initialized) {
+        return;
+    }
+
+    unregisterPathfinderToolActions();
+    deinitAutoSummary();
+    removeCommands();
+    initialized = false;
+    console.info('[Pathfinder] Disabled and unregistered.');
 }
 
 export async function buildPathfinderTree(bookName, bookData, useLLM = false, llmGenerate = null) {

--- a/public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js
@@ -6,7 +6,7 @@ import { renderExtensionTemplateAsync, getContext } from '../../extensions.js';
 import { saveSettingsDebounced } from '../../../script.js';
 import { escapeHtml } from '../../utils.js';
 import { world_names, loadWorldInfo } from '../../world-info.js';
-import { isAgentEnabledForCurrentScope, persistAgentGlobalSettings, saveAgent, setAgentEnabledForCurrentScope } from './agent-store.js';
+import { isAgentEnabledForCurrentScope, isPathfinderSubmoduleEnabled, persistAgentGlobalSettings, saveAgent, setAgentEnabledForCurrentScope } from './agent-store.js';
 import {
     getPathfinderSettings,
     setPathfinderSettings,
@@ -221,6 +221,11 @@ async function syncAutoAttachedLorebooks(lorebooks, settings) {
  * @param {Object} agent - The Pathfinder agent object
  */
 export async function openPathfinderSettings(agent) {
+    if (!isPathfinderSubmoduleEnabled()) {
+        toastr.warning('Pathfinder is disabled in In-Chat Agents settings.');
+        return null;
+    }
+
     currentAgent = agent;
     const existingSettings = getPathfinderSettings();
     setPathfinderSettings({

--- a/public/scripts/extensions/in-chat-agents/pathfinder/auto-summary.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/auto-summary.js
@@ -2,21 +2,48 @@ import { getSettings, normalizeAutoSummaryInterval } from './tree-store.js';
 import { getActiveTunnelVisionBooks } from './pathfinder-tool-bridge.js';
 
 let autoSummaryCount = 0;
+let autoSummaryEventSource = null;
+let autoSummaryEventTypes = null;
+let autoSummaryMessageReceivedHandler = null;
+let autoSummaryMessageSentHandler = null;
 
 export function initAutoSummary(eventSource, eventTypes) {
+    deinitAutoSummary();
     autoSummaryCount = 0;
 
-    eventSource.on(eventTypes.MESSAGE_RECEIVED, () => {
+    autoSummaryEventSource = eventSource;
+    autoSummaryEventTypes = eventTypes;
+    autoSummaryMessageReceivedHandler = () => {
         const s = getSettings();
         if (!s.autoSummary) return;
         autoSummaryCount++;
-    });
+    };
 
-    eventSource.on(eventTypes.MESSAGE_SENT, () => {
+    autoSummaryMessageSentHandler = () => {
         const s = getSettings();
         if (!s.autoSummary) return;
         autoSummaryCount++;
-    });
+    };
+
+    eventSource.on(eventTypes.MESSAGE_RECEIVED, autoSummaryMessageReceivedHandler);
+    eventSource.on(eventTypes.MESSAGE_SENT, autoSummaryMessageSentHandler);
+}
+
+export function deinitAutoSummary() {
+    if (autoSummaryEventSource && autoSummaryEventTypes) {
+        if (autoSummaryMessageReceivedHandler) {
+            autoSummaryEventSource.removeListener(autoSummaryEventTypes.MESSAGE_RECEIVED, autoSummaryMessageReceivedHandler);
+        }
+        if (autoSummaryMessageSentHandler) {
+            autoSummaryEventSource.removeListener(autoSummaryEventTypes.MESSAGE_SENT, autoSummaryMessageSentHandler);
+        }
+    }
+
+    autoSummaryEventSource = null;
+    autoSummaryEventTypes = null;
+    autoSummaryMessageReceivedHandler = null;
+    autoSummaryMessageSentHandler = null;
+    autoSummaryCount = 0;
 }
 
 export function markAutoSummaryComplete() {

--- a/public/scripts/extensions/in-chat-agents/pathfinder/commands.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/commands.js
@@ -2,9 +2,12 @@ import { SlashCommand } from '../../../slash-commands/SlashCommand.js';
 import { ARGUMENT_TYPE, SlashCommandArgument } from '../../../slash-commands/SlashCommandArgument.js';
 import { SlashCommandParser } from '../../../slash-commands/SlashCommandParser.js';
 
+import { isPathfinderSubmoduleEnabled } from '../agent-store.js';
 import { getTree, findNodeById } from './tree-store.js';
 import { createEntry } from './entry-manager.js';
 import { getActiveTunnelVisionBooks } from './pathfinder-tool-bridge.js';
+
+const registeredCommands = [];
 
 function buildCommand(props) {
     return SlashCommand.fromProps({
@@ -19,15 +22,29 @@ function buildCommand(props) {
     });
 }
 
+export function removeCommands() {
+    for (const command of registeredCommands.splice(0)) {
+        for (const name of [command.name, ...(command.aliases || [])]) {
+            if (SlashCommandParser.commands?.[name] === command) {
+                delete SlashCommandParser.commands[name];
+            }
+        }
+    }
+}
+
 export function initCommands(registerSlashCommand) {
+    removeCommands();
+
     const registerCommand = (command) => {
         if (typeof SlashCommandParser?.addCommandObject === 'function') {
             SlashCommandParser.addCommandObject(command);
+            registeredCommands.push(command);
             return;
         }
 
         if (typeof registerSlashCommand === 'function') {
             registerSlashCommand(command.name, command.callback, command.aliases, command.helpString);
+            registeredCommands.push(command);
         }
     };
 
@@ -36,6 +53,9 @@ export function initCommands(registerSlashCommand) {
         helpString: 'Force Pathfinder to save something to memory.',
         argumentDescription: 'Content to remember',
         callback: async (_, content) => {
+            if (!isPathfinderSubmoduleEnabled()) {
+                return 'Pathfinder is disabled.';
+            }
             content = String(content || '').trim();
             if (!content) return 'Nothing to remember.';
             const books = getActiveTunnelVisionBooks();
@@ -55,6 +75,9 @@ export function initCommands(registerSlashCommand) {
         helpString: 'Force Pathfinder to search the waypoint map.',
         argumentDescription: 'Search query',
         callback: async (_, query) => {
+            if (!isPathfinderSubmoduleEnabled()) {
+                return 'Pathfinder is disabled.';
+            }
             query = String(query || '').trim();
             if (!query) return 'No search query.';
             const results = [];

--- a/public/scripts/extensions/in-chat-agents/pathfinder/pathfinder-tool-bridge.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/pathfinder-tool-bridge.js
@@ -1,3 +1,4 @@
+import { isPathfinderSubmoduleEnabled } from '../agent-store.js';
 import { getSettings, getTree, isLorebookEnabled, canReadBook, canWriteBook, canDeleteBook } from './tree-store.js';
 
 const CHAT_LOREBOOK_METADATA_KEY = 'world_info';
@@ -31,6 +32,10 @@ export const CONFIRMABLE_TOOLS = new Set([
 ]);
 
 export function getActiveTunnelVisionBooks() {
+    if (!isPathfinderSubmoduleEnabled()) {
+        return [];
+    }
+
     const s = getSettings();
     const books = Array.isArray(s.enabledLorebooks)
         ? s.enabledLorebooks.filter(b => isLorebookEnabled(b))

--- a/public/scripts/extensions/in-chat-agents/pathfinder/sidecar-retrieval.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/sidecar-retrieval.js
@@ -1,5 +1,6 @@
 import { chat, substituteParams } from '../../../../script.js';
 import { parseRegexFromString, world_info_logic, world_info_match_whole_words } from '../../../world-info.js';
+import { isPathfinderSubmoduleEnabled } from '../agent-store.js';
 import { getTree, findNodeById, getAllEntryUids, getSettings } from './tree-store.js';
 import { getReadableBooks, getEntryContent } from './pathfinder-tool-bridge.js';
 import { sidecarGenerate } from './llm-sidecar.js';
@@ -471,6 +472,10 @@ async function runLegacySidecarRetrieval(setExtensionPrompt, extensionPromptType
 }
 
 export async function runSidecarRetrieval(setExtensionPrompt, extensionPromptTypes, extensionPromptRoles, signal = null) {
+    if (!isPathfinderSubmoduleEnabled()) {
+        return;
+    }
+
     const s = getSettings();
     if (!(s.sidecarEnabled || s.pipelineEnabled)) return;
 

--- a/public/scripts/extensions/in-chat-agents/settings.html
+++ b/public/scripts/extensions/in-chat-agents/settings.html
@@ -128,6 +128,10 @@
                 <input type="checkbox" id="ica--promptTransformShowNotifications" />
                 <span>Allow prompt pass toast notifications</span>
             </label>
+            <label class="checkbox_label" title="Enable or disable the built-in Pathfinder submodule without disabling shared In-Chat Agents.">
+                <input type="checkbox" id="ica--pathfinderSubmoduleEnabled" />
+                <span>Enable Pathfinder submodule</span>
+            </label>
             <div id="ica--resetDefaults" class="menu_button menu_button_icon caution" title="Reset all bundled agents to their original template settings (custom agents are not affected)">
                 <i class="fa-solid fa-rotate-left"></i>
                 <span>Reset Bundled Agents to Defaults</span>

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -260,6 +260,7 @@ describe('in-chat agent post-processing runner', () => {
             getEnabledToolAgents: jest.fn(() => []),
             getGlobalSettings: jest.fn(() => globalSettings),
             getPromptTransformMode: jest.fn(agent => agent?.postProcess?.promptTransformMode === 'append' ? 'append' : 'rewrite'),
+            isPathfinderSubmoduleEnabled: jest.fn(() => true),
             saveAgent: jest.fn(async () => {}),
             isToolAgent: jest.fn(() => false),
             normalizePreProcessMaxTokens: jest.fn(value => Number.isFinite(Number(value)) ? Math.max(16, Math.min(16000, Number(value))) : 8192),


### PR DESCRIPTION
## What?
Adds a persisted, default-on Pathfinder submodule toggle inside In-Chat Agents settings.

## Why?
Issue #223 asks for graceful submodule toggles for built-in extension functionality. This PR handles the Pathfinder-first slice without disabling shared In-Chat Agents features.

## How?
- Stores `pathfinderEnabled` in In-Chat Agents global settings, defaulting to enabled for existing users.
- Adds an In-Chat Agents settings checkbox for Pathfinder only.
- When disabled, removes Pathfinder settings UI, unregisters Pathfinder tool actions and slash commands, removes auto-summary listeners, aborts/clears retrieval prompts, blocks runtime Pathfinder tool-agent registration, blocks lorebook bridge access, and makes sidecar retrieval no-op.
- Leaves shared In-Chat Agents initialization, agent runner behavior, and non-Pathfinder tooling active.

## Testing?
- `node --check` for every modified JavaScript file.
- Targeted ESLint for modified JavaScript files with installed repo dependencies.
- `git diff --check -- public/scripts/extensions/in-chat-agents`
- Ran `graphify update .` and removed generated graph output from the PR scope.

## Screenshots (optional)
Not included. Browser QA should verify the toggle persists across reloads and Pathfinder-specific UI/tools stay disabled while shared In-Chat Agents remain active.

## Anything Else?
Closes #223.
