### PR TITLE
fix: defer iOS streaming scroll during touch

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -643,6 +643,7 @@ let mobileStreamingBottomPinTimer = 0;
 let mobileStreamingBottomPinSettle = false;
 let mobileStreamingBottomPinSmooth = false;
 let deferredMobileStreamingBottomPin = false;
+let deferredMobileStreamingBottomPinTimer = 0;
 let lastMobileStreamingBottomPinAt = 0;
 let chatLoadBottomLockUntil = 0;
 let chatLoadBottomPinFrame = 0;
@@ -1941,6 +1942,9 @@ function markMobileChatManualScroll({ touchActive = false, suppressMs = MOBILE_C
     }
 
     mobileChatManualScrollSuppressedUntil = Math.max(mobileChatManualScrollSuppressedUntil, Date.now() + suppressMs);
+    if (deferredMobileStreamingBottomPin && !mobileChatTouchScrolling) {
+        scheduleDeferredMobileStreamingBottomPinFlush();
+    }
     scrollLockImmunityUntil = 0;
 }
 
@@ -1952,11 +1956,27 @@ function releaseMobileChatTouchScroll() {
 
     mobileChatTouchScrolling = false;
     markMobileChatManualScroll();
-    flushDeferredMobileStreamingBottomPin();
+    scheduleDeferredMobileStreamingBottomPinFlush();
+}
+
+function isMobileChatManualScrollSuppressionWindowActive() {
+    return Date.now() < mobileChatManualScrollSuppressedUntil;
 }
 
 function isMobileChatManualScrollSuppressionActive() {
-    return shouldGuardMobileChatScroll() && (mobileChatTouchScrolling || Date.now() < mobileChatManualScrollSuppressedUntil);
+    return shouldGuardMobileChatScroll() && (mobileChatTouchScrolling || isMobileChatManualScrollSuppressionWindowActive());
+}
+
+function shouldYieldMobileChatScrollToActiveGesture() {
+    if (!shouldGuardMobileChatScroll()) {
+        return false;
+    }
+
+    if (mobileChatTouchScrolling) {
+        return true;
+    }
+
+    return isIOSWebKitPlatform() && isMobileChatManualScrollSuppressionWindowActive();
 }
 
 function shouldSuppressMobileChatAutoScroll() {
@@ -1972,7 +1992,19 @@ function shouldSuppressMobileChatAutoScroll() {
         return true;
     }
 
-    return Date.now() < mobileChatManualScrollSuppressedUntil && !isChatScrolledNearBottom();
+    const isManualSuppressionActive = isMobileChatManualScrollSuppressionWindowActive();
+    if (isIOSWebKitPlatform() && isManualSuppressionActive) {
+        return true;
+    }
+
+    return isManualSuppressionActive && !isChatScrolledNearBottom();
+}
+
+function clearDeferredMobileStreamingBottomPinTimer() {
+    if (deferredMobileStreamingBottomPinTimer) {
+        clearTimeout(deferredMobileStreamingBottomPinTimer);
+        deferredMobileStreamingBottomPinTimer = 0;
+    }
 }
 
 function queueDeferredMobileStreamingBottomPin() {
@@ -1981,11 +2013,43 @@ function queueDeferredMobileStreamingBottomPin() {
     }
 
     deferredMobileStreamingBottomPin = true;
+    if (!mobileChatTouchScrolling) {
+        scheduleDeferredMobileStreamingBottomPinFlush();
+    }
     return true;
 }
 
 function clearDeferredMobileStreamingBottomPin() {
+    clearDeferredMobileStreamingBottomPinTimer();
     deferredMobileStreamingBottomPin = false;
+}
+
+function scheduleDeferredMobileStreamingBottomPinFlush() {
+    if (!deferredMobileStreamingBottomPin) {
+        return false;
+    }
+
+    clearDeferredMobileStreamingBottomPinTimer();
+
+    if (!shouldGuardMobileChatScroll()) {
+        clearDeferredMobileStreamingBottomPin();
+        return false;
+    }
+
+    if (mobileChatTouchScrolling) {
+        return true;
+    }
+
+    const delayMs = isIOSWebKitPlatform() ? Math.max(0, mobileChatManualScrollSuppressedUntil - Date.now()) : 0;
+    if (delayMs <= 0) {
+        return flushDeferredMobileStreamingBottomPin();
+    }
+
+    deferredMobileStreamingBottomPinTimer = setTimeout(() => {
+        deferredMobileStreamingBottomPinTimer = 0;
+        flushDeferredMobileStreamingBottomPin();
+    }, delayMs);
+    return true;
 }
 
 function flushDeferredMobileStreamingBottomPin() {
@@ -1993,21 +2057,29 @@ function flushDeferredMobileStreamingBottomPin() {
         return false;
     }
 
-    clearDeferredMobileStreamingBottomPin();
-
-    if (!shouldGuardMobileChatScroll() || mobileChatTouchScrolling) {
+    if (!shouldGuardMobileChatScroll()) {
+        clearDeferredMobileStreamingBottomPin();
         return false;
     }
 
-    // The deferred pin already yielded to touch; allow one catch-up pin after release.
-    mobileChatManualScrollSuppressedUntil = 0;
+    if (shouldYieldMobileChatScrollToActiveGesture()) {
+        scheduleDeferredMobileStreamingBottomPinFlush();
+        return false;
+    }
+
+    if (!isChatScrolledNearBottom()) {
+        clearDeferredMobileStreamingBottomPin();
+        return false;
+    }
+
+    clearDeferredMobileStreamingBottomPin();
     requestMobileChatBottomPin({ requireNearBottom: false });
     scheduleMobileStreamingBottomPin({ isFinal: true });
     return true;
 }
 
 function requestMobileChatBottomPin({ requireNearBottom = true, durationMs = MOBILE_CHAT_BOTTOM_PIN_MS } = {}) {
-    if (!shouldGuardMobileChatScroll() || mobileChatTouchScrolling) {
+    if (!shouldGuardMobileChatScroll() || shouldYieldMobileChatScrollToActiveGesture()) {
         return false;
     }
 
@@ -2028,7 +2100,7 @@ function shouldPinMobileChatToBottom() {
 }
 
 function pinMobileChatToBottom({ waitForFrame = true, settle = false, immediate = true, behavior = 'auto' } = {}) {
-    if (!shouldGuardMobileChatScroll()) {
+    if (!shouldGuardMobileChatScroll() || shouldYieldMobileChatScrollToActiveGesture()) {
         return;
     }
 
@@ -2038,6 +2110,10 @@ function pinMobileChatToBottom({ waitForFrame = true, settle = false, immediate 
     scrollLockImmunityUntil = Math.max(scrollLockImmunityUntil, Date.now() + MOBILE_SEND_SCROLL_IMMUNITY_MS);
 
     const pin = () => {
+        if (shouldYieldMobileChatScrollToActiveGesture()) {
+            return;
+        }
+
         scrollChatElementToBottom({ behavior });
     };
 
@@ -2095,7 +2171,7 @@ function requestMobileStreamingBottomPinFrame({ isFinal = false } = {}) {
         mobileStreamingBottomPinSettle = false;
         mobileStreamingBottomPinSmooth = false;
 
-        if (mobileChatTouchScrolling) {
+        if (shouldYieldMobileChatScrollToActiveGesture()) {
             queueDeferredMobileStreamingBottomPin();
             return;
         }
@@ -2456,6 +2532,11 @@ async function applyChatMessageResizeAction(element, entry, metadata) {
 
     if (shouldApplyChatBottomScrollAction(action)) {
         requestAnimationFrame(() => {
+            if (shouldSuppressMobileChatAutoScroll()) {
+                refreshChatMessageResizeState(element, metadata, entry);
+                return;
+            }
+
             scrollChatElementToBottom();
             refreshChatMessageResizeState(element, metadata, entry);
         });
@@ -2569,7 +2650,7 @@ function scrollStartedStreamingMessageThroughLifecycle() {
         autoScrollEnabled: power_user.auto_scroll_chat_to_bottom,
         isNearBottom: isChatScrolledNearBottom(),
         isManualScrollSuppressed: shouldSuppressMobileChatAutoScroll(),
-        isTouchActive: mobileChatTouchScrolling,
+        isTouchActive: shouldYieldMobileChatScrollToActiveGesture(),
     });
 
     if (action.action === CHAT_SCROLL_ACTION.DEFER_UNTIL_TOUCH_END) {
@@ -2579,6 +2660,11 @@ function scrollStartedStreamingMessageThroughLifecycle() {
 
     if (shouldApplyChatBottomScrollAction(action)) {
         requestAnimationFrame(() => {
+            if (shouldYieldMobileChatScrollToActiveGesture()) {
+                queueDeferredMobileStreamingBottomPin();
+                return;
+            }
+
             scrollChatElementToBottom();
         });
     }
@@ -5478,7 +5564,7 @@ class StreamingProcessor {
             autoScrollEnabled: true,
             isNearBottom: isChatScrolledNearBottom(),
             isManualScrollSuppressed: shouldSuppressMobileChatAutoScroll(),
-            isTouchActive: mobileChatTouchScrolling,
+            isTouchActive: shouldYieldMobileChatScrollToActiveGesture(),
         }) : null;
         const shouldPinMobileBottom = shouldUseMobileStreamingPin && shouldPinMobileChatToBottom();
 

--- a/public/script.js
+++ b/public/script.js
@@ -15379,12 +15379,17 @@ jQuery(async function () {
             markMobileChatManualScroll({ touchMoved: mobileChatTouchScrolling || isIOSWebKitPlatform() });
         }
 
+        const scrollIsAtBottom = isChatScrolledNearBottom();
+        const canReleaseUserScrollLock = canReleaseMobileChatUserScrollLock();
+
+        // User scroll-away must win even during immunity; immunity only protects programmatic bottom-lock release.
+        if (!scrollLock && !scrollIsAtBottom) {
+            scrollLock = true;
+        }
+
         if (Date.now() < scrollLockImmunityUntil) {
             return;
         }
-
-        const scrollIsAtBottom = isChatScrolledNearBottom();
-        const canReleaseUserScrollLock = canReleaseMobileChatUserScrollLock();
 
         if (scrollIsAtBottom && canReleaseUserScrollLock) {
             releaseMobileChatUserScrollLockIfAtBottom();
@@ -15395,10 +15400,7 @@ jQuery(async function () {
             scrollLock = false;
         }
 
-        // Cancel autoscroll if the user scrolls up
-        if (!scrollLock && !scrollIsAtBottom) {
-            scrollLock = true;
-        }
+        // Scroll-away cancellation happens before the immunity return above.
     };
     chatElementScroll.addEventListener('scroll', chatScrollHandler, { passive: true });
 

--- a/public/script.js
+++ b/public/script.js
@@ -638,6 +638,7 @@ let scrollLockImmunityUntil = 0;
 let mobileChatTouchScrolling = false;
 let mobileChatTouchGestureMoved = false;
 let mobileChatUserScrollLocked = false;
+let mobileChatManualScrollVersion = 0;
 let mobileChatManualScrollSuppressedUntil = 0;
 let mobileChatBottomPinUntil = 0;
 let mobileStreamingBottomPinFrame = 0;
@@ -1945,6 +1946,7 @@ function markMobileChatManualScroll({ touchActive = false, touchMoved = false, s
     }
 
     if (touchMoved) {
+        mobileChatManualScrollVersion += 1;
         mobileChatTouchGestureMoved = true;
         mobileChatUserScrollLocked = true;
         scrollLock = true;
@@ -2246,6 +2248,7 @@ function resetMobileViewportScrollState() {
     mobileChatTouchScrolling = false;
     mobileChatTouchGestureMoved = false;
     mobileChatUserScrollLocked = false;
+    mobileChatManualScrollVersion += 1;
     mobileChatManualScrollSuppressedUntil = 0;
     mobileChatBottomPinUntil = 0;
     clearMobileStreamingBottomPin();
@@ -2443,26 +2446,37 @@ function getMobileMessageUpdateQueue() {
     return mobileMessageUpdateQueue;
 }
 
-function captureMobileStreamingScrollTop() {
-    const element = chatElement[0];
-
-    if (!element || !shouldGuardMobileChatScroll() || !shouldSuppressMobileChatAutoScroll()) {
+function captureMobileStreamingScrollAnchor() {
+    if (!shouldGuardMobileChatScroll() || !shouldSuppressMobileChatAutoScroll()) {
         return null;
     }
 
-    return element.scrollTop;
+    const anchor = captureVisibleChatMessageAnchor();
+    if (!anchor) {
+        return null;
+    }
+
+    return {
+        anchor,
+        version: mobileChatManualScrollVersion,
+    };
 }
 
-function restoreMobileStreamingScrollTop(scrollTop) {
-    const element = chatElement[0];
+function restoreMobileStreamingScrollAnchor(snapshot) {
+    if (!snapshot?.anchor || snapshot.version !== mobileChatManualScrollVersion || !shouldGuardMobileChatScroll() || !shouldSuppressMobileChatAutoScroll()) {
+        return false;
+    }
 
-    if (!element || typeof scrollTop !== 'number' || !shouldGuardMobileChatScroll() || !shouldSuppressMobileChatAutoScroll()) {
+    restoreVisibleChatMessageAnchor(snapshot.anchor);
+    return true;
+}
+
+function settleMobileStreamingScrollAnchor(snapshot) {
+    if (!restoreMobileStreamingScrollAnchor(snapshot)) {
         return;
     }
 
-    if (Math.abs(element.scrollTop - scrollTop) > 0.5) {
-        element.scrollTop = scrollTop;
-    }
+    requestAnimationFrame(() => restoreMobileStreamingScrollAnchor(snapshot));
 }
 
 function applyStreamingVisibleWrite(messageId, {
@@ -2479,7 +2493,7 @@ function applyStreamingVisibleWrite(messageId, {
     shouldUseStreamFadeIn,
     bypassFadeIn,
 }, { isFinal = false } = {}) {
-    const preservedMobileScrollTop = captureMobileStreamingScrollTop();
+    const preservedMobileScrollAnchor = captureMobileStreamingScrollAnchor();
 
     if (shouldRefreshTokenCount && messageTokenCounterDom instanceof HTMLElement) {
         messageTokenCounterDom.textContent = `${currentTokenCount}t`;
@@ -2502,7 +2516,7 @@ function applyStreamingVisibleWrite(messageId, {
         messageTimerDom.title = timePassed.timerTitle;
     }
 
-    restoreMobileStreamingScrollTop(preservedMobileScrollTop);
+    settleMobileStreamingScrollAnchor(preservedMobileScrollAnchor);
 
     return isFinal;
 }
@@ -15231,7 +15245,7 @@ jQuery(async function () {
         }
 
         if (mobileChatTouchScrolling || Date.now() < mobileChatManualScrollSuppressedUntil) {
-            markMobileChatManualScroll({ touchMoved: mobileChatTouchScrolling });
+            markMobileChatManualScroll({ touchMoved: mobileChatTouchScrolling || isIOSWebKitPlatform() });
         }
 
         if (Date.now() < scrollLockImmunityUntil) {

--- a/public/script.js
+++ b/public/script.js
@@ -647,6 +647,8 @@ let mobileStreamingBottomPinSettle = false;
 let mobileStreamingBottomPinSmooth = false;
 let deferredMobileStreamingBottomPin = false;
 let deferredMobileStreamingBottomPinTimer = 0;
+const deferredMobileStreamingVisibleWrites = new Map();
+let deferredMobileStreamingVisibleWriteTimer = 0;
 let lastMobileStreamingBottomPinAt = 0;
 let chatLoadBottomLockUntil = 0;
 let chatLoadBottomPinFrame = 0;
@@ -1957,6 +1959,9 @@ function markMobileChatManualScroll({ touchActive = false, touchMoved = false, s
     if (deferredMobileStreamingBottomPin && !mobileChatTouchScrolling) {
         scheduleDeferredMobileStreamingBottomPinFlush();
     }
+    if (deferredMobileStreamingVisibleWrites.size > 0 && !mobileChatTouchScrolling) {
+        scheduleDeferredMobileStreamingVisibleWriteFlush();
+    }
     scrollLockImmunityUntil = 0;
 }
 
@@ -1968,6 +1973,7 @@ function releaseMobileChatTouchScroll() {
 
     mobileChatTouchScrolling = false;
     markMobileChatManualScroll();
+    scheduleDeferredMobileStreamingVisibleWriteFlush();
 
     if (mobileChatTouchGestureMoved) {
         clearDeferredMobileStreamingBottomPin();
@@ -2012,6 +2018,7 @@ function releaseMobileChatUserScrollLockIfAtBottom() {
 
     mobileChatUserScrollLocked = false;
     mobileChatTouchGestureMoved = false;
+    flushDeferredMobileStreamingVisibleWrites();
     return true;
 }
 
@@ -2269,6 +2276,7 @@ function resetMobileViewportScrollState() {
     mobileChatBottomPinUntil = 0;
     clearMobileStreamingBottomPin();
     clearDeferredMobileStreamingBottomPin();
+    clearDeferredMobileStreamingVisibleWrites();
 }
 
 function getMobileViewportScrollHandler() {
@@ -2462,6 +2470,96 @@ function getMobileMessageUpdateQueue() {
     return mobileMessageUpdateQueue;
 }
 
+function shouldDeferMobileStreamingVisibleWrite() {
+    return shouldYieldMobileChatScrollToActiveGesture();
+}
+
+function clearDeferredMobileStreamingVisibleWriteTimer() {
+    if (deferredMobileStreamingVisibleWriteTimer) {
+        clearTimeout(deferredMobileStreamingVisibleWriteTimer);
+        deferredMobileStreamingVisibleWriteTimer = 0;
+    }
+}
+
+function clearDeferredMobileStreamingVisibleWrites() {
+    clearDeferredMobileStreamingVisibleWriteTimer();
+    deferredMobileStreamingVisibleWrites.clear();
+}
+
+function flushDeferredMobileStreamingVisibleWrites() {
+    if (deferredMobileStreamingVisibleWrites.size === 0) {
+        return 0;
+    }
+
+    if (shouldDeferMobileStreamingVisibleWrite()) {
+        scheduleDeferredMobileStreamingVisibleWriteFlush();
+        return 0;
+    }
+
+    clearDeferredMobileStreamingVisibleWriteTimer();
+    const writes = [...deferredMobileStreamingVisibleWrites.entries()];
+    deferredMobileStreamingVisibleWrites.clear();
+
+    for (const [messageId, { write, options }] of writes) {
+        applyStreamingVisibleWrite(messageId, write, options);
+    }
+
+    return writes.length;
+}
+
+function scheduleDeferredMobileStreamingVisibleWriteFlush() {
+    if (deferredMobileStreamingVisibleWrites.size === 0) {
+        return false;
+    }
+
+    clearDeferredMobileStreamingVisibleWriteTimer();
+
+    if (!shouldGuardMobileChatScroll()) {
+        flushDeferredMobileStreamingVisibleWrites();
+        return true;
+    }
+
+    if (mobileChatTouchScrolling) {
+        return true;
+    }
+
+    if (mobileChatUserScrollLocked) {
+        const delayMs = Math.max(0, mobileChatManualScrollSuppressedUntil - Date.now());
+        if (delayMs <= 0) {
+            releaseMobileChatUserScrollLockIfAtBottom();
+            return true;
+        }
+
+        deferredMobileStreamingVisibleWriteTimer = setTimeout(() => {
+            deferredMobileStreamingVisibleWriteTimer = 0;
+            releaseMobileChatUserScrollLockIfAtBottom();
+        }, delayMs);
+        return true;
+    }
+
+    const delayMs = isIOSWebKitPlatform() ? Math.max(0, mobileChatManualScrollSuppressedUntil - Date.now()) : 0;
+    if (delayMs <= 0) {
+        flushDeferredMobileStreamingVisibleWrites();
+        return true;
+    }
+
+    deferredMobileStreamingVisibleWriteTimer = setTimeout(() => {
+        deferredMobileStreamingVisibleWriteTimer = 0;
+        flushDeferredMobileStreamingVisibleWrites();
+    }, delayMs);
+    return true;
+}
+
+function queueDeferredMobileStreamingVisibleWrite(messageId, write, options) {
+    if (!shouldDeferMobileStreamingVisibleWrite()) {
+        return false;
+    }
+
+    deferredMobileStreamingVisibleWrites.set(messageId, { write, options });
+    scheduleDeferredMobileStreamingVisibleWriteFlush();
+    return true;
+}
+
 function captureMobileStreamingScrollAnchor() {
     if (!shouldGuardMobileChatScroll() || shouldYieldMobileChatScrollToActiveGesture() || !shouldSuppressMobileChatAutoScroll()) {
         return null;
@@ -2509,6 +2607,23 @@ function applyStreamingVisibleWrite(messageId, {
     shouldUseStreamFadeIn,
     bypassFadeIn,
 }, { isFinal = false } = {}) {
+    if (queueDeferredMobileStreamingVisibleWrite(messageId, {
+        messageTextDom,
+        messageTimerDom,
+        messageTokenCounterDom,
+        messageDom,
+        message,
+        formattedText,
+        timePassed,
+        currentTokenCount,
+        shouldRefreshTokenCount,
+        shouldUpdateMetaBadges,
+        shouldUseStreamFadeIn,
+        bypassFadeIn,
+    }, { isFinal })) {
+        return isFinal;
+    }
+
     const preservedMobileScrollAnchor = captureMobileStreamingScrollAnchor();
 
     if (shouldRefreshTokenCount && messageTokenCounterDom instanceof HTMLElement) {

--- a/public/script.js
+++ b/public/script.js
@@ -2001,6 +2001,20 @@ function shouldYieldMobileChatScrollToActiveGesture() {
     return isIOSWebKitPlatform() && isMobileChatManualScrollSuppressionWindowActive();
 }
 
+function canReleaseMobileChatUserScrollLock() {
+    return !mobileChatTouchScrolling && !isMobileChatManualScrollSuppressionWindowActive();
+}
+
+function releaseMobileChatUserScrollLockIfAtBottom() {
+    if (!shouldGuardMobileChatScroll() || !mobileChatUserScrollLocked || !canReleaseMobileChatUserScrollLock() || !isChatScrolledNearBottom()) {
+        return false;
+    }
+
+    mobileChatUserScrollLocked = false;
+    mobileChatTouchGestureMoved = false;
+    return true;
+}
+
 function shouldSuppressMobileChatAutoScroll() {
     if (!shouldGuardMobileChatScroll()) {
         return false;
@@ -2118,6 +2132,8 @@ function requestMobileChatBottomPin({ requireNearBottom = true, durationMs = MOB
 }
 
 function shouldPinMobileChatToBottom() {
+    releaseMobileChatUserScrollLockIfAtBottom();
+
     if (!shouldGuardMobileChatScroll() || isMobileChatManualScrollSuppressionActive() || mobileChatUserScrollLocked || scrollLock) {
         return false;
     }
@@ -2447,7 +2463,7 @@ function getMobileMessageUpdateQueue() {
 }
 
 function captureMobileStreamingScrollAnchor() {
-    if (!shouldGuardMobileChatScroll() || !shouldSuppressMobileChatAutoScroll()) {
+    if (!shouldGuardMobileChatScroll() || shouldYieldMobileChatScrollToActiveGesture() || !shouldSuppressMobileChatAutoScroll()) {
         return null;
     }
 
@@ -2463,7 +2479,7 @@ function captureMobileStreamingScrollAnchor() {
 }
 
 function restoreMobileStreamingScrollAnchor(snapshot) {
-    if (!snapshot?.anchor || snapshot.version !== mobileChatManualScrollVersion || !shouldGuardMobileChatScroll() || !shouldSuppressMobileChatAutoScroll()) {
+    if (!snapshot?.anchor || snapshot.version !== mobileChatManualScrollVersion || !shouldGuardMobileChatScroll() || shouldYieldMobileChatScrollToActiveGesture() || !shouldSuppressMobileChatAutoScroll()) {
         return false;
     }
 
@@ -15253,14 +15269,14 @@ jQuery(async function () {
         }
 
         const scrollIsAtBottom = isChatScrolledNearBottom();
+        const canReleaseUserScrollLock = canReleaseMobileChatUserScrollLock();
 
-        if (scrollIsAtBottom) {
-            mobileChatUserScrollLocked = false;
-            mobileChatTouchGestureMoved = false;
+        if (scrollIsAtBottom && canReleaseUserScrollLock) {
+            releaseMobileChatUserScrollLockIfAtBottom();
         }
 
         // Resume autoscroll if the user scrolls to the bottom
-        if (scrollLock && scrollIsAtBottom) {
+        if (scrollLock && scrollIsAtBottom && canReleaseUserScrollLock) {
             scrollLock = false;
         }
 

--- a/public/script.js
+++ b/public/script.js
@@ -314,7 +314,7 @@ import { onboardingExperimentalMacroEngine } from './scripts/macros/engine/Macro
 import { compressRequest, setRequestCompressionConfig } from './scripts/request-compression.js';
 import { canJumpToSwipeForMessage, canOpenSwipePickerForMessage, initSwipePicker } from './scripts/swipe-picker.js';
 import { bindIOSFastTapSendButton, isIOSWebKitPlatform } from './scripts/mobile-send-button.js';
-import { getMobileStreamingBottomPinBehavior, getStreamingUpdateInterval } from './scripts/mobile-streaming.js';
+import { getMobileStreamingBottomPinBehavior, getStreamingUpdateInterval, IOS_STREAMING_UPDATE_INTERVAL_MS } from './scripts/mobile-streaming.js';
 import {
     CHAT_RENDER_LIFECYCLE_ROLLOUT_KEY,
     CHAT_RENDER_LIFECYCLE_ROUTE,
@@ -603,7 +603,7 @@ const MOBILE_CHAT_LOAD_SCROLL_SETTLE_MS = 400;
 const MOBILE_CHAT_MANUAL_SCROLL_SUPPRESS_MS = 1400;
 const MOBILE_CHAT_VIEWPORT_SCROLL_SUPPRESS_MS = 500;
 const MOBILE_CHAT_BOTTOM_PIN_MS = 1500;
-const MOBILE_STREAMING_SCROLL_MIN_INTERVAL_MS = isIOSWebKitPlatform() ? 1000 : 750;
+const MOBILE_STREAMING_SCROLL_MIN_INTERVAL_MS = isIOSWebKitPlatform() ? IOS_STREAMING_UPDATE_INTERVAL_MS : 750;
 const CHAT_SCROLL_BOTTOM_THRESHOLD_PX = 24;
 const CHAT_LOAD_BOTTOM_LOCK_EXTRA_MS = 250;
 const CHAT_LOAD_SCROLL_SETTLE_DELAYS_MS = Object.freeze([80, 250, MOBILE_CHAT_LOAD_SCROLL_SETTLE_MS, 900, 1600, 2400]);
@@ -636,6 +636,7 @@ let fav_ch_checked = false;
 let scrollLock = false;
 let scrollLockImmunityUntil = 0;
 let mobileChatTouchScrolling = false;
+let mobileChatTouchGestureMoved = false;
 let mobileChatManualScrollSuppressedUntil = 0;
 let mobileChatBottomPinUntil = 0;
 let mobileStreamingBottomPinFrame = 0;
@@ -1925,7 +1926,7 @@ function beginChatLoadBottomLock({ durationMs = Math.max(...CHAT_LOAD_SCROLL_SET
     pinChatLoadToBottom();
 }
 
-function markMobileChatManualScroll({ touchActive = false, suppressMs = MOBILE_CHAT_MANUAL_SCROLL_SUPPRESS_MS } = {}) {
+function markMobileChatManualScroll({ touchActive = false, touchMoved = false, suppressMs = MOBILE_CHAT_MANUAL_SCROLL_SUPPRESS_MS } = {}) {
     if (!shouldGuardMobileChatScroll()) {
         return;
     }
@@ -1939,6 +1940,12 @@ function markMobileChatManualScroll({ touchActive = false, suppressMs = MOBILE_C
 
     if (touchActive) {
         mobileChatTouchScrolling = true;
+        mobileChatTouchGestureMoved = false;
+    }
+
+    if (touchMoved) {
+        mobileChatTouchGestureMoved = true;
+        clearDeferredMobileStreamingBottomPin();
     }
 
     mobileChatManualScrollSuppressedUntil = Math.max(mobileChatManualScrollSuppressedUntil, Date.now() + suppressMs);
@@ -1956,6 +1963,12 @@ function releaseMobileChatTouchScroll() {
 
     mobileChatTouchScrolling = false;
     markMobileChatManualScroll();
+
+    if (mobileChatTouchGestureMoved) {
+        clearDeferredMobileStreamingBottomPin();
+        return;
+    }
+
     scheduleDeferredMobileStreamingBottomPinFlush();
 }
 
@@ -2009,6 +2022,10 @@ function clearDeferredMobileStreamingBottomPinTimer() {
 
 function queueDeferredMobileStreamingBottomPin() {
     if (!shouldGuardMobileChatScroll()) {
+        return false;
+    }
+
+    if (mobileChatTouchGestureMoved) {
         return false;
     }
 
@@ -2220,6 +2237,7 @@ function scheduleMobileStreamingBottomPin({ isFinal = false } = {}) {
 
 function resetMobileViewportScrollState() {
     mobileChatTouchScrolling = false;
+    mobileChatTouchGestureMoved = false;
     mobileChatManualScrollSuppressedUntil = 0;
     mobileChatBottomPinUntil = 0;
     clearMobileStreamingBottomPin();
@@ -15149,7 +15167,7 @@ jQuery(async function () {
     };
     const markMobileChatTouchScrollMove = () => {
         clearChatLoadBottomLock();
-        markMobileChatManualScroll();
+        markMobileChatManualScroll({ touchMoved: true });
     };
     const markMobileChatWheelScroll = () => {
         clearChatLoadBottomLock();
@@ -15179,7 +15197,7 @@ jQuery(async function () {
         }
 
         if (mobileChatTouchScrolling || Date.now() < mobileChatManualScrollSuppressedUntil) {
-            markMobileChatManualScroll();
+            markMobileChatManualScroll({ touchMoved: mobileChatTouchScrolling });
         }
 
         if (Date.now() < scrollLockImmunityUntil) {

--- a/public/script.js
+++ b/public/script.js
@@ -637,6 +637,7 @@ let scrollLock = false;
 let scrollLockImmunityUntil = 0;
 let mobileChatTouchScrolling = false;
 let mobileChatTouchGestureMoved = false;
+let mobileChatUserScrollLocked = false;
 let mobileChatManualScrollSuppressedUntil = 0;
 let mobileChatBottomPinUntil = 0;
 let mobileStreamingBottomPinFrame = 0;
@@ -1945,6 +1946,8 @@ function markMobileChatManualScroll({ touchActive = false, touchMoved = false, s
 
     if (touchMoved) {
         mobileChatTouchGestureMoved = true;
+        mobileChatUserScrollLocked = true;
+        scrollLock = true;
         clearDeferredMobileStreamingBottomPin();
     }
 
@@ -1989,6 +1992,10 @@ function shouldYieldMobileChatScrollToActiveGesture() {
         return true;
     }
 
+    if (mobileChatUserScrollLocked) {
+        return true;
+    }
+
     return isIOSWebKitPlatform() && isMobileChatManualScrollSuppressionWindowActive();
 }
 
@@ -1997,12 +2004,12 @@ function shouldSuppressMobileChatAutoScroll() {
         return false;
     }
 
-    if (Date.now() < mobileChatBottomPinUntil) {
-        return false;
+    if (mobileChatTouchScrolling || mobileChatUserScrollLocked) {
+        return true;
     }
 
-    if (mobileChatTouchScrolling) {
-        return true;
+    if (Date.now() < mobileChatBottomPinUntil) {
+        return false;
     }
 
     const isManualSuppressionActive = isMobileChatManualScrollSuppressionWindowActive();
@@ -2025,7 +2032,7 @@ function queueDeferredMobileStreamingBottomPin() {
         return false;
     }
 
-    if (mobileChatTouchGestureMoved) {
+    if (mobileChatTouchGestureMoved || mobileChatUserScrollLocked) {
         return false;
     }
 
@@ -2109,7 +2116,7 @@ function requestMobileChatBottomPin({ requireNearBottom = true, durationMs = MOB
 }
 
 function shouldPinMobileChatToBottom() {
-    if (!shouldGuardMobileChatScroll() || isMobileChatManualScrollSuppressionActive()) {
+    if (!shouldGuardMobileChatScroll() || isMobileChatManualScrollSuppressionActive() || mobileChatUserScrollLocked || scrollLock) {
         return false;
     }
 
@@ -2238,6 +2245,7 @@ function scheduleMobileStreamingBottomPin({ isFinal = false } = {}) {
 function resetMobileViewportScrollState() {
     mobileChatTouchScrolling = false;
     mobileChatTouchGestureMoved = false;
+    mobileChatUserScrollLocked = false;
     mobileChatManualScrollSuppressedUntil = 0;
     mobileChatBottomPinUntil = 0;
     clearMobileStreamingBottomPin();
@@ -2435,6 +2443,28 @@ function getMobileMessageUpdateQueue() {
     return mobileMessageUpdateQueue;
 }
 
+function captureMobileStreamingScrollTop() {
+    const element = chatElement[0];
+
+    if (!element || !shouldGuardMobileChatScroll() || !shouldSuppressMobileChatAutoScroll()) {
+        return null;
+    }
+
+    return element.scrollTop;
+}
+
+function restoreMobileStreamingScrollTop(scrollTop) {
+    const element = chatElement[0];
+
+    if (!element || typeof scrollTop !== 'number' || !shouldGuardMobileChatScroll() || !shouldSuppressMobileChatAutoScroll()) {
+        return;
+    }
+
+    if (Math.abs(element.scrollTop - scrollTop) > 0.5) {
+        element.scrollTop = scrollTop;
+    }
+}
+
 function applyStreamingVisibleWrite(messageId, {
     messageTextDom,
     messageTimerDom,
@@ -2449,6 +2479,8 @@ function applyStreamingVisibleWrite(messageId, {
     shouldUseStreamFadeIn,
     bypassFadeIn,
 }, { isFinal = false } = {}) {
+    const preservedMobileScrollTop = captureMobileStreamingScrollTop();
+
     if (shouldRefreshTokenCount && messageTokenCounterDom instanceof HTMLElement) {
         messageTokenCounterDom.textContent = `${currentTokenCount}t`;
     }
@@ -2469,6 +2501,8 @@ function applyStreamingVisibleWrite(messageId, {
         messageTimerDom.textContent = timePassed.timerValue;
         messageTimerDom.title = timePassed.timerTitle;
     }
+
+    restoreMobileStreamingScrollTop(preservedMobileScrollTop);
 
     return isFinal;
 }
@@ -15205,6 +15239,11 @@ jQuery(async function () {
         }
 
         const scrollIsAtBottom = isChatScrolledNearBottom();
+
+        if (scrollIsAtBottom) {
+            mobileChatUserScrollLocked = false;
+            mobileChatTouchGestureMoved = false;
+        }
 
         // Resume autoscroll if the user scrolls to the bottom
         if (scrollLock && scrollIsAtBottom) {

--- a/public/script.js
+++ b/public/script.js
@@ -603,7 +603,7 @@ const MOBILE_CHAT_LOAD_SCROLL_SETTLE_MS = 400;
 const MOBILE_CHAT_MANUAL_SCROLL_SUPPRESS_MS = 1400;
 const MOBILE_CHAT_VIEWPORT_SCROLL_SUPPRESS_MS = 500;
 const MOBILE_CHAT_BOTTOM_PIN_MS = 1500;
-const MOBILE_STREAMING_SCROLL_MIN_INTERVAL_MS = 750;
+const MOBILE_STREAMING_SCROLL_MIN_INTERVAL_MS = isIOSWebKitPlatform() ? 1000 : 750;
 const CHAT_SCROLL_BOTTOM_THRESHOLD_PX = 24;
 const CHAT_LOAD_BOTTOM_LOCK_EXTRA_MS = 250;
 const CHAT_LOAD_SCROLL_SETTLE_DELAYS_MS = Object.freeze([80, 250, MOBILE_CHAT_LOAD_SCROLL_SETTLE_MS, 900, 1600, 2400]);
@@ -642,6 +642,7 @@ let mobileStreamingBottomPinFrame = 0;
 let mobileStreamingBottomPinTimer = 0;
 let mobileStreamingBottomPinSettle = false;
 let mobileStreamingBottomPinSmooth = false;
+let deferredMobileStreamingBottomPin = false;
 let lastMobileStreamingBottomPinAt = 0;
 let chatLoadBottomLockUntil = 0;
 let chatLoadBottomPinFrame = 0;
@@ -1931,6 +1932,10 @@ function markMobileChatManualScroll({ touchActive = false, suppressMs = MOBILE_C
     mobileChatBottomPinUntil = 0;
     clearMobileStreamingBottomPin();
 
+    if (!isChatScrolledNearBottom()) {
+        clearDeferredMobileStreamingBottomPin();
+    }
+
     if (touchActive) {
         mobileChatTouchScrolling = true;
     }
@@ -1947,6 +1952,7 @@ function releaseMobileChatTouchScroll() {
 
     mobileChatTouchScrolling = false;
     markMobileChatManualScroll();
+    flushDeferredMobileStreamingBottomPin();
 }
 
 function isMobileChatManualScrollSuppressionActive() {
@@ -1967,6 +1973,37 @@ function shouldSuppressMobileChatAutoScroll() {
     }
 
     return Date.now() < mobileChatManualScrollSuppressedUntil && !isChatScrolledNearBottom();
+}
+
+function queueDeferredMobileStreamingBottomPin() {
+    if (!shouldGuardMobileChatScroll()) {
+        return false;
+    }
+
+    deferredMobileStreamingBottomPin = true;
+    return true;
+}
+
+function clearDeferredMobileStreamingBottomPin() {
+    deferredMobileStreamingBottomPin = false;
+}
+
+function flushDeferredMobileStreamingBottomPin() {
+    if (!deferredMobileStreamingBottomPin) {
+        return false;
+    }
+
+    clearDeferredMobileStreamingBottomPin();
+
+    if (!shouldGuardMobileChatScroll() || mobileChatTouchScrolling) {
+        return false;
+    }
+
+    // The deferred pin already yielded to touch; allow one catch-up pin after release.
+    mobileChatManualScrollSuppressedUntil = 0;
+    requestMobileChatBottomPin({ requireNearBottom: false });
+    scheduleMobileStreamingBottomPin({ isFinal: true });
+    return true;
 }
 
 function requestMobileChatBottomPin({ requireNearBottom = true, durationMs = MOBILE_CHAT_BOTTOM_PIN_MS } = {}) {
@@ -2058,6 +2095,11 @@ function requestMobileStreamingBottomPinFrame({ isFinal = false } = {}) {
         mobileStreamingBottomPinSettle = false;
         mobileStreamingBottomPinSmooth = false;
 
+        if (mobileChatTouchScrolling) {
+            queueDeferredMobileStreamingBottomPin();
+            return;
+        }
+
         if (!shouldPinMobileChatToBottom()) {
             return;
         }
@@ -2105,6 +2147,7 @@ function resetMobileViewportScrollState() {
     mobileChatManualScrollSuppressedUntil = 0;
     mobileChatBottomPinUntil = 0;
     clearMobileStreamingBottomPin();
+    clearDeferredMobileStreamingBottomPin();
 }
 
 function getMobileViewportScrollHandler() {
@@ -2526,7 +2569,13 @@ function scrollStartedStreamingMessageThroughLifecycle() {
         autoScrollEnabled: power_user.auto_scroll_chat_to_bottom,
         isNearBottom: isChatScrolledNearBottom(),
         isManualScrollSuppressed: shouldSuppressMobileChatAutoScroll(),
+        isTouchActive: mobileChatTouchScrolling,
     });
+
+    if (action.action === CHAT_SCROLL_ACTION.DEFER_UNTIL_TOUCH_END) {
+        queueDeferredMobileStreamingBottomPin();
+        return;
+    }
 
     if (shouldApplyChatBottomScrollAction(action)) {
         requestAnimationFrame(() => {
@@ -5424,6 +5473,13 @@ class StreamingProcessor {
         const isIOSWebKit = isIOSWebKitPlatform();
         const shouldReduceIntermediateStreamingWork = !isFinal && isIOSWebKit && power_user.ios_webkit_reduce_streaming_work;
         const shouldUseMobileStreamingPin = !isImpersonate && shouldGuardMobileChatScroll();
+        const mobileStreamingScrollAction = shouldUseMobileStreamingPin ? resolveChatScrollAction({
+            intent: CHAT_SCROLL_INTENT.STREAM_PROGRESS,
+            autoScrollEnabled: true,
+            isNearBottom: isChatScrolledNearBottom(),
+            isManualScrollSuppressed: shouldSuppressMobileChatAutoScroll(),
+            isTouchActive: mobileChatTouchScrolling,
+        }) : null;
         const shouldPinMobileBottom = shouldUseMobileStreamingPin && shouldPinMobileChatToBottom();
 
         if (!isImpersonate && !isContinue && Array.isArray(this.swipes) && this.swipes.length > 0) {
@@ -5537,7 +5593,9 @@ class StreamingProcessor {
             }
         }
 
-        if (shouldPinMobileBottom && shouldPinMobileChatToBottom()) {
+        if (mobileStreamingScrollAction?.action === CHAT_SCROLL_ACTION.DEFER_UNTIL_TOUCH_END) {
+            queueDeferredMobileStreamingBottomPin();
+        } else if (shouldPinMobileBottom && shouldPinMobileChatToBottom()) {
             scheduleMobileStreamingBottomPin({ isFinal });
         } else if (!scrollLock && (!shouldUseMobileStreamingPin || !isMobileChatManualScrollSuppressionActive())) {
             scrollChatToBottom({

--- a/public/scripts/chat-render-lifecycle/scroll-intent.js
+++ b/public/scripts/chat-render-lifecycle/scroll-intent.js
@@ -15,6 +15,7 @@ export const CHAT_SCROLL_ACTION = Object.freeze({
     PRESERVE_ANCHOR: 'preserve-anchor',
     FORCE_EDGE: 'force-edge',
     SUPPRESS_AUTO_SCROLL: 'suppress-auto-scroll',
+    DEFER_UNTIL_TOUCH_END: 'defer-until-touch-end',
 });
 
 function canPinBottom({ autoScrollEnabled, isNearBottom, isManualScrollSuppressed }) {
@@ -37,6 +38,7 @@ function preserveAnchorOrNone({ hasAnchor }, reason) {
  * @param {boolean} [options.isNearBottom=false] Whether the viewport is already near bottom.
  * @param {boolean} [options.hasAnchor=false] Whether an anchor is available for restoration.
  * @param {boolean} [options.isManualScrollSuppressed=false] Whether user scroll/touch suppression is active.
+ * @param {boolean} [options.isTouchActive=false] Whether the user is actively touching the scroll surface.
  * @param {string} [options.edge='bottom'] Forced scroll edge for explicit jumps.
  * @returns {{action: string, reason: string, edge?: string, force?: boolean}}
  */
@@ -46,6 +48,7 @@ export function resolveChatScrollAction({
     isNearBottom = false,
     hasAnchor = false,
     isManualScrollSuppressed = false,
+    isTouchActive = false,
     edge = 'bottom',
 } = {}) {
     switch (intent) {
@@ -71,8 +74,16 @@ export function resolveChatScrollAction({
                 ? { action: CHAT_SCROLL_ACTION.PIN_BOTTOM, reason: intent }
                 : { action: CHAT_SCROLL_ACTION.NONE, reason: `${intent}-not-pinned` };
 
-        case CHAT_SCROLL_INTENT.TAIL_APPEND:
         case CHAT_SCROLL_INTENT.STREAM_PROGRESS:
+            if (autoScrollEnabled && isNearBottom && isTouchActive) {
+                return { action: CHAT_SCROLL_ACTION.DEFER_UNTIL_TOUCH_END, reason: `${intent}-touch-active` };
+            }
+
+            return canPinBottom({ autoScrollEnabled, isNearBottom, isManualScrollSuppressed })
+                ? { action: CHAT_SCROLL_ACTION.PIN_BOTTOM, reason: intent }
+                : { action: CHAT_SCROLL_ACTION.NONE, reason: `${intent}-not-pinned` };
+
+        case CHAT_SCROLL_INTENT.TAIL_APPEND:
             return canPinBottom({ autoScrollEnabled, isNearBottom, isManualScrollSuppressed })
                 ? { action: CHAT_SCROLL_ACTION.PIN_BOTTOM, reason: intent }
                 : { action: CHAT_SCROLL_ACTION.NONE, reason: `${intent}-not-pinned` };

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -383,7 +383,7 @@ describe('chat render lifecycle script wiring', () => {
 
         expect(source).toContain('const shouldUseMobileStreamingPin = !isImpersonate && shouldGuardMobileChatScroll();');
         expect(source).toContain('const mobileStreamingScrollAction = shouldUseMobileStreamingPin ? resolveChatScrollAction({');
-        expect(source).toContain('isTouchActive: mobileChatTouchScrolling');
+        expect(source).toContain('isTouchActive: shouldYieldMobileChatScrollToActiveGesture()');
         expect(source).toContain('const shouldPinMobileBottom = shouldUseMobileStreamingPin && shouldPinMobileChatToBottom();');
         expect(source).toContain('if (mobileStreamingScrollAction?.action === CHAT_SCROLL_ACTION.DEFER_UNTIL_TOUCH_END)');
         expect(source).toContain('queueDeferredMobileStreamingBottomPin();');
@@ -397,12 +397,15 @@ describe('chat render lifecycle script wiring', () => {
         expect(scriptSource).toContain('let mobileStreamingBottomPinFrame = 0;');
         expect(scriptSource).toContain('let mobileStreamingBottomPinTimer = 0;');
         expect(scriptSource).toContain('let deferredMobileStreamingBottomPin = false;');
+        expect(scriptSource).toContain('let deferredMobileStreamingBottomPinTimer = 0;');
+        expect(scriptSource).toContain('function shouldYieldMobileChatScrollToActiveGesture()');
+        expect(scriptSource).toContain('scheduleDeferredMobileStreamingBottomPinFlush();');
 
         const requestFrame = findFunctionDeclaration('requestMobileStreamingBottomPinFrame');
         const requestFrameSource = getSource(requestFrame);
         expect(requestFrameSource).toContain('requestAnimationFrame(() =>');
         expect(requestFrameSource).toContain('const behavior = getMobileStreamingBottomPinBehavior({');
-        expect(requestFrameSource).toContain('if (mobileChatTouchScrolling)');
+        expect(requestFrameSource).toContain('if (shouldYieldMobileChatScrollToActiveGesture())');
         expect(requestFrameSource).toContain('queueDeferredMobileStreamingBottomPin();');
         expect(requestFrameSource).toContain('if (!shouldPinMobileChatToBottom())');
         expect(requestFrameSource).toContain('pinMobileChatToBottom({');

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -402,10 +402,13 @@ describe('chat render lifecycle script wiring', () => {
         expect(scriptSource).toContain('let deferredMobileStreamingBottomPin = false;');
         expect(scriptSource).toContain('let deferredMobileStreamingBottomPinTimer = 0;');
         expect(scriptSource).toContain('function shouldYieldMobileChatScrollToActiveGesture()');
+        expect(scriptSource).toContain('function canReleaseMobileChatUserScrollLock()');
+        expect(scriptSource).toContain('function releaseMobileChatUserScrollLockIfAtBottom()');
         expect(scriptSource).toContain('scheduleDeferredMobileStreamingBottomPinFlush();');
         expect(scriptSource).toContain('markMobileChatManualScroll({ touchMoved: true });');
         expect(scriptSource).toContain('mobileChatUserScrollLocked = true;');
         expect(scriptSource).toContain('mobileChatManualScrollVersion += 1;');
+        expect(scriptSource).toContain('releaseMobileChatUserScrollLockIfAtBottom();');
 
         const requestFrame = findFunctionDeclaration('requestMobileStreamingBottomPinFrame');
         const requestFrameSource = getSource(requestFrame);
@@ -439,6 +442,7 @@ describe('chat render lifecycle script wiring', () => {
 
         expect(scriptSource).toContain('function captureMobileStreamingScrollAnchor()');
         expect(scriptSource).toContain('function settleMobileStreamingScrollAnchor(snapshot)');
+        expect(scriptSource).toContain('shouldYieldMobileChatScrollToActiveGesture() || !shouldSuppressMobileChatAutoScroll()');
         expect(applySource).toContain('const preservedMobileScrollAnchor = captureMobileStreamingScrollAnchor();');
         expect(applySource).toContain('applyStreamFadeIn(messageTextDom, formattedText,');
         expect(applySource).toContain('messageTextDom.innerHTML = formattedText;');
@@ -565,6 +569,8 @@ describe('chat render lifecycle script wiring', () => {
         expect(scriptSource).toContain('const chatScrollHandler = function () {');
         expect(scriptSource).toContain('refreshObservedChatMessageResizeViewportStates();');
         expect(scriptSource).toContain('markMobileChatManualScroll({ touchMoved: mobileChatTouchScrolling || isIOSWebKitPlatform() });');
+        expect(scriptSource).toContain('const canReleaseUserScrollLock = canReleaseMobileChatUserScrollLock();');
+        expect(scriptSource).toContain('if (scrollLock && scrollIsAtBottom && canReleaseUserScrollLock)');
     });
 
     test('message resize observer cleans up on chat removal paths', () => {

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -382,21 +382,28 @@ describe('chat render lifecycle script wiring', () => {
         const source = getSource(onProgressStreaming.value);
 
         expect(source).toContain('const shouldUseMobileStreamingPin = !isImpersonate && shouldGuardMobileChatScroll();');
+        expect(source).toContain('const mobileStreamingScrollAction = shouldUseMobileStreamingPin ? resolveChatScrollAction({');
+        expect(source).toContain('isTouchActive: mobileChatTouchScrolling');
         expect(source).toContain('const shouldPinMobileBottom = shouldUseMobileStreamingPin && shouldPinMobileChatToBottom();');
-        expect(source).toContain('if (shouldPinMobileBottom && shouldPinMobileChatToBottom())');
+        expect(source).toContain('if (mobileStreamingScrollAction?.action === CHAT_SCROLL_ACTION.DEFER_UNTIL_TOUCH_END)');
+        expect(source).toContain('queueDeferredMobileStreamingBottomPin();');
+        expect(source).toContain('} else if (shouldPinMobileBottom && shouldPinMobileChatToBottom())');
         expect(source).toContain('scheduleMobileStreamingBottomPin({ isFinal });');
         expect(source).not.toContain('pinMobileChatToBottom({ waitForFrame: true, settle: isFinal });');
     });
 
     test('mobile streaming bottom pin scheduling coalesces smooth intermediate pins', () => {
-        expect(scriptSource).toContain('const MOBILE_STREAMING_SCROLL_MIN_INTERVAL_MS = 750;');
+        expect(scriptSource).toContain('const MOBILE_STREAMING_SCROLL_MIN_INTERVAL_MS = isIOSWebKitPlatform() ? 1000 : 750;');
         expect(scriptSource).toContain('let mobileStreamingBottomPinFrame = 0;');
         expect(scriptSource).toContain('let mobileStreamingBottomPinTimer = 0;');
+        expect(scriptSource).toContain('let deferredMobileStreamingBottomPin = false;');
 
         const requestFrame = findFunctionDeclaration('requestMobileStreamingBottomPinFrame');
         const requestFrameSource = getSource(requestFrame);
         expect(requestFrameSource).toContain('requestAnimationFrame(() =>');
         expect(requestFrameSource).toContain('const behavior = getMobileStreamingBottomPinBehavior({');
+        expect(requestFrameSource).toContain('if (mobileChatTouchScrolling)');
+        expect(requestFrameSource).toContain('queueDeferredMobileStreamingBottomPin();');
         expect(requestFrameSource).toContain('if (!shouldPinMobileChatToBottom())');
         expect(requestFrameSource).toContain('pinMobileChatToBottom({');
         expect(requestFrameSource).toContain('waitForFrame: false');

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -401,14 +401,20 @@ describe('chat render lifecycle script wiring', () => {
         expect(scriptSource).toContain('let mobileChatManualScrollVersion = 0;');
         expect(scriptSource).toContain('let deferredMobileStreamingBottomPin = false;');
         expect(scriptSource).toContain('let deferredMobileStreamingBottomPinTimer = 0;');
+        expect(scriptSource).toContain('const deferredMobileStreamingVisibleWrites = new Map();');
+        expect(scriptSource).toContain('let deferredMobileStreamingVisibleWriteTimer = 0;');
         expect(scriptSource).toContain('function shouldYieldMobileChatScrollToActiveGesture()');
         expect(scriptSource).toContain('function canReleaseMobileChatUserScrollLock()');
         expect(scriptSource).toContain('function releaseMobileChatUserScrollLockIfAtBottom()');
+        expect(scriptSource).toContain('function queueDeferredMobileStreamingVisibleWrite(messageId, write, options)');
+        expect(scriptSource).toContain('function flushDeferredMobileStreamingVisibleWrites()');
         expect(scriptSource).toContain('scheduleDeferredMobileStreamingBottomPinFlush();');
+        expect(scriptSource).toContain('scheduleDeferredMobileStreamingVisibleWriteFlush();');
         expect(scriptSource).toContain('markMobileChatManualScroll({ touchMoved: true });');
         expect(scriptSource).toContain('mobileChatUserScrollLocked = true;');
         expect(scriptSource).toContain('mobileChatManualScrollVersion += 1;');
         expect(scriptSource).toContain('releaseMobileChatUserScrollLockIfAtBottom();');
+        expect(scriptSource).toContain('flushDeferredMobileStreamingVisibleWrites();');
 
         const requestFrame = findFunctionDeclaration('requestMobileStreamingBottomPinFrame');
         const requestFrameSource = getSource(requestFrame);
@@ -443,6 +449,7 @@ describe('chat render lifecycle script wiring', () => {
         expect(scriptSource).toContain('function captureMobileStreamingScrollAnchor()');
         expect(scriptSource).toContain('function settleMobileStreamingScrollAnchor(snapshot)');
         expect(scriptSource).toContain('shouldYieldMobileChatScrollToActiveGesture() || !shouldSuppressMobileChatAutoScroll()');
+        expect(applySource).toContain('if (queueDeferredMobileStreamingVisibleWrite(messageId, {');
         expect(applySource).toContain('const preservedMobileScrollAnchor = captureMobileStreamingScrollAnchor();');
         expect(applySource).toContain('applyStreamFadeIn(messageTextDom, formattedText,');
         expect(applySource).toContain('messageTextDom.innerHTML = formattedText;');
@@ -671,6 +678,7 @@ describe('chat render lifecycle script wiring', () => {
         expect(resetSource).toContain('mobileChatManualScrollVersion += 1;');
         expect(resetSource).toContain('mobileChatManualScrollSuppressedUntil = 0;');
         expect(resetSource).toContain('mobileChatBottomPinUntil = 0;');
+        expect(resetSource).toContain('clearDeferredMobileStreamingVisibleWrites();');
     });
 
     test('mobile viewport lifecycle observer resets on chat clear and disposes on unload', () => {

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -393,13 +393,15 @@ describe('chat render lifecycle script wiring', () => {
     });
 
     test('mobile streaming bottom pin scheduling coalesces smooth intermediate pins', () => {
-        expect(scriptSource).toContain('const MOBILE_STREAMING_SCROLL_MIN_INTERVAL_MS = isIOSWebKitPlatform() ? 1000 : 750;');
+        expect(scriptSource).toContain('const MOBILE_STREAMING_SCROLL_MIN_INTERVAL_MS = isIOSWebKitPlatform() ? IOS_STREAMING_UPDATE_INTERVAL_MS : 750;');
         expect(scriptSource).toContain('let mobileStreamingBottomPinFrame = 0;');
         expect(scriptSource).toContain('let mobileStreamingBottomPinTimer = 0;');
+        expect(scriptSource).toContain('let mobileChatTouchGestureMoved = false;');
         expect(scriptSource).toContain('let deferredMobileStreamingBottomPin = false;');
         expect(scriptSource).toContain('let deferredMobileStreamingBottomPinTimer = 0;');
         expect(scriptSource).toContain('function shouldYieldMobileChatScrollToActiveGesture()');
         expect(scriptSource).toContain('scheduleDeferredMobileStreamingBottomPinFlush();');
+        expect(scriptSource).toContain('markMobileChatManualScroll({ touchMoved: true });');
 
         const requestFrame = findFunctionDeclaration('requestMobileStreamingBottomPinFrame');
         const requestFrameSource = getSource(requestFrame);
@@ -649,6 +651,7 @@ describe('chat render lifecycle script wiring', () => {
         const resetSource = getSource(resetMobileViewportScrollState);
 
         expect(resetSource).toContain('mobileChatTouchScrolling = false;');
+        expect(resetSource).toContain('mobileChatTouchGestureMoved = false;');
         expect(resetSource).toContain('mobileChatManualScrollSuppressedUntil = 0;');
         expect(resetSource).toContain('mobileChatBottomPinUntil = 0;');
     });

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -398,12 +398,14 @@ describe('chat render lifecycle script wiring', () => {
         expect(scriptSource).toContain('let mobileStreamingBottomPinTimer = 0;');
         expect(scriptSource).toContain('let mobileChatTouchGestureMoved = false;');
         expect(scriptSource).toContain('let mobileChatUserScrollLocked = false;');
+        expect(scriptSource).toContain('let mobileChatManualScrollVersion = 0;');
         expect(scriptSource).toContain('let deferredMobileStreamingBottomPin = false;');
         expect(scriptSource).toContain('let deferredMobileStreamingBottomPinTimer = 0;');
         expect(scriptSource).toContain('function shouldYieldMobileChatScrollToActiveGesture()');
         expect(scriptSource).toContain('scheduleDeferredMobileStreamingBottomPinFlush();');
         expect(scriptSource).toContain('markMobileChatManualScroll({ touchMoved: true });');
         expect(scriptSource).toContain('mobileChatUserScrollLocked = true;');
+        expect(scriptSource).toContain('mobileChatManualScrollVersion += 1;');
 
         const requestFrame = findFunctionDeclaration('requestMobileStreamingBottomPinFrame');
         const requestFrameSource = getSource(requestFrame);
@@ -435,13 +437,15 @@ describe('chat render lifecycle script wiring', () => {
         const applyStreamingVisibleWrite = findFunctionDeclaration('applyStreamingVisibleWrite');
         const applySource = getSource(applyStreamingVisibleWrite);
 
-        expect(applySource).toContain('const preservedMobileScrollTop = captureMobileStreamingScrollTop();');
+        expect(scriptSource).toContain('function captureMobileStreamingScrollAnchor()');
+        expect(scriptSource).toContain('function settleMobileStreamingScrollAnchor(snapshot)');
+        expect(applySource).toContain('const preservedMobileScrollAnchor = captureMobileStreamingScrollAnchor();');
         expect(applySource).toContain('applyStreamFadeIn(messageTextDom, formattedText,');
         expect(applySource).toContain('messageTextDom.innerHTML = formattedText;');
         expect(applySource).toContain('messageTokenCounterDom.textContent = `${currentTokenCount}t`;');
         expect(applySource).toContain('messageTimerDom.textContent = timePassed.timerValue;');
         expect(applySource).toContain('messageTimerDom.title = timePassed.timerTitle;');
-        expect(applySource).toContain('restoreMobileStreamingScrollTop(preservedMobileScrollTop);');
+        expect(applySource).toContain('settleMobileStreamingScrollAnchor(preservedMobileScrollAnchor);');
 
         const queueStreamingVisibleWrite = findNode(scriptAst, node => node.type === 'MethodDefinition'
             && node.key?.name === 'queueStreamingVisibleWrite');
@@ -560,6 +564,7 @@ describe('chat render lifecycle script wiring', () => {
 
         expect(scriptSource).toContain('const chatScrollHandler = function () {');
         expect(scriptSource).toContain('refreshObservedChatMessageResizeViewportStates();');
+        expect(scriptSource).toContain('markMobileChatManualScroll({ touchMoved: mobileChatTouchScrolling || isIOSWebKitPlatform() });');
     });
 
     test('message resize observer cleans up on chat removal paths', () => {
@@ -657,6 +662,7 @@ describe('chat render lifecycle script wiring', () => {
         expect(resetSource).toContain('mobileChatTouchScrolling = false;');
         expect(resetSource).toContain('mobileChatTouchGestureMoved = false;');
         expect(resetSource).toContain('mobileChatUserScrollLocked = false;');
+        expect(resetSource).toContain('mobileChatManualScrollVersion += 1;');
         expect(resetSource).toContain('mobileChatManualScrollSuppressedUntil = 0;');
         expect(resetSource).toContain('mobileChatBottomPinUntil = 0;');
     });

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -397,11 +397,13 @@ describe('chat render lifecycle script wiring', () => {
         expect(scriptSource).toContain('let mobileStreamingBottomPinFrame = 0;');
         expect(scriptSource).toContain('let mobileStreamingBottomPinTimer = 0;');
         expect(scriptSource).toContain('let mobileChatTouchGestureMoved = false;');
+        expect(scriptSource).toContain('let mobileChatUserScrollLocked = false;');
         expect(scriptSource).toContain('let deferredMobileStreamingBottomPin = false;');
         expect(scriptSource).toContain('let deferredMobileStreamingBottomPinTimer = 0;');
         expect(scriptSource).toContain('function shouldYieldMobileChatScrollToActiveGesture()');
         expect(scriptSource).toContain('scheduleDeferredMobileStreamingBottomPinFlush();');
         expect(scriptSource).toContain('markMobileChatManualScroll({ touchMoved: true });');
+        expect(scriptSource).toContain('mobileChatUserScrollLocked = true;');
 
         const requestFrame = findFunctionDeclaration('requestMobileStreamingBottomPinFrame');
         const requestFrameSource = getSource(requestFrame);
@@ -433,11 +435,13 @@ describe('chat render lifecycle script wiring', () => {
         const applyStreamingVisibleWrite = findFunctionDeclaration('applyStreamingVisibleWrite');
         const applySource = getSource(applyStreamingVisibleWrite);
 
+        expect(applySource).toContain('const preservedMobileScrollTop = captureMobileStreamingScrollTop();');
         expect(applySource).toContain('applyStreamFadeIn(messageTextDom, formattedText,');
         expect(applySource).toContain('messageTextDom.innerHTML = formattedText;');
         expect(applySource).toContain('messageTokenCounterDom.textContent = `${currentTokenCount}t`;');
         expect(applySource).toContain('messageTimerDom.textContent = timePassed.timerValue;');
         expect(applySource).toContain('messageTimerDom.title = timePassed.timerTitle;');
+        expect(applySource).toContain('restoreMobileStreamingScrollTop(preservedMobileScrollTop);');
 
         const queueStreamingVisibleWrite = findNode(scriptAst, node => node.type === 'MethodDefinition'
             && node.key?.name === 'queueStreamingVisibleWrite');
@@ -652,6 +656,7 @@ describe('chat render lifecycle script wiring', () => {
 
         expect(resetSource).toContain('mobileChatTouchScrolling = false;');
         expect(resetSource).toContain('mobileChatTouchGestureMoved = false;');
+        expect(resetSource).toContain('mobileChatUserScrollLocked = false;');
         expect(resetSource).toContain('mobileChatManualScrollSuppressedUntil = 0;');
         expect(resetSource).toContain('mobileChatBottomPinUntil = 0;');
     });

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -577,6 +577,8 @@ describe('chat render lifecycle script wiring', () => {
         expect(scriptSource).toContain('refreshObservedChatMessageResizeViewportStates();');
         expect(scriptSource).toContain('markMobileChatManualScroll({ touchMoved: mobileChatTouchScrolling || isIOSWebKitPlatform() });');
         expect(scriptSource).toContain('const canReleaseUserScrollLock = canReleaseMobileChatUserScrollLock();');
+        expect(scriptSource).toContain('User scroll-away must win even during immunity; immunity only protects programmatic bottom-lock release.');
+        expect(scriptSource.indexOf('if (!scrollLock && !scrollIsAtBottom)')).toBeLessThan(scriptSource.indexOf('if (Date.now() < scrollLockImmunityUntil)'));
         expect(scriptSource).toContain('if (scrollLock && scrollIsAtBottom && canReleaseUserScrollLock)');
     });
 

--- a/tests/chat-render-lifecycle-scroll-intent.test.js
+++ b/tests/chat-render-lifecycle-scroll-intent.test.js
@@ -69,6 +69,16 @@ describe('chat render lifecycle scroll intent', () => {
         })).toEqual(expect.objectContaining({ action: CHAT_SCROLL_ACTION.NONE }));
     });
 
+    test('stream progress defers bottom pinning during an active touch', () => {
+        expect(resolveChatScrollAction({
+            intent: CHAT_SCROLL_INTENT.STREAM_PROGRESS,
+            autoScrollEnabled: true,
+            isNearBottom: true,
+            isManualScrollSuppressed: true,
+            isTouchActive: true,
+        })).toEqual(expect.objectContaining({ action: CHAT_SCROLL_ACTION.DEFER_UNTIL_TOUCH_END }));
+    });
+
     test('initial load forces bottom regardless of auto-scroll preference', () => {
         expect(resolveChatScrollAction({
             intent: CHAT_SCROLL_INTENT.INITIAL_LOAD,


### PR DESCRIPTION
## Summary
- defer streaming bottom pins while mobile touch, iOS momentum, or user-scroll lock is active
- stop mobile streaming autoscroll after real user movement until the user returns to bottom
- defer live streaming DOM writes during mobile gestures so fast iOS scrolling is not pulled by reflow
- preserve viewport only when it will not fight an active gesture

## Tests
- npm run test:unit -- --runTestsByPath chat-render-lifecycle-scroll-intent.test.js chat-render-lifecycle-bottom-scroll.test.js chat-render-lifecycle-script-wiring.test.js mobile-streaming.test.js
- npx eslint public/script.js public/scripts/chat-render-lifecycle/scroll-intent.js
- npx eslint chat-render-lifecycle-scroll-intent.test.js chat-render-lifecycle-script-wiring.test.js
- git diff --check -- public/script.js tests/chat-render-lifecycle-script-wiring.test.js

## Manual testing
- Needs latest physical iOS verification on this branch.