### PR TITLE
feat: add desktop vertical navigation settings

### DIFF
--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -6,6 +6,7 @@
     --sb-density-scale: 1;
     --sb-topbar-scale-desktop: 1;
     --sb-topbar-scale-mobile: 1;
+    --sb-desktop-button-scale: 1;
     --sb-mobile-button-scale: 1;
     --sb-bottom-bar-scale: 1;
     --sb-bottom-chat-min-touch: 32px;
@@ -305,6 +306,30 @@ body.sb-topbar-compact #sb-chatbar-layer {
 }
 
 @media screen and (min-width: 769px) {
+    :root {
+        --sb-proxy-button-padding-x: calc(var(--sb-proxy-button-padding-x-base) * var(--sb-desktop-button-scale));
+        --sb-proxy-button-height: calc(var(--sb-proxy-button-height-base) * var(--sb-desktop-button-scale));
+        --sb-proxy-button-min-width: calc(var(--sb-proxy-button-min-width-base) * var(--sb-desktop-button-scale));
+        --sb-proxy-button-gap: calc(var(--sb-proxy-button-gap-base) * var(--sb-desktop-button-scale));
+        --sb-proxy-icon-size: calc(var(--mainFontSize) * var(--sb-proxy-icon-scale-base) * var(--sb-desktop-button-scale));
+        --sb-proxy-label-size: calc(var(--mainFontSize) * var(--sb-proxy-label-scale-base) * var(--sb-desktop-button-scale));
+    }
+
+    .sb-shell-tab {
+        min-height: calc(44px * var(--sb-desktop-button-scale));
+        padding: calc(8px * var(--sb-desktop-button-scale)) calc(14px * var(--sb-desktop-button-scale));
+        gap: calc(8px * var(--sb-desktop-button-scale));
+    }
+
+    .sb-shell-tab i {
+        width: calc(18px * var(--sb-desktop-button-scale));
+        font-size: calc(var(--mainFontSize) * var(--sb-desktop-button-scale));
+    }
+
+    .sb-shell-tab-copy strong {
+        font-size: calc(var(--mainFontSize) * 0.9 * var(--sb-desktop-button-scale));
+    }
+
     #sb-topbar-primary .sb-topbar-group-right {
         align-items: center;
         flex-wrap: nowrap;
@@ -3667,6 +3692,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 }
 
 .sb-mobile-nav-layout-group,
+#sb-desktop-settings-outlet,
 #sb-mobile-settings-outlet {
     gap: 12px;
 }
@@ -4102,94 +4128,6 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     max-height: var(--sb-composer-action-size, 30px) !important;
     flex: 0 0 var(--sb-composer-send-width, calc(var(--sb-composer-action-size, 30px) * 1.45)) !important;
     border-radius: var(--sb-radius-button, 14px) !important;
-}
-
-@media screen and (min-width: 769px) {
-    body.verticalChatLayout #chat {
-        min-height: 0;
-    }
-
-    body.verticalChatLayout #form_sheld {
-        flex: 0 0 auto;
-    }
-
-    body.verticalChatLayout #nonQRFormItems {
-        --sb-vertical-composer-action-size: clamp(26px, calc(var(--bottomFormBlockSize, 42px) * 0.72), 36px);
-        --sb-vertical-composer-send-width: calc(var(--sb-vertical-composer-action-size) * 1.45);
-        --sb-vertical-composer-icon-size: clamp(12px, calc(var(--bottomFormIconSize, 20px) * 0.62), 16px);
-        display: grid !important;
-        grid-template-columns: minmax(0, 1fr) auto !important;
-        grid-template-rows: auto minmax(58px, auto) !important;
-        grid-template-areas:
-            'tools action'
-            'input input' !important;
-        align-items: center !important;
-        gap: 6px !important;
-        padding: 6px !important;
-        border-radius: 16px !important;
-        overflow: visible !important;
-    }
-
-    body.verticalChatLayout #leftSendForm,
-    body.verticalChatLayout #rightSendForm {
-        min-width: 0 !important;
-        gap: 4px !important;
-    }
-
-    body.verticalChatLayout #leftSendForm {
-        grid-area: tools !important;
-        width: 100% !important;
-        max-width: 100% !important;
-        justify-content: flex-start !important;
-        overflow-x: auto !important;
-        overflow-y: hidden !important;
-    }
-
-    body.verticalChatLayout #rightSendForm {
-        grid-area: action !important;
-        width: auto !important;
-        min-width: max-content !important;
-        max-width: max-content !important;
-        justify-self: end !important;
-        justify-content: flex-end !important;
-        overflow: visible !important;
-    }
-
-    body.verticalChatLayout #send_textarea {
-        grid-area: input !important;
-        width: 100% !important;
-        min-width: 0 !important;
-        max-width: 100% !important;
-        min-height: clamp(68px, 14dvh, 160px) !important;
-        max-height: min(42dvh, 24rem) !important;
-        align-self: stretch !important;
-        justify-self: stretch !important;
-        resize: vertical !important;
-        box-sizing: border-box !important;
-        font-size: var(--mainFontSize) !important;
-        line-height: 1.35 !important;
-    }
-
-    body.verticalChatLayout #leftSendForm > div,
-    body.verticalChatLayout #rightSendForm > div:not(.mes_stop),
-    body.verticalChatLayout #send_form .mes_stop {
-        width: var(--sb-vertical-composer-action-size) !important;
-        min-width: var(--sb-vertical-composer-action-size) !important;
-        max-width: var(--sb-vertical-composer-action-size) !important;
-        height: var(--sb-vertical-composer-action-size) !important;
-        min-height: var(--sb-vertical-composer-action-size) !important;
-        max-height: var(--sb-vertical-composer-action-size) !important;
-        flex: 0 0 var(--sb-vertical-composer-action-size) !important;
-        font-size: var(--sb-vertical-composer-icon-size) !important;
-    }
-
-    body.verticalChatLayout #send_but,
-    body.verticalChatLayout #send_form.sb-generating-controls #mes_stop {
-        width: var(--sb-vertical-composer-send-width) !important;
-        min-width: var(--sb-vertical-composer-send-width) !important;
-        max-width: var(--sb-vertical-composer-send-width) !important;
-        flex-basis: var(--sb-vertical-composer-send-width) !important;
-    }
 }
 
 @media screen and (min-width: 1001px) {
@@ -6351,6 +6289,145 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 @media screen and (min-width: 769px) {
     .sb-mobile-setting {
         display: none !important;
+    }
+
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-frame,
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-frame {
+        flex-direction: row;
+    }
+
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-nav-wrapper,
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-nav-wrapper {
+        flex: 0 0 86px;
+        width: 86px;
+        height: 100%;
+    }
+
+    :root[data-sb-desktop-nav-layout='vertical'][data-sb-desktop-nav-mode='icon-only'] .sb-shell-root-left.openDrawer .sb-shell-nav-wrapper,
+    :root[data-sb-desktop-nav-layout='vertical'][data-sb-desktop-nav-mode='icon-only'] .sb-shell-root-right.openDrawer .sb-shell-nav-wrapper {
+        flex-basis: 62px;
+        width: 62px;
+    }
+
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-nav,
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-nav {
+        height: 100%;
+        flex-direction: column;
+        align-items: stretch;
+        justify-content: flex-start;
+        gap: 6px;
+        padding: 18px 8px;
+        overflow-x: hidden;
+        overflow-y: auto;
+        border-right: 1px solid color-mix(in srgb, var(--sb-shell-border) 80%, transparent);
+        border-bottom: 0;
+        scroll-snap-type: none;
+    }
+
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-rail-shortcuts,
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-rail-shortcuts {
+        display: contents;
+    }
+
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-rail-divider,
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-rail-divider {
+        display: block;
+        width: calc(100% - 8px);
+        height: 1px;
+        min-height: 1px;
+        align-self: center;
+        margin: 4px 0;
+        border-radius: 999px;
+        background: color-mix(in srgb, var(--sb-shell-border) 82%, transparent);
+    }
+
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-nav-scroll,
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-nav-wrapper::before,
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-nav-wrapper::after,
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-nav-scroll,
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-nav-wrapper::before,
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-nav-wrapper::after {
+        display: none !important;
+    }
+
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-tab,
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-tab {
+        width: 100%;
+        min-width: 0;
+        max-width: 100%;
+        min-height: calc(50px * var(--sb-desktop-button-scale));
+        flex: 0 0 auto;
+        flex-direction: column;
+        justify-content: center;
+        gap: 4px;
+        padding: 7px 4px;
+        text-align: center;
+        white-space: normal;
+    }
+
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-tab-mobile-rail-hidden,
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-tab-mobile-rail-hidden {
+        display: none;
+    }
+
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-tab:is(.is-active, .active, .selected, .is-selected, .is-current, [aria-selected='true'], [aria-current]),
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-tab:is(.is-active, .active, .selected, .is-selected, .is-current, [aria-selected='true'], [aria-current]) {
+        background: transparent;
+        border-color: transparent;
+        box-shadow: none;
+    }
+
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-rail-action,
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-rail-action {
+        width: calc(46px * var(--sb-desktop-button-scale));
+        min-width: calc(46px * var(--sb-desktop-button-scale));
+        max-width: calc(46px * var(--sb-desktop-button-scale));
+        min-height: calc(46px * var(--sb-desktop-button-scale));
+        align-self: center;
+        padding: 0;
+        border-color: transparent;
+        background: transparent;
+        box-shadow: none;
+    }
+
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-tab i,
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-tab i {
+        width: 100%;
+        flex-basis: auto;
+        margin: 0;
+    }
+
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-tab-copy,
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-tab-copy {
+        align-items: center;
+        text-align: center;
+    }
+
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-tab-copy strong,
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-tab-copy strong {
+        font-size: calc(var(--mainFontSize) * 0.66 * var(--sb-desktop-button-scale));
+        white-space: normal;
+        line-height: 1.1;
+    }
+
+    :root[data-sb-desktop-nav-layout='vertical'][data-sb-desktop-nav-mode='icon-only'] .sb-shell-root-left.openDrawer .sb-shell-tab,
+    :root[data-sb-desktop-nav-layout='vertical'][data-sb-desktop-nav-mode='icon-only'] .sb-shell-root-right.openDrawer .sb-shell-tab {
+        width: calc(46px * var(--sb-desktop-button-scale));
+        min-height: calc(46px * var(--sb-desktop-button-scale));
+        align-self: center;
+        padding: 0;
+    }
+
+    :root[data-sb-desktop-nav-layout='vertical'][data-sb-desktop-nav-mode='icon-only'] .sb-shell-root-left.openDrawer .sb-shell-tab-copy,
+    :root[data-sb-desktop-nav-layout='vertical'][data-sb-desktop-nav-mode='icon-only'] .sb-shell-root-right.openDrawer .sb-shell-tab-copy,
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-rail-action .sb-shell-tab-copy,
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-rail-action .sb-shell-tab-copy {
+        display: none;
+    }
+
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-rail-empty,
+    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-rail-empty {
+        display: none;
     }
 }
 

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -6291,26 +6291,22 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
         display: none !important;
     }
 
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-frame,
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-frame {
+    :root[data-sb-desktop-nav-layout='vertical'] :is(.sb-shell-root-left, .sb-shell-root-right).openDrawer .sb-shell-frame {
         flex-direction: row;
     }
 
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-nav-wrapper,
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-nav-wrapper {
+    :root[data-sb-desktop-nav-layout='vertical'] :is(.sb-shell-root-left, .sb-shell-root-right).openDrawer .sb-shell-nav-wrapper {
         flex: 0 0 86px;
         width: 86px;
         height: 100%;
     }
 
-    :root[data-sb-desktop-nav-layout='vertical'][data-sb-desktop-nav-mode='icon-only'] .sb-shell-root-left.openDrawer .sb-shell-nav-wrapper,
-    :root[data-sb-desktop-nav-layout='vertical'][data-sb-desktop-nav-mode='icon-only'] .sb-shell-root-right.openDrawer .sb-shell-nav-wrapper {
-        flex-basis: 62px;
-        width: 62px;
+    :root[data-sb-desktop-nav-layout='vertical'][data-sb-desktop-nav-mode='icon-only'] :is(.sb-shell-root-left, .sb-shell-root-right).openDrawer .sb-shell-nav-wrapper {
+        flex-basis: calc((46px * var(--sb-desktop-button-scale)) + 16px);
+        width: calc((46px * var(--sb-desktop-button-scale)) + 16px);
     }
 
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-nav,
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-nav {
+    :root[data-sb-desktop-nav-layout='vertical'] :is(.sb-shell-root-left, .sb-shell-root-right).openDrawer .sb-shell-nav {
         height: 100%;
         flex-direction: column;
         align-items: stretch;
@@ -6324,13 +6320,11 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
         scroll-snap-type: none;
     }
 
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-rail-shortcuts,
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-rail-shortcuts {
+    :root[data-sb-desktop-nav-layout='vertical'] :is(.sb-shell-root-left, .sb-shell-root-right).openDrawer .sb-shell-rail-shortcuts {
         display: contents;
     }
 
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-rail-divider,
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-rail-divider {
+    :root[data-sb-desktop-nav-layout='vertical'] :is(.sb-shell-root-left, .sb-shell-root-right).openDrawer .sb-shell-rail-divider {
         display: block;
         width: calc(100% - 8px);
         height: 1px;
@@ -6350,8 +6344,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
         display: none !important;
     }
 
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-tab,
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-tab {
+    :root[data-sb-desktop-nav-layout='vertical'] :is(.sb-shell-root-left, .sb-shell-root-right).openDrawer .sb-shell-tab {
         width: 100%;
         min-width: 0;
         max-width: 100%;
@@ -6365,20 +6358,17 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
         white-space: normal;
     }
 
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-tab-mobile-rail-hidden,
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-tab-mobile-rail-hidden {
+    :root[data-sb-desktop-nav-layout='vertical'] :is(.sb-shell-root-left, .sb-shell-root-right).openDrawer .sb-shell-tab-mobile-rail-hidden {
         display: none;
     }
 
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-tab:is(.is-active, .active, .selected, .is-selected, .is-current, [aria-selected='true'], [aria-current]),
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-tab:is(.is-active, .active, .selected, .is-selected, .is-current, [aria-selected='true'], [aria-current]) {
+    :root[data-sb-desktop-nav-layout='vertical'] :is(.sb-shell-root-left, .sb-shell-root-right).openDrawer .sb-shell-tab:is(.is-active, .active, .selected, .is-selected, .is-current, [aria-selected='true'], [aria-current]) {
         background: transparent;
         border-color: transparent;
         box-shadow: none;
     }
 
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-rail-action,
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-rail-action {
+    :root[data-sb-desktop-nav-layout='vertical'] :is(.sb-shell-root-left, .sb-shell-root-right).openDrawer .sb-shell-rail-action {
         width: calc(46px * var(--sb-desktop-button-scale));
         min-width: calc(46px * var(--sb-desktop-button-scale));
         max-width: calc(46px * var(--sb-desktop-button-scale));
@@ -6390,43 +6380,36 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
         box-shadow: none;
     }
 
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-tab i,
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-tab i {
+    :root[data-sb-desktop-nav-layout='vertical'] :is(.sb-shell-root-left, .sb-shell-root-right).openDrawer .sb-shell-tab i {
         width: 100%;
         flex-basis: auto;
         margin: 0;
     }
 
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-tab-copy,
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-tab-copy {
+    :root[data-sb-desktop-nav-layout='vertical'] :is(.sb-shell-root-left, .sb-shell-root-right).openDrawer .sb-shell-tab-copy {
         align-items: center;
         text-align: center;
     }
 
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-tab-copy strong,
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-tab-copy strong {
+    :root[data-sb-desktop-nav-layout='vertical'] :is(.sb-shell-root-left, .sb-shell-root-right).openDrawer .sb-shell-tab-copy strong {
         font-size: calc(var(--mainFontSize) * 0.66 * var(--sb-desktop-button-scale));
         white-space: normal;
         line-height: 1.1;
     }
 
-    :root[data-sb-desktop-nav-layout='vertical'][data-sb-desktop-nav-mode='icon-only'] .sb-shell-root-left.openDrawer .sb-shell-tab,
-    :root[data-sb-desktop-nav-layout='vertical'][data-sb-desktop-nav-mode='icon-only'] .sb-shell-root-right.openDrawer .sb-shell-tab {
+    :root[data-sb-desktop-nav-layout='vertical'][data-sb-desktop-nav-mode='icon-only'] :is(.sb-shell-root-left, .sb-shell-root-right).openDrawer .sb-shell-tab {
         width: calc(46px * var(--sb-desktop-button-scale));
         min-height: calc(46px * var(--sb-desktop-button-scale));
         align-self: center;
         padding: 0;
     }
 
-    :root[data-sb-desktop-nav-layout='vertical'][data-sb-desktop-nav-mode='icon-only'] .sb-shell-root-left.openDrawer .sb-shell-tab-copy,
-    :root[data-sb-desktop-nav-layout='vertical'][data-sb-desktop-nav-mode='icon-only'] .sb-shell-root-right.openDrawer .sb-shell-tab-copy,
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-rail-action .sb-shell-tab-copy,
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-rail-action .sb-shell-tab-copy {
+    :root[data-sb-desktop-nav-layout='vertical'][data-sb-desktop-nav-mode='icon-only'] :is(.sb-shell-root-left, .sb-shell-root-right).openDrawer .sb-shell-tab-copy,
+    :root[data-sb-desktop-nav-layout='vertical'] :is(.sb-shell-root-left, .sb-shell-root-right).openDrawer .sb-shell-rail-action .sb-shell-tab-copy {
         display: none;
     }
 
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-left.openDrawer .sb-shell-rail-empty,
-    :root[data-sb-desktop-nav-layout='vertical'] .sb-shell-root-right.openDrawer .sb-shell-rail-empty {
+    :root[data-sb-desktop-nav-layout='vertical'] :is(.sb-shell-root-left, .sb-shell-root-right).openDrawer .sb-shell-rail-empty {
         display: none;
     }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -5275,10 +5275,6 @@
                                     <input id="compact_input_area" type="checkbox" />
                                     <small data-i18n="Compact Input Area (Mobile)">Compact Input Area</small><i class="fa-solid fa-mobile-screen-button"></i>
                                 </label>
-                                <label for="vertical_chat_layout" class="checkbox_label" title="Use a taller mobile-style chat composer on desktop and tablet widths. No effect on phone-size layouts.">
-                                    <input id="vertical_chat_layout" type="checkbox" />
-                                    <small>Vertical Chat Layout</small><i class="fa-solid fa-desktop"></i><i class="fa-solid fa-tablet-screen-button"></i>
-                                </label>
                                 <label for="show_swipe_num_all_messages" class="checkbox_label" title="Display swipe numbers for all messages, not just the last." data-i18n="[title]Display swipe numbers for all messages, not just the last.">
                                     <input id="show_swipe_num_all_messages" type="checkbox" />
                                     <small data-i18n="Swipe # for All Messages">Swipe # for All Messages</small>
@@ -5721,7 +5717,16 @@
                                 </div>
                             </div>
                             </div>
-                            <div class="inline-drawer wide100p flexFlowColumn sb-settings-subdrawer" id="MobileSection">
+                            <div class="inline-drawer wide100p flexFlowColumn sb-settings-subdrawer sb-desktop-setting" id="DesktopSection">
+                                <div class="inline-drawer-toggle inline-drawer-header userSettingsInnerExpandable">
+                                    <b><i class="fa-solid fa-desktop"></i> <span data-i18n="Desktop">Desktop</span></b>
+                                    <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
+                                </div>
+                                <div class="inline-drawer-content flex-container flexFlowColumn sb-settings-subdrawer-body" style="display:none">
+                                    <div id="sb-desktop-settings-outlet" class="flex-container flexFlowColumn"></div>
+                                </div>
+                            </div>
+                            <div class="inline-drawer wide100p flexFlowColumn sb-settings-subdrawer sb-mobile-setting" id="MobileSection">
                                 <div class="inline-drawer-toggle inline-drawer-header userSettingsInnerExpandable">
                                     <b><i class="fa-solid fa-mobile-screen-button"></i> <span data-i18n="Mobile">Mobile</span></b>
                                     <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -1824,6 +1824,10 @@ export async function loadPowerUserSettings(settings, data) {
         delete power_user.import_card_tags;
     }
 
+    if (power_user.vertical_chat_layout !== undefined) {
+        delete power_user.vertical_chat_layout;
+    }
+
     if (power_user?.instruct?.derived === true) {
         power_user.instruct_derived = true;
         delete power_user.instruct.derived;
@@ -2001,7 +2005,6 @@ export async function loadPowerUserSettings(settings, data) {
     $(`#character_sort_order option[data-order="${power_user.sort_order}"][data-field="${power_user.sort_field}"]`).prop('selected', true);
     switchReducedMotion();
     switchCompactInputArea();
-    switchVerticalChatLayout();
     reloadMarkdownProcessor();
     await loadInstructMode(data);
     await loadContextSettings();

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -279,7 +279,6 @@ export const power_user = {
     chat_display: chat_styles.DEFAULT,
     toastr_position: defaultToastPosition,
     chat_width: 100,
-    vertical_chat_layout: false,
     never_resize_avatars: false,
     show_card_avatar_urls: false,
     play_message_sound: false,
@@ -677,12 +676,6 @@ function switchReducedMotion() {
 function switchCompactInputArea() {
     $('#send_form').toggleClass('compact', power_user.compact_input_area);
     $('#compact_input_area').prop('checked', power_user.compact_input_area);
-}
-
-function switchVerticalChatLayout() {
-    $('body').toggleClass('verticalChatLayout', power_user.vertical_chat_layout);
-    $('#vertical_chat_layout').prop('checked', power_user.vertical_chat_layout);
-    scrollChatToBottom();
 }
 
 function switchSwipeNumAllMessages() {
@@ -1821,10 +1814,6 @@ export async function loadPowerUserSettings(settings, data) {
         power_user.chat_width = 100;
     }
 
-    if (typeof power_user.vertical_chat_layout !== 'boolean') {
-        power_user.vertical_chat_layout = false;
-    }
-
     if (power_user.tokenizer === tokenizers.LEGACY) {
         power_user.tokenizer = tokenizers.GPT2;
     }
@@ -1931,7 +1920,6 @@ export async function loadPowerUserSettings(settings, data) {
 
     $(`#toastr_position option[value=${power_user.toastr_position}]`).prop('selected', true).trigger('change');
     $('#chat_width_slider').val(power_user.chat_width);
-    $('#vertical_chat_layout').prop('checked', power_user.vertical_chat_layout);
     $('#token_padding').val(power_user.token_padding);
     $('#aux_field').val(power_user.aux_field);
     $('#tag_import_setting').val(power_user.tag_import_setting);
@@ -4395,12 +4383,6 @@ jQuery(async () => {
     $('#compact_input_area').on('input', function () {
         power_user.compact_input_area = !!$(this).prop('checked');
         switchCompactInputArea();
-        saveSettingsDebounced();
-    });
-
-    $('#vertical_chat_layout').on('input', function () {
-        power_user.vertical_chat_layout = !!$(this).prop('checked');
-        switchVerticalChatLayout();
         saveSettingsDebounced();
     });
 

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -29,7 +29,15 @@ const SB_STORAGE_KEYS = Object.freeze({
     shortcutRight: 'sb-shortcut-right',
     bottomBarScale: 'sb-bottom-bar-scale',
     bottomChatSecondaryOpen: 'sb-bottom-chat-secondary-open',
+    desktopButtonScale: 'sb-desktop-button-scale',
     mobileButtonScale: 'sb-mobile-button-scale',
+    desktopNavLayout: 'sb-desktop-nav-layout',
+    desktopNavIconOnly: 'sb-desktop-nav-icon-only',
+    desktopNavShowCustomize: 'sb-desktop-nav-show-customize',
+    desktopNavShowQuickActions: 'sb-desktop-nav-show-quick-actions',
+    desktopNavReplaceQuickActions: 'sb-desktop-nav-replace-quick-actions',
+    desktopNavReplacementTarget: 'sb-desktop-nav-replacement-target',
+    desktopQuickActions: 'sb-desktop-quick-actions-v1',
     mobileNavLayout: 'sb-mobile-nav-layout',
     mobileNavIconOnly: 'sb-mobile-nav-icon-only',
     mobileNavShowCustomize: 'sb-mobile-nav-show-customize',
@@ -634,6 +642,7 @@ const sbState = {
     surfaceTransparency: normalizeSurfaceTransparency(safeGetItem(SB_STORAGE_KEYS.surfaceTransparency)),
     compactMode: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.compactMode), false),
     bottomBarScale: normalizeTopbarScale(safeGetItem(SB_STORAGE_KEYS.bottomBarScale)),
+    desktopButtonScale: normalizeTopbarScale(safeGetItem(SB_STORAGE_KEYS.desktopButtonScale)),
     mobileButtonScale: normalizeTopbarScale(safeGetItem(SB_STORAGE_KEYS.mobileButtonScale)),
     topbarScale: {
         desktop: normalizeTopbarScale(safeGetItem(SB_STORAGE_KEYS.topbarScaleDesktop)),
@@ -694,6 +703,15 @@ const sbState = {
         replaceQuickActions: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.mobileNavReplaceQuickActions), false),
         replacementTarget: normalizeMobileNavReplacementTarget(safeGetItem(SB_STORAGE_KEYS.mobileNavReplacementTarget)),
     },
+    desktopNav: {
+        layout: normalizeMobileNavLayout(safeGetItem(SB_STORAGE_KEYS.desktopNavLayout)),
+        iconOnly: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.desktopNavIconOnly), true),
+        showCustomize: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.desktopNavShowCustomize), true),
+        showQuickActions: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.desktopNavShowQuickActions), false),
+        replaceQuickActions: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.desktopNavReplaceQuickActions), false),
+        replacementTarget: normalizeMobileNavReplacementTarget(safeGetItem(SB_STORAGE_KEYS.desktopNavReplacementTarget)),
+    },
+    desktopQuickActions: [],
     mobileQuickActions: [],
     chatbar: {
         desktop: null,
@@ -865,8 +883,20 @@ function normalizeMobileNavLayout(value) {
     return SB_MOBILE_NAV_LAYOUTS.includes(normalizedValue) ? normalizedValue : 'vertical';
 }
 
-function getMobileNavCustomizeLocationLabel() {
-    return sbState.mobileNav.layout === 'horizontal'
+function getNavState(mode) {
+    return mode === 'desktop' ? sbState.desktopNav : sbState.mobileNav;
+}
+
+function getQuickActionState(mode) {
+    return mode === 'desktop' ? sbState.desktopQuickActions : sbState.mobileQuickActions;
+}
+
+function getActiveShellRailMode() {
+    return isMobileViewport() ? 'mobile' : 'desktop';
+}
+
+function getMobileNavCustomizeLocationLabel(mode = 'mobile') {
+    return getNavState(mode).layout === 'horizontal'
         ? 'Show Workspace and Customize buttons in top bar'
         : 'Show Workspace and Customize buttons in side rail';
 }
@@ -1070,6 +1100,10 @@ function getDefaultMobileQuickActions() {
     return normalizeMobileQuickActionList(SB_MOBILE_DEFAULT_QUICK_ACTIONS);
 }
 
+function getDefaultDesktopQuickActions() {
+    return getDefaultMobileQuickActions();
+}
+
 function migrateLegacyMobileQuickAction(action) {
     if (!action || typeof action !== 'object') {
         return action;
@@ -1123,8 +1157,23 @@ function loadMobileQuickActions() {
     return nextActions;
 }
 
+function loadDesktopQuickActions() {
+    const storedActions = parseMobileQuickActionStorage(safeGetItem(SB_STORAGE_KEYS.desktopQuickActions));
+    if (storedActions) {
+        return storedActions;
+    }
+
+    const nextActions = getDefaultDesktopQuickActions();
+    safeSetItem(SB_STORAGE_KEYS.desktopQuickActions, JSON.stringify(nextActions));
+    return nextActions;
+}
+
 function saveMobileQuickActions() {
     safeSetItem(SB_STORAGE_KEYS.mobileQuickActions, JSON.stringify(sbState.mobileQuickActions));
+}
+
+function saveDesktopQuickActions() {
+    safeSetItem(SB_STORAGE_KEYS.desktopQuickActions, JSON.stringify(sbState.desktopQuickActions));
 }
 
 function getMobileQuickActionKey(action) {
@@ -1156,44 +1205,76 @@ function createMobileQuickActionFromMatch(match) {
     return normalizedMatch;
 }
 
-function setMobileQuickActions(actions, { persist = true } = {}) {
-    sbState.mobileQuickActions = normalizeMobileQuickActionList(actions);
+function setQuickActionsForMode(mode, actions, { persist = true } = {}) {
+    const normalizedActions = normalizeMobileQuickActionList(actions);
+
+    if (mode === 'desktop') {
+        sbState.desktopQuickActions = normalizedActions;
+
+        if (persist) {
+            saveDesktopQuickActions();
+        }
+
+        renderMobileQuickActionSettingsList('desktop');
+        refreshMobileQuickActionSearchResults('desktop');
+        syncMobileShellRailActions();
+        return;
+    }
+
+    sbState.mobileQuickActions = normalizedActions;
 
     if (persist) {
         saveMobileQuickActions();
     }
 
-    renderMobileQuickActionSettingsList();
-    refreshMobileQuickActionSearchResults();
+    renderMobileQuickActionSettingsList('mobile');
+    refreshMobileQuickActionSearchResults('mobile');
     refreshMobileNavQuickActions();
     syncMobileShellRailActions();
 }
 
-function addMobileQuickActionFromMatch(match) {
+function setMobileQuickActions(actions, options = {}) {
+    setQuickActionsForMode('mobile', actions, options);
+}
+
+function setDesktopQuickActions(actions, options = {}) {
+    setQuickActionsForMode('desktop', actions, options);
+}
+
+function addQuickActionFromMatch(mode, match) {
     const action = createMobileQuickActionFromMatch(match);
     if (!action) {
         return false;
     }
 
-    if (sbState.mobileQuickActions.length >= SB_MOBILE_QUICK_ACTION_LIMIT) {
+    const currentActions = getQuickActionState(mode);
+    if (currentActions.length >= SB_MOBILE_QUICK_ACTION_LIMIT) {
         return false;
     }
 
     const actionKey = getMobileQuickActionKey(action);
-    if (sbState.mobileQuickActions.some(existingAction => getMobileQuickActionKey(existingAction) === actionKey)) {
+    if (currentActions.some(existingAction => getMobileQuickActionKey(existingAction) === actionKey)) {
         return false;
     }
 
-    setMobileQuickActions([...sbState.mobileQuickActions, action]);
+    setQuickActionsForMode(mode, [...currentActions, action]);
     return true;
 }
 
-function removeMobileQuickAction(actionKey) {
-    setMobileQuickActions(sbState.mobileQuickActions.filter(action => getMobileQuickActionKey(action) !== actionKey));
+function addMobileQuickActionFromMatch(match) {
+    return addQuickActionFromMatch('mobile', match);
 }
 
-function setMobileQuickActionIcon(actionKey, iconClass) {
-    setMobileQuickActions(sbState.mobileQuickActions.map(action => {
+function removeQuickAction(mode, actionKey) {
+    setQuickActionsForMode(mode, getQuickActionState(mode).filter(action => getMobileQuickActionKey(action) !== actionKey));
+}
+
+function removeMobileQuickAction(actionKey) {
+    removeQuickAction('mobile', actionKey);
+}
+
+function setQuickActionIcon(mode, actionKey, iconClass) {
+    setQuickActionsForMode(mode, getQuickActionState(mode).map(action => {
         if (getMobileQuickActionKey(action) !== actionKey) {
             return action;
         }
@@ -1205,8 +1286,12 @@ function setMobileQuickActionIcon(actionKey, iconClass) {
     }));
 }
 
-async function chooseMobileQuickActionIcon(actionKey) {
-    const action = sbState.mobileQuickActions.find(action => getMobileQuickActionKey(action) === actionKey);
+function setMobileQuickActionIcon(actionKey, iconClass) {
+    setQuickActionIcon('mobile', actionKey, iconClass);
+}
+
+async function chooseQuickActionIcon(mode, actionKey) {
+    const action = getQuickActionState(mode).find(action => getMobileQuickActionKey(action) === actionKey);
     const normalizedAction = normalizeMobileQuickAction(action);
 
     if (!normalizedAction || normalizedAction.type !== 'custom') {
@@ -1218,11 +1303,19 @@ async function chooseMobileQuickActionIcon(actionKey) {
         return;
     }
 
-    setMobileQuickActionIcon(actionKey, iconClass);
+    setQuickActionIcon(mode, actionKey, iconClass);
+}
+
+async function chooseMobileQuickActionIcon(actionKey) {
+    await chooseQuickActionIcon('mobile', actionKey);
 }
 
 function resetMobileQuickActions() {
     setMobileQuickActions(getDefaultMobileQuickActions());
+}
+
+function resetDesktopQuickActions() {
+    setDesktopQuickActions(getDefaultDesktopQuickActions());
 }
 
 function normalizeTopbarScale(value) {
@@ -1257,6 +1350,10 @@ function seedTopbarScaleDefaults() {
         safeSetItem(SB_STORAGE_KEYS.bottomBarScale, String(SB_TOPBAR_SCALE.defaultValue));
     }
 
+    if (safeGetItem(SB_STORAGE_KEYS.desktopButtonScale) === null) {
+        safeSetItem(SB_STORAGE_KEYS.desktopButtonScale, String(SB_TOPBAR_SCALE.defaultValue));
+    }
+
     if (safeGetItem(SB_STORAGE_KEYS.mobileButtonScale) === null) {
         safeSetItem(SB_STORAGE_KEYS.mobileButtonScale, String(SB_TOPBAR_SCALE.defaultValue));
     }
@@ -1266,6 +1363,7 @@ function restorePersistedTopbarState() {
     sbState.topbarScale.desktop = normalizeTopbarScale(safeGetItem(SB_STORAGE_KEYS.topbarScaleDesktop));
     sbState.topbarScale.mobile = normalizeTopbarScale(safeGetItem(SB_STORAGE_KEYS.topbarScaleMobile));
     sbState.bottomBarScale = normalizeTopbarScale(safeGetItem(SB_STORAGE_KEYS.bottomBarScale));
+    sbState.desktopButtonScale = normalizeTopbarScale(safeGetItem(SB_STORAGE_KEYS.desktopButtonScale));
     sbState.mobileButtonScale = normalizeTopbarScale(safeGetItem(SB_STORAGE_KEYS.mobileButtonScale));
     sbState.frontendIcon = normalizeFrontendIcon(safeGetItem(SB_STORAGE_KEYS.frontendIcon));
     sbState.topbarLabel.desktopParts = safeGetItem(SB_STORAGE_KEYS.topbarLabelDesktopParts) === null
@@ -1284,6 +1382,13 @@ function restorePersistedTopbarState() {
     sbState.mobileNav.showQuickActions = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.mobileNavShowQuickActions), sbState.mobileNav.showQuickActions);
     sbState.mobileNav.replaceQuickActions = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.mobileNavReplaceQuickActions), sbState.mobileNav.replaceQuickActions);
     sbState.mobileNav.replacementTarget = normalizeMobileNavReplacementTarget(safeGetItem(SB_STORAGE_KEYS.mobileNavReplacementTarget));
+    sbState.desktopNav.layout = normalizeMobileNavLayout(safeGetItem(SB_STORAGE_KEYS.desktopNavLayout));
+    sbState.desktopNav.iconOnly = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.desktopNavIconOnly), sbState.desktopNav.iconOnly);
+    sbState.desktopNav.showCustomize = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.desktopNavShowCustomize), sbState.desktopNav.showCustomize);
+    sbState.desktopNav.showQuickActions = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.desktopNavShowQuickActions), sbState.desktopNav.showQuickActions);
+    sbState.desktopNav.replaceQuickActions = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.desktopNavReplaceQuickActions), sbState.desktopNav.replaceQuickActions);
+    sbState.desktopNav.replacementTarget = normalizeMobileNavReplacementTarget(safeGetItem(SB_STORAGE_KEYS.desktopNavReplacementTarget));
+    sbState.desktopQuickActions = loadDesktopQuickActions();
     sbState.mobileQuickActions = loadMobileQuickActions();
     sbState.characterDrawer.rightLocked = normalizeStoredBoolean(
         getPersistentStorageItem(SB_STORAGE_KEYS.characterDrawerRightLocked),
@@ -1373,6 +1478,20 @@ function setBottomBarScale(value, { persist = true } = {}) {
     updateThemePickerUi();
 }
 
+function setDesktopButtonScale(value, { persist = true } = {}) {
+    const nextScale = normalizeTopbarScale(value);
+    const scaleFactor = Number((nextScale / 100).toFixed(2)).toString();
+
+    sbState.desktopButtonScale = nextScale;
+    document.documentElement.style.setProperty('--sb-desktop-button-scale', scaleFactor);
+
+    if (persist) {
+        safeSetItem(SB_STORAGE_KEYS.desktopButtonScale, String(nextScale));
+    }
+
+    updateThemePickerUi();
+}
+
 function setMobileButtonScale(value, { persist = true } = {}) {
     const nextScale = normalizeTopbarScale(value);
     const scaleFactor = Number((nextScale / 100).toFixed(2)).toString();
@@ -1394,6 +1513,15 @@ function applyMobileNavPreferences() {
     document.documentElement.dataset.sbMobileNavCustomize = sbState.mobileNav.showCustomize ? 'shown' : 'hidden';
     document.documentElement.dataset.sbMobileNavQuickActions = quickActionsShown ? 'shown' : 'hidden';
     document.documentElement.dataset.sbMobileNavReplacement = sbState.mobileNav.replaceQuickActions ? 'shown' : 'hidden';
+}
+
+function applyDesktopNavPreferences() {
+    const quickActionsShown = sbState.desktopNav.showQuickActions;
+    document.documentElement.dataset.sbDesktopNavLayout = sbState.desktopNav.layout;
+    document.documentElement.dataset.sbDesktopNavMode = sbState.desktopNav.iconOnly ? 'icon-only' : 'labeled';
+    document.documentElement.dataset.sbDesktopNavCustomize = sbState.desktopNav.showCustomize ? 'shown' : 'hidden';
+    document.documentElement.dataset.sbDesktopNavQuickActions = quickActionsShown ? 'shown' : 'hidden';
+    document.documentElement.dataset.sbDesktopNavReplacement = sbState.desktopNav.replaceQuickActions ? 'shown' : 'hidden';
 }
 
 function setMobileNavLayout(layout, { persist = true } = {}) {
@@ -1472,6 +1600,81 @@ function setMobileNavReplacementTarget(target, { persist = true } = {}) {
     }
 
     updateMobileNavButtonLabel();
+    updateThemePickerUi();
+}
+
+function setDesktopNavLayout(layout, { persist = true } = {}) {
+    const nextLayout = normalizeMobileNavLayout(layout);
+    sbState.desktopNav.layout = nextLayout;
+    applyDesktopNavPreferences();
+
+    if (persist) {
+        safeSetItem(SB_STORAGE_KEYS.desktopNavLayout, nextLayout);
+    }
+
+    syncMobileShellRailActions();
+    updateThemePickerUi();
+}
+
+function setDesktopNavIconOnly(enabled, { persist = true } = {}) {
+    const nextEnabled = Boolean(enabled);
+    sbState.desktopNav.iconOnly = nextEnabled;
+    applyDesktopNavPreferences();
+
+    if (persist) {
+        safeSetItem(SB_STORAGE_KEYS.desktopNavIconOnly, String(nextEnabled));
+    }
+
+    updateThemePickerUi();
+}
+
+function setDesktopNavShowCustomize(enabled, { persist = true } = {}) {
+    const nextEnabled = Boolean(enabled);
+    sbState.desktopNav.showCustomize = nextEnabled;
+    applyDesktopNavPreferences();
+
+    if (persist) {
+        safeSetItem(SB_STORAGE_KEYS.desktopNavShowCustomize, String(nextEnabled));
+    }
+
+    syncMobileShellRailActions();
+    updateThemePickerUi();
+}
+
+function setDesktopNavShowQuickActions(enabled, { persist = true } = {}) {
+    const nextEnabled = Boolean(enabled);
+    sbState.desktopNav.showQuickActions = nextEnabled;
+    applyDesktopNavPreferences();
+
+    if (persist) {
+        safeSetItem(SB_STORAGE_KEYS.desktopNavShowQuickActions, String(nextEnabled));
+    }
+
+    syncMobileShellRailActions();
+    updateThemePickerUi();
+}
+
+function setDesktopNavReplaceQuickActions(enabled, { persist = true } = {}) {
+    const nextEnabled = Boolean(enabled);
+    sbState.desktopNav.replaceQuickActions = nextEnabled;
+    applyDesktopNavPreferences();
+
+    if (persist) {
+        safeSetItem(SB_STORAGE_KEYS.desktopNavReplaceQuickActions, String(nextEnabled));
+    }
+
+    syncMobileShellRailActions();
+    updateThemePickerUi();
+}
+
+function setDesktopNavReplacementTarget(target, { persist = true } = {}) {
+    const nextTarget = normalizeMobileNavReplacementTarget(target);
+    sbState.desktopNav.replacementTarget = nextTarget;
+
+    if (persist) {
+        safeSetItem(SB_STORAGE_KEYS.desktopNavReplacementTarget, nextTarget);
+    }
+
     updateThemePickerUi();
 }
 
@@ -10258,7 +10461,7 @@ function createMobileQuickActionIconElement(iconClass) {
     });
 }
 
-function createMobileQuickActionIconControl(action, actionKey) {
+function createMobileQuickActionIconControl(action, actionKey, mode = 'mobile') {
     const normalizedAction = normalizeMobileQuickAction(action);
     const iconClass = normalizedAction?.icon || SB_MOBILE_QUICK_ACTION_ICON_FALLBACK;
 
@@ -10273,7 +10476,7 @@ function createMobileQuickActionIconControl(action, actionKey) {
         });
         button.appendChild(createMobileQuickActionIconElement(iconClass));
         button.addEventListener('click', () => {
-            void chooseMobileQuickActionIcon(actionKey);
+            void chooseQuickActionIcon(mode, actionKey);
         });
         return button;
     }
@@ -10289,34 +10492,39 @@ function createMobileQuickActionIconControl(action, actionKey) {
     return preview;
 }
 
-function updateMobileQuickActionSettingsStatus() {
-    const status = document.getElementById('sb-mobile-quick-action-status');
+function updateMobileQuickActionSettingsStatus(mode = 'mobile') {
+    const currentActions = getQuickActionState(mode);
+    const status = document.getElementById(`sb-${mode}-quick-action-status`);
     if (status instanceof HTMLElement) {
-        status.textContent = `${sbState.mobileQuickActions.length}/${SB_MOBILE_QUICK_ACTION_LIMIT} selected. This list replaces the mobile quick shortcuts.`;
+        status.textContent = mode === 'desktop'
+            ? `${currentActions.length}/${SB_MOBILE_QUICK_ACTION_LIMIT} selected. This list controls the desktop side rail shortcuts.`
+            : `${currentActions.length}/${SB_MOBILE_QUICK_ACTION_LIMIT} selected. This list replaces the mobile quick shortcuts.`;
     }
 
-    const resetButton = document.getElementById('sb-mobile-quick-action-reset');
+    const resetButton = document.getElementById(`sb-${mode}-quick-action-reset`);
     if (resetButton instanceof HTMLButtonElement) {
-        const currentKeys = sbState.mobileQuickActions.map(getMobileQuickActionKey);
-        const defaultKeys = getDefaultMobileQuickActions().map(getMobileQuickActionKey);
+        const currentKeys = currentActions.map(getMobileQuickActionKey);
+        const defaultKeys = (mode === 'desktop' ? getDefaultDesktopQuickActions() : getDefaultMobileQuickActions()).map(getMobileQuickActionKey);
         resetButton.disabled = currentKeys.length === defaultKeys.length
             && currentKeys.every((key, index) => key === defaultKeys[index]);
     }
 }
 
-function refreshMobileQuickActionSearchResults() {
-    const searchInput = document.getElementById('sb-mobile-quick-action-search');
-    const results = document.getElementById('sb-mobile-quick-action-results');
+function refreshMobileQuickActionSearchResults(mode = 'mobile') {
+    const searchInput = document.getElementById(`sb-${mode}-quick-action-search`);
+    const results = document.getElementById(`sb-${mode}-quick-action-results`);
 
     if (searchInput instanceof HTMLInputElement && results instanceof HTMLElement) {
-        renderMobileQuickActionResults(searchInput.value, results);
+        renderMobileQuickActionResults(searchInput.value, results, mode);
     }
 }
 
-function renderMobileQuickActionResults(query, resultsElement) {
+function renderMobileQuickActionResults(query, resultsElement, mode = 'mobile') {
     if (!(resultsElement instanceof HTMLElement)) {
         return;
     }
+
+    const modeLabel = mode === 'desktop' ? 'desktop' : 'mobile';
 
     resultsElement.replaceChildren();
 
@@ -10338,7 +10546,8 @@ function renderMobileQuickActionResults(query, resultsElement) {
         return;
     }
 
-    const currentKeys = new Set(sbState.mobileQuickActions.map(getMobileQuickActionKey));
+    const currentActions = getQuickActionState(mode);
+    const currentKeys = new Set(currentActions.map(getMobileQuickActionKey));
     for (const match of matches) {
         const action = createMobileQuickActionFromMatch(match);
         if (!action) {
@@ -10347,7 +10556,7 @@ function renderMobileQuickActionResults(query, resultsElement) {
 
         const actionKey = getMobileQuickActionKey(action);
         const isAdded = currentKeys.has(actionKey);
-        const isFull = sbState.mobileQuickActions.length >= SB_MOBILE_QUICK_ACTION_LIMIT;
+        const isFull = currentActions.length >= SB_MOBILE_QUICK_ACTION_LIMIT;
         const buttonText = isAdded ? 'Added' : isFull ? 'Full' : 'Add';
         const row = createElement('div', { className: 'sb-mobile-quick-action-result' });
         const copy = createElement('span', { className: 'sb-mobile-quick-action-copy' });
@@ -10361,13 +10570,13 @@ function renderMobileQuickActionResults(query, resultsElement) {
             attrs: {
                 type: 'button',
                 'aria-label': isAdded
-                    ? `${action.label} is already in mobile Quick Actions`
-                    : `Add ${action.label} to mobile Quick Actions`,
+                    ? `${action.label} is already in ${modeLabel} Quick Actions`
+                    : `Add ${action.label} to ${modeLabel} Quick Actions`,
             },
         });
 
         button.disabled = isAdded || isFull;
-        button.addEventListener('click', () => addMobileQuickActionFromMatch(match));
+        button.addEventListener('click', () => addQuickActionFromMatch(mode, match));
 
         copy.append(title, detail);
         row.append(copy, button);
@@ -10375,42 +10584,45 @@ function renderMobileQuickActionResults(query, resultsElement) {
     }
 }
 
-function renderMobileQuickActionSettingsList() {
-    updateMobileQuickActionSettingsStatus();
+function renderMobileQuickActionSettingsList(mode = 'mobile') {
+    updateMobileQuickActionSettingsStatus(mode);
 
-    const list = document.getElementById('sb-mobile-quick-action-list');
+    const list = document.getElementById(`sb-${mode}-quick-action-list`);
     if (!(list instanceof HTMLElement)) {
         return;
     }
 
+    const modeLabel = mode === 'desktop' ? 'desktop' : 'mobile';
+    const currentActions = getQuickActionState(mode);
+
     list.replaceChildren();
 
-    if (!sbState.mobileQuickActions.length) {
+    if (!currentActions.length) {
         list.appendChild(createElement('div', {
             className: 'sb-mobile-quick-action-empty',
-            text: 'No mobile Quick Actions selected. Add one from search or reset to defaults.',
+            text: `No ${modeLabel} Quick Actions selected. Add one from search or reset to defaults.`,
         }));
         return;
     }
 
-    for (const action of sbState.mobileQuickActions) {
+    for (const action of currentActions) {
         const actionKey = getMobileQuickActionKey(action);
         const row = createElement('div', { className: 'sb-mobile-quick-action-current' });
         const copy = createElement('span', { className: 'sb-mobile-quick-action-copy' });
         const title = createElement('strong', { text: action.label });
         const detail = createElement('small', { text: getMobileQuickActionContextLabel(action) });
         const controls = createElement('span', { className: 'sb-mobile-quick-action-controls' });
-        const iconControl = createMobileQuickActionIconControl(action, actionKey);
+        const iconControl = createMobileQuickActionIconControl(action, actionKey, mode);
         const removeButton = createElement('button', {
             className: 'menu_button sb-mobile-quick-action-remove',
             text: 'Remove',
             attrs: {
                 type: 'button',
-                'aria-label': `Remove ${action.label} from mobile Quick Actions`,
+                'aria-label': `Remove ${action.label} from ${modeLabel} Quick Actions`,
             },
         });
 
-        removeButton.addEventListener('click', () => removeMobileQuickAction(actionKey));
+        removeButton.addEventListener('click', () => removeQuickAction(mode, actionKey));
 
         copy.append(title, detail);
         controls.append(iconControl, removeButton);
@@ -10419,19 +10631,24 @@ function renderMobileQuickActionSettingsList() {
     }
 }
 
-function createMobileQuickActionSettingsGroup() {
+function createMobileQuickActionSettingsGroup(mode = 'mobile') {
+    const isDesktop = mode === 'desktop';
+    const modeTitle = isDesktop ? 'Desktop' : 'Mobile';
+    const modeLabel = isDesktop ? 'desktop' : 'mobile';
     const group = createElement('section', {
-        className: 'sb-theme-slider-group sb-mobile-quick-actions-group',
+        className: `sb-theme-slider-group sb-mobile-quick-actions-group sb-${mode}-quick-actions-group`,
     });
     const header = createElement('div', { className: 'sb-mobile-quick-action-header' });
     const heading = createElement('div', { className: 'sb-mobile-quick-action-heading' });
-    const title = createElement('strong', { text: 'Mobile Quick Actions' });
+    const title = createElement('strong', { text: `${modeTitle} Quick Actions` });
     const description = createElement('p', {
         className: 'sb-theme-slider-caption',
-        text: 'Choose the shortcuts shown in the mobile quick drawer. Defaults can be removed or restored.',
+        text: isDesktop
+            ? 'Choose the shortcuts shown below Customize in the desktop side rail. Defaults can be removed or restored.'
+            : 'Choose the shortcuts shown in the mobile quick drawer. Defaults can be removed or restored.',
     });
     const resetButton = createElement('button', {
-        id: 'sb-mobile-quick-action-reset',
+        id: `sb-${mode}-quick-action-reset`,
         className: 'menu_button sb-mobile-quick-action-reset',
         text: 'Reset to defaults',
         attrs: {
@@ -10440,60 +10657,62 @@ function createMobileQuickActionSettingsGroup() {
     });
 
     const searchInput = createElement('input', {
-        id: 'sb-mobile-quick-action-search',
+        id: `sb-${mode}-quick-action-search`,
         className: 'text_pole sb-mobile-quick-action-search',
         attrs: {
             type: 'search',
             placeholder: 'Search settings or extensions...',
             autocomplete: 'off',
-            'aria-label': 'Search settings and extensions to add as mobile Quick Actions',
+            'aria-label': `Search settings and extensions to add as ${modeLabel} Quick Actions`,
         },
     });
     const results = createElement('div', {
-        id: 'sb-mobile-quick-action-results',
+        id: `sb-${mode}-quick-action-results`,
         className: 'sb-mobile-quick-action-results',
     });
     const list = createElement('div', {
-        id: 'sb-mobile-quick-action-list',
+        id: `sb-${mode}-quick-action-list`,
         className: 'sb-mobile-quick-action-list',
     });
     const status = createElement('p', {
-        id: 'sb-mobile-quick-action-status',
+        id: `sb-${mode}-quick-action-status`,
         className: 'sb-theme-slider-caption',
     });
 
     heading.append(title, description);
     header.append(heading, resetButton);
 
-    resetButton.addEventListener('click', resetMobileQuickActions);
+    resetButton.addEventListener('click', isDesktop ? resetDesktopQuickActions : resetMobileQuickActions);
 
     searchInput.addEventListener('input', event => {
         const input = event.currentTarget;
-        renderMobileQuickActionResults(input instanceof HTMLInputElement ? input.value : '', results);
+        renderMobileQuickActionResults(input instanceof HTMLInputElement ? input.value : '', results, mode);
     });
 
     group.append(header, searchInput, results, list, status);
-    renderMobileQuickActionResults('', results);
+    renderMobileQuickActionResults('', results, mode);
 
-    window.requestAnimationFrame(renderMobileQuickActionSettingsList);
+    window.requestAnimationFrame(() => renderMobileQuickActionSettingsList(mode));
     return group;
 }
 
-function createCompactModeSettingsGroup() {
+function createCompactModeSettingsGroup(mode = 'mobile') {
+    const inputId = mode === 'desktop' ? 'sb-desktop-compact-mode-input' : 'sb-mobile-compact-mode-input';
     const group = createElement('section', {
         className: 'sb-theme-slider-group sb-compact-mode-group',
     });
     const label = createElement('label', {
         className: 'sb-compact-mode-option',
         attrs: {
-            for: 'sb-compact-mode-input',
+            for: inputId,
         },
     });
     const checkbox = createElement('input', {
-        id: 'sb-compact-mode-input',
+        id: inputId,
         className: 'sb-compact-mode-checkbox',
         attrs: {
             type: 'checkbox',
+            'data-sb-compact-mode-input': mode,
         },
     });
     const copy = createElement('span', { className: 'sb-compact-mode-copy' });
@@ -10572,60 +10791,63 @@ function createMobileNavDivider(label = '') {
     return divider;
 }
 
-function createMobileNavLayoutSettingsGroup() {
+function createNavigationSettingsGroup(mode = 'mobile') {
+    const isDesktop = mode === 'desktop';
+    const modeTitle = isDesktop ? 'Desktop' : 'Mobile';
+    const modePrefix = isDesktop ? 'desktop' : 'mobile';
     const group = createElement('section', {
-        className: 'sb-theme-slider-group sb-mobile-nav-layout-group',
+        className: `sb-theme-slider-group sb-mobile-nav-layout-group sb-${modePrefix}-nav-layout-group`,
     });
     const header = createElement('div', { className: 'sb-mobile-nav-settings-header' });
-    const title = createElement('strong', { text: 'Mobile Navigation' });
+    const title = createElement('strong', { text: `${modeTitle} Navigation` });
     const layoutGrid = createElement('div', {
         className: 'sb-mobile-nav-choice-grid',
         attrs: {
             role: 'radiogroup',
-            'aria-label': 'Mobile navigation layout',
+            'aria-label': `${modeTitle} navigation layout`,
         },
     });
     const iconOnlyChoice = createMobileNavChoice({
-        id: 'sb-mobile-nav-icon-only-input',
+        id: `sb-${modePrefix}-nav-icon-only-input`,
         type: 'checkbox',
         value: 'icon-only',
         label: 'Icons only in shell tabs',
         icon: 'fa-icons',
-        onChange: input => setMobileNavIconOnly(input.checked),
+        onChange: input => isDesktop ? setDesktopNavIconOnly(input.checked) : setMobileNavIconOnly(input.checked),
     });
     const showCustomizeChoice = createMobileNavChoice({
-        id: 'sb-mobile-nav-show-customize-input',
+        id: `sb-${modePrefix}-nav-show-customize-input`,
         type: 'checkbox',
         value: 'show-customize',
-        label: getMobileNavCustomizeLocationLabel(),
+        label: getMobileNavCustomizeLocationLabel(mode),
         icon: 'fa-sliders',
-        onChange: input => setMobileNavShowCustomize(input.checked),
+        onChange: input => isDesktop ? setDesktopNavShowCustomize(input.checked) : setMobileNavShowCustomize(input.checked),
     });
     const showQuickActionsChoice = createMobileNavChoice({
-        id: 'sb-mobile-nav-show-quick-actions-input',
+        id: `sb-${modePrefix}-nav-show-quick-actions-input`,
         type: 'checkbox',
         value: 'show-quick-actions',
         label: 'Show Custom Quick Actions below Customize',
         icon: 'fa-bolt',
-        onChange: input => setMobileNavShowQuickActions(input.checked),
+        onChange: input => isDesktop ? setDesktopNavShowQuickActions(input.checked) : setMobileNavShowQuickActions(input.checked),
     });
     const replaceQuickActionsChoice = createMobileNavChoice({
-        id: 'sb-mobile-nav-replace-quick-actions-input',
+        id: `sb-${modePrefix}-nav-replace-quick-actions-input`,
         type: 'checkbox',
         value: 'replace-quick-actions',
         label: 'Use a chosen page instead of Quick Actions',
         icon: 'fa-map-location-dot',
-        onChange: input => setMobileNavReplaceQuickActions(input.checked),
+        onChange: input => isDesktop ? setDesktopNavReplaceQuickActions(input.checked) : setMobileNavReplaceQuickActions(input.checked),
     });
     const replacementField = createElement('label', {
         className: 'sb-mobile-nav-replacement-field',
         attrs: {
-            for: 'sb-mobile-nav-replacement-select',
+            for: `sb-${modePrefix}-nav-replacement-select`,
         },
     });
     const replacementLabel = createElement('span', { text: 'Replacement page' });
     const replacementSelect = createElement('select', {
-        id: 'sb-mobile-nav-replacement-select',
+        id: `sb-${modePrefix}-nav-replacement-select`,
         className: 'text_pole sb-mobile-nav-replacement-select',
     });
 
@@ -10641,25 +10863,30 @@ function createMobileNavLayoutSettingsGroup() {
 
     replacementSelect.addEventListener('change', event => {
         const select = event.currentTarget;
-        setMobileNavReplacementTarget(select instanceof HTMLSelectElement ? select.value : '');
+        const nextValue = select instanceof HTMLSelectElement ? select.value : '';
+        if (isDesktop) {
+            setDesktopNavReplacementTarget(nextValue);
+        } else {
+            setMobileNavReplacementTarget(nextValue);
+        }
     });
 
     layoutGrid.append(
         createMobileNavChoice({
-            id: 'sb-mobile-nav-layout-horizontal',
-            name: 'sb-mobile-nav-layout',
+            id: `sb-${modePrefix}-nav-layout-horizontal`,
+            name: `sb-${modePrefix}-nav-layout`,
             value: 'horizontal',
             label: 'Horizontal top bar',
             icon: 'fa-grip-lines',
-            onChange: input => setMobileNavLayout(input.value),
+            onChange: input => isDesktop ? setDesktopNavLayout(input.value) : setMobileNavLayout(input.value),
         }),
         createMobileNavChoice({
-            id: 'sb-mobile-nav-layout-vertical',
-            name: 'sb-mobile-nav-layout',
+            id: `sb-${modePrefix}-nav-layout-vertical`,
+            name: `sb-${modePrefix}-nav-layout`,
             value: 'vertical',
             label: 'Vertical side rail',
             icon: 'fa-table-columns',
-            onChange: input => setMobileNavLayout(input.value),
+            onChange: input => isDesktop ? setDesktopNavLayout(input.value) : setMobileNavLayout(input.value),
         }),
     );
 
@@ -10676,6 +10903,14 @@ function createMobileNavLayoutSettingsGroup() {
         replacementField,
     );
     return group;
+}
+
+function createMobileNavLayoutSettingsGroup() {
+    return createNavigationSettingsGroup('mobile');
+}
+
+function createDesktopNavLayoutSettingsGroup() {
+    return createNavigationSettingsGroup('desktop');
 }
 
 function createFrontendIconSettingsGroup() {
@@ -10863,6 +11098,19 @@ function injectThemePicker() {
         caption: 'Resize the bottom chat bar, send form, and action buttons without editing CSS.',
         onInput: nextValue => setBottomBarScale(nextValue),
     });
+    const desktopButtonSliderGroup = createThemeSliderGroup({
+        title: 'Desktop Button Size',
+        valueId: 'sb-desktop-button-scale-value',
+        inputId: 'sb-desktop-button-scale-input',
+        value: sbState.desktopButtonScale,
+        min: SB_TOPBAR_SCALE.min,
+        max: SB_TOPBAR_SCALE.max,
+        step: SB_TOPBAR_SCALE.step,
+        ariaLabel: 'Desktop button size',
+        caption: 'Increase or decrease the desktop top bar and shell navigation buttons without changing mobile controls.',
+        onInput: nextValue => setDesktopButtonScale(nextValue),
+        className: 'sb-desktop-setting',
+    });
     const mobileButtonSliderGroup = createThemeSliderGroup({
         title: 'Mobile Button Size',
         valueId: 'sb-mobile-button-scale-value',
@@ -10877,12 +11125,17 @@ function injectThemePicker() {
         className: 'sb-mobile-only-setting',
     });
     const topbarLabelSettingsGroup = createTopbarLabelSettingsGroup();
+    const desktopNavLayoutSettingsGroup = createDesktopNavLayoutSettingsGroup();
     const mobileNavLayoutSettingsGroup = createMobileNavLayoutSettingsGroup();
+    const desktopSettingsDivider = createMobileNavDivider();
     const mobileSettingsDivider = createMobileNavDivider();
-    const compactModeSettingsGroup = createCompactModeSettingsGroup();
+    const desktopCompactModeSettingsGroup = createCompactModeSettingsGroup('desktop');
+    const mobileCompactModeSettingsGroup = createCompactModeSettingsGroup('mobile');
     const frontendIconSettingsGroup = createFrontendIconSettingsGroup();
     const shortcutSettingsGroup = createShortcutSettingsGroup();
+    const desktopQuickActionSettingsGroup = createMobileQuickActionSettingsGroup('desktop');
     const mobileQuickActionSettingsGroup = createMobileQuickActionSettingsGroup();
+    const desktopSettingsOutlet = document.getElementById('sb-desktop-settings-outlet');
     const mobileSettingsOutlet = document.getElementById('sb-mobile-settings-outlet');
     header.append(title, description);
 
@@ -10907,23 +11160,43 @@ function injectThemePicker() {
     getMessageStyleSelect()?.addEventListener('change', updateThemePickerUi);
     document.addEventListener('sb:chat-style-updated', updateThemePickerUi);
 
+    if (desktopSettingsOutlet instanceof HTMLElement) {
+        desktopSettingsOutlet.replaceChildren(
+            desktopNavLayoutSettingsGroup,
+            desktopSettingsDivider,
+            desktopButtonSliderGroup,
+            desktopCompactModeSettingsGroup,
+            desktopQuickActionSettingsGroup,
+        );
+    }
+
     if (mobileSettingsOutlet instanceof HTMLElement) {
         mobileSettingsOutlet.replaceChildren(
             mobileNavLayoutSettingsGroup,
             mobileSettingsDivider,
             mobileButtonSliderGroup,
-            compactModeSettingsGroup,
+            mobileCompactModeSettingsGroup,
             mobileQuickActionSettingsGroup,
         );
     }
 
     card.append(header, optionRow, frontendIconSettingsGroup, surfaceSliderGroup, bottomBarSliderGroup, topbarLabelSettingsGroup, shortcutSettingsGroup);
+    if (!(desktopSettingsOutlet instanceof HTMLElement)) {
+        card.append(
+            desktopNavLayoutSettingsGroup,
+            desktopSettingsDivider,
+            desktopButtonSliderGroup,
+            desktopCompactModeSettingsGroup,
+            desktopQuickActionSettingsGroup,
+        );
+    }
+
     if (!(mobileSettingsOutlet instanceof HTMLElement)) {
         card.append(
             mobileNavLayoutSettingsGroup,
             mobileSettingsDivider,
             mobileButtonSliderGroup,
-            compactModeSettingsGroup,
+            mobileCompactModeSettingsGroup,
             mobileQuickActionSettingsGroup,
         );
     }
@@ -10938,10 +11211,16 @@ function updateThemePickerUi() {
     const desktopTopbarScaleValue = document.getElementById('sb-topbar-scale-desktop-value');
     const bottomBarScaleInput = document.getElementById('sb-bottom-bar-scale-input');
     const bottomBarScaleValue = document.getElementById('sb-bottom-bar-scale-value');
+    const desktopButtonScaleInput = document.getElementById('sb-desktop-button-scale-input');
+    const desktopButtonScaleValue = document.getElementById('sb-desktop-button-scale-value');
     const mobileButtonScaleInput = document.getElementById('sb-mobile-button-scale-input');
     const mobileButtonScaleValue = document.getElementById('sb-mobile-button-scale-value');
     const customTextInput = document.getElementById('sb-topbar-custom-text-input');
-    const compactModeInput = document.getElementById('sb-compact-mode-input');
+    const desktopNavIconOnlyInput = document.getElementById('sb-desktop-nav-icon-only-input');
+    const desktopNavShowCustomizeInput = document.getElementById('sb-desktop-nav-show-customize-input');
+    const desktopNavShowQuickActionsInput = document.getElementById('sb-desktop-nav-show-quick-actions-input');
+    const desktopNavReplaceQuickActionsInput = document.getElementById('sb-desktop-nav-replace-quick-actions-input');
+    const desktopNavReplacementSelect = document.getElementById('sb-desktop-nav-replacement-select');
     const mobileNavIconOnlyInput = document.getElementById('sb-mobile-nav-icon-only-input');
     const mobileNavShowCustomizeInput = document.getElementById('sb-mobile-nav-show-customize-input');
     const mobileNavShowQuickActionsInput = document.getElementById('sb-mobile-nav-show-quick-actions-input');
@@ -10989,6 +11268,14 @@ function updateThemePickerUi() {
         bottomBarScaleValue.textContent = formatTopbarScale(sbState.bottomBarScale);
     }
 
+    if (desktopButtonScaleInput instanceof HTMLInputElement) {
+        desktopButtonScaleInput.value = String(sbState.desktopButtonScale);
+    }
+
+    if (desktopButtonScaleValue instanceof HTMLElement) {
+        desktopButtonScaleValue.textContent = formatTopbarScale(sbState.desktopButtonScale);
+    }
+
     if (mobileButtonScaleInput instanceof HTMLInputElement) {
         mobileButtonScaleInput.value = String(sbState.mobileButtonScale);
     }
@@ -11016,9 +11303,23 @@ function updateThemePickerUi() {
         customTextInput.value = sbState.topbarLabel.customText;
     }
 
-    if (compactModeInput instanceof HTMLInputElement) {
-        compactModeInput.checked = sbState.compactMode;
-        compactModeInput.closest('.sb-compact-mode-option')?.classList.toggle('is-selected', sbState.compactMode);
+    for (const input of document.querySelectorAll('[data-sb-compact-mode-input]')) {
+        if (!(input instanceof HTMLInputElement)) {
+            continue;
+        }
+
+        input.checked = sbState.compactMode;
+        input.closest('.sb-compact-mode-option')?.classList.toggle('is-selected', sbState.compactMode);
+    }
+
+    for (const input of document.querySelectorAll('input[name="sb-desktop-nav-layout"]')) {
+        if (!(input instanceof HTMLInputElement)) {
+            continue;
+        }
+
+        const isChecked = input.value === sbState.desktopNav.layout;
+        input.checked = isChecked;
+        input.closest('.sb-mobile-nav-choice')?.classList.toggle('is-selected', isChecked);
     }
 
     for (const input of document.querySelectorAll('input[name="sb-mobile-nav-layout"]')) {
@@ -11029,6 +11330,45 @@ function updateThemePickerUi() {
         const isChecked = input.value === sbState.mobileNav.layout;
         input.checked = isChecked;
         input.closest('.sb-mobile-nav-choice')?.classList.toggle('is-selected', isChecked);
+    }
+
+    if (desktopNavIconOnlyInput instanceof HTMLInputElement) {
+        desktopNavIconOnlyInput.checked = sbState.desktopNav.iconOnly;
+        const choice = desktopNavIconOnlyInput.closest('.sb-mobile-nav-choice');
+        choice?.classList.toggle('is-selected', sbState.desktopNav.iconOnly);
+        choice?.classList.toggle('is-disabled', false);
+    }
+
+    if (desktopNavShowCustomizeInput instanceof HTMLInputElement) {
+        desktopNavShowCustomizeInput.checked = sbState.desktopNav.showCustomize;
+        desktopNavShowCustomizeInput.disabled = false;
+        const choice = desktopNavShowCustomizeInput.closest('.sb-mobile-nav-choice');
+        const label = choice?.querySelector('.sb-mobile-nav-choice-copy > strong');
+        if (label instanceof HTMLElement) {
+            label.textContent = getMobileNavCustomizeLocationLabel('desktop');
+        }
+        choice?.classList.toggle('is-selected', sbState.desktopNav.showCustomize);
+        choice?.classList.toggle('is-disabled', false);
+    }
+
+    if (desktopNavShowQuickActionsInput instanceof HTMLInputElement) {
+        desktopNavShowQuickActionsInput.checked = sbState.desktopNav.showQuickActions;
+        desktopNavShowQuickActionsInput.disabled = false;
+        const choice = desktopNavShowQuickActionsInput.closest('.sb-mobile-nav-choice');
+        choice?.classList.toggle('is-selected', sbState.desktopNav.showQuickActions);
+        choice?.classList.toggle('is-disabled', false);
+    }
+
+    if (desktopNavReplaceQuickActionsInput instanceof HTMLInputElement) {
+        desktopNavReplaceQuickActionsInput.checked = sbState.desktopNav.replaceQuickActions;
+        const choice = desktopNavReplaceQuickActionsInput.closest('.sb-mobile-nav-choice');
+        choice?.classList.toggle('is-selected', sbState.desktopNav.replaceQuickActions);
+    }
+
+    if (desktopNavReplacementSelect instanceof HTMLSelectElement) {
+        desktopNavReplacementSelect.value = normalizeMobileNavReplacementTarget(sbState.desktopNav.replacementTarget);
+        desktopNavReplacementSelect.disabled = !sbState.desktopNav.replaceQuickActions;
+        desktopNavReplacementSelect.closest('.sb-mobile-nav-replacement-field')?.classList.toggle('is-disabled', !sbState.desktopNav.replaceQuickActions);
     }
 
     if (mobileNavIconOnlyInput instanceof HTMLInputElement) {
@@ -11086,7 +11426,7 @@ function createSearchIndex(tabState, { includeThemeCard = false } = {}) {
     const entries = [];
     const seen = new Set();
     const excludedSelector = includeThemeCard
-        ? '.sb-search-result, .sb-legacy-search-hidden, .sb-mobile-quick-actions-group'
+        ? '.sb-search-result, .sb-legacy-search-hidden, .sb-mobile-quick-actions-group, .sb-desktop-quick-actions-group'
         : '.sb-search-result, .sb-theme-card, .sb-legacy-search-hidden';
 
     for (const element of searchRoot.querySelectorAll(SB_SEARCH_TARGET_SELECTOR)) {
@@ -11388,7 +11728,9 @@ function activateMobileNavAction(action) {
         return;
     }
 
-    closeMobileNav();
+    if (isMobileViewport()) {
+        closeMobileNav();
+    }
 
     if (normalizedAction.type === 'custom') {
         activateMobileQuickAction(normalizedAction);
@@ -11960,7 +12302,9 @@ function buildShell(shellKey) {
 
         if (isOpen) {
             shellState.lastOpenedAt = performance.now();
-            closeMobileNav();
+            if (isMobileViewport()) {
+                closeMobileNav();
+            }
             const activeTab = shellState.tabs.get(shellState.activeTabId);
             activeTab?.onActivate?.();
             dispatchShellTabActivated(shellKey, activeTab);
@@ -12247,7 +12591,10 @@ function syncMobileShellRailTabVisibility(shellState, currentShellKey, hideCusto
 
 function syncMobileShellRailActions(shellKey = null) {
     const shellKeys = shellKey ? [shellKey] : ['left', 'right'];
-    const hasVerticalRail = isMobileViewport() && sbState.mobileNav.layout === 'vertical';
+    const railMode = getActiveShellRailMode();
+    const navState = getNavState(railMode);
+    const hasVerticalRail = navState.layout === 'vertical';
+    const railQuickActionState = getQuickActionState(railMode);
 
     for (const currentShellKey of shellKeys) {
         const shellState = getShellState(currentShellKey);
@@ -12256,7 +12603,7 @@ function syncMobileShellRailActions(shellKey = null) {
         }
 
         shellState.nav.querySelectorAll('.sb-shell-rail-shortcuts').forEach(element => element.remove());
-        const showCustomize = hasVerticalRail && sbState.mobileNav.showCustomize;
+        const showCustomize = hasVerticalRail && navState.showCustomize;
         const shouldHideCustomizeTabs = showCustomize;
         syncMobileShellRailTabVisibility(shellState, currentShellKey, shouldHideCustomizeTabs);
 
@@ -12273,7 +12620,7 @@ function syncMobileShellRailActions(shellKey = null) {
         }
 
         const builtInRailActionKeys = new Set(SB_MOBILE_RAIL_CUSTOMIZE_ACTIONS.map(getMobileQuickActionKey));
-        const railQuickActions = sbState.mobileQuickActions.filter(
+        const railQuickActions = railQuickActionState.filter(
             action => !builtInRailActionKeys.has(getMobileQuickActionKey(action)),
         );
         const createQuickActionsGroup = () => {
@@ -12312,7 +12659,7 @@ function syncMobileShellRailActions(shellKey = null) {
             shellState.nav.prepend(beforeBlock);
         }
 
-        if (sbState.mobileNav.showQuickActions) {
+        if (navState.showQuickActions) {
             const afterBlock = createRailBlock('after');
             afterBlock.append(
                 createMobileShellRailDivider('Quick Actions'),
@@ -13778,7 +14125,9 @@ function initAll() {
     setTopbarScale('desktop', sbState.topbarScale.desktop, { persist: false });
     setTopbarScale('mobile', sbState.topbarScale.mobile, { persist: false });
     setBottomBarScale(sbState.bottomBarScale, { persist: false });
+    setDesktopButtonScale(sbState.desktopButtonScale, { persist: false });
     setMobileButtonScale(sbState.mobileButtonScale, { persist: false });
+    applyDesktopNavPreferences();
     applyMobileNavPreferences();
     bindComposerControlPlacement();
     initChatAvatarVariables();
@@ -13863,6 +14212,9 @@ function initAll() {
         setMobileButtonScale(value) {
             setMobileButtonScale(value);
         },
+        setDesktopButtonScale(value) {
+            setDesktopButtonScale(value);
+        },
         setCompactMode(value) {
             setCompactMode(value);
         },
@@ -13901,6 +14253,9 @@ function initAll() {
         },
         getMobileButtonScale() {
             return sbState.mobileButtonScale;
+        },
+        getDesktopButtonScale() {
+            return sbState.desktopButtonScale;
         },
         getCompactMode() {
             return sbState.compactMode;

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -37,7 +37,7 @@ const SB_STORAGE_KEYS = Object.freeze({
     desktopNavShowQuickActions: 'sb-desktop-nav-show-quick-actions',
     desktopNavReplaceQuickActions: 'sb-desktop-nav-replace-quick-actions',
     desktopNavReplacementTarget: 'sb-desktop-nav-replacement-target',
-    desktopQuickActions: 'sb-desktop-quick-actions-v1',
+    desktopQuickActions: 'sb-desktop-quick-actions-v2',
     mobileNavLayout: 'sb-mobile-nav-layout',
     mobileNavIconOnly: 'sb-mobile-nav-icon-only',
     mobileNavShowCustomize: 'sb-mobile-nav-show-customize',
@@ -602,6 +602,9 @@ const SB_MOBILE_DEFAULT_QUICK_ACTIONS = Object.freeze([
     { type: 'tab', shellKey: 'characters', tabId: 'world-info', icon: 'fa-book-atlas', label: 'World Info' },
     { type: 'tab', shellKey: 'left', tabId: 'agents', icon: 'fa-robot', label: 'Agents' },
 ]);
+const SB_DESKTOP_DEFAULT_QUICK_ACTIONS = Object.freeze([
+    { type: 'tab', shellKey: 'characters', tabId: 'world-info', icon: 'fa-book-atlas', label: 'World Info' },
+]);
 const SB_MOBILE_RAIL_CUSTOMIZE_ACTIONS = Object.freeze([
     { type: 'tab', shellKey: 'left', tabId: 'presets', icon: 'fa-sliders', label: 'Presets' },
     { type: 'tab', shellKey: 'left', tabId: 'api', icon: 'fa-plug', label: 'API' },
@@ -914,6 +917,17 @@ function getMobileNavReplacementTargetConfig(target = sbState.mobileNav.replacem
         ?? SB_MOBILE_NAV_PAGE_TARGETS[0];
 }
 
+function createNavReplacementQuickAction(target) {
+    const config = getMobileNavReplacementTargetConfig(target);
+    return normalizeMobileQuickAction({
+        type: 'tab',
+        shellKey: config.shellKey,
+        tabId: config.tabId,
+        icon: config.icon,
+        label: config.label,
+    });
+}
+
 function normalizeShellSize(value) {
     let source = value;
 
@@ -1101,7 +1115,7 @@ function getDefaultMobileQuickActions() {
 }
 
 function getDefaultDesktopQuickActions() {
-    return getDefaultMobileQuickActions();
+    return normalizeMobileQuickActionList(SB_DESKTOP_DEFAULT_QUICK_ACTIONS);
 }
 
 function migrateLegacyMobileQuickAction(action) {
@@ -1261,16 +1275,8 @@ function addQuickActionFromMatch(mode, match) {
     return true;
 }
 
-function addMobileQuickActionFromMatch(match) {
-    return addQuickActionFromMatch('mobile', match);
-}
-
 function removeQuickAction(mode, actionKey) {
     setQuickActionsForMode(mode, getQuickActionState(mode).filter(action => getMobileQuickActionKey(action) !== actionKey));
-}
-
-function removeMobileQuickAction(actionKey) {
-    removeQuickAction('mobile', actionKey);
 }
 
 function setQuickActionIcon(mode, actionKey, iconClass) {
@@ -1284,10 +1290,6 @@ function setQuickActionIcon(mode, actionKey, iconClass) {
             icon: normalizeFontAwesomeIcon(iconClass),
         };
     }));
-}
-
-function setMobileQuickActionIcon(actionKey, iconClass) {
-    setQuickActionIcon('mobile', actionKey, iconClass);
 }
 
 async function chooseQuickActionIcon(mode, actionKey) {
@@ -1304,10 +1306,6 @@ async function chooseQuickActionIcon(mode, actionKey) {
     }
 
     setQuickActionIcon(mode, actionKey, iconClass);
-}
-
-async function chooseMobileQuickActionIcon(actionKey) {
-    await chooseQuickActionIcon('mobile', actionKey);
 }
 
 function resetMobileQuickActions() {
@@ -1675,6 +1673,7 @@ function setDesktopNavReplacementTarget(target, { persist = true } = {}) {
         safeSetItem(SB_STORAGE_KEYS.desktopNavReplacementTarget, nextTarget);
     }
 
+    syncMobileShellRailActions();
     updateThemePickerUi();
 }
 
@@ -12402,6 +12401,8 @@ function registerShellTab(shellKey, tabConfig, panelBundle, explicitSearchRoot =
             role: 'tab',
             tabindex: '-1',
             'aria-selected': 'false',
+            'aria-label': tabConfig.label,
+            title: tabConfig.label,
             'data-sb-tab': tabConfig.id,
         },
     });
@@ -12419,7 +12420,7 @@ function registerShellTab(shellKey, tabConfig, panelBundle, explicitSearchRoot =
     });
 
     button.addEventListener('keydown', event => {
-        const buttons = Array.from(shellState.nav.querySelectorAll('.sb-shell-tab')).filter(
+        const buttons = Array.from(shellState.nav.querySelectorAll('.sb-shell-tab[data-sb-tab]')).filter(
             item => item instanceof HTMLElement && !item.classList.contains('sb-shell-tab-mobile-rail-hidden'),
         );
         const currentIndex = buttons.indexOf(button);
@@ -12619,10 +12620,15 @@ function syncMobileShellRailActions(shellKey = null) {
             continue;
         }
 
-        const builtInRailActionKeys = new Set(SB_MOBILE_RAIL_CUSTOMIZE_ACTIONS.map(getMobileQuickActionKey));
-        const railQuickActions = railQuickActionState.filter(
-            action => !builtInRailActionKeys.has(getMobileQuickActionKey(action)),
-        );
+        const builtInRailActionKeys = showCustomize
+            ? new Set(SB_MOBILE_RAIL_CUSTOMIZE_ACTIONS.map(getMobileQuickActionKey))
+            : new Set();
+        const replacementAction = railMode === 'desktop' && navState.replaceQuickActions
+            ? createNavReplacementQuickAction(navState.replacementTarget)
+            : null;
+        const railQuickActions = replacementAction
+            ? [replacementAction]
+            : railQuickActionState.filter(action => !builtInRailActionKeys.has(getMobileQuickActionKey(action)));
         const createQuickActionsGroup = () => {
             const quickActionsGroup = createElement('div', {
                 className: 'sb-shell-rail-group sb-shell-rail-group-quick-actions',
@@ -12659,7 +12665,7 @@ function syncMobileShellRailActions(shellKey = null) {
             shellState.nav.prepend(beforeBlock);
         }
 
-        if (navState.showQuickActions) {
+        if (navState.showQuickActions && railQuickActions.length > 0) {
             const afterBlock = createRailBlock('after');
             afterBlock.append(
                 createMobileShellRailDivider('Quick Actions'),


### PR DESCRIPTION
## Summary
- remove the previous vertical chat layout power-user setting and composer CSS
- add a desktop-only settings drawer that mirrors the mobile navigation controls with independent desktop state
- default desktop shell navigation to the vertical side rail and add desktop rail/button scaling support
- keep compact mode shared while syncing separate Desktop and Mobile controls

## Testing
- git diff --check
- node --check public/scripts/sillybunny-tabs.js
- node --check public/scripts/power-user.js
- npm run test:unit --prefix tests
- Firefox desktop smoke: confirmed default vertical desktop rail and populated Desktop settings controls
- Mobile viewport smoke was limited by the Firefox harness retaining desktop innerWidth after viewport resize; CSS media rules and JS mobile/desktop viewport gates were verified directly