### PR TITLE
fix: chat shell wheel routing

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2142,6 +2142,38 @@ function hasScrollableWheelTarget(target, boundaryElement) {
     return false;
 }
 
+const CHAT_SHELL_WHEEL_SURFACE_SELECTOR = '#sheld, #chat_wrapper, #form_sheld, #top-bar, #send_form';
+
+function getChatShellWheelBoundary(target) {
+    if (!(target instanceof Element)) {
+        return null;
+    }
+
+    return target.closest(CHAT_SHELL_WHEEL_SURFACE_SELECTOR);
+}
+
+function isInteractiveShellWheelTarget(target) {
+    if (!(target instanceof Element)) {
+        return false;
+    }
+
+    return Boolean(target.closest([
+        '#left-nav-panel',
+        '#right-nav-panel',
+        '.popup',
+        'dialog',
+        '.scrollableInner',
+        '.inline-drawer-content',
+        '.select2-container',
+        'input',
+        'textarea',
+        'select',
+        'button',
+        'a',
+        '[contenteditable="true"]',
+    ].join(',')));
+}
+
 function getWheelDeltaYPixels(event, scrollElement) {
     if (event.deltaMode === WheelEvent.DOM_DELTA_PAGE) {
         return event.deltaY * scrollElement.clientHeight;
@@ -2169,7 +2201,16 @@ function routeShellWheelToChat(event) {
         return;
     }
 
-    if (hasScrollableWheelTarget(event.target, event.currentTarget)) {
+    const shellBoundary = getChatShellWheelBoundary(event.target);
+    if (!shellBoundary) {
+        return;
+    }
+
+    if (isInteractiveShellWheelTarget(event.target)) {
+        return;
+    }
+
+    if (hasScrollableWheelTarget(event.target, shellBoundary)) {
         return;
     }
 
@@ -15015,7 +15056,6 @@ jQuery(async function () {
     }
 
     const chatElementScroll = document.getElementById('chat');
-    const chatShellElement = document.getElementById('sheld');
     const markMobileChatTouchScrollStart = () => {
         clearChatLoadBottomLock();
         markMobileChatManualScroll({ touchActive: true });
@@ -15035,7 +15075,7 @@ jQuery(async function () {
     chatElementScroll.addEventListener('touchend', releaseMobileChatTouchScroll, { passive: true });
     chatElementScroll.addEventListener('touchcancel', releaseMobileChatTouchScroll, { passive: true });
     chatElementScroll.addEventListener('wheel', markMobileChatWheelScroll, { passive: true });
-    chatShellElement?.addEventListener('wheel', routeShellWheelToChat, { passive: false });
+    document.addEventListener('wheel', routeShellWheelToChat, { passive: false, capture: true });
     setupMobileChatViewportObserver(markMobileViewportScroll);
 
     const chatScrollHandler = function () {

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -599,8 +599,10 @@ describe('chat render lifecycle script wiring', () => {
 
         const initSource = scriptSource.slice(scriptSource.indexOf('const chatElementScroll = document.getElementById(\'chat\');'));
         expect(initSource).toContain('const markMobileViewportScroll = getMobileViewportScrollHandler();');
-        expect(initSource).toContain('const chatShellElement = document.getElementById(\'sheld\');');
-        expect(initSource).toContain('chatShellElement?.addEventListener(\'wheel\', routeShellWheelToChat, { passive: false });');
+        expect(scriptSource).toContain('const CHAT_SHELL_WHEEL_SURFACE_SELECTOR = \'#sheld, #chat_wrapper, #form_sheld, #top-bar, #send_form\';');
+        expect(scriptSource).toContain('const shellBoundary = getChatShellWheelBoundary(event.target);');
+        expect(scriptSource).toContain('hasScrollableWheelTarget(event.target, shellBoundary)');
+        expect(initSource).toContain('document.addEventListener(\'wheel\', routeShellWheelToChat, { passive: false, capture: true });');
         expect(initSource).toContain('setupMobileChatViewportObserver(markMobileViewportScroll);');
     });
 

--- a/tests/chat-scroll-regressions.e2e.js
+++ b/tests/chat-scroll-regressions.e2e.js
@@ -1,4 +1,4 @@
-/* global window */
+/* global document, WheelEvent, window */
 import { expect, test } from '@playwright/test';
 import {
     getChatScrollSnapshot,
@@ -102,6 +102,36 @@ test.describe('issue 167 chat scroll regressions', () => {
         expect(after.firstVisibleMesId).toBe(before.firstVisibleMesId);
         expect(Math.abs(after.firstVisibleOffsetTop - before.firstVisibleOffsetTop)).toBeLessThanOrEqual(8);
         expect(after.scrollTop).toBeGreaterThan(before.scrollTop + 300);
+    });
+
+    test('desktop wheel over chat shell scrolls the chat viewport', async ({ page }) => {
+        await installSyntheticLongChat(page, { messageCount: 96, visibleCount: 96 });
+        await expect.poll(async () => {
+            await page.evaluate(() => {
+                const chat = document.querySelector('#chat');
+                const maxScrollTop = Math.max(0, chat.scrollHeight - chat.clientHeight);
+
+                chat.scrollTop = Math.min(640, Math.max(0, maxScrollTop - 720));
+                chat.dispatchEvent(new Event('scroll', { bubbles: true }));
+            });
+            await waitForAnimationFrames(page, 2);
+
+            return (await getChatScrollSnapshot(page)).bottomDelta;
+        }, { timeout: 5000 }).toBeGreaterThan(360);
+
+        const before = await getChatScrollSnapshot(page);
+        await page.evaluate(() => {
+            const shellTarget = document.querySelector('#form_sheld');
+            shellTarget.dispatchEvent(new WheelEvent('wheel', {
+                bubbles: true,
+                cancelable: true,
+                deltaY: 360,
+            }));
+        });
+        await waitForAnimationFrames(page, 2);
+        const after = await getChatScrollSnapshot(page);
+
+        expect(after.scrollTop).toBeGreaterThan(before.scrollTop + 100);
     });
 });
 


### PR DESCRIPTION
## What?
Fixes #167 by routing desktop wheel events from chat shell surfaces to the chat viewport when the wheel target is not the chat itself, an interactive control, or another nested scrollable area.

This covers the composer shell, top bar, send form, chat wrapper, and main shell, with regression coverage for `#form_sheld`.

## Why?
Current `staging` had partial shell-wheel routing, but it only listened on `#sheld`. Wheel events over the composer shell could be stopped before they reached that handler, so the user could hover near the composer/topbar and fail to scroll the chat.

## How?
The handler now runs in document capture phase, finds the nearest known chat shell boundary, skips interactive surfaces and nested scrollables, clears the chat-load bottom lock, and applies the vertical wheel delta directly to `#chat`.

The guard list keeps sidebars, popups, dialogs, select2 widgets, inputs, buttons, links, contenteditable regions, and existing scrollable panels in control of their own wheel behavior.

## Testing?
- `npm run lint`
- `npm run lint --prefix tests -- chat-scroll-regressions.e2e.js chat-render-lifecycle-script-wiring.test.js`
- `npm run test:unit --prefix tests -- chat-render-lifecycle-script-wiring.test.js`
- `SILLYBUNNY_TEST_BASE_URL=http://127.0.0.1:5107 npm run test:e2e --prefix tests -- chat-scroll-regressions.e2e.js -g "desktop wheel over chat shell"`
- `git diff --check`

## Anything Else?
Targets `staging`.