### PR TITLE
Add vertical chat layout setting

### DIFF
--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -4063,6 +4063,94 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     border-radius: var(--sb-radius-button, 14px) !important;
 }
 
+@media screen and (min-width: 769px) {
+    body.verticalChatLayout #chat {
+        min-height: 0;
+    }
+
+    body.verticalChatLayout #form_sheld {
+        flex: 0 0 auto;
+    }
+
+    body.verticalChatLayout #nonQRFormItems {
+        --sb-vertical-composer-action-size: clamp(26px, calc(var(--bottomFormBlockSize, 42px) * 0.72), 36px);
+        --sb-vertical-composer-send-width: calc(var(--sb-vertical-composer-action-size) * 1.45);
+        --sb-vertical-composer-icon-size: clamp(12px, calc(var(--bottomFormIconSize, 20px) * 0.62), 16px);
+        display: grid !important;
+        grid-template-columns: minmax(0, 1fr) auto !important;
+        grid-template-rows: auto minmax(58px, auto) !important;
+        grid-template-areas:
+            'tools action'
+            'input input' !important;
+        align-items: center !important;
+        gap: 6px !important;
+        padding: 6px !important;
+        border-radius: 16px !important;
+        overflow: visible !important;
+    }
+
+    body.verticalChatLayout #leftSendForm,
+    body.verticalChatLayout #rightSendForm {
+        min-width: 0 !important;
+        gap: 4px !important;
+    }
+
+    body.verticalChatLayout #leftSendForm {
+        grid-area: tools !important;
+        width: 100% !important;
+        max-width: 100% !important;
+        justify-content: flex-start !important;
+        overflow-x: auto !important;
+        overflow-y: hidden !important;
+    }
+
+    body.verticalChatLayout #rightSendForm {
+        grid-area: action !important;
+        width: auto !important;
+        min-width: max-content !important;
+        max-width: max-content !important;
+        justify-self: end !important;
+        justify-content: flex-end !important;
+        overflow: visible !important;
+    }
+
+    body.verticalChatLayout #send_textarea {
+        grid-area: input !important;
+        width: 100% !important;
+        min-width: 0 !important;
+        max-width: 100% !important;
+        min-height: clamp(68px, 14dvh, 160px) !important;
+        max-height: min(42dvh, 24rem) !important;
+        align-self: stretch !important;
+        justify-self: stretch !important;
+        resize: vertical !important;
+        box-sizing: border-box !important;
+        font-size: var(--mainFontSize) !important;
+        line-height: 1.35 !important;
+    }
+
+    body.verticalChatLayout #leftSendForm > div,
+    body.verticalChatLayout #rightSendForm > div:not(.mes_stop),
+    body.verticalChatLayout #send_form .mes_stop {
+        width: var(--sb-vertical-composer-action-size) !important;
+        min-width: var(--sb-vertical-composer-action-size) !important;
+        max-width: var(--sb-vertical-composer-action-size) !important;
+        height: var(--sb-vertical-composer-action-size) !important;
+        min-height: var(--sb-vertical-composer-action-size) !important;
+        max-height: var(--sb-vertical-composer-action-size) !important;
+        flex: 0 0 var(--sb-vertical-composer-action-size) !important;
+        font-size: var(--sb-vertical-composer-icon-size) !important;
+    }
+
+    body.verticalChatLayout #send_but,
+    body.verticalChatLayout #send_form.sb-generating-controls #mes_stop {
+        width: var(--sb-vertical-composer-send-width) !important;
+        min-width: var(--sb-vertical-composer-send-width) !important;
+        max-width: var(--sb-vertical-composer-send-width) !important;
+        flex-basis: var(--sb-vertical-composer-send-width) !important;
+    }
+}
+
 @media screen and (min-width: 1001px) {
     #send_form #qig-input-btn {
         padding: 0 !important;

--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,7 @@
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css">
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260516d" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260523a">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260523b">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260528a">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260523b" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
@@ -5274,6 +5274,10 @@
                                 <label for="compact_input_area" class="checkbox_label" title="Single-row message input area. Mobile only, no effect on PC." data-i18n="[title]Single-row message input area. Mobile only, no effect on PC">
                                     <input id="compact_input_area" type="checkbox" />
                                     <small data-i18n="Compact Input Area (Mobile)">Compact Input Area</small><i class="fa-solid fa-mobile-screen-button"></i>
+                                </label>
+                                <label for="vertical_chat_layout" class="checkbox_label" title="Use a taller mobile-style chat composer on desktop and tablet widths. No effect on phone-size layouts.">
+                                    <input id="vertical_chat_layout" type="checkbox" />
+                                    <small>Vertical Chat Layout</small><i class="fa-solid fa-desktop"></i><i class="fa-solid fa-tablet-screen-button"></i>
                                 </label>
                                 <label for="show_swipe_num_all_messages" class="checkbox_label" title="Display swipe numbers for all messages, not just the last." data-i18n="[title]Display swipe numbers for all messages, not just the last.">
                                     <input id="show_swipe_num_all_messages" type="checkbox" />

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -279,6 +279,7 @@ export const power_user = {
     chat_display: chat_styles.DEFAULT,
     toastr_position: defaultToastPosition,
     chat_width: 100,
+    vertical_chat_layout: false,
     never_resize_avatars: false,
     show_card_avatar_urls: false,
     play_message_sound: false,
@@ -676,6 +677,12 @@ function switchReducedMotion() {
 function switchCompactInputArea() {
     $('#send_form').toggleClass('compact', power_user.compact_input_area);
     $('#compact_input_area').prop('checked', power_user.compact_input_area);
+}
+
+function switchVerticalChatLayout() {
+    $('body').toggleClass('verticalChatLayout', power_user.vertical_chat_layout);
+    $('#vertical_chat_layout').prop('checked', power_user.vertical_chat_layout);
+    scrollChatToBottom();
 }
 
 function switchSwipeNumAllMessages() {
@@ -1814,6 +1821,10 @@ export async function loadPowerUserSettings(settings, data) {
         power_user.chat_width = 100;
     }
 
+    if (typeof power_user.vertical_chat_layout !== 'boolean') {
+        power_user.vertical_chat_layout = false;
+    }
+
     if (power_user.tokenizer === tokenizers.LEGACY) {
         power_user.tokenizer = tokenizers.GPT2;
     }
@@ -1920,6 +1931,7 @@ export async function loadPowerUserSettings(settings, data) {
 
     $(`#toastr_position option[value=${power_user.toastr_position}]`).prop('selected', true).trigger('change');
     $('#chat_width_slider').val(power_user.chat_width);
+    $('#vertical_chat_layout').prop('checked', power_user.vertical_chat_layout);
     $('#token_padding').val(power_user.token_padding);
     $('#aux_field').val(power_user.aux_field);
     $('#tag_import_setting').val(power_user.tag_import_setting);
@@ -2001,6 +2013,7 @@ export async function loadPowerUserSettings(settings, data) {
     $(`#character_sort_order option[data-order="${power_user.sort_order}"][data-field="${power_user.sort_field}"]`).prop('selected', true);
     switchReducedMotion();
     switchCompactInputArea();
+    switchVerticalChatLayout();
     reloadMarkdownProcessor();
     await loadInstructMode(data);
     await loadContextSettings();
@@ -4382,6 +4395,12 @@ jQuery(async () => {
     $('#compact_input_area').on('input', function () {
         power_user.compact_input_area = !!$(this).prop('checked');
         switchCompactInputArea();
+        saveSettingsDebounced();
+    });
+
+    $('#vertical_chat_layout').on('input', function () {
+        power_user.vertical_chat_layout = !!$(this).prop('checked');
+        switchVerticalChatLayout();
         saveSettingsDebounced();
     });
 


### PR DESCRIPTION
## What?
Adds a persisted, default-off Vertical Chat Layout setting for desktop and tablet widths.

## Why?
Issue #224 asks for the mobile-style vertical composer layout to be available outside phone-sized layouts without changing the current desktop/tablet default.

## How?
- Adds `vertical_chat_layout` to power-user settings with a default of `false`.
- Toggles a body class when the setting changes or loads.
- Adds a settings checkbox under theme/layout controls.
- Adds desktop/tablet-only composer CSS guarded by `min-width: 769px`, leaving phone layouts unchanged.

## Testing?
- `node --check public/scripts/power-user.js`
- Targeted ESLint for `public/scripts/power-user.js`.
- `git diff --check` for touched files.
- Runtime Chromium check on temporary port `4446`: default off unchanged, opt-in layout active at desktop/tablet widths, inactive under mobile width, persisted after reload. Temporary server was stopped.
- Ran `graphify update .` and removed generated graph output from the PR scope.

## Screenshots (optional)
Not included; runtime behavior was checked in Chromium as described above.

## Anything Else?
Closes #224.
