### PR TITLE
Fix in-chat agent regex refresh

### DIFF
--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -1601,6 +1601,113 @@ function ensureMessageRegexSnapshot(messageIndex, generationType, activationSnap
     return true;
 }
 
+function isRegexRefreshAgentCandidate(agent, generationType, { respectGenerationTypes = true } = {}) {
+    if (!agent || getAgentRegexScripts(agent).length === 0) {
+        return false;
+    }
+
+    if (!respectGenerationTypes) {
+        return true;
+    }
+
+    const normalizedGenerationType = normalizeGenerationType(generationType);
+    const generationTypes = agent.conditions?.generationTypes;
+    return !Array.isArray(generationTypes)
+        || generationTypes.length === 0
+        || generationTypes.includes(normalizedGenerationType);
+}
+
+function getRegexSnapshotRefreshAgents(message, agentId, generationType, { includeForcedAgent = false, respectGenerationTypes = true } = {}) {
+    const enabledAgentsById = new Map(getEnabledAgents().map(agent => [agent.id, agent]));
+    const previousSnapshot = getAgentExtraValue(message, MESSAGE_EXTRA_KEY);
+    const agentIds = new Set(Array.isArray(previousSnapshot?.activeAgentIds) ? previousSnapshot.activeAgentIds : []);
+
+    if (agentId) {
+        agentIds.add(agentId);
+    }
+
+    const refreshAgents = [];
+    for (const id of agentIds) {
+        let agent = enabledAgentsById.get(id);
+
+        if (!agent && includeForcedAgent && id === agentId) {
+            agent = getAgentById(id);
+        }
+
+        if (isRegexRefreshAgentCandidate(agent, generationType, { respectGenerationTypes })) {
+            refreshAgents.push(agent);
+        }
+    }
+
+    return refreshAgents;
+}
+
+function refreshRegexSnapshotForAgentOnMessage(agentId, messageIndex, options = {}) {
+    const {
+        generationType = 'normal',
+        includeForcedAgent = false,
+        refresh = true,
+        respectGenerationTypes = true,
+        save = true,
+        markPendingSave = !save,
+    } = options;
+    const normalizedGenerationType = normalizeGenerationType(generationType);
+    if (!isAssistantPostProcessingGenerationType(normalizedGenerationType)) {
+        return false;
+    }
+
+    const numericMessageIndex = Number(messageIndex);
+    if (!Number.isInteger(numericMessageIndex)) {
+        return false;
+    }
+
+    const message = chat[numericMessageIndex];
+    if (!message || message.is_user || message.is_system) {
+        return false;
+    }
+
+    const activeAgents = getRegexSnapshotRefreshAgents(message, agentId, normalizedGenerationType, {
+        includeForcedAgent,
+        respectGenerationTypes,
+    });
+
+    if (!updateMessageRegexSnapshot(message, activeAgents, normalizedGenerationType)) {
+        return false;
+    }
+
+    if (save) {
+        pendingRegexSnapshotSaves.delete(message);
+        saveChatDebounced();
+    } else if (markPendingSave) {
+        pendingRegexSnapshotSaves.add(message);
+    }
+
+    if (refresh) {
+        scheduleMessageRefresh(numericMessageIndex, message);
+    }
+
+    return true;
+}
+
+export function refreshRegexSnapshotsForAgent(agentId, { generationType = 'normal' } = {}) {
+    let refreshed = 0;
+    for (let messageIndex = 0; messageIndex < chat.length; messageIndex++) {
+        if (refreshRegexSnapshotForAgentOnMessage(agentId, messageIndex, {
+            generationType,
+            markPendingSave: false,
+            save: false,
+        })) {
+            refreshed++;
+        }
+    }
+
+    if (refreshed > 0) {
+        saveChatDebounced();
+    }
+
+    return refreshed;
+}
+
 function resolveAgentConnectionProfile(agent) {
     return resolveConnectionProfile(agent?.connectionProfile);
 }
@@ -3929,6 +4036,13 @@ async function executeManualAgentRun(agentId, messageIndex, cancelRevision = age
     }
 
     const generationType = 'normal';
+    const regexSnapshotChanged = refreshRegexSnapshotForAgentOnMessage(agent.id, messageIndex, {
+        generationType,
+        includeForcedAgent: true,
+        markPendingSave: false,
+        respectGenerationTypes: false,
+        save: false,
+    });
     const result = await runPromptTransformAgent(agent, message, generationType, null, messageIndex, {
         applyToMessage: false,
     });
@@ -3941,7 +4055,8 @@ async function executeManualAgentRun(agentId, messageIndex, cancelRevision = age
         await syncPromptTransformMessageStateAsync(message, messageIndex);
     }
 
-    if (updatePromptTransformRuns(message, [result])) {
+    const promptTransformRunsChanged = updatePromptTransformRuns(message, [result]);
+    if (regexSnapshotChanged || promptTransformRunsChanged) {
         saveChatDebounced();
     }
 
@@ -3951,7 +4066,7 @@ async function executeManualAgentRun(agentId, messageIndex, cancelRevision = age
         saveChatDebounced();
     }
 
-    if (result.changed) {
+    if (result.changed || regexSnapshotChanged) {
         scheduleMessageRefresh(messageIndex, message);
     }
 

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -52,6 +52,7 @@ import {
     onAgentGenerationStateChanged,
     getPreGenerationInterceptHistoryForMessage,
     getPromptTransformHistoryForMessage,
+    refreshRegexSnapshotsForAgent,
     runAgentOnMessage,
     syncToolAgentRegistrations,
     undoPromptTransform,
@@ -210,6 +211,7 @@ function sortAgentsByOrder(agentList = []) {
 async function toggleAgentEnabled(agent) {
     setAgentEnabledForCurrentScope(agent, !isAgentEnabledForCurrentScope(agent));
     await saveAgent(agent);
+    refreshRegexSnapshotsForAgent(agent.id);
     persistExtensionState();
     syncToolAgentRegistrations();
     renderAgentList();
@@ -2282,6 +2284,7 @@ async function openEditor(agentId = null) {
     }
 
     await saveAgent(agent);
+    refreshRegexSnapshotsForAgent(agent.id);
     renderAgentList();
 }
 

--- a/tests/in-chat-agents-pre-intercept-summary.test.js
+++ b/tests/in-chat-agents-pre-intercept-summary.test.js
@@ -119,6 +119,7 @@ beforeAll(async () => {
         onAgentGenerationStateChanged: jest.fn(),
         getPreGenerationInterceptHistoryForMessage: jest.fn(() => []),
         getPromptTransformHistoryForMessage: jest.fn(() => []),
+        refreshRegexSnapshotsForAgent: jest.fn(() => 0),
         runAgentOnMessage: jest.fn(),
         syncToolAgentRegistrations: jest.fn(),
         undoPromptTransform: jest.fn(async () => false),

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -1130,6 +1130,74 @@ describe('in-chat agent post-processing runner', () => {
         expect(saveChatDebounced).toHaveBeenCalledTimes(1);
     });
 
+    test('refreshes existing regex snapshots when an agent regex changes', async () => {
+        useRegexOnlyAgent();
+
+        const { initAgentRunner, refreshRegexSnapshotsForAgent } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+
+        chat.push({
+            name: 'Assistant',
+            mes: '[STATUS|ready]',
+            is_user: false,
+            is_system: false,
+            extra: {
+                inChatAgents: {
+                    activeAgentIds: ['agent-regex-only'],
+                    generationType: 'normal',
+                    regexScripts: [{
+                        ...enabledAgents[0].regexScripts[0],
+                        replaceString: '<div class="status old">$1</div>',
+                    }],
+                    edited: false,
+                },
+            },
+        });
+        chat[0].swipes = [chat[0].mes];
+        chat[0].swipe_id = 0;
+        chat[0].swipe_info = [{ extra: structuredClone(chat[0].extra) }];
+
+        enabledAgents[0].regexScripts[0].replaceString = '<div class="status new">$1</div>';
+
+        expect(refreshRegexSnapshotsForAgent('agent-regex-only')).toBe(1);
+
+        expect(chat[0].extra.inChatAgents.regexScripts[0].replaceString).toBe('<div class="status new">$1</div>');
+        expect(chat[0].swipe_info[0].extra.inChatAgents.regexScripts[0].replaceString).toBe('<div class="status new">$1</div>');
+        expect(saveChatDebounced).toHaveBeenCalledTimes(1);
+
+        await new Promise(resolve => setTimeout(resolve, 5));
+        expect(saveChat).toHaveBeenCalledTimes(1);
+    });
+
+    test('manual regex-only agent runs snapshot and refresh the target message', async () => {
+        useRegexOnlyAgent();
+
+        const { initAgentRunner, runAgentOnMessage } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+
+        chat.push({
+            name: 'Assistant',
+            mes: '[STATUS|ready]',
+            is_user: false,
+            is_system: false,
+            extra: {},
+        });
+
+        const result = await runAgentOnMessage('agent-regex-only', 0);
+
+        expect(result.status).toBe('skipped-empty-prompt');
+        expect(chat[0].extra.inChatAgents).toEqual({
+            activeAgentIds: ['agent-regex-only'],
+            generationType: 'normal',
+            regexScripts: enabledAgents[0].regexScripts,
+            edited: false,
+        });
+        expect(saveChatDebounced).toHaveBeenCalled();
+
+        await new Promise(resolve => setTimeout(resolve, 5));
+        expect(saveChat).toHaveBeenCalledTimes(1);
+    });
+
     test('snapshots regex-only agents on streamed tokens before final message events', async () => {
         useRegexOnlyAgent();
 


### PR DESCRIPTION
Summary:
- refresh existing message regex snapshots when an agent is saved or enabled
- let manual regex-only agent runs snapshot and re-render the target message
- keep swipe metadata regex snapshots in sync

Tests:
- NODE_OPTIONS=--experimental-vm-modules bunx jest --config tests/jest.config.json tests/in-chat-agents-runner.test.js