### PR TITLE
Fix post agents after provider errors

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -5379,8 +5379,12 @@ class StreamingProcessor {
         deactivateSendButtons();
     }
 
-    markUIGenStopped() {
-        unblockGeneration();
+    markUIGenStopped({ emitGenerationEnded = true, emitGenerationStopped = false } = {}) {
+        if (emitGenerationStopped) {
+            eventSource.emit(event_types.GENERATION_STOPPED);
+        }
+
+        unblockGeneration(this.type, { emitGenerationEnded });
     }
 
     async onStartStreaming(text) {
@@ -5618,7 +5622,7 @@ class StreamingProcessor {
         this.isStopped = true;
         this.isFinished = true;
 
-        this.markUIGenStopped();
+        this.markUIGenStopped({ emitGenerationEnded: false, emitGenerationStopped: true });
 
         const noEmitTypes = ['swipe', 'impersonate', 'continue'];
         if (!noEmitTypes.includes(this.type)) {
@@ -7503,7 +7507,8 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             toastr.error(exception.error.message, t`Text generation error`, { timeOut: 10000, extendedTimeOut: 20000 });
         }
 
-        unblockGeneration(type);
+        eventSource.emit(event_types.GENERATION_STOPPED);
+        unblockGeneration(type, { emitGenerationEnded: false });
         console.log(exception);
         streamingProcessor = null;
         throw exception;

--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -127,6 +127,8 @@ let toolRecursionDepth = 0;
 const processedPostProcessingRuns = new WeakMap();
 const processedPostProcessingRunsByIndex = new Map();
 const postProcessingInFlightKeys = new Set();
+const stoppedStreamingMessageIndexes = new Set();
+let stoppedGenerationRunId = -1;
 
 function escapeToastHtml(value) {
     return String(value ?? '')
@@ -625,16 +627,31 @@ function isMainGenerationStillActive() {
 }
 
 function wasStreamingMessageStopped(messageIndex) {
+    const numericMessageIndex = Number(messageIndex);
+    if (!Number.isInteger(numericMessageIndex)) {
+        return false;
+    }
+
+    if (stoppedStreamingMessageIndexes.has(numericMessageIndex)) {
+        return true;
+    }
+
     const liveStreamingProcessor = getStreamingTarget(messageIndex);
     if (!liveStreamingProcessor) {
         return false;
     }
 
-    return Boolean(
+    const isStopped = Boolean(
         generationStopRequested ||
         liveStreamingProcessor.isStopped ||
         liveStreamingProcessor.abortController?.signal?.aborted,
     );
+
+    if (isStopped) {
+        stoppedStreamingMessageIndexes.add(numericMessageIndex);
+    }
+
+    return isStopped;
 }
 
 function clearDeferredPostProcessing(messageIndex = null) {
@@ -993,6 +1010,7 @@ function deferPostProcessing(messageIndex, generationType, activationSnapshot = 
         generationType: snapshot.generationType,
         message: chat[numericMessageIndex] ?? null,
         activationSnapshot: snapshot,
+        wasStreamingStopped: wasStreamingMessageStopped(numericMessageIndex),
     });
 
     if (!isGenerationInProgress) {
@@ -1068,14 +1086,14 @@ function scheduleDeferredPostProcessingFlush(delayMs = 0) {
                 continue;
             }
 
+            if (pendingMessage.wasStreamingStopped || wasStreamingMessageStopped(pendingMessage.messageIndex)) {
+                deferredPostProcessingQueue.delete(pendingMessage.messageIndex);
+                continue;
+            }
+
             if (isStreamingMessageStillActive(pendingMessage.messageIndex)) {
                 scheduleDeferredPostProcessingFlush(DEFERRED_POST_PROCESSING_RETRY_MS);
                 return;
-            }
-
-            if (wasStreamingMessageStopped(pendingMessage.messageIndex)) {
-                deferredPostProcessingQueue.delete(pendingMessage.messageIndex);
-                continue;
             }
 
             deferredPostProcessingQueue.delete(pendingMessage.messageIndex);
@@ -1452,6 +1470,10 @@ function queueLatestAssistantPostProcessingFromSnapshot() {
     const message = chat[messageIndex];
     if (!isGenerationAssistantCandidate(messageIndex, message)) {
         return { queued: false, retry: true };
+    }
+
+    if (wasStreamingMessageStopped(messageIndex)) {
+        return { queued: false, retry: false };
     }
 
     const runKey = getPostProcessingRunKey(message, activationSnapshot.generationType, activationSnapshot);
@@ -2831,6 +2853,8 @@ function onGenerationStarted(generationType, _options, dryRun) {
     generationStartedAt = Date.now();
     lastMainGenerationEndedAt = 0;
     postProcessingGenerationRunId++;
+    stoppedGenerationRunId = -1;
+    stoppedStreamingMessageIndexes.clear();
     clearLatestAssistantPostProcessingFallback();
     clearPostGenerationRecoveryCheck();
     clearMissedGenerationEndRecoveryCheck();
@@ -2857,6 +2881,18 @@ function onGenerationStarted(generationType, _options, dryRun) {
 
 function onGenerationEnded() {
     if (internalPromptTransformDepth > 0) {
+        return;
+    }
+
+    if (stoppedGenerationRunId === postProcessingGenerationRunId) {
+        isGenerationInProgress = false;
+        lastMainGenerationEndedAt = Date.now();
+        toolSyncDuringGeneration = false;
+        clearLatestAssistantPostProcessingFallback();
+        clearPostGenerationRecoveryCheck();
+        clearMissedGenerationEndRecoveryCheck();
+        clearDeferredPostProcessing();
+        clearAllPromptTransformRunningToasts();
         return;
     }
 
@@ -2888,6 +2924,11 @@ function onGenerationStopped() {
     }
 
     generationStopRequested = true;
+    stoppedGenerationRunId = postProcessingGenerationRunId;
+    const stoppedMessageIndex = Number(streamingProcessor?.messageId);
+    if (Number.isInteger(stoppedMessageIndex) && stoppedMessageIndex >= 0) {
+        stoppedStreamingMessageIndexes.add(stoppedMessageIndex);
+    }
     isGenerationInProgress = false;
     lastMainGenerationEndedAt = Date.now();
     clearLatestAssistantPostProcessingFallback();
@@ -3203,13 +3244,13 @@ async function onMessageReceived(messageIndex, generationType) {
 
     ensureMessageRegexSnapshot(numericMessageIndex, generationType);
 
-    if (isStreamingMessageStillActive(numericMessageIndex)) {
-        deferPostProcessing(numericMessageIndex, generationType);
+    if (generationStopRequested || wasStreamingMessageStopped(numericMessageIndex)) {
+        clearDeferredPostProcessing(numericMessageIndex);
         return;
     }
 
-    if (wasStreamingMessageStopped(numericMessageIndex)) {
-        clearDeferredPostProcessing(numericMessageIndex);
+    if (isStreamingMessageStillActive(numericMessageIndex)) {
+        deferPostProcessing(numericMessageIndex, generationType);
         return;
     }
 

--- a/tests/generation-lifecycle-wiring.test.js
+++ b/tests/generation-lifecycle-wiring.test.js
@@ -82,4 +82,9 @@ describe('generation lifecycle wiring', () => {
         expect(unblockSource).toContain('unblockState.shouldFlushEphemeralState');
         expect(unblockSource).not.toContain('type === \'quiet\' && streamingProcessor && !streamingProcessor.isFinished');
     });
+
+    test('routes provider-error cleanup through stopped lifecycle semantics', () => {
+        expect(scriptSource).toContain('this.markUIGenStopped({ emitGenerationEnded: false, emitGenerationStopped: true });');
+        expect(scriptSource).toContain('eventSource.emit(event_types.GENERATION_STOPPED);\n        unblockGeneration(type, { emitGenerationEnded: false });');
+    });
 });

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -1212,6 +1212,45 @@ describe('in-chat agent post-processing runner', () => {
         expect(saveChatDebounced).toHaveBeenCalledTimes(2);
     });
 
+    test('does not run post-processing for provider-stopped streaming messages', async () => {
+        useAppendPostAgent();
+
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        await eventSource.emit(eventTypes.GENERATION_AFTER_COMMANDS, 'normal', {}, false);
+        document.body.dataset.generating = 'true';
+        chat.push({
+            name: 'Assistant',
+            mes: 'Partial provider error output',
+            is_user: false,
+            is_system: false,
+            extra: {},
+        });
+        Object.assign(streamingProcessor, {
+            messageId: 0,
+            type: 'normal',
+            isFinished: true,
+            isStopped: true,
+            abortController: { signal: { aborted: true } },
+        });
+
+        await eventSource.emit(eventTypes.GENERATION_STOPPED);
+        delete document.body.dataset.generating;
+        await eventSource.emit(eventTypes.MESSAGE_RECEIVED, 0, 'normal');
+        Object.assign(streamingProcessor, {
+            messageId: -1,
+            isStopped: false,
+            abortController: { signal: { aborted: false } },
+        });
+        await eventSource.emit(eventTypes.GENERATION_ENDED, chat.length);
+        await new Promise(resolve => setTimeout(resolve, 75));
+
+        expect(chat[0].mes).toBe('Partial provider error output');
+        expect(saveChatDebounced).not.toHaveBeenCalled();
+    });
+
     test('handles non-stream mobile order where generation ends before the body flag clears', async () => {
         useAppendPostAgent();
 


### PR DESCRIPTION
Summary:
- route streaming and non-stream provider errors through stopped generation lifecycle semantics
- suppress late/spurious generation-ended post-processing after stopped/error streams
- persist stopped streaming message state across deferred post-processing cleanup

Tests:
- NODE_OPTIONS=--experimental-vm-modules bunx jest --config tests/jest.config.json tests/in-chat-agents-runner.test.js tests/generation-lifecycle-wiring.test.js