### PR TITLE
Fix chat vectorization toggle persistence

### DIFF
--- a/public/scripts/extensions/vectors/index.js
+++ b/public/scripts/extensions/vectors/index.js
@@ -36,7 +36,7 @@ import { commonEnumProviders } from '../../slash-commands/SlashCommandCommonEnum
 import { slashCommandReturnHelper } from '../../slash-commands/SlashCommandReturnHelper.js';
 import { generateWebLlmChatPrompt, isWebLlmSupported } from '../shared.js';
 import { WebLlmVectorProvider } from './webllm.js';
-import { applyLegacyVectorEnabledSetting, bindVectorEnabledSettingsStore, getVectorEnabledState, normalizeVectorEnabledOptions } from './settings-utils.js';
+import { applyLegacyVectorEnabledSetting, bindVectorEnabledSettingsStore, getPersistableVectorSettings, getVectorEnabledState, normalizeVectorEnabledOptions, stripLegacyVectorEnabledSetting } from './settings-utils.js';
 import { removeReasoningFromString } from '../../reasoning.js';
 import { oai_settings } from '../../openai.js';
 
@@ -929,7 +929,7 @@ function bindVectorSettingsStore() {
 
 function persistVectorSettings({ save = true, updateUi = true } = {}) {
     const store = ensureVectorSettingsStore();
-    Object.assign(store, settings);
+    Object.assign(store, getPersistableVectorSettings(settings));
     bindVectorSettingsStore();
 
     if (updateUi) {
@@ -1854,11 +1854,12 @@ export async function init() {
     if (settings.enabled) {
         settings.enabled_chats = true;
     }
+    stripLegacyVectorEnabledSetting(settings);
 
     // Migrate from TensorFlow to Transformers
     settings.source = settings.source !== 'local' ? settings.source : 'transformers';
     settings.summary_source = settings.summary_source === 'extras' ? 'main' : settings.summary_source;
-    Object.assign(savedVectorSettings, settings);
+    Object.assign(savedVectorSettings, getPersistableVectorSettings(settings));
     bindVectorSettingsStore();
     const template = await renderExtensionTemplateAsync(MODULE_NAME, 'settings');
     $('#vectors_container').append(template);

--- a/public/scripts/extensions/vectors/settings-utils.js
+++ b/public/scripts/extensions/vectors/settings-utils.js
@@ -47,6 +47,28 @@ export function applyLegacyVectorEnabledSetting(settings, savedSettings = {}) {
 }
 
 /**
+ * Removes the deprecated runtime `enabled` flag after migration so stale values
+ * cannot overwrite the scoped enable flags through the compatibility setter.
+ * @param {Record<string, any>} settings Runtime vector settings.
+ * @returns {Record<string, any>} Mutated runtime settings.
+ */
+export function stripLegacyVectorEnabledSetting(settings) {
+    delete settings.enabled;
+    return settings;
+}
+
+/**
+ * Gets vector settings that are safe to copy into the saved settings store.
+ * @param {Record<string, any>} settings Runtime vector settings.
+ * @returns {Record<string, any>} Persistable settings without deprecated runtime aliases.
+ */
+export function getPersistableVectorSettings(settings) {
+    const persistableSettings = { ...settings };
+    stripLegacyVectorEnabledSetting(persistableSettings);
+    return persistableSettings;
+}
+
+/**
  * Normalizes extension-facing RAG enable options to the internal vector flags.
  * @param {unknown} options Enable options.
  * @returns {Partial<{enabled_chats: boolean, enabled_files: boolean, enabled_world_info: boolean}>}

--- a/tests/vector-settings-utils.test.js
+++ b/tests/vector-settings-utils.test.js
@@ -3,8 +3,10 @@ import {
     applyLegacyVectorEnabledSetting,
     bindVectorEnabledSettingsStore,
     coerceVectorBoolean,
+    getPersistableVectorSettings,
     getVectorEnabledState,
     normalizeVectorEnabledOptions,
+    stripLegacyVectorEnabledSetting,
 } from '../public/scripts/extensions/vectors/settings-utils.js';
 
 describe('vector settings utilities', () => {
@@ -33,6 +35,27 @@ describe('vector settings utilities', () => {
         applyLegacyVectorEnabledSetting(settings, { enabled: false });
 
         expect(settings.enabled_chats).toBe(true);
+    });
+
+    test('strips deprecated runtime enabled flag after migration', () => {
+        const settings = { enabled: false, enabled_chats: true };
+
+        stripLegacyVectorEnabledSetting(settings);
+
+        expect(settings).toEqual({ enabled_chats: true });
+    });
+
+    test('omits stale legacy enabled values when persisting vector settings', () => {
+        expect(getPersistableVectorSettings({
+            enabled: false,
+            enabled_chats: true,
+            enabled_files: false,
+            enabled_world_info: false,
+        })).toEqual({
+            enabled_chats: true,
+            enabled_files: false,
+            enabled_world_info: false,
+        });
     });
 
     test('normalizes extension-facing RAG enable options', () => {
@@ -104,5 +127,37 @@ describe('vector settings utilities', () => {
 
         store.enabled = false;
         expect(settings.enabled_chats).toBe(false);
+    });
+
+    test('stale legacy enabled=false does not override chat RAG during persistence', () => {
+        const settings = {
+            enabled: false,
+            enabled_chats: true,
+            enabled_files: false,
+            enabled_world_info: false,
+        };
+        const store = {};
+
+        bindVectorEnabledSettingsStore(settings, store);
+        Object.assign(store, getPersistableVectorSettings(settings));
+
+        expect(settings.enabled_chats).toBe(true);
+        expect(store.enabled).toBe(true);
+    });
+
+    test('stale legacy enabled=true does not block disabling chat RAG during persistence', () => {
+        const settings = {
+            enabled: true,
+            enabled_chats: false,
+            enabled_files: false,
+            enabled_world_info: false,
+        };
+        const store = {};
+
+        bindVectorEnabledSettingsStore(settings, store);
+        Object.assign(store, getPersistableVectorSettings(settings));
+
+        expect(settings.enabled_chats).toBe(false);
+        expect(store.enabled).toBe(false);
     });
 });


### PR DESCRIPTION
Summary:
- strip deprecated runtime vector enabled alias after migration
- persist vector settings without stale legacy enabled values
- keep the saved compatibility alias bound to current chat vector state

Tests:
- NODE_OPTIONS=--experimental-vm-modules bunx jest --config tests/jest.config.json tests/vector-settings-utils.test.js