### PR TITLE
fix: encode Google Font family spaces correctly

### DIFF
--- a/public/scripts/macros/engine/MacroEnvBuilder.js
+++ b/public/scripts/macros/engine/MacroEnvBuilder.js
@@ -1,7 +1,7 @@
 import { name1, name2, characters, getCharacterCardFieldsLazy, getGeneratingModel } from '../../../script.js';
 import { groups, selected_group } from '../../../scripts/group-chats.js';
 import { logMacroGeneralError } from './MacroDiagnostics.js';
-import { getStringHash } from '/scripts/utils.js';
+import { getStringHash } from '../../utils.js';
 /**
  * MacroEnvBuilder is responsible for constructing the MacroEnv object
  * that is passed to macro handlers.

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -1495,7 +1495,7 @@ function buildGoogleFontHref(fontName) {
         return '';
     }
 
-    const encodedFamily = family.split(/\s+/).filter(Boolean).join('+');
+    const encodedFamily = family.split(/\s+/).filter(Boolean).join(' ');
     return `https://fonts.googleapis.com/css2?family=${encodeURIComponent(encodedFamily)}:wght@400;500;600;700&display=swap`;
 }
 

--- a/tests/in-chat-agents-pre-intercept-summary.test.js
+++ b/tests/in-chat-agents-pre-intercept-summary.test.js
@@ -93,12 +93,14 @@ beforeAll(async () => {
         normalizeAgentCategory: jest.fn(value => value),
         getAgentChatScopeLabel: jest.fn(() => 'Individual chat'),
         getPromptTransformMode: jest.fn(() => 'rewrite'),
+        isPathfinderSubmoduleEnabled: jest.fn(() => false),
         findTemplateForAgentSnapshot: jest.fn(() => null),
         getRedundantBundledAgentDuplicateIds: jest.fn(() => []),
         reconcileScopedEnabledAgentIdsFromLegacyFlags: jest.fn(() => false),
         resolveConnectionProfile: jest.fn(value => value ?? ''),
         setAgentEnabledForCurrentScope: jest.fn(),
         setGlobalSettings: jest.fn(),
+        setPathfinderSubmoduleEnabled: jest.fn(),
         getGroups: jest.fn(() => []),
         getCustomGroups: jest.fn(() => []),
         loadBuiltinGroups: jest.fn(),
@@ -111,6 +113,7 @@ beforeAll(async () => {
     await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-runner.js', () => ({
         cancelAgentGeneration: jest.fn(),
         buildPromptDynamicMacros: jest.fn(() => ({})),
+        deactivatePathfinderRuntime: jest.fn(),
         initAgentRunner: jest.fn(),
         isAgentGenerationActive: jest.fn(() => false),
         onAgentGenerationStateChanged: jest.fn(),
@@ -140,6 +143,7 @@ beforeAll(async () => {
 
     await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder-init.js', () => ({
         initPathfinder: jest.fn(),
+        teardownPathfinder: jest.fn(),
     }));
 
     await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js', () => ({

--- a/tests/pathfinder-tool-bridge.test.js
+++ b/tests/pathfinder-tool-bridge.test.js
@@ -4,6 +4,10 @@ import { describe, test, expect, jest, beforeEach, afterEach } from '@jest/globa
 
 let mockSettings;
 
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-store.js', () => ({
+    isPathfinderSubmoduleEnabled: jest.fn(() => true),
+}));
+
 await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js', () => ({
     getSettings: jest.fn(() => mockSettings),
     getTree: jest.fn(() => null),


### PR DESCRIPTION
## Summary
- Preserve spaces before URL-encoding Google Font family names
- Fix custom fonts with spaces like Gowun Dodum loading as literal plus-separated family names

## Testing
- node --check public/scripts/power-user.js