### PR TITLE
fix: stabilize streaming resize scroll pins

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2389,6 +2389,18 @@ function refreshObservedChatMessageResizeViewportStates() {
     }
 }
 
+function isActiveStreamingMessageResizeBlock(element) {
+    if (!streamingProcessor || streamingProcessor.isFinished) {
+        return false;
+    }
+
+    const streamingMessageId = Number(streamingProcessor.messageId);
+    const messageElement = element?.closest?.('.mes');
+    const resizeMessageId = messageElement?.getAttribute('mesid');
+
+    return Number.isInteger(streamingMessageId) && resizeMessageId !== null && Number(resizeMessageId) === streamingMessageId;
+}
+
 async function applyChatMessageResizeAction(element, entry, metadata) {
     if (!isChatRenderLifecycleRolloutEnabled(CHAT_RENDER_LIFECYCLE_ROUTE.MEDIA_RESIZE)) {
         return;
@@ -2403,6 +2415,12 @@ async function applyChatMessageResizeAction(element, entry, metadata) {
         return;
     }
 
+    // SillyBunny: streaming progress owns the live message's scroll lane; skip resize scrolls for that block.
+    if (isActiveStreamingMessageResizeBlock(element)) {
+        refreshChatMessageResizeState(element, metadata, entry);
+        return;
+    }
+
     const action = resolveChatScrollAction({
         intent: CHAT_SCROLL_INTENT.MEDIA_RESIZE,
         autoScrollEnabled: power_user.auto_scroll_chat_to_bottom,
@@ -2412,10 +2430,9 @@ async function applyChatMessageResizeAction(element, entry, metadata) {
     });
 
     if (shouldApplyChatBottomScrollAction(action)) {
-        requestAnimationFrame(() => {
-            scrollChatElementToBottom();
-            refreshChatMessageResizeState(element, metadata, entry);
-        });
+        // SillyBunny: coalesce media resize pins with the shared bottom-scroll rAF lane.
+        scrollChatToBottom({ waitForFrame: true, isNearBottom: true });
+        requestAnimationFrame(() => refreshChatMessageResizeState(element, metadata, entry));
         return;
     }
 

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -515,18 +515,28 @@ describe('chat render lifecycle script wiring', () => {
     });
 
     test('guard-on message resize resolves media-resize intent through lifecycle scroll rules', () => {
+        const isActiveStreamingMessageResizeBlock = findFunctionDeclaration('isActiveStreamingMessageResizeBlock');
+        const streamingResizeSource = getSource(isActiveStreamingMessageResizeBlock);
+
+        expect(streamingResizeSource).toContain('!streamingProcessor || streamingProcessor.isFinished');
+        expect(streamingResizeSource).toContain('const streamingMessageId = Number(streamingProcessor.messageId);');
+        expect(streamingResizeSource).toContain('element?.closest?.(\'.mes\')');
+        expect(streamingResizeSource).toContain('messageElement?.getAttribute(\'mesid\')');
+
         const applyChatMessageResizeAction = findFunctionDeclaration('applyChatMessageResizeAction');
         const source = getSource(applyChatMessageResizeAction);
 
         expect(source).toContain('if (!isChatRenderLifecycleRolloutEnabled(CHAT_RENDER_LIFECYCLE_ROUTE.MEDIA_RESIZE))');
         expect(source).toContain('const resizeState = metadata ?? captureChatMessageResizeState(element, entry);');
+        expect(source).toContain('if (isActiveStreamingMessageResizeBlock(element))');
+        expect(source).toContain('refreshChatMessageResizeState(element, metadata, entry);');
         expect(source).toContain('intent: CHAT_SCROLL_INTENT.MEDIA_RESIZE');
         expect(source).toContain('autoScrollEnabled: power_user.auto_scroll_chat_to_bottom');
         expect(source).toContain('isNearBottom: Boolean(resizeState.isNearBottom)');
         expect(source).toContain('hasAnchor: Boolean(resizeState.anchor)');
         expect(source).toContain('isManualScrollSuppressed: shouldSuppressMobileChatAutoScroll()');
         expect(source).toContain('shouldApplyChatBottomScrollAction(action)');
-        expect(source).toContain('scrollChatElementToBottom();');
+        expect(source).toContain('scrollChatToBottom({ waitForFrame: true, isNearBottom: true });');
         expect(source).toContain('action.action === CHAT_SCROLL_ACTION.PRESERVE_ANCHOR');
         expect(source).toContain('await settleVisibleChatMessageAnchor(resizeState.anchor);');
         expect(source).toContain('refreshChatMessageResizeState(element, metadata, entry);');


### PR DESCRIPTION
## Summary
- Suppress media-resize scroll handling for the active streaming message so stream progress is the only scroll authority for that block.
- Route non-streaming media-resize bottom pins through the shared scrollChatToBottom rAF lane instead of a separate scrollTop writer.
- Update lifecycle script wiring coverage for the new streaming resize guard.

## Testing
- bun test tests/chat-render-lifecycle-script-wiring.test.js
- bun test tests/chat-render-lifecycle-resize-observer.test.js tests/chat-render-lifecycle-scroll-intent.test.js tests/chat-render-lifecycle-bottom-scroll.test.js tests/chat-scroll-edges.test.js tests/chat-render-lifecycle-anchor.test.js tests/chat-render-lifecycle-script-wiring.test.js
- npm run lint

## Notes
- Full bun test was attempted but is blocked by existing unrelated Bun/Jest shim and test-runner issues in this checkout: missing jest.resetModules / jest.unstable_mockModule, missing Playwright module under tests/node_modules, and an unrelated openai-responses ECONNRESET path.