### PR TITLE
Fix iOS streaming scroll jitter

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -314,7 +314,7 @@ import { onboardingExperimentalMacroEngine } from './scripts/macros/engine/Macro
 import { compressRequest, setRequestCompressionConfig } from './scripts/request-compression.js';
 import { canJumpToSwipeForMessage, canOpenSwipePickerForMessage, initSwipePicker } from './scripts/swipe-picker.js';
 import { bindIOSFastTapSendButton, isIOSWebKitPlatform } from './scripts/mobile-send-button.js';
-import { getStreamingUpdateInterval } from './scripts/mobile-streaming.js';
+import { getMobileStreamingBottomPinBehavior, getStreamingUpdateInterval } from './scripts/mobile-streaming.js';
 import {
     CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY,
     CHAT_RENDER_LIFECYCLE_ROUTE,
@@ -1949,6 +1949,10 @@ function releaseMobileChatTouchScroll() {
     markMobileChatManualScroll();
 }
 
+function isMobileChatManualScrollSuppressionActive() {
+    return shouldGuardMobileChatScroll() && (mobileChatTouchScrolling || Date.now() < mobileChatManualScrollSuppressedUntil);
+}
+
 function shouldSuppressMobileChatAutoScroll() {
     if (!shouldGuardMobileChatScroll()) {
         return false;
@@ -1979,7 +1983,7 @@ function requestMobileChatBottomPin({ requireNearBottom = true, durationMs = MOB
 }
 
 function shouldPinMobileChatToBottom() {
-    if (!shouldGuardMobileChatScroll() || mobileChatTouchScrolling) {
+    if (!shouldGuardMobileChatScroll() || isMobileChatManualScrollSuppressionActive()) {
         return false;
     }
 
@@ -2047,7 +2051,10 @@ function requestMobileStreamingBottomPinFrame({ isFinal = false } = {}) {
     mobileStreamingBottomPinFrame = requestAnimationFrame(() => {
         mobileStreamingBottomPinFrame = 0;
         const shouldSettle = mobileStreamingBottomPinSettle;
-        const behavior = shouldSettle || !mobileStreamingBottomPinSmooth ? 'auto' : 'smooth';
+        const behavior = getMobileStreamingBottomPinBehavior({
+            isFinal: shouldSettle,
+            allowSmooth: mobileStreamingBottomPinSmooth,
+        });
         mobileStreamingBottomPinSettle = false;
         mobileStreamingBottomPinSmooth = false;
 
@@ -5412,7 +5419,8 @@ class StreamingProcessor {
         const isContinue = this.type == 'continue';
         const isIOSWebKit = isIOSWebKitPlatform();
         const shouldReduceIntermediateStreamingWork = !isFinal && isIOSWebKit && power_user.ios_webkit_reduce_streaming_work;
-        const shouldPinMobileBottom = !isImpersonate && shouldPinMobileChatToBottom();
+        const shouldUseMobileStreamingPin = !isImpersonate && shouldGuardMobileChatScroll();
+        const shouldPinMobileBottom = shouldUseMobileStreamingPin && shouldPinMobileChatToBottom();
 
         if (!isImpersonate && !isContinue && Array.isArray(this.swipes) && this.swipes.length > 0) {
             for (let i = 0; i < this.swipes.length; i++) {
@@ -5525,10 +5533,13 @@ class StreamingProcessor {
             }
         }
 
-        if (shouldPinMobileBottom) {
+        if (shouldPinMobileBottom && shouldPinMobileChatToBottom()) {
             scheduleMobileStreamingBottomPin({ isFinal });
-        } else if (!scrollLock) {
-            scrollChatToBottom({ waitForFrame: true });
+        } else if (!scrollLock && (!shouldUseMobileStreamingPin || !isMobileChatManualScrollSuppressionActive())) {
+            scrollChatToBottom({
+                waitForFrame: true,
+                isNearBottom: shouldUseMobileStreamingPin ? shouldPinMobileBottom : true,
+            });
         }
     }
 

--- a/public/scripts/mobile-streaming.js
+++ b/public/scripts/mobile-streaming.js
@@ -22,6 +22,28 @@ export function isSmoothStreamingEffectivelyEnabled({
 }
 
 /**
+ * Resolves the scroll behavior for mobile streaming bottom pins.
+ * Native smooth scrolling can keep running after an iOS touch gesture starts,
+ * which makes streaming fight manual/momentum scroll and visibly snap.
+ * @param {object} [options]
+ * @param {boolean} [options.isFinal] Whether this is the final streaming pin
+ * @param {boolean} [options.allowSmooth] Whether the scheduler requested a smooth intermediate pin
+ * @param {Navigator} [options.navigatorRef] Navigator-like object
+ * @returns {'auto'|'smooth'}
+ */
+export function getMobileStreamingBottomPinBehavior({
+    isFinal = false,
+    allowSmooth = true,
+    navigatorRef = globalThis.navigator,
+} = {}) {
+    if (isFinal || !allowSmooth || isIOSWebKitPlatform(navigatorRef)) {
+        return 'auto';
+    }
+
+    return 'smooth';
+}
+
+/**
  * Checks whether live streaming DOM work should be reduced for the current browser.
  * @param {Navigator} [navigatorRef] Navigator-like object
  * @param {object} [options]

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -381,7 +381,9 @@ describe('chat render lifecycle script wiring', () => {
             && node.key?.name === 'onProgressStreaming');
         const source = getSource(onProgressStreaming.value);
 
-        expect(source).toContain('const shouldPinMobileBottom = !isImpersonate && shouldPinMobileChatToBottom();');
+        expect(source).toContain('const shouldUseMobileStreamingPin = !isImpersonate && shouldGuardMobileChatScroll();');
+        expect(source).toContain('const shouldPinMobileBottom = shouldUseMobileStreamingPin && shouldPinMobileChatToBottom();');
+        expect(source).toContain('if (shouldPinMobileBottom && shouldPinMobileChatToBottom())');
         expect(source).toContain('scheduleMobileStreamingBottomPin({ isFinal });');
         expect(source).not.toContain('pinMobileChatToBottom({ waitForFrame: true, settle: isFinal });');
     });
@@ -394,7 +396,7 @@ describe('chat render lifecycle script wiring', () => {
         const requestFrame = findFunctionDeclaration('requestMobileStreamingBottomPinFrame');
         const requestFrameSource = getSource(requestFrame);
         expect(requestFrameSource).toContain('requestAnimationFrame(() =>');
-        expect(requestFrameSource).toContain('const behavior = shouldSettle || !mobileStreamingBottomPinSmooth ? \'auto\' : \'smooth\';');
+        expect(requestFrameSource).toContain('const behavior = getMobileStreamingBottomPinBehavior({');
         expect(requestFrameSource).toContain('if (!shouldPinMobileChatToBottom())');
         expect(requestFrameSource).toContain('pinMobileChatToBottom({');
         expect(requestFrameSource).toContain('waitForFrame: false');

--- a/tests/mobile-streaming.test.js
+++ b/tests/mobile-streaming.test.js
@@ -1,4 +1,5 @@
 import {
+    getMobileStreamingBottomPinBehavior,
     getStreamingUpdateInterval,
     IOS_REASONING_RENDER_INTERVAL_MS,
     IOS_STREAMING_UPDATE_INTERVAL_MS,
@@ -59,6 +60,21 @@ describe('mobile streaming helpers', () => {
             iosWebKitDisableSmoothStreaming: true,
             navigatorRef: { platform: 'iPhone', maxTouchPoints: 1 },
         })).toBe(false);
+    });
+
+    test('uses instant streaming bottom pins on iOS WebKit', () => {
+        expect(getMobileStreamingBottomPinBehavior({
+            navigatorRef: { platform: 'Linux x86_64', maxTouchPoints: 1 },
+        })).toBe('smooth');
+
+        expect(getMobileStreamingBottomPinBehavior({
+            isFinal: true,
+            navigatorRef: { platform: 'Linux x86_64', maxTouchPoints: 1 },
+        })).toBe('auto');
+
+        expect(getMobileStreamingBottomPinBehavior({
+            navigatorRef: { platform: 'iPhone', maxTouchPoints: 1 },
+        })).toBe('auto');
     });
 
     test('skips repeated hidden live reasoning renders on reduced DOM platforms', () => {


### PR DESCRIPTION
Summary:
- use instant mobile streaming bottom pins on iOS WebKit
- respect manual scroll suppression before and after streaming DOM updates
- avoid fallback bottom scrolling when mobile manual-scroll suppression is active

Tests:
- bun test tests/mobile-streaming.test.js tests/chat-render-lifecycle-script-wiring.test.js