### PR TITLE
Add current chat files access

### DIFF
--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -733,6 +733,7 @@ const sbState = {
         secondaryRow: null,
         scrollTopButton: null,
         scrollBottomButton: null,
+        managerButton: null,
         massDeleteButton: null,
         autoNameButton: null,
         secondaryOpen: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.bottomChatSecondaryOpen), true),
@@ -13146,6 +13147,7 @@ function buildBottomChatBar() {
 
     const topBtn = createBottomChatButton({ icon: 'fa-arrow-up', title: 'Go to top of chat' }, scrollCurrentChatToTop);
     const bottomBtn = createBottomChatButton({ icon: 'fa-arrow-down', title: 'Go to bottom of chat' }, scrollCurrentChatToBottom);
+    const chatManagerBtn = createBottomChatButton({ icon: 'fa-address-book', title: 'View chat files' }, handleChatManagerClick);
     const newBtn = createBottomChatButton({ icon: 'fa-plus', title: 'New chat' }, handleNewChat);
     const massDeleteBtn = createBottomChatButton({ icon: 'fa-list-check', title: 'Mass delete chats' }, () => { void handleMassDeleteChats(); });
     const autoNameBtn = createBottomChatButton({ icon: 'fa-wand-magic-sparkles', title: 'Ask the LLM to name this chat' }, () => { void handleAutoNameChat(); });
@@ -13153,7 +13155,7 @@ function buildBottomChatBar() {
     const deleteBtn = createBottomChatButton({ icon: 'fa-trash', title: 'Delete chat' }, () => { void handleDeleteChat(); });
 
     navCluster.append(topBtn, bottomBtn);
-    managementCluster.append(newBtn, massDeleteBtn, autoNameBtn, renameBtn, searchToggleBtn, deleteBtn);
+    managementCluster.append(chatManagerBtn, newBtn, massDeleteBtn, autoNameBtn, renameBtn, searchToggleBtn, deleteBtn);
     secondaryRow.append(managementCluster);
     container.append(personaBubble, chatSelect, search.field, navCluster, collapseToggleBtn, secondaryRow);
 
@@ -13169,6 +13171,7 @@ function buildBottomChatBar() {
         secondaryRow,
         scrollTopButton: topBtn,
         scrollBottomButton: bottomBtn,
+        managerButton: chatManagerBtn,
         massDeleteButton: massDeleteBtn,
         autoNameButton: autoNameBtn,
     });
@@ -13214,6 +13217,7 @@ async function refreshBottomChatSelect() {
     setButtonDisabled(sbState.bottomChatBar?.searchToggleButton, !chatContext.hasChat);
     setButtonDisabled(sbState.bottomChatBar?.scrollTopButton, !chatContext.hasChat);
     setButtonDisabled(sbState.bottomChatBar?.scrollBottomButton, !chatContext.hasChat);
+    setButtonDisabled(sbState.bottomChatBar?.managerButton, !chatContext.canBrowseChats);
     setButtonDisabled(sbState.bottomChatBar?.massDeleteButton, !chatContext.canBrowseChats);
     setButtonDisabled(sbState.bottomChatBar?.autoNameButton, !chatContext.hasChat);
 


### PR DESCRIPTION
## What?
Adds a chat-files button to the bottom chat bar so users can open the existing searchable chat-files popup from the current character or group chat context.

## Why?
Issue #186 asks for easier access to all chats without returning Home first. The capability already exists elsewhere, but it was not exposed in the bottom chat workflow.

## How?
- Adds a bottom-bar address-book button wired to the existing chat manager handler.
- Tracks the button in bottom chat bar state.
- Disables it when the current context cannot browse chats, matching the existing chat management controls.

## Testing?
- `node --check public/scripts/sillybunny-tabs.js`
- Targeted ESLint for `public/scripts/sillybunny-tabs.js` with installed repo dependencies.
- `git diff --check HEAD~1..HEAD -- public/scripts/sillybunny-tabs.js`
- Ran `graphify update .` and removed generated graph output from the PR scope.

## Screenshots (optional)
Not included. Browser QA should verify the bottom chat bar button opens the existing searchable chat-files popup for current character/group chats.

## Anything Else?
Closes #186.
