### PR TITLE
fix: make mobile quick action icons tappable

### DIFF
--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -3969,13 +3969,22 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-width: 30px;
-    width: 30px;
-    min-height: 30px;
     margin: 0;
 }
 
+.sb-mobile-quick-action-icon-picker {
+    min-width: var(--sb-mobile-touch-target, 44px);
+    width: var(--sb-mobile-touch-target, 44px);
+    min-height: var(--sb-mobile-touch-target, 44px);
+    height: var(--sb-mobile-touch-target, 44px);
+    touch-action: manipulation;
+}
+
 .sb-mobile-quick-action-icon-preview {
+    min-width: 30px;
+    width: 30px;
+    min-height: 30px;
+    height: 30px;
     border-radius: 9px;
     border: 1px solid color-mix(in srgb, var(--sb-shell-border) 60%, transparent);
     background: color-mix(in srgb, var(--SmartThemeBodyColor) 4%, transparent);

--- a/public/scripts/macros/engine/MacroEnvBuilder.js
+++ b/public/scripts/macros/engine/MacroEnvBuilder.js
@@ -1,7 +1,7 @@
 import { name1, name2, characters, getCharacterCardFieldsLazy, getGeneratingModel } from '../../../script.js';
 import { groups, selected_group } from '../../../scripts/group-chats.js';
 import { logMacroGeneralError } from './MacroDiagnostics.js';
-import { getStringHash } from '/scripts/utils.js';
+import { getStringHash } from '../../utils.js';
 /**
  * MacroEnvBuilder is responsible for constructing the MacroEnv object
  * that is passed to macro handlers.

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -4,7 +4,7 @@ import {
     MOBILE_SHELL_NAV_TOGGLE_ACTION,
 } from './mobile-shell-lifecycle/index.js';
 import { createPresetApiSyncLifecycle } from './preset-api-sync-lifecycle/index.js';
-import { flashHighlight } from './utils.js';
+import { flashHighlight, showFontAwesomePicker } from './utils.js';
 
 const sbMobileShellLifecycle = createMobileShellLifecycle();
 const sbPresetApiSyncLifecycle = createPresetApiSyncLifecycle();

--- a/tests/in-chat-agents-pre-intercept-summary.test.js
+++ b/tests/in-chat-agents-pre-intercept-summary.test.js
@@ -93,12 +93,14 @@ beforeAll(async () => {
         normalizeAgentCategory: jest.fn(value => value),
         getAgentChatScopeLabel: jest.fn(() => 'Individual chat'),
         getPromptTransformMode: jest.fn(() => 'rewrite'),
+        isPathfinderSubmoduleEnabled: jest.fn(() => false),
         findTemplateForAgentSnapshot: jest.fn(() => null),
         getRedundantBundledAgentDuplicateIds: jest.fn(() => []),
         reconcileScopedEnabledAgentIdsFromLegacyFlags: jest.fn(() => false),
         resolveConnectionProfile: jest.fn(value => value ?? ''),
         setAgentEnabledForCurrentScope: jest.fn(),
         setGlobalSettings: jest.fn(),
+        setPathfinderSubmoduleEnabled: jest.fn(),
         getGroups: jest.fn(() => []),
         getCustomGroups: jest.fn(() => []),
         loadBuiltinGroups: jest.fn(),
@@ -111,6 +113,7 @@ beforeAll(async () => {
     await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-runner.js', () => ({
         cancelAgentGeneration: jest.fn(),
         buildPromptDynamicMacros: jest.fn(() => ({})),
+        deactivatePathfinderRuntime: jest.fn(),
         initAgentRunner: jest.fn(),
         isAgentGenerationActive: jest.fn(() => false),
         onAgentGenerationStateChanged: jest.fn(),
@@ -140,6 +143,7 @@ beforeAll(async () => {
 
     await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder-init.js', () => ({
         initPathfinder: jest.fn(),
+        teardownPathfinder: jest.fn(),
     }));
 
     await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js', () => ({

--- a/tests/jest.config.json
+++ b/tests/jest.config.json
@@ -1,5 +1,8 @@
 {
     "verbose": true,
     "transform": {},
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+        "^/scripts/(.*)$": "<rootDir>/../public/scripts/$1"
+    }
 }

--- a/tests/pathfinder-tool-bridge.test.js
+++ b/tests/pathfinder-tool-bridge.test.js
@@ -4,6 +4,10 @@ import { describe, test, expect, jest, beforeEach, afterEach } from '@jest/globa
 
 let mockSettings;
 
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-store.js', () => ({
+    isPathfinderSubmoduleEnabled: jest.fn(() => true),
+}));
+
 await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js', () => ({
     getSettings: jest.fn(() => mockSettings),
     getTree: jest.fn(() => null),


### PR DESCRIPTION
## Summary
- Import the Font Awesome picker used by custom mobile Quick Action icon buttons
- Increase the icon picker to the standard 44px mobile touch target
- Keep non-interactive icon previews compact

## Testing
- node --check public/scripts/sillybunny-tabs.js
- ./node_modules/.bin/eslint public/scripts/sillybunny-tabs.js