### PR TITLE
fix: stabilize chat scrolling

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -201,6 +201,13 @@ import {
     loadFileToDocument,
     getSanitizedFilename,
 } from './scripts/utils.js';
+import {
+    TOOLING_UI_HYDRATION_STATUS,
+    buildToolingCaptureFilename,
+    normalizeToolingCaptureRange,
+    resolveLazyToolingLibraryHydration,
+    resolveToolingAssetWait,
+} from './scripts/tooling-ui-hydration/index.js';
 import { debounce_timeout, GENERATION_TYPE_TRIGGERS, IGNORE_SYMBOL, inject_ids, MEDIA_DISPLAY, MEDIA_SOURCE, MEDIA_TYPE, OVERSWIPE_BEHAVIOR, SCROLL_BEHAVIOR, SWIPE_DIRECTION, SWIPE_SOURCE, SWIPE_STATE } from './scripts/constants.js';
 
 import { cancelDebouncedMetadataSave, doDailyExtensionUpdatesCheck, extension_settings, initExtensions, loadExtensionSettings, runGenerationInterceptors } from './scripts/extensions.js';

--- a/public/script.js
+++ b/public/script.js
@@ -605,7 +605,8 @@ const MOBILE_CHAT_VIEWPORT_SCROLL_SUPPRESS_MS = 500;
 const MOBILE_CHAT_BOTTOM_PIN_MS = 1500;
 const MOBILE_STREAMING_SCROLL_MIN_INTERVAL_MS = 750;
 const CHAT_SCROLL_BOTTOM_THRESHOLD_PX = 24;
-const CHAT_LOAD_SCROLL_SETTLE_DELAYS_MS = Object.freeze([80, 250, MOBILE_CHAT_LOAD_SCROLL_SETTLE_MS, 900]);
+const CHAT_LOAD_BOTTOM_LOCK_EXTRA_MS = 250;
+const CHAT_LOAD_SCROLL_SETTLE_DELAYS_MS = Object.freeze([80, 250, MOBILE_CHAT_LOAD_SCROLL_SETTLE_MS, 900, 1600, 2400]);
 const SHOW_MORE_DUPLICATE_EVENT_GUARD_MS = 750;
 const SHOW_MORE_TOUCH_MOVE_CANCEL_PX = 12;
 const ENTITY_SELECTION_PULSE_CLEANUP_MS = 900;
@@ -642,6 +643,8 @@ let mobileStreamingBottomPinTimer = 0;
 let mobileStreamingBottomPinSettle = false;
 let mobileStreamingBottomPinSmooth = false;
 let lastMobileStreamingBottomPinAt = 0;
+let chatLoadBottomLockUntil = 0;
+let chatLoadBottomPinFrame = 0;
 export let abortStatusCheck = new AbortController();
 export let charDragDropHandler = null;
 export let chatDragDropHandler = null;
@@ -1871,6 +1874,55 @@ function isChatScrolledNearBottom(threshold = CHAT_SCROLL_BOTTOM_THRESHOLD_PX) {
     return Math.abs(element.scrollHeight - element.clientHeight - element.scrollTop) <= threshold;
 }
 
+function isChatLoadBottomLockActive() {
+    return Date.now() < chatLoadBottomLockUntil;
+}
+
+function clearChatLoadBottomLock() {
+    chatLoadBottomLockUntil = 0;
+
+    if (chatLoadBottomPinFrame) {
+        cancelAnimationFrame(chatLoadBottomPinFrame);
+        chatLoadBottomPinFrame = 0;
+    }
+}
+
+function pinChatLoadToBottom({ waitForFrame = false } = {}) {
+    if (!isChatLoadBottomLockActive()) {
+        return false;
+    }
+
+    const pin = () => {
+        if (!isChatLoadBottomLockActive()) {
+            return;
+        }
+
+        scrollLock = false;
+        scrollChatElementToBottom();
+    };
+
+    if (waitForFrame) {
+        if (!chatLoadBottomPinFrame) {
+            chatLoadBottomPinFrame = requestAnimationFrame(() => {
+                chatLoadBottomPinFrame = 0;
+                pin();
+            });
+        }
+
+        return true;
+    }
+
+    pin();
+    return true;
+}
+
+function beginChatLoadBottomLock({ durationMs = Math.max(...CHAT_LOAD_SCROLL_SETTLE_DELAYS_MS) + CHAT_LOAD_BOTTOM_LOCK_EXTRA_MS } = {}) {
+    chatLoadBottomLockUntil = Math.max(chatLoadBottomLockUntil, Date.now() + durationMs);
+    scrollLock = false;
+    scrollLockImmunityUntil = Math.max(scrollLockImmunityUntil, chatLoadBottomLockUntil);
+    pinChatLoadToBottom();
+}
+
 function markMobileChatManualScroll({ touchActive = false, suppressMs = MOBILE_CHAT_MANUAL_SCROLL_SUPPRESS_MS } = {}) {
     if (!shouldGuardMobileChatScroll()) {
         return;
@@ -2126,6 +2178,7 @@ function routeShellWheelToChat(event) {
         return;
     }
 
+    clearChatLoadBottomLock();
     chatNode.scrollTop = nextScrollTop;
     event.preventDefault();
 }
@@ -2716,7 +2769,8 @@ export async function printMessages() {
         chatElement.append('<div id="show_more_messages">Show more messages</div>');
     }
 
-    await redisplayChat({ startIndex, fade: false });
+    beginChatLoadBottomLock();
+    await redisplayChat({ startIndex, fade: false, pinBottomDuringRender: true });
 
     // Wait for next frame to ensure batch rendering completes
     await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
@@ -2742,12 +2796,14 @@ function scrollLoadedChatToBottomThroughLifecycle() {
 function scrollLoadedChatToBottom() {
     // SillyBunny: previous-chat taps can leave the mobile manual-scroll guard active.
     const latestSettleDelay = Math.max(...CHAT_LOAD_SCROLL_SETTLE_DELAYS_MS);
+    const bottomLockDurationMs = latestSettleDelay + CHAT_LOAD_BOTTOM_LOCK_EXTRA_MS;
+    beginChatLoadBottomLock({ durationMs: bottomLockDurationMs });
     scrollLock = false;
-    scrollLockImmunityUntil = Math.max(scrollLockImmunityUntil, Date.now() + latestSettleDelay + 50);
+    scrollLockImmunityUntil = Math.max(scrollLockImmunityUntil, chatLoadBottomLockUntil);
 
     if (shouldGuardMobileChatScroll()) {
         mobileChatManualScrollSuppressedUntil = 0;
-        requestMobileChatBottomPin({ requireNearBottom: false, durationMs: latestSettleDelay + MOBILE_SEND_SCROLL_SETTLE_MS });
+        requestMobileChatBottomPin({ requireNearBottom: false, durationMs: bottomLockDurationMs + MOBILE_SEND_SCROLL_SETTLE_MS });
     }
 
     scrollChatToBottom({ force: true });
@@ -2755,7 +2811,7 @@ function scrollLoadedChatToBottom() {
 
     for (const delayMs of CHAT_LOAD_SCROLL_SETTLE_DELAYS_MS) {
         setTimeout(() => {
-            if (Date.now() >= scrollLockImmunityUntil) {
+            if (!isChatLoadBottomLockActive()) {
                 return;
             }
 
@@ -2764,7 +2820,7 @@ function scrollLoadedChatToBottom() {
     }
 }
 
-async function renderRedisplayChatMessagesLegacy({ messages, startIndex, batchSize }) {
+async function renderRedisplayChatMessagesLegacy({ messages, startIndex, batchSize, pinBottomDuringRender }) {
     const renderedMessageIds = lodash.range(startIndex, startIndex + messages.length, 1);
     const shouldYieldBetweenBatches = batchSize < messages.length;
 
@@ -2789,6 +2845,10 @@ async function renderRedisplayChatMessagesLegacy({ messages, startIndex, batchSi
         }
         chatElement[0].appendChild(fragment);
 
+        if (pinBottomDuringRender) {
+            beginChatLoadBottomLock();
+        }
+
         if (shouldYieldBetweenBatches && offset + batchSize < messages.length) {
             await waitForNextFrame();
         }
@@ -2797,7 +2857,7 @@ async function renderRedisplayChatMessagesLegacy({ messages, startIndex, batchSi
     return renderedMessageIds;
 }
 
-async function renderRedisplayChatMessagesThroughLifecycle({ messages, startIndex, batchSize }) {
+async function renderRedisplayChatMessagesThroughLifecycle({ messages, startIndex, batchSize, pinBottomDuringRender }) {
     const { renderedMessageIds } = await renderMessagesInBatches({
         messages,
         firstMessageId: startIndex,
@@ -2806,19 +2866,20 @@ async function renderRedisplayChatMessagesThroughLifecycle({ messages, startInde
         insertFragment: fragment => chatElement[0].appendChild(fragment),
         waitForNextFrame,
         markLastMessage: true,
+        afterBatch: pinBottomDuringRender ? () => beginChatLoadBottomLock() : undefined,
     });
 
     return renderedMessageIds;
 }
 
-async function renderRedisplayChatMessages({ messages, startIndex }) {
+async function renderRedisplayChatMessages({ messages, startIndex, pinBottomDuringRender = false }) {
     const batchSize = getMobileChatRenderBatchSize(messages.length);
 
     if (isChatRenderLifecycleRolloutEnabled(CHAT_RENDER_LIFECYCLE_ROUTE.REDISPLAY_BATCH)) {
-        return renderRedisplayChatMessagesThroughLifecycle({ messages, startIndex, batchSize });
+        return renderRedisplayChatMessagesThroughLifecycle({ messages, startIndex, batchSize, pinBottomDuringRender });
     }
 
-    return renderRedisplayChatMessagesLegacy({ messages, startIndex, batchSize });
+    return renderRedisplayChatMessagesLegacy({ messages, startIndex, batchSize, pinBottomDuringRender });
 }
 
 /**
@@ -2827,8 +2888,9 @@ async function renderRedisplayChatMessages({ messages, startIndex }) {
  * @param {ChatMessage[]} [options.targetChat=chat] All messages in chat before startIndex will remain unchanged.
  * @param {Number} [options.startIndex=0] Everything including and after startIndex will be replaced.
  * @param {Boolean} [options.fade=true] When false, the swipe chevrons will not fade in.
+ * @param {Boolean} [options.pinBottomDuringRender=false] Keep initial chat loads at the newest rendered message while batches append.
  */
-export async function redisplayChat({ targetChat = chat, startIndex = 0, fade = true } = {}) {
+export async function redisplayChat({ targetChat = chat, startIndex = 0, fade = true, pinBottomDuringRender = false } = {}) {
     const messageElements = chatElement.find('.mes');
     messageElements.removeClass('last_mes');
 
@@ -2842,7 +2904,7 @@ export async function redisplayChat({ targetChat = chat, startIndex = 0, fade = 
     const messages = targetChat.slice(startIndex);
 
     if (messages.length > 0) {
-        const renderedMessageIds = await renderRedisplayChatMessages({ messages, startIndex });
+        const renderedMessageIds = await renderRedisplayChatMessages({ messages, startIndex, pinBottomDuringRender });
 
         applyCharacterTagsToMessageDivs({ mesIds: renderedMessageIds });
     }
@@ -2914,6 +2976,7 @@ export async function clearChat({ clearData = false } = {}) {
     cancelDebouncedChatSave();
     cancelDebouncedMetadataSave();
     closeMessageEditor();
+    clearChatLoadBottomLock();
     disposeChatMessageResizeObserver();
     resetMobileChatViewportLifecycle();
     extension_prompts = {};
@@ -14920,9 +14983,18 @@ jQuery(async function () {
 
     const chatElementScroll = document.getElementById('chat');
     const chatShellElement = document.getElementById('sheld');
-    const markMobileChatTouchScrollStart = () => markMobileChatManualScroll({ touchActive: true });
-    const markMobileChatTouchScrollMove = () => markMobileChatManualScroll();
-    const markMobileChatWheelScroll = () => markMobileChatManualScroll();
+    const markMobileChatTouchScrollStart = () => {
+        clearChatLoadBottomLock();
+        markMobileChatManualScroll({ touchActive: true });
+    };
+    const markMobileChatTouchScrollMove = () => {
+        clearChatLoadBottomLock();
+        markMobileChatManualScroll();
+    };
+    const markMobileChatWheelScroll = () => {
+        clearChatLoadBottomLock();
+        markMobileChatManualScroll();
+    };
     const markMobileViewportScroll = getMobileViewportScrollHandler();
 
     chatElementScroll.addEventListener('touchstart', markMobileChatTouchScrollStart, { passive: true });
@@ -14935,6 +15007,11 @@ jQuery(async function () {
 
     const chatScrollHandler = function () {
         refreshObservedChatMessageResizeViewportStates();
+
+        if (isChatLoadBottomLockActive() && !isChatScrolledNearBottom()) {
+            pinChatLoadToBottom();
+            return;
+        }
 
         if (power_user.waifuMode) {
             scrollLock = true;

--- a/public/script.js
+++ b/public/script.js
@@ -596,7 +596,9 @@ const MOBILE_CHAT_LOAD_SCROLL_SETTLE_MS = 400;
 const MOBILE_CHAT_MANUAL_SCROLL_SUPPRESS_MS = 1400;
 const MOBILE_CHAT_VIEWPORT_SCROLL_SUPPRESS_MS = 500;
 const MOBILE_CHAT_BOTTOM_PIN_MS = 1500;
-const CHAT_SCROLL_BOTTOM_THRESHOLD_PX = 8;
+const MOBILE_STREAMING_SCROLL_MIN_INTERVAL_MS = 750;
+const CHAT_SCROLL_BOTTOM_THRESHOLD_PX = 24;
+const CHAT_LOAD_SCROLL_SETTLE_DELAYS_MS = Object.freeze([80, 250, MOBILE_CHAT_LOAD_SCROLL_SETTLE_MS, 900]);
 const SHOW_MORE_DUPLICATE_EVENT_GUARD_MS = 750;
 const SHOW_MORE_TOUCH_MOVE_CANCEL_PX = 12;
 const ENTITY_SELECTION_PULSE_CLEANUP_MS = 900;
@@ -628,9 +630,22 @@ let scrollLockImmunityUntil = 0;
 let mobileChatTouchScrolling = false;
 let mobileChatManualScrollSuppressedUntil = 0;
 let mobileChatBottomPinUntil = 0;
+let mobileStreamingBottomPinFrame = 0;
+let mobileStreamingBottomPinTimer = 0;
+let mobileStreamingBottomPinSettle = false;
+let mobileStreamingBottomPinSmooth = false;
+let lastMobileStreamingBottomPinAt = 0;
 export let abortStatusCheck = new AbortController();
 export let charDragDropHandler = null;
 export let chatDragDropHandler = null;
+
+try {
+    if ('scrollRestoration' in history) {
+        history.scrollRestoration = 'manual';
+    }
+} catch {
+    // Ignore browsers that deny access to history state during early startup.
+}
 
 /** @type {debounce_timeout} The debounce timeout used for chat/settings save. debounce_timeout.long: 1.000 ms */
 export const DEFAULT_SAVE_EDIT_TIMEOUT = debounce_timeout.relaxed;
@@ -1855,6 +1870,7 @@ function markMobileChatManualScroll({ touchActive = false, suppressMs = MOBILE_C
     }
 
     mobileChatBottomPinUntil = 0;
+    clearMobileStreamingBottomPin();
 
     if (touchActive) {
         mobileChatTouchScrolling = true;
@@ -1911,7 +1927,7 @@ function shouldPinMobileChatToBottom() {
     return Date.now() < mobileChatBottomPinUntil || isChatScrolledNearBottom();
 }
 
-function pinMobileChatToBottom({ waitForFrame = true, settle = false } = {}) {
+function pinMobileChatToBottom({ waitForFrame = true, settle = false, immediate = true, behavior = 'auto' } = {}) {
     if (!shouldGuardMobileChatScroll()) {
         return;
     }
@@ -1922,13 +1938,12 @@ function pinMobileChatToBottom({ waitForFrame = true, settle = false } = {}) {
     scrollLockImmunityUntil = Math.max(scrollLockImmunityUntil, Date.now() + MOBILE_SEND_SCROLL_IMMUNITY_MS);
 
     const pin = () => {
-        const element = chatElement[0];
-        if (element) {
-            element.scrollTop = element.scrollHeight;
-        }
+        scrollChatElementToBottom({ behavior });
     };
 
-    pin();
+    if (immediate) {
+        pin();
+    }
 
     if (waitForFrame) {
         requestAnimationFrame(pin);
@@ -1943,10 +1958,87 @@ function pinMobileChatToBottom({ waitForFrame = true, settle = false } = {}) {
     }
 }
 
+function clearMobileStreamingBottomPinTimer() {
+    if (mobileStreamingBottomPinTimer) {
+        clearTimeout(mobileStreamingBottomPinTimer);
+        mobileStreamingBottomPinTimer = 0;
+    }
+}
+
+function clearMobileStreamingBottomPin() {
+    clearMobileStreamingBottomPinTimer();
+
+    if (mobileStreamingBottomPinFrame) {
+        cancelAnimationFrame(mobileStreamingBottomPinFrame);
+        mobileStreamingBottomPinFrame = 0;
+    }
+
+    mobileStreamingBottomPinSettle = false;
+    mobileStreamingBottomPinSmooth = false;
+}
+
+function requestMobileStreamingBottomPinFrame({ isFinal = false } = {}) {
+    mobileStreamingBottomPinSettle = mobileStreamingBottomPinSettle || isFinal;
+    mobileStreamingBottomPinSmooth = mobileStreamingBottomPinSmooth || !isFinal;
+
+    if (mobileStreamingBottomPinFrame) {
+        return;
+    }
+
+    mobileStreamingBottomPinFrame = requestAnimationFrame(() => {
+        mobileStreamingBottomPinFrame = 0;
+        const shouldSettle = mobileStreamingBottomPinSettle;
+        const behavior = shouldSettle || !mobileStreamingBottomPinSmooth ? 'auto' : 'smooth';
+        mobileStreamingBottomPinSettle = false;
+        mobileStreamingBottomPinSmooth = false;
+
+        if (!shouldPinMobileChatToBottom()) {
+            return;
+        }
+
+        lastMobileStreamingBottomPinAt = Date.now();
+        pinMobileChatToBottom({
+            waitForFrame: false,
+            settle: shouldSettle,
+            behavior,
+        });
+    });
+}
+
+function scheduleMobileStreamingBottomPin({ isFinal = false } = {}) {
+    if (!shouldGuardMobileChatScroll()) {
+        return false;
+    }
+
+    if (isFinal) {
+        clearMobileStreamingBottomPinTimer();
+        requestMobileStreamingBottomPinFrame({ isFinal: true });
+        return true;
+    }
+
+    const now = Date.now();
+    const elapsed = now - lastMobileStreamingBottomPinAt;
+
+    if (elapsed >= MOBILE_STREAMING_SCROLL_MIN_INTERVAL_MS) {
+        requestMobileStreamingBottomPinFrame();
+        return true;
+    }
+
+    if (!mobileStreamingBottomPinTimer) {
+        mobileStreamingBottomPinTimer = setTimeout(() => {
+            mobileStreamingBottomPinTimer = 0;
+            requestMobileStreamingBottomPinFrame();
+        }, MOBILE_STREAMING_SCROLL_MIN_INTERVAL_MS - elapsed);
+    }
+
+    return false;
+}
+
 function resetMobileViewportScrollState() {
     mobileChatTouchScrolling = false;
     mobileChatManualScrollSuppressedUntil = 0;
     mobileChatBottomPinUntil = 0;
+    clearMobileStreamingBottomPin();
 }
 
 function getMobileViewportScrollHandler() {
@@ -1955,6 +2047,80 @@ function getMobileViewportScrollHandler() {
             markMobileChatManualScroll({ suppressMs: MOBILE_CHAT_VIEWPORT_SCROLL_SUPPRESS_MS });
         }
     };
+}
+
+function isVerticallyScrollableElement(element) {
+    if (!(element instanceof HTMLElement)) {
+        return false;
+    }
+
+    const style = getComputedStyle(element);
+    const canScrollY = style.overflowY === 'auto' || style.overflowY === 'scroll' || style.overflowY === 'overlay';
+
+    return canScrollY && element.scrollHeight - element.clientHeight > 1;
+}
+
+function hasScrollableWheelTarget(target, boundaryElement) {
+    if (!(target instanceof Element)) {
+        return false;
+    }
+
+    const chatNode = chatElement[0];
+
+    for (let element = target; element && element !== boundaryElement; element = element.parentElement) {
+        if (element === chatNode || isVerticallyScrollableElement(element)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function getWheelDeltaYPixels(event, scrollElement) {
+    if (event.deltaMode === WheelEvent.DOM_DELTA_PAGE) {
+        return event.deltaY * scrollElement.clientHeight;
+    }
+
+    if (event.deltaMode === WheelEvent.DOM_DELTA_LINE) {
+        return event.deltaY * 16;
+    }
+
+    return event.deltaY;
+}
+
+function routeShellWheelToChat(event) {
+    const chatNode = chatElement[0];
+
+    if (!(chatNode instanceof HTMLElement) || event.defaultPrevented || event.ctrlKey || event.metaKey) {
+        return;
+    }
+
+    if (Math.abs(event.deltaY) <= Math.abs(event.deltaX)) {
+        return;
+    }
+
+    if (event.target instanceof Node && chatNode.contains(event.target)) {
+        return;
+    }
+
+    if (hasScrollableWheelTarget(event.target, event.currentTarget)) {
+        return;
+    }
+
+    const maxScrollTop = Math.max(0, chatNode.scrollHeight - chatNode.clientHeight);
+    if (maxScrollTop <= 0) {
+        return;
+    }
+
+    const currentScrollTop = chatNode.scrollTop;
+    const nextScrollTop = clamp(currentScrollTop + getWheelDeltaYPixels(event, chatNode), 0, maxScrollTop);
+
+    if (Math.abs(nextScrollTop - currentScrollTop) < 1) {
+        return;
+    }
+
+    chatNode.scrollTop = nextScrollTop;
+    event.preventDefault();
 }
 
 function disposeMobileChatViewportObserver() {
@@ -2568,13 +2734,26 @@ function scrollLoadedChatToBottomThroughLifecycle() {
 
 function scrollLoadedChatToBottom() {
     // SillyBunny: previous-chat taps can leave the mobile manual-scroll guard active.
+    const latestSettleDelay = Math.max(...CHAT_LOAD_SCROLL_SETTLE_DELAYS_MS);
+    scrollLock = false;
+    scrollLockImmunityUntil = Math.max(scrollLockImmunityUntil, Date.now() + latestSettleDelay + 50);
+
+    if (shouldGuardMobileChatScroll()) {
+        mobileChatManualScrollSuppressedUntil = 0;
+        requestMobileChatBottomPin({ requireNearBottom: false, durationMs: latestSettleDelay + MOBILE_SEND_SCROLL_SETTLE_MS });
+    }
+
     scrollChatToBottom({ force: true });
     scrollChatToBottom({ waitForFrame: true, force: true });
 
-    if (shouldGuardMobileChatScroll()) {
+    for (const delayMs of CHAT_LOAD_SCROLL_SETTLE_DELAYS_MS) {
         setTimeout(() => {
+            if (Date.now() >= scrollLockImmunityUntil) {
+                return;
+            }
+
             scrollChatToBottom({ waitForFrame: true, force: true });
-        }, MOBILE_CHAT_LOAD_SCROLL_SETTLE_MS);
+        }, delayMs);
     }
 }
 
@@ -4191,7 +4370,7 @@ function formatGenerationTimer(gen_started, gen_finished, tokenCount, reasoningD
 
 let requestId = null;
 
-function scrollChatElementToBottom() {
+function scrollChatElementToBottom({ behavior = 'auto' } = {}) {
     let position = chatElement[0].scrollHeight;
 
     if (power_user.waifuMode) {
@@ -4200,6 +4379,12 @@ function scrollChatElementToBottom() {
             const lastMessagePosition = lastMessage.position().top;
             position = chatElement.scrollTop() + lastMessagePosition;
         }
+    }
+
+    const element = chatElement[0];
+    if (behavior === 'smooth' && typeof element?.scrollTo === 'function') {
+        element.scrollTo({ top: position, behavior });
+        return;
     }
 
     chatElement.scrollTop(position);
@@ -5271,7 +5456,7 @@ class StreamingProcessor {
         }
 
         if (shouldPinMobileBottom) {
-            pinMobileChatToBottom({ waitForFrame: true, settle: isFinal });
+            scheduleMobileStreamingBottomPin({ isFinal });
         } else if (!scrollLock) {
             scrollChatToBottom({ waitForFrame: true });
         }
@@ -14727,6 +14912,7 @@ jQuery(async function () {
     }
 
     const chatElementScroll = document.getElementById('chat');
+    const chatShellElement = document.getElementById('sheld');
     const markMobileChatTouchScrollStart = () => markMobileChatManualScroll({ touchActive: true });
     const markMobileChatTouchScrollMove = () => markMobileChatManualScroll();
     const markMobileChatWheelScroll = () => markMobileChatManualScroll();
@@ -14737,6 +14923,7 @@ jQuery(async function () {
     chatElementScroll.addEventListener('touchend', releaseMobileChatTouchScroll, { passive: true });
     chatElementScroll.addEventListener('touchcancel', releaseMobileChatTouchScroll, { passive: true });
     chatElementScroll.addEventListener('wheel', markMobileChatWheelScroll, { passive: true });
+    chatShellElement?.addEventListener('wheel', routeShellWheelToChat, { passive: false });
     setupMobileChatViewportObserver(markMobileViewportScroll);
 
     const chatScrollHandler = function () {
@@ -14755,7 +14942,7 @@ jQuery(async function () {
             return;
         }
 
-        const scrollIsAtBottom = isChatScrolledNearBottom(5);
+        const scrollIsAtBottom = isChatScrolledNearBottom();
 
         // Resume autoscroll if the user scrolls to the bottom
         if (scrollLock && scrollIsAtBottom) {

--- a/public/scripts/macros/engine/MacroEnvBuilder.js
+++ b/public/scripts/macros/engine/MacroEnvBuilder.js
@@ -1,7 +1,7 @@
 import { name1, name2, characters, getCharacterCardFieldsLazy, getGeneratingModel } from '../../../script.js';
 import { groups, selected_group } from '../../../scripts/group-chats.js';
 import { logMacroGeneralError } from './MacroDiagnostics.js';
-import { getStringHash } from '/scripts/utils.js';
+import { getStringHash } from '../../utils.js';
 /**
  * MacroEnvBuilder is responsible for constructing the MacroEnv object
  * that is passed to macro handlers.

--- a/public/style.css
+++ b/public/style.css
@@ -943,10 +943,6 @@ body .panelControlBar {
     flex-direction: column;
     z-index: 30;
     flex-grow: 1;
-}
-
-/* macOS browser scroll anchoring fights chat scroll preservation during message loads. */
-body.is-macos #chat {
     overflow-anchor: none;
 }
 

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -371,6 +371,37 @@ describe('chat render lifecycle script wiring', () => {
         expect(source).toContain('isFinal,');
     });
 
+    test('streaming progress throttles mobile bottom pins through the streaming scheduler', () => {
+        const onProgressStreaming = findNode(scriptAst, node => node.type === 'MethodDefinition'
+            && node.key?.name === 'onProgressStreaming');
+        const source = getSource(onProgressStreaming.value);
+
+        expect(source).toContain('const shouldPinMobileBottom = !isImpersonate && shouldPinMobileChatToBottom();');
+        expect(source).toContain('scheduleMobileStreamingBottomPin({ isFinal });');
+        expect(source).not.toContain('pinMobileChatToBottom({ waitForFrame: true, settle: isFinal });');
+    });
+
+    test('mobile streaming bottom pin scheduling coalesces smooth intermediate pins', () => {
+        expect(scriptSource).toContain('const MOBILE_STREAMING_SCROLL_MIN_INTERVAL_MS = 750;');
+        expect(scriptSource).toContain('let mobileStreamingBottomPinFrame = 0;');
+        expect(scriptSource).toContain('let mobileStreamingBottomPinTimer = 0;');
+
+        const requestFrame = findFunctionDeclaration('requestMobileStreamingBottomPinFrame');
+        const requestFrameSource = getSource(requestFrame);
+        expect(requestFrameSource).toContain('requestAnimationFrame(() =>');
+        expect(requestFrameSource).toContain('const behavior = shouldSettle || !mobileStreamingBottomPinSmooth ? \'auto\' : \'smooth\';');
+        expect(requestFrameSource).toContain('if (!shouldPinMobileChatToBottom())');
+        expect(requestFrameSource).toContain('pinMobileChatToBottom({');
+        expect(requestFrameSource).toContain('waitForFrame: false');
+        expect(requestFrameSource).toContain('behavior,');
+
+        const scheduler = findFunctionDeclaration('scheduleMobileStreamingBottomPin');
+        const schedulerSource = getSource(scheduler);
+        expect(schedulerSource).toContain('clearMobileStreamingBottomPinTimer();');
+        expect(schedulerSource).toContain('elapsed >= MOBILE_STREAMING_SCROLL_MIN_INTERVAL_MS');
+        expect(schedulerSource).toContain('mobileStreamingBottomPinTimer = setTimeout(() =>');
+    });
+
     test('guard-on streaming progress delegates visible DOM writes to the lifecycle stream buffer', () => {
         expect(scriptSource).toContain('createStreamWriteBuffer,');
 
@@ -551,7 +582,23 @@ describe('chat render lifecycle script wiring', () => {
 
         const initSource = scriptSource.slice(scriptSource.indexOf('const chatElementScroll = document.getElementById(\'chat\');'));
         expect(initSource).toContain('const markMobileViewportScroll = getMobileViewportScrollHandler();');
+        expect(initSource).toContain('const chatShellElement = document.getElementById(\'sheld\');');
+        expect(initSource).toContain('chatShellElement?.addEventListener(\'wheel\', routeShellWheelToChat, { passive: false });');
         expect(initSource).toContain('setupMobileChatViewportObserver(markMobileViewportScroll);');
+    });
+
+    test('initial chat load keeps bottom pin settling across late layout passes', () => {
+        expect(scriptSource).toContain('const CHAT_SCROLL_BOTTOM_THRESHOLD_PX = 24;');
+        expect(scriptSource).toContain('const CHAT_LOAD_SCROLL_SETTLE_DELAYS_MS = Object.freeze([80, 250, MOBILE_CHAT_LOAD_SCROLL_SETTLE_MS, 900]);');
+        expect(scriptSource).toContain('history.scrollRestoration = \'manual\';');
+
+        const scrollLoadedChatToBottom = findFunctionDeclaration('scrollLoadedChatToBottom');
+        const source = getSource(scrollLoadedChatToBottom);
+        expect(source).toContain('const latestSettleDelay = Math.max(...CHAT_LOAD_SCROLL_SETTLE_DELAYS_MS);');
+        expect(source).toContain('scrollLockImmunityUntil = Math.max(scrollLockImmunityUntil, Date.now() + latestSettleDelay + 50);');
+        expect(source).toContain('requestMobileChatBottomPin({ requireNearBottom: false, durationMs: latestSettleDelay + MOBILE_SEND_SCROLL_SETTLE_MS });');
+        expect(source).toContain('for (const delayMs of CHAT_LOAD_SCROLL_SETTLE_DELAYS_MS)');
+        expect(source).toContain('scrollChatToBottom({ waitForFrame: true, force: true });');
     });
 
     test('mobile viewport lifecycle route preserves existing scroll suppression policy', () => {

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -79,6 +79,8 @@ describe('chat render lifecycle script wiring', () => {
         const printMessages = findExportedFunction('printMessages');
         const source = getSource(printMessages);
 
+        expect(source).toContain('beginChatLoadBottomLock();');
+        expect(source).toContain('await redisplayChat({ startIndex, fade: false, pinBottomDuringRender: true });');
         expect(source).toContain('scrollLoadedChatToBottomThroughLifecycle();');
         expect(source).toContain('delay(debounce_timeout.short).then(() => scrollOnMediaLoad({ force: true }));');
 
@@ -98,7 +100,7 @@ describe('chat render lifecycle script wiring', () => {
         const source = getSource(redisplayChat);
 
         expect(source).toContain('const messages = targetChat.slice(startIndex);');
-        expect(source).toContain('const renderedMessageIds = await renderRedisplayChatMessages({ messages, startIndex });');
+        expect(source).toContain('const renderedMessageIds = await renderRedisplayChatMessages({ messages, startIndex, pinBottomDuringRender });');
         expect(source).toContain('applyCharacterTagsToMessageDivs({ mesIds: renderedMessageIds });');
         expect(source).toContain('refreshSwipeButtons(false, fade);');
         expect(source).toContain('applyStylePins();');
@@ -111,8 +113,8 @@ describe('chat render lifecycle script wiring', () => {
 
         expect(source).toContain('const batchSize = getMobileChatRenderBatchSize(messages.length);');
         expect(source).toContain('if (isChatRenderLifecycleRolloutEnabled(CHAT_RENDER_LIFECYCLE_ROUTE.REDISPLAY_BATCH))');
-        expect(source).toContain('return renderRedisplayChatMessagesThroughLifecycle({ messages, startIndex, batchSize });');
-        expect(source).toContain('return renderRedisplayChatMessagesLegacy({ messages, startIndex, batchSize });');
+        expect(source).toContain('return renderRedisplayChatMessagesThroughLifecycle({ messages, startIndex, batchSize, pinBottomDuringRender });');
+        expect(source).toContain('return renderRedisplayChatMessagesLegacy({ messages, startIndex, batchSize, pinBottomDuringRender });');
     });
 
     test('guard-on redisplayChat delegates batch mechanics to the lifecycle render batch helper', () => {
@@ -127,6 +129,7 @@ describe('chat render lifecycle script wiring', () => {
         expect(source).toContain('insertFragment: fragment => chatElement[0].appendChild(fragment)');
         expect(source).toContain('waitForNextFrame,');
         expect(source).toContain('markLastMessage: true');
+        expect(source).toContain('afterBatch: pinBottomDuringRender ? () => beginChatLoadBottomLock() : undefined');
     });
 
     test('guard-off redisplayChat keeps legacy inline batching', () => {
@@ -139,6 +142,8 @@ describe('chat render lifecycle script wiring', () => {
         expect(source).toContain('const messageElement = updateMessageElement(message, { messageId });');
         expect(source).toContain('newMessageElements.at(-1).classList.add(\'last_mes\');');
         expect(source).toContain('chatElement[0].appendChild(fragment);');
+        expect(source).toContain('if (pinBottomDuringRender)');
+        expect(source).toContain('beginChatLoadBottomLock();');
         expect(source).toContain('await waitForNextFrame();');
         expect(source).toContain('return renderedMessageIds;');
     });
@@ -589,16 +594,36 @@ describe('chat render lifecycle script wiring', () => {
 
     test('initial chat load keeps bottom pin settling across late layout passes', () => {
         expect(scriptSource).toContain('const CHAT_SCROLL_BOTTOM_THRESHOLD_PX = 24;');
-        expect(scriptSource).toContain('const CHAT_LOAD_SCROLL_SETTLE_DELAYS_MS = Object.freeze([80, 250, MOBILE_CHAT_LOAD_SCROLL_SETTLE_MS, 900]);');
+        expect(scriptSource).toContain('const CHAT_LOAD_BOTTOM_LOCK_EXTRA_MS = 250;');
+        expect(scriptSource).toContain('const CHAT_LOAD_SCROLL_SETTLE_DELAYS_MS = Object.freeze([80, 250, MOBILE_CHAT_LOAD_SCROLL_SETTLE_MS, 900, 1600, 2400]);');
         expect(scriptSource).toContain('history.scrollRestoration = \'manual\';');
+
+        const beginChatLoadBottomLock = findFunctionDeclaration('beginChatLoadBottomLock');
+        const lockSource = getSource(beginChatLoadBottomLock);
+        expect(lockSource).toContain('chatLoadBottomLockUntil = Math.max(chatLoadBottomLockUntil, Date.now() + durationMs);');
+        expect(lockSource).toContain('scrollLockImmunityUntil = Math.max(scrollLockImmunityUntil, chatLoadBottomLockUntil);');
+        expect(lockSource).toContain('pinChatLoadToBottom();');
+
+        const pinChatLoadToBottom = findFunctionDeclaration('pinChatLoadToBottom');
+        const pinSource = getSource(pinChatLoadToBottom);
+        expect(pinSource).toContain('if (!isChatLoadBottomLockActive())');
+        expect(pinSource).toContain('scrollChatElementToBottom();');
 
         const scrollLoadedChatToBottom = findFunctionDeclaration('scrollLoadedChatToBottom');
         const source = getSource(scrollLoadedChatToBottom);
         expect(source).toContain('const latestSettleDelay = Math.max(...CHAT_LOAD_SCROLL_SETTLE_DELAYS_MS);');
-        expect(source).toContain('scrollLockImmunityUntil = Math.max(scrollLockImmunityUntil, Date.now() + latestSettleDelay + 50);');
-        expect(source).toContain('requestMobileChatBottomPin({ requireNearBottom: false, durationMs: latestSettleDelay + MOBILE_SEND_SCROLL_SETTLE_MS });');
+        expect(source).toContain('const bottomLockDurationMs = latestSettleDelay + CHAT_LOAD_BOTTOM_LOCK_EXTRA_MS;');
+        expect(source).toContain('beginChatLoadBottomLock({ durationMs: bottomLockDurationMs });');
+        expect(source).toContain('scrollLockImmunityUntil = Math.max(scrollLockImmunityUntil, chatLoadBottomLockUntil);');
+        expect(source).toContain('requestMobileChatBottomPin({ requireNearBottom: false, durationMs: bottomLockDurationMs + MOBILE_SEND_SCROLL_SETTLE_MS });');
         expect(source).toContain('for (const delayMs of CHAT_LOAD_SCROLL_SETTLE_DELAYS_MS)');
+        expect(source).toContain('if (!isChatLoadBottomLockActive())');
         expect(source).toContain('scrollChatToBottom({ waitForFrame: true, force: true });');
+
+        const initSource = scriptSource.slice(scriptSource.indexOf('const chatElementScroll = document.getElementById(\'chat\');'));
+        expect(initSource).toContain('clearChatLoadBottomLock();');
+        expect(initSource).toContain('if (isChatLoadBottomLockActive() && !isChatScrolledNearBottom())');
+        expect(initSource).toContain('pinChatLoadToBottom();');
     });
 
     test('mobile viewport lifecycle route preserves existing scroll suppression policy', () => {

--- a/tests/in-chat-agents-pre-intercept-summary.test.js
+++ b/tests/in-chat-agents-pre-intercept-summary.test.js
@@ -93,12 +93,14 @@ beforeAll(async () => {
         normalizeAgentCategory: jest.fn(value => value),
         getAgentChatScopeLabel: jest.fn(() => 'Individual chat'),
         getPromptTransformMode: jest.fn(() => 'rewrite'),
+        isPathfinderSubmoduleEnabled: jest.fn(() => false),
         findTemplateForAgentSnapshot: jest.fn(() => null),
         getRedundantBundledAgentDuplicateIds: jest.fn(() => []),
         reconcileScopedEnabledAgentIdsFromLegacyFlags: jest.fn(() => false),
         resolveConnectionProfile: jest.fn(value => value ?? ''),
         setAgentEnabledForCurrentScope: jest.fn(),
         setGlobalSettings: jest.fn(),
+        setPathfinderSubmoduleEnabled: jest.fn(),
         getGroups: jest.fn(() => []),
         getCustomGroups: jest.fn(() => []),
         loadBuiltinGroups: jest.fn(),
@@ -111,6 +113,7 @@ beforeAll(async () => {
     await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-runner.js', () => ({
         cancelAgentGeneration: jest.fn(),
         buildPromptDynamicMacros: jest.fn(() => ({})),
+        deactivatePathfinderRuntime: jest.fn(),
         initAgentRunner: jest.fn(),
         isAgentGenerationActive: jest.fn(() => false),
         onAgentGenerationStateChanged: jest.fn(),
@@ -140,6 +143,7 @@ beforeAll(async () => {
 
     await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder-init.js', () => ({
         initPathfinder: jest.fn(),
+        teardownPathfinder: jest.fn(),
     }));
 
     await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js', () => ({

--- a/tests/jest.config.json
+++ b/tests/jest.config.json
@@ -1,5 +1,8 @@
 {
     "verbose": true,
     "transform": {},
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+        "^/scripts/(.*)$": "<rootDir>/../public/scripts/$1"
+    }
 }

--- a/tests/pathfinder-tool-bridge.test.js
+++ b/tests/pathfinder-tool-bridge.test.js
@@ -4,6 +4,10 @@ import { describe, test, expect, jest, beforeEach, afterEach } from '@jest/globa
 
 let mockSettings;
 
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-store.js', () => ({
+    isPathfinderSubmoduleEnabled: jest.fn(() => true),
+}));
+
 await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/tree-store.js', () => ({
     getSettings: jest.fn(() => mockSettings),
     getTree: jest.fn(() => null),


### PR DESCRIPTION
Fixes #167

## Summary
- throttle and coalesce mobile streaming bottom pins through a requestAnimationFrame scheduler, using smooth intermediate pins and an auto final settle
- cancel pending streaming pins on manual mobile scroll so user gestures are not pulled back down
- harden initial chat load bottom landing with manual browser scroll restoration, delayed settle passes, and a wider near-bottom threshold
- route wheel gestures from the chat shell into the chat scroller when the pointer is outside the message list, while preserving nested scrollable targets
- make `#chat` own scroll anchoring consistently by disabling browser overflow anchoring outside macOS too

## Testing
- `node --check public/script.js`
- `node --check public/scripts/mobile-streaming.js`
- `node --check tests/chat-render-lifecycle-script-wiring.test.js`
- `./node_modules/.bin/eslint tests/chat-render-lifecycle-script-wiring.test.js`
- `git diff --check`
- `bun test tests/chat-render-lifecycle-script-wiring.test.js`
- `bun test tests/chat-render-lifecycle-script-wiring.test.js tests/chat-render-lifecycle-scroll-intent.test.js tests/chat-render-lifecycle-bottom-scroll.test.js tests/chat-scroll-edges.test.js tests/chat-render-lifecycle-mobile-viewport.test.js tests/mobile-streaming.test.js tests/mobile-send-button.test.js`

## Notes
- `./node_modules/.bin/eslint public/script.js` still reports pre-existing unrelated `no-undef` errors in tooling capture helpers.
- A broad `bun test tests` run is noisy in this checkout because Bun also picked up unrelated untracked `worktree-*` test directories.