### PR TITLE
Fix Quick Image Gen collapsed drawer layout

### DIFF
--- a/public/scripts/extensions/quick-image-gen/style.css
+++ b/public/scripts/extensions/quick-image-gen/style.css
@@ -11,11 +11,12 @@
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
 }
 
-#qig-settings .inline-drawer-content {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+#qig-settings > .inline-drawer > .inline-drawer-content {
     padding-top: 10px;
+}
+
+#qig-settings > .inline-drawer > .inline-drawer-content > * + * {
+    margin-top: 16px;
 }
 
 #qig-settings label {


### PR DESCRIPTION
## What?
Fixes the Quick Image Gen settings drawer so its shared inline drawer can remain collapsed by default while preserving vertical spacing between QIG controls.

## Why?
Issue #175 reports that the Quick Image Gen panel opens expanded by default and its controls scroll with the page. The extension stylesheet was forcing the shared drawer content to `display: flex`, overriding the collapsed drawer state.

## How?
- Removes the QIG-specific `display: flex` override from `.inline-drawer-content`.
- Keeps QIG-only spacing with direct-child margins.
- Leaves the existing sticky QIG action bar behavior in place.

## Testing?
- `node --check public/scripts/extensions/quick-image-gen/index.js`
- Parsed `public/scripts/extensions/quick-image-gen/style.css` with `@adobe/css-tools`.
- `git diff --check -- public/scripts/extensions/quick-image-gen/style.css`
- Ran `graphify update .` and removed generated graph output from the PR scope.

## Screenshots (optional)
Not included. Browser QA should verify collapsed drawer state and sticky QIG controls during the shared UI pass.

## Anything Else?
Closes #175.
