### PR TITLE
feat: add post-main in-chat agent intercept timing

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -335,6 +335,7 @@ import {
 } from './scripts/chat-render-lifecycle/index.js';
 import {
     resolveGenerationUiLockState,
+    resolveGenerationOutputBufferState,
     resolveGenerationUnblockState,
     resolveStopGenerationState,
 } from './scripts/generation-lifecycle/index.js';
@@ -5304,6 +5305,46 @@ function hideStopButton({ emitGenerationEnded = true } = {}) {
     }
 }
 
+async function shouldBufferMainGenerationOutput({ type, isStreaming = false } = {}) {
+    const eventData = {
+        type,
+        isStreaming: Boolean(isStreaming),
+        hasPostMainInterceptors: false,
+    };
+
+    await eventSource.emit(event_types.GENERATION_OUTPUT_BUFFERING_DECISION, eventData);
+    return resolveGenerationOutputBufferState({
+        type,
+        isStreaming,
+        hasPostMainInterceptors: Boolean(eventData.hasPostMainInterceptors),
+    }).shouldBuffer;
+}
+
+async function applyMainGenerationOutputInterceptors({ type, text, isStreaming = false } = {}) {
+    const outputState = resolveGenerationOutputBufferState({
+        type,
+        isStreaming,
+        hasPostMainInterceptors: true,
+    });
+
+    if (!outputState.canInterceptMainOutput) {
+        return { text, cancelled: false };
+    }
+
+    const eventData = {
+        type,
+        isStreaming: Boolean(isStreaming),
+        text: String(text ?? ''),
+        cancelled: false,
+    };
+
+    await eventSource.emit(event_types.MAIN_GENERATION_OUTPUT_READY, eventData);
+    return {
+        text: typeof eventData.text === 'string' ? eventData.text : String(text ?? ''),
+        cancelled: Boolean(eventData.cancelled),
+    };
+}
+
 class StreamingProcessor {
     /**
      * Creates a new streaming processor.
@@ -5688,6 +5729,62 @@ class StreamingProcessor {
      */
     async* nullStreamingGeneration() {
         throw new Error('Generation function for streaming is not hooked up');
+    }
+
+    async generateBuffered() {
+        const isImpersonate = this.type == 'impersonate';
+        const isContinue = this.type == 'continue';
+        this.stoppingStrings = getStoppingStrings(isImpersonate, isContinue, main_api);
+
+        try {
+            const timestamps = [];
+            for await (const { text, swipes, logprobs, toolCalls, state } of this.generator()) {
+                const now = Date.now();
+                timestamps.push(now);
+                if (!this.timeToFirstToken) {
+                    this.timeToFirstToken = now - this.createdAt.getTime();
+                }
+                if (this.isStopped || this.abortController.signal.aborted) {
+                    this.isStopped = true;
+                    this.isFinished = true;
+                    return this.result;
+                }
+
+                this.toolCalls = toolCalls;
+                this.result = text;
+                this.swipes = Array.from(swipes ?? []);
+                if (logprobs) {
+                    this.messageLogprobs.push(...(Array.isArray(logprobs) ? logprobs : [logprobs]));
+                }
+                this.pendingReasoning = typeof state?.reasoning === 'string' ? state.reasoning : null;
+                if (this.pendingReasoning !== null) {
+                    this.reasoningHandler.reasoning = getRegexedString(this.pendingReasoning, regex_placement.REASONING);
+                }
+                this.images = state?.images ?? [];
+                this.reasoningSignature = state?.signature ?? null;
+                this.reasoningTokens = state?.reasoning_tokens ?? 0;
+            }
+            const seconds = (timestamps[timestamps.length - 1] - timestamps[0]) / 1000;
+            console.warn(`Stream stats: ${timestamps.length} tokens, ${seconds.toFixed(2)} seconds, rate: ${Number(timestamps.length / seconds).toFixed(2)} TPS`);
+        } catch (err) {
+            const isCancelled = this.isCancelled || this.abortController.signal.aborted;
+            if (!this.isFinished && isCancelled) {
+                this.isStopped = true;
+                this.isFinished = true;
+                return this.result;
+            }
+
+            if (!this.isFinished) {
+                console.error(err);
+                this.abortController.abort();
+                this.isStopped = true;
+                this.isFinished = true;
+            }
+            return this.result;
+        }
+
+        this.isFinished = true;
+        return this.result;
     }
 
     async generate() {
@@ -7318,10 +7415,13 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
                     activeStreamingProcessor.firstMessageText = '';
                 }
 
+                const shouldBufferOutput = await shouldBufferMainGenerationOutput({ type, isStreaming: true });
                 activeStreamingProcessor.generator = await sendStreamingRequest(type, generate_data, { jsonSchema, cacheScope: generate_data.cacheScope });
 
                 hideSwipeButtons();
-                let getMessage = await activeStreamingProcessor.generate();
+                let getMessage = shouldBufferOutput
+                    ? await activeStreamingProcessor.generateBuffered()
+                    : await activeStreamingProcessor.generate();
                 let messageChunk = cleanUpMessage({
                     getMessage: getMessage,
                     isImpersonate: isImpersonate,
@@ -7339,11 +7439,11 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
                 const isStreamFinished = !isStreamCancelled && activeStreamingProcessor.isFinished;
                 const isStreamWithToolCalls = Array.isArray(activeStreamingProcessor.toolCalls) && activeStreamingProcessor.toolCalls.length;
                 if (canPerformToolCalls && isStreamFinished && isStreamWithToolCalls) {
-                    const lastMessage = chat[chat.length - 1];
                     const hasToolCalls = ToolManager.hasToolCalls(activeStreamingProcessor.toolCalls);
-                    const shouldDeleteMessage = type !== 'swipe' && ['', '...'].includes(lastMessage?.mes) && !lastMessage?.extra?.reasoning && ['', '...'].includes(activeStreamingProcessor.result);
+                    const lastMessage = chat[chat.length - 1];
+                    const shouldDeleteMessage = !shouldBufferOutput && type !== 'swipe' && ['', '...'].includes(lastMessage?.mes) && !lastMessage?.extra?.reasoning && ['', '...'].includes(activeStreamingProcessor.result);
                     hasToolCalls && shouldDeleteMessage && await deleteLastMessage();
-                    if (hasToolCalls && !shouldDeleteMessage) {
+                    if (!shouldBufferOutput && hasToolCalls && !shouldDeleteMessage) {
                         await activeStreamingProcessor.finalizeIntermediaryMessage(activeStreamingProcessor.messageId, getMessage, { unlockUI: false });
                     }
                     const invocationResult = await ToolManager.invokeFunctionTools(activeStreamingProcessor.toolCalls, {
@@ -7369,6 +7469,55 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
                 }
 
                 if (isStreamFinished) {
+                    if (shouldBufferOutput) {
+                        const interceptResult = await applyMainGenerationOutputInterceptors({
+                            type,
+                            text: getMessage,
+                            isStreaming: true,
+                        });
+
+                        if (interceptResult.cancelled || activeStreamingProcessor.abortController.signal.aborted) {
+                            unblockGeneration(type, { emitGenerationEnded: false });
+                            clearStreamingProcessorIfCurrent(activeStreamingProcessor);
+                            return;
+                        }
+
+                        getMessage = interceptResult.text;
+                        messageChunk = cleanUpMessage({
+                            getMessage: getMessage,
+                            isImpersonate: isImpersonate,
+                            isContinue: isContinue,
+                            displayIncompleteSentences: false,
+                        });
+
+                        const saveReplyType = originalType !== 'continue' ? type : 'appendFinal';
+                        ({ type, getMessage } = await saveReply({
+                            type: saveReplyType,
+                            getMessage,
+                            swipes: activeStreamingProcessor.swipes,
+                            reasoning: activeStreamingProcessor.reasoningHandler.reasoning,
+                            imageUrls: activeStreamingProcessor.images,
+                            reasoningSignature: activeStreamingProcessor.reasoningSignature,
+                            reasoningTokens: activeStreamingProcessor.reasoningTokens,
+                        }));
+                        saveLogprobsForActiveMessage(activeStreamingProcessor.messageLogprobs.filter(Boolean), continue_mag);
+                        unblockGeneration(type);
+                        clearStreamingProcessorIfCurrent(activeStreamingProcessor);
+
+                        const isAborted = activeStreamingProcessor.abortController.signal.aborted;
+                        if (!isAborted && power_user.auto_swipe && generatedTextFiltered(getMessage)) {
+                            return await swipe(null, SWIPE_DIRECTION.RIGHT, { source: SWIPE_SOURCE.AUTO_SWIPE, repeated: true, forceMesId: chat.length - 1 });
+                        }
+
+                        await saveChatConditional();
+                        playMessageSound();
+                        triggerAutoContinue(messageChunk, isImpersonate);
+                        return Object.defineProperties(new String(getMessage), {
+                            'messageChunk': { value: messageChunk },
+                            'fromStream': { value: true },
+                        });
+                    }
+
                     await activeStreamingProcessor.onFinishStreaming(activeStreamingProcessor.messageId, getMessage);
                     clearStreamingProcessorIfCurrent(activeStreamingProcessor);
                     triggerAutoContinue(messageChunk, isImpersonate);
@@ -7460,6 +7609,26 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             isImpersonate: isImpersonate,
             isContinue: isContinue,
             displayIncompleteSentences: displayIncomplete,
+        });
+
+        const interceptResult = await applyMainGenerationOutputInterceptors({
+            type,
+            text: getMessage,
+            isStreaming: false,
+        });
+
+        if (interceptResult.cancelled || (abortController && abortController.signal.aborted)) {
+            unblockGeneration(type, { emitGenerationEnded: false });
+            streamingProcessor = null;
+            return;
+        }
+
+        getMessage = interceptResult.text;
+        messageChunk = cleanUpMessage({
+            getMessage: getMessage,
+            isImpersonate: isImpersonate,
+            isContinue: isContinue,
+            displayIncompleteSentences: false,
         });
 
         if (isImpersonate) {

--- a/public/scripts/events.js
+++ b/public/scripts/events.js
@@ -55,6 +55,8 @@ export const event_types = {
     GROUP_CHAT_CREATED: 'group_chat_created',
     GENERATE_BEFORE_COMBINE_PROMPTS: 'generate_before_combine_prompts',
     GENERATE_AFTER_COMBINE_PROMPTS: 'generate_after_combine_prompts',
+    GENERATION_OUTPUT_BUFFERING_DECISION: 'generation_output_buffering_decision',
+    MAIN_GENERATION_OUTPUT_READY: 'main_generation_output_ready',
     GENERATE_AFTER_DATA: 'generate_after_data',
     GROUP_MEMBER_DRAFTED: 'group_member_drafted',
     GROUP_WRAPPER_STARTED: 'group_wrapper_started',

--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -76,6 +76,8 @@ const DEFERRED_POST_PROCESSING_RETRY_MS = 50;
 const LATEST_ASSISTANT_POST_PROCESSING_FALLBACK_WINDOW_MS = 30000;
 const MISSED_GENERATION_END_RECOVERY_MS = 200;
 const PATHFINDER_SUMMARIZE_TOOL_NAME = 'Pathfinder_Summarize';
+const PRE_GENERATION_INTERCEPT_TIMING = 'pre-generation';
+const POST_MAIN_GENERATION_INTERCEPT_TIMING = 'post-main-generation';
 
 /** @type {{ generationType: string, activeAgentIds: string[], chatId: string } | null} */
 let pendingGenerationSnapshot = null;
@@ -1771,6 +1773,17 @@ function getPreGenerationInterceptAgents(activeAgents) {
         !isToolAgent(agent) &&
         (agent.phase === 'pre' || agent.phase === 'both') &&
         agent.preProcess?.mode === 'intercept' &&
+        agent.preProcess?.interceptTiming !== POST_MAIN_GENERATION_INTERCEPT_TIMING &&
+        String(agent.prompt ?? '').trim(),
+    ).sort((a, b) => Number(a?.injection?.order ?? 100) - Number(b?.injection?.order ?? 100));
+}
+
+function getPostMainGenerationInterceptAgents(activeAgents) {
+    return activeAgents.filter(agent =>
+        !isToolAgent(agent) &&
+        (agent.phase === 'pre' || agent.phase === 'both') &&
+        agent.preProcess?.mode === 'intercept' &&
+        agent.preProcess?.interceptTiming === POST_MAIN_GENERATION_INTERCEPT_TIMING &&
         String(agent.prompt ?? '').trim(),
     ).sort((a, b) => Number(a?.injection?.order ?? 100) - Number(b?.injection?.order ?? 100));
 }
@@ -1843,13 +1856,17 @@ function showPromptTransformRunningToast(agent, mode, profileId = '', options = 
     const targetLabel = describePromptTransformTarget(profileId, profileId ? 'profile' : 'main');
     const metadata = getPromptTransformRunMetadata(agent, profileId);
     const cancelButtonClass = 'ica--toast-cancel-agent';
-    const kind = options?.kind === 'preIntercept' ? 'preIntercept' : 'postGen';
+    const kind = ['preIntercept', 'postMainIntercept'].includes(String(options?.kind))
+        ? String(options.kind)
+        : 'postGen';
     const applyMode = ['wrap', 'patch'].includes(String(options?.applyMode))
         ? String(options.applyMode)
         : 'replace';
     const runningLabel = kind === 'preIntercept'
         ? `Running pre-generation ${applyMode} intercept...`
-        : `Running ${modeLabel} via ${targetLabel}...`;
+        : kind === 'postMainIntercept'
+            ? `Running post-main ${applyMode} intercept...`
+            : `Running ${modeLabel} via ${targetLabel}...`;
     const messageHtml = `
         <div>${escapeToastHtml(runningLabel)}</div>
         <div>${escapeToastHtml(`Order ${metadata.order} | Model: ${metadata.modelLabel}`)}</div>
@@ -2254,7 +2271,20 @@ function buildPromptTransformMessages(agentPrompt, messageText, assistantName, g
     ];
 }
 
-function buildContextInterceptMessages(agentPrompt, contextText, generationType, contextFormat) {
+function buildContextInterceptMessages(agentPrompt, contextText, generationType, contextFormat, timing = PRE_GENERATION_INTERCEPT_TIMING) {
+    if (timing === POST_MAIN_GENERATION_INTERCEPT_TIMING) {
+        return [
+            {
+                role: 'system',
+                content: `${agentPrompt}\n\nYou are modifying the assistant response after the main model generated it, before it is shown or saved. Return only the final assistant response requested by the instructions above. Do not add commentary, labels, or code fences unless they are part of the response itself. If no changes are needed, return the original response verbatim.`,
+            },
+            {
+                role: 'user',
+                content: `Generation type: ${generationType}\n\nMain model output:\n<assistant_response>\n${contextText}\n</assistant_response>`,
+            },
+        ];
+    }
+
     const formatLabel = contextFormat === 'chat' ? 'JSON array of chat-completion messages' : 'plain text completion prompt';
 
     return [
@@ -2344,6 +2374,9 @@ function sanitizePreGenerationInterceptRunForStorage(result) {
         agentId: result.agentId,
         agentName: result.agentName,
         applyMode: result.applyMode,
+        timing: result.timing === POST_MAIN_GENERATION_INTERCEPT_TIMING
+            ? POST_MAIN_GENERATION_INTERCEPT_TIMING
+            : PRE_GENERATION_INTERCEPT_TIMING,
         contextFormat: result.contextFormat,
         status: result.status,
         changed: Boolean(result.changed),
@@ -3510,7 +3543,10 @@ async function runPromptTransformAgentsForText(promptTransformAgents, initialTex
     };
 }
 
-async function runContextInterceptAgent(agent, currentContextText, generationType, contextFormat) {
+async function runContextInterceptAgent(agent, currentContextText, generationType, contextFormat, options = {}) {
+    const timing = options.timing === POST_MAIN_GENERATION_INTERCEPT_TIMING
+        ? POST_MAIN_GENERATION_INTERCEPT_TIMING
+        : PRE_GENERATION_INTERCEPT_TIMING;
     const beforeText = normalizeContentText(currentContextText);
     const applyMode = ['wrap', 'patch'].includes(String(agent?.preProcess?.applyMode))
         ? String(agent.preProcess.applyMode)
@@ -3520,6 +3556,7 @@ async function runContextInterceptAgent(agent, currentContextText, generationTyp
         agentId: agent.id,
         agentName: agent.name,
         applyMode,
+        timing,
         contextFormat,
         changed: false,
         beforeText,
@@ -3541,10 +3578,13 @@ async function runContextInterceptAgent(agent, currentContextText, generationTyp
         };
     }
 
-    const promptMessages = buildContextInterceptMessages(expandedPrompt, currentContextText, generationType, contextFormat);
+    const promptMessages = buildContextInterceptMessages(expandedPrompt, currentContextText, generationType, contextFormat, timing);
     const cancelRevision = agentGenerationCancelRevision;
     const runningToast = shouldShowPreInterceptNotifications(agent)
-        ? showPromptTransformRunningToast(agent, applyMode, profileId, { kind: 'preIntercept', applyMode })
+        ? showPromptTransformRunningToast(agent, applyMode, profileId, {
+            kind: timing === POST_MAIN_GENERATION_INTERCEPT_TIMING ? 'postMainIntercept' : 'preIntercept',
+            applyMode,
+        })
         : null;
 
     try {
@@ -3641,6 +3681,7 @@ async function runPreGenerationInterceptorsOnText(initialContextText, generation
                 agentId: agent.id,
                 agentName: agent.name,
                 applyMode: ['wrap', 'patch'].includes(String(agent?.preProcess?.applyMode)) ? String(agent.preProcess.applyMode) : 'replace',
+                timing: PRE_GENERATION_INTERCEPT_TIMING,
                 contextFormat,
                 changed: false,
                 status: 'error',
@@ -3752,6 +3793,7 @@ async function runPreGenerationInterceptorsOnChat(initialChatMessages, generatio
                 agentId: agent.id,
                 agentName: agent.name,
                 applyMode: ['wrap', 'patch'].includes(String(agent?.preProcess?.applyMode)) ? String(agent.preProcess.applyMode) : 'replace',
+                timing: PRE_GENERATION_INTERCEPT_TIMING,
                 contextFormat: 'chat',
                 changed: false,
                 status: 'error',
@@ -3767,6 +3809,93 @@ async function runPreGenerationInterceptorsOnChat(initialChatMessages, generatio
     }
 
     return { chat: currentChatMessages, runs };
+}
+
+async function runPostMainGenerationInterceptorsOnText(initialOutputText, generationType) {
+    if (internalPromptTransformDepth > 0 || !areAgentsGloballyEnabled()) {
+        return { text: initialOutputText, runs: [], cancelled: false };
+    }
+
+    let currentOutputText = String(initialOutputText ?? '');
+    if (!currentOutputText.trim()) {
+        return { text: currentOutputText, runs: [], cancelled: false };
+    }
+
+    if (generationStopRequested) {
+        return { text: currentOutputText, runs: [], cancelled: true };
+    }
+
+    const activationSnapshot = getGenerationContextSnapshot(generationType);
+    const interceptAgents = getPostMainGenerationInterceptAgents(getSnapshotAgents(activationSnapshot));
+    if (interceptAgents.length === 0) {
+        return { text: currentOutputText, runs: [], cancelled: false };
+    }
+
+    const runs = [];
+    for (const agent of interceptAgents) {
+        if (generationStopRequested) {
+            return { text: currentOutputText, runs, cancelled: true };
+        }
+
+        try {
+            const result = await runContextInterceptAgent(
+                agent,
+                currentOutputText,
+                activationSnapshot.generationType,
+                'text',
+                { timing: POST_MAIN_GENERATION_INTERCEPT_TIMING },
+            );
+
+            if (generationStopRequested || result.status === 'cancelled') {
+                runs.push({ ...result, status: 'cancelled', changed: false, afterText: currentOutputText });
+                return { text: currentOutputText, runs, cancelled: true };
+            }
+
+            if (result.status !== 'changed') {
+                runs.push(result);
+                continue;
+            }
+
+            currentOutputText = applyContextInterceptText(currentOutputText, result.outputText, agent.preProcess);
+            result.afterText = currentOutputText;
+            result.changed = result.afterText !== result.beforeText;
+            result.status = result.changed ? 'changed' : 'unchanged';
+            runs.push(result);
+        } catch (error) {
+            console.warn(`[InChatAgents] Post-main intercept agent "${agent.name}" failed. Leaving generated output unchanged for this agent.`, error);
+            runs.push({
+                agentId: agent.id,
+                agentName: agent.name,
+                applyMode: ['wrap', 'patch'].includes(String(agent?.preProcess?.applyMode)) ? String(agent.preProcess.applyMode) : 'replace',
+                timing: POST_MAIN_GENERATION_INTERCEPT_TIMING,
+                contextFormat: 'text',
+                changed: false,
+                status: 'error',
+                error: error instanceof Error ? error.message : String(error),
+                beforeText: currentOutputText,
+                afterText: currentOutputText,
+                outputText: '',
+                profileId: '',
+                runner: 'error',
+                timestamp: new Date().toISOString(),
+            });
+
+            if (generationStopRequested) {
+                return { text: currentOutputText, runs, cancelled: true };
+            }
+        }
+    }
+
+    return { text: currentOutputText, runs, cancelled: false };
+}
+
+function hasPostMainGenerationInterceptors(generationType) {
+    if (internalPromptTransformDepth > 0 || !areAgentsGloballyEnabled()) {
+        return false;
+    }
+
+    const activationSnapshot = getGenerationContextSnapshot(generationType);
+    return getPostMainGenerationInterceptAgents(getSnapshotAgents(activationSnapshot)).length > 0;
 }
 
 async function onGenerateAfterCombinePrompts(eventData) {
@@ -3806,6 +3935,42 @@ async function onChatCompletionPromptReady(eventData) {
 
     originalChat.splice(0, originalChat.length, ...nextChat);
     eventData.chat = originalChat;
+}
+
+async function onGenerationOutputBufferingDecision(eventData) {
+    if (!eventData || eventData.dryRun || internalPromptTransformDepth > 0 || !isGenerationInProgress) {
+        return;
+    }
+
+    if (hasPostMainGenerationInterceptors(eventData.type ?? currentMainGenerationType)) {
+        eventData.hasPostMainInterceptors = true;
+    }
+}
+
+async function onMainGenerationOutputReady(eventData) {
+    if (!eventData || eventData.dryRun || internalPromptTransformDepth > 0) {
+        return;
+    }
+
+    if (generationStopRequested) {
+        eventData.cancelled = true;
+        return;
+    }
+
+    if (!isGenerationInProgress || typeof eventData.text !== 'string') {
+        return;
+    }
+
+    const generationType = eventData.type ?? currentMainGenerationType;
+    const result = await runPostMainGenerationInterceptorsOnText(eventData.text, generationType);
+    pendingPreGenerationInterceptRuns.push(...result.runs);
+
+    if (result.cancelled || generationStopRequested) {
+        eventData.cancelled = true;
+        return;
+    }
+
+    eventData.text = result.text;
 }
 
 async function onImpersonateReady(text = '') {
@@ -4047,6 +4212,14 @@ export function initAgentRunner() {
 
     if (event_types.CHAT_COMPLETION_PROMPT_READY) {
         eventSource.on(event_types.CHAT_COMPLETION_PROMPT_READY, onChatCompletionPromptReady);
+    }
+
+    if (event_types.GENERATION_OUTPUT_BUFFERING_DECISION) {
+        eventSource.on(event_types.GENERATION_OUTPUT_BUFFERING_DECISION, onGenerationOutputBufferingDecision);
+    }
+
+    if (event_types.MAIN_GENERATION_OUTPUT_READY) {
+        eventSource.on(event_types.MAIN_GENERATION_OUTPUT_READY, onMainGenerationOutputReady);
     }
 
     if (event_types.WORLDINFO_ENTRIES_LOADED) {

--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -115,6 +115,7 @@ let postProcessingGenerationRunId = 0;
 let swipeNavigationPending = false;
 const activePathfinderRetrievalAbortControllers = new Set();
 let activePathfinderRetrievalToast = null;
+let activeInitialGenerationToast = null;
 
 /** Track which tool names were registered by the agent system so we can cleanly unregister only our own. */
 const agentRegisteredToolNames = new Set();
@@ -213,6 +214,7 @@ export function cancelAgentGeneration() {
     clearDeferredPostProcessing();
     clearMissedGenerationEndRecoveryCheck();
     clearAllPromptTransformRunningToasts();
+    clearInitialGenerationToast();
     clearPathfinderRetrievalToast();
     abortActivePathfinderRetrieval('Pathfinder retrieval cancelled by user.');
 
@@ -253,6 +255,23 @@ function clearPathfinderRetrievalToast() {
 
     toastr.clear(activePathfinderRetrievalToast);
     activePathfinderRetrievalToast = null;
+}
+
+function showInitialGenerationToast() {
+    if (activeInitialGenerationToast) {
+        return;
+    }
+
+    activeInitialGenerationToast = toastr.info('Generating initial message', 'In-Chat Agents', { timeOut: 0, extendedTimeOut: 0 });
+}
+
+function clearInitialGenerationToast() {
+    if (!activeInitialGenerationToast) {
+        return;
+    }
+
+    toastr.clear(activeInitialGenerationToast);
+    activeInitialGenerationToast = null;
 }
 
 function shouldShowPathfinderRetrievalToast(pathfinderAgent) {
@@ -1294,6 +1313,7 @@ function recoverMissedGenerationEnd(reason = 'fallback') {
     toolSyncDuringGeneration = false;
     generationStopRequested = false;
     clearMissedGenerationEndRecoveryCheck();
+    clearInitialGenerationToast();
     queueLatestAssistantPostProcessingFromSnapshot();
     scheduleDeferredPostProcessingFlush();
     schedulePostGenerationRecoveryCheck();
@@ -2999,6 +3019,7 @@ function onGenerationStarted(generationType, _options, dryRun) {
     clearPostGenerationRecoveryCheck();
     clearMissedGenerationEndRecoveryCheck();
     clearAllPromptTransformRunningToasts();
+    clearInitialGenerationToast();
     takePendingPreGenerationInterceptRuns();
     pendingGenerationSnapshot = buildActivationSnapshot(currentMainGenerationType);
     generationStartChatLength = chat.length;
@@ -3023,6 +3044,8 @@ function onGenerationEnded() {
     if (internalPromptTransformDepth > 0) {
         return;
     }
+
+    clearInitialGenerationToast();
 
     if (stoppedGenerationRunId === postProcessingGenerationRunId) {
         isGenerationInProgress = false;
@@ -3077,6 +3100,7 @@ function onGenerationStopped() {
     clearDeferredPostProcessing();
     clearAllPromptTransformRunningToasts();
     clearPathfinderRetrievalToast();
+    clearInitialGenerationToast();
     takePendingPreGenerationInterceptRuns();
     abortActivePathfinderRetrieval('Pathfinder retrieval cancelled because generation stopped.');
 }
@@ -3889,13 +3913,13 @@ async function runPostMainGenerationInterceptorsOnText(initialOutputText, genera
     return { text: currentOutputText, runs, cancelled: false };
 }
 
-function hasPostMainGenerationInterceptors(generationType) {
+function getPostMainGenerationInterceptorsForGeneration(generationType) {
     if (internalPromptTransformDepth > 0 || !areAgentsGloballyEnabled()) {
-        return false;
+        return [];
     }
 
     const activationSnapshot = getGenerationContextSnapshot(generationType);
-    return getPostMainGenerationInterceptAgents(getSnapshotAgents(activationSnapshot)).length > 0;
+    return getPostMainGenerationInterceptAgents(getSnapshotAgents(activationSnapshot));
 }
 
 async function onGenerateAfterCombinePrompts(eventData) {
@@ -3942,8 +3966,12 @@ async function onGenerationOutputBufferingDecision(eventData) {
         return;
     }
 
-    if (hasPostMainGenerationInterceptors(eventData.type ?? currentMainGenerationType)) {
+    const interceptAgents = getPostMainGenerationInterceptorsForGeneration(eventData.type ?? currentMainGenerationType);
+    if (interceptAgents.length > 0) {
         eventData.hasPostMainInterceptors = true;
+        if (interceptAgents.some(shouldShowPreInterceptNotifications)) {
+            showInitialGenerationToast();
+        }
     }
 }
 
@@ -3951,6 +3979,8 @@ async function onMainGenerationOutputReady(eventData) {
     if (!eventData || eventData.dryRun || internalPromptTransformDepth > 0) {
         return;
     }
+
+    clearInitialGenerationToast();
 
     if (generationStopRequested) {
         eventData.cancelled = true;

--- a/public/scripts/extensions/in-chat-agents/agent-store.js
+++ b/public/scripts/extensions/in-chat-agents/agent-store.js
@@ -19,6 +19,7 @@ import {
 /**
  * @typedef {object} AgentPreProcess
  * @property {'inject'|'intercept'} mode - Inject is the existing setExtensionPrompt flow; intercept rewrites the assembled outgoing context.
+ * @property {'pre-generation'|'post-main-generation'} interceptTiming - When intercept mode runs.
  * @property {'replace'|'wrap'|'patch'} applyMode
  * @property {'before'|'after'} wrapPosition
  * @property {string} wrapPrefix
@@ -792,6 +793,7 @@ export function createDefaultAgent() {
         },
         preProcess: {
             mode: 'inject',
+            interceptTiming: 'pre-generation',
             applyMode: 'replace',
             wrapPosition: 'after',
             wrapPrefix: '',
@@ -890,6 +892,9 @@ export function normalizeAgent(rawAgent = {}) {
             mode: ['inject', 'intercept'].includes(String(rawPreProcess.mode))
                 ? String(rawPreProcess.mode)
                 : defaults.preProcess.mode,
+            interceptTiming: ['pre-generation', 'post-main-generation'].includes(String(rawPreProcess.interceptTiming))
+                ? String(rawPreProcess.interceptTiming)
+                : defaults.preProcess.interceptTiming,
             applyMode: ['replace', 'wrap', 'patch'].includes(String(rawPreProcess.applyMode))
                 ? String(rawPreProcess.applyMode)
                 : defaults.preProcess.applyMode,

--- a/public/scripts/extensions/in-chat-agents/editor.html
+++ b/public/scripts/extensions/in-chat-agents/editor.html
@@ -104,6 +104,14 @@
             </label>
         </div>
         <div id="ica--pre-intercept-options" style="display:none">
+            <div class="ica--editor-row">
+                <label>Timing
+                    <select id="ica--editor-pre-interceptTiming" class="text_pole">
+                        <option value="pre-generation">Pre-generation</option>
+                        <option value="post-main-generation">Post-main generation</option>
+                    </select>
+                </label>
+            </div>
             <div class="ica--editor-row flex-container flexGap5">
                 <label class="flex1">Apply Mode
                     <select id="ica--editor-pre-applyMode" class="text_pole">
@@ -146,7 +154,7 @@
                     </label>
                 </div>
             </div>
-            <div class="ica--regex-note">Intercept mode runs this agent before the main model receives the assembled context. Agents run by Order. Replace mode expects a full replacement context; for chat completion that must be a JSON array of chat messages. Wrap and patch add a new message on chat-completion APIs using the Role below.</div>
+            <div class="ica--regex-note">Pre-generation timing runs before the main model receives the assembled context. Post-main timing runs after the main model finishes and before the response is shown or saved. Agents run by Order. Replace mode expects a full replacement context in pre-generation timing; for chat completion that must be a JSON array of chat messages. Wrap and patch add a new message on chat-completion APIs using the Role below.</div>
         </div>
         <div class="ica--regex-note" id="ica--pre-injection-note">Inject mode uses the existing extension prompt path. Position, Depth, Role, and World Info scanning control where the prompt is inserted.</div>
         <div class="ica--editor-row flex-container flexGap5">

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -144,6 +144,7 @@ const AGENT_PHASE_LABELS = {
 };
 const DEFAULT_PRE_PROCESS = {
     mode: 'inject',
+    interceptTiming: 'pre-generation',
     applyMode: 'replace',
     wrapPosition: 'after',
     wrapPrefix: '',
@@ -508,6 +509,13 @@ function isPreGenerationInterceptAgent(agent) {
     );
 }
 
+function isPostMainGenerationInterceptAgent(agent) {
+    return Boolean(
+        isPreGenerationInterceptAgent(agent) &&
+        getAgentPreProcess(agent).interceptTiming === 'post-main-generation',
+    );
+}
+
 function canPreviewPreGenerationPrompt(agent) {
     return Boolean(
         !isPathfinderAgent(agent) &&
@@ -531,7 +539,9 @@ async function previewPreGenerationPrompt(agent, promptOverride = null) {
         dynamicMacros: buildPromptDynamicMacros('', null, agent, 'normal'),
     });
     const previewNote = isPreGenerationInterceptAgent(agent)
-        ? 'Preview shows the agent instruction after macro substitution. At runtime, intercept mode also receives the assembled outgoing context and can rewrite it before the main model sees it.'
+        ? isPostMainGenerationInterceptAgent(agent)
+            ? 'Preview shows the agent instruction after macro substitution. At runtime, post-main intercept mode also receives the fresh assistant output and can rewrite it before it is shown or saved.'
+            : 'Preview shows the agent instruction after macro substitution. At runtime, intercept mode also receives the assembled outgoing context and can rewrite it before the main model sees it.'
         : 'Preview uses the current chat context with no generated assistant message yet. Random macros are evaluated now and may differ when the agent runs.';
     const previewHtml = $(
         `<div class="ica--prompt-preview">
@@ -1618,6 +1628,7 @@ function renderAgentList() {
             const promptTransformEnabled = hasPromptTransform(agent);
             const promptTransformLabel = getPromptTransformLabel(agent);
             const preInterceptEnabled = isPreGenerationInterceptAgent(agent);
+            const preInterceptLabel = isPostMainGenerationInterceptAgent(agent) ? 'post-main intercept' : 'pre intercept';
             const previewPromptButton = canPreviewPreGenerationPrompt(agent)
                 ? `<button type="button" class="ica--card-btn ica--btn-preview-prompt" title="Preview this pre-generation prompt after macro substitution" aria-label="${preInterceptEnabled ? 'Preview Instruction' : 'Preview Prompt'}"><i class="fa-solid fa-eye"></i></button>`
                 : '';
@@ -1646,7 +1657,7 @@ function renderAgentList() {
                     <div class="ica--card-desc">${escapeHtml(desc)}</div>
                     <div class="ica--card-meta">
                         ${agent.conditions.triggerProbability < 100 ? `<span class="ica--card-pill"><i class="fa-solid fa-dice fa-xs"></i> ${agent.conditions.triggerProbability}%</span>` : ''}
-                        ${preInterceptEnabled ? '<span class="ica--card-pill"><i class="fa-solid fa-shuffle fa-xs"></i> pre intercept</span>' : ''}
+                        ${preInterceptEnabled ? `<span class="ica--card-pill"><i class="fa-solid fa-shuffle fa-xs"></i> ${preInterceptLabel}</span>` : ''}
                         ${!preInterceptEnabled && agent.injection.position === 1 ? `<span class="ica--card-pill">depth ${agent.injection.depth}</span>` : ''}
                         ${promptTransformEnabled ? `<span class="ica--card-pill"><i class="fa-solid fa-robot fa-xs"></i> ${promptTransformLabel}</span>` : ''}
                         ${regexCount > 0 ? `<span class="ica--card-pill"><i class="fa-solid fa-wand-magic-sparkles fa-xs"></i> ${regexCount} regex</span>` : ''}
@@ -1928,6 +1939,7 @@ async function openEditor(agentId = null) {
     editorEl.find('#ica--editor-scan').prop('checked', agent.injection.scan);
     const preProcess = getAgentPreProcess(agent);
     editorEl.find('#ica--editor-pre-mode').val(preProcess.mode);
+    editorEl.find('#ica--editor-pre-interceptTiming').val(preProcess.interceptTiming);
     editorEl.find('#ica--editor-pre-applyMode').val(preProcess.applyMode);
     editorEl.find('#ica--editor-pre-wrapPosition').val(preProcess.wrapPosition);
     editorEl.find('#ica--editor-pre-wrapPrefix').val(preProcess.wrapPrefix);
@@ -2200,6 +2212,9 @@ async function openEditor(agentId = null) {
             preProcess: {
                 ...getAgentPreProcess(agent),
                 mode: editorEl.find('#ica--editor-pre-mode').val()?.toString() || 'inject',
+                interceptTiming: editorEl.find('#ica--editor-pre-interceptTiming').val()?.toString() === 'post-main-generation'
+                    ? 'post-main-generation'
+                    : 'pre-generation',
             },
         };
         await previewPreGenerationPrompt(previewAgent, editorEl.find('#ica--editor-prompt').val()?.toString() || '');
@@ -2235,6 +2250,9 @@ async function openEditor(agentId = null) {
     agent.preProcess = {
         ...getAgentPreProcess(agent),
         mode: editorEl.find('#ica--editor-pre-mode').val()?.toString() === 'intercept' ? 'intercept' : 'inject',
+        interceptTiming: editorEl.find('#ica--editor-pre-interceptTiming').val()?.toString() === 'post-main-generation'
+            ? 'post-main-generation'
+            : 'pre-generation',
         applyMode: ['replace', 'wrap', 'patch'].includes(editorEl.find('#ica--editor-pre-applyMode').val()?.toString())
             ? editorEl.find('#ica--editor-pre-applyMode').val().toString()
             : 'replace',
@@ -3024,13 +3042,14 @@ function buildPromptTransformDiffMarkup(beforeText, afterText) {
 
 function getPreGenerationInterceptModeLabel(entry) {
     const mode = String(entry?.applyMode ?? 'replace');
+    const timing = entry?.timing === 'post-main-generation' ? 'post-main' : 'pre-gen';
     if (mode === 'wrap') {
-        return 'wrap';
+        return `${timing} wrap`;
     }
     if (mode === 'patch') {
-        return 'patch';
+        return `${timing} patch`;
     }
-    return 'replace';
+    return `${timing} replace`;
 }
 
 function parseChatInterceptSummaryMessages(value) {
@@ -3242,7 +3261,7 @@ function buildPreGenerationInterceptEntryMarkup(entry, i) {
 
     return `
         <div class="ica-transform-history-entry ica-preintercept-history-entry" data-index="${i}">
-            <h5>${escapeHtml(entry.agentName || 'Agent')} <small>(pre-gen ${escapeHtml(modeLabel)})</small></h5>
+            <h5>${escapeHtml(entry.agentName || 'Agent')} <small>(${escapeHtml(modeLabel)})</small></h5>
             <small>${escapeHtml(timestamp)}${timestamp ? ' · ' : ''}${escapeHtml(statusText)}</small>
             ${buildPreGenerationInterceptSummaryMarkup(entry)}
             <details class="ica-preintercept-raw">
@@ -3284,7 +3303,7 @@ async function openPromptTransformHistoryPopup(messageIndex) {
     }).join('');
 
     const html = $(`<div class="ica-transform-history">
-        ${preGenerationEntries ? `<section class="ica-transform-history-section"><h4>Pre-Generation Intercepts</h4>${preGenerationEntries}</section>` : ''}
+        ${preGenerationEntries ? `<section class="ica-transform-history-section"><h4>Generation Intercepts</h4>${preGenerationEntries}</section>` : ''}
         ${postGenerationEntries ? `<section class="ica-transform-history-section"><h4>Post-Generation Changes</h4>${postGenerationEntries}</section>` : ''}
     </div>`);
 

--- a/public/scripts/extensions/in-chat-agents/templates/grounded-prose.json
+++ b/public/scripts/extensions/in-chat-agents/templates/grounded-prose.json
@@ -3,15 +3,16 @@
     "name": "Grounded Prose",
     "description": "Anti-slop rules: avoid purple prose, cliches, and AI writing tics",
     "icon": "",
-    "category": "custom",
+    "category": "content",
+    "subcategory": "prose-quality",
     "tags": [
         "anti-slop",
         "quality",
         "prose"
     ],
-    "version": 1,
+    "version": 2,
     "author": "Purachina",
-    "prompt": "### Grounded Prose Rules\n- Each beat must alter pressure, leverage, focus, relation, or access.\n- Sensory detail only where it has material relevance to the scene.\n- Replace abstraction and statistical phrasing with observable detail.\n- Sparse dialogue tags when speaker and tone are already legible. After dialogue, move through action, reaction, or a new beat.\n- Default to contractions in dialogue; preserve character-appropriate formality.\n- Fresh, concrete phrasing. Render emphasis through behavior, timing, syntax, and consequence.\n- State what something is, does, or changes. Direct positive construction.\n- Similes rare, exact, and materially specific.\n- Replace every banned construction below with something narratively consistent:\n\n**Banned constructions:** \"not X,\" \"not X but Y,\" \"not quite X,\" synthetic negative parallelisms, flat-affect comparisons to weather or groceries, \"and yet,\" \"a beat,\" \"say that again,\" \"somewhere, X...,\" \"they don't X,\" \"that does it,\" \"that lands,\" \"that lands X,\" \"not a question,\" \"not really a question,\" \"not quite a question,\" \"statement than question,\" \"really looks at,\" \"like a physical blow,\" \"like a stone into still water,\" \"blood rushing,\" \"a sound between X and Y,\" \"dust motes,\" \"predator and prey\" constructions\n\n**Banned tics:** jaw-clenching, jaw-tightening, mouth open-close cycling, breath-catching, knuckle-whitening, knuckles turning pale, cheeks burning\n\n**Banned scents:** ozone, sandalwood, cedar, cardamom\n\n**Banned nicknames:** gremlin, goblin\n\n- If introducing a new unnamed character this turn, their name must start with: {{random::A::B::C::D::E::F::G::H::I::J::K::L::M::N::O::P::R::S::T::V::W::Y}} and/or {{random::A::B::C::D::E::F::G::H::I::J::K::L::M::N::O::P::R::S::T::V::W::Y}}. Create new NPCs sparingly.",
+    "prompt": "### Grounded Prose Rules\n- Each beat must alter pressure, leverage, focus, relation, or access.\n- Write sensory detail only where materially relevant. Focus on visuals and personalities of environment. Messiness or items strewn about are more informative than smells.\n- Scents allowed aside from banned ones.\n- Echoing and parroting any dialogue from any characters is forbidden.\n- Instead of stating what a character doesn't do, just say what they're currently doing. The implication is already in the active action.\n- Replace abstraction and statistical phrasing with observable detail.\n- Sparse dialogue tags when speaker and tone are already legible. After dialogue, move through action, reaction, or a new beat.\n- Default to contractions in dialogue; preserve character-appropriate formality.\n- Fresh, concrete phrasing. Render emphasis through behavior, timing, syntax, and consequence.\n- Similes rare, exact, and materially specific.\n- Replace every banned construction below with something narratively consistent, or skip it entirely:\n\n**Banned constructions:** \"not X,\" \"not X but Y,\" \"not quite X,\" synthetic negative parallelisms, flat-affect comparisons to weather or groceries, \"say that again,\" \"somewhere, X...,\" \"they don't X,\" \"that does it,\" \"that lands,\" \"that lands X,\" \"not a question,\" \"not really a question,\" \"not quite a question,\" \"statement than question,\" \"really looks at,\" \"like a physical blow,\" \"like a stone into still water,\" \"blood rushing,\" \"a sound between X and Y,\" \"dust motes,\" \"predator and prey\" constructions, \"doesn't just X, but Y\", \"doesn't X; Y\"\n\n**Banned tics:** jaw-clenching, jaw-tightening, jaw-shifting, mouth open-close cycling, breath-catching, knuckle-whitening, knuckles turning pale, cheeks burning, specific word repetition. Replace with character-specific quirks, gestures, movements, muttering.\n\n**Banned scents:** ozone, sandalwood, cedar, cardamom\n\n**Banned nicknames:** gremlin, goblin\n\n**Ban animal-esque sounds for humans:** \"they chirp\", \"they purr\", \"they growl\"\n\n**Banned Fillers:** \"A beat\", \"A pause\"\n\n**Banned number counting:** e.g. \"I see,\" Two words.\n\n**Banned combined sounds:** \"between an X and a Y\", \"half X, half Y\", \"makes a/an X sound\"\n\n**Banned environmental details:** \"dust motes\", \"metallic tang of X\"\n\n- If introducing a new unnamed character this turn, their name must start with: {{random::A::B::C::D::E::F::G::H::I::J::K::L::M::N::O::P::R::S::T::V::W::Y}} and/or {{random::A::B::C::D::E::F::G::H::I::J::K::L::M::N::O::P::R::S::T::V::W::Y}}. Create new NPCs sparingly.",
     "phase": "pre",
     "injection": {
         "position": 0,
@@ -19,6 +20,17 @@
         "role": 0,
         "order": 100,
         "scan": false
+    },
+    "preProcess": {
+        "mode": "intercept",
+        "interceptTiming": "post-main-generation",
+        "applyMode": "replace",
+        "wrapPosition": "after",
+        "wrapPrefix": "",
+        "wrapSuffix": "",
+        "patchStartTag": "<context_patch>",
+        "patchEndTag": "</context_patch>",
+        "maxTokens": 32000
     },
     "postProcess": {
         "enabled": false,

--- a/public/scripts/extensions/in-chat-agents/templates/index.json
+++ b/public/scripts/extensions/in-chat-agents/templates/index.json
@@ -520,9 +520,9 @@
       "quality",
       "prose"
     ],
-    "version": 1,
+    "version": 2,
     "author": "Purachina",
-    "prompt": "### Grounded Prose Rules\n- Each beat must alter pressure, leverage, focus, relation, or access.\n- Sensory detail only where it has material relevance to the scene.\n- Replace abstraction and statistical phrasing with observable detail.\n- Sparse dialogue tags when speaker and tone are already legible. After dialogue, move through action, reaction, or a new beat.\n- Default to contractions in dialogue; preserve character-appropriate formality.\n- Fresh, concrete phrasing. Render emphasis through behavior, timing, syntax, and consequence.\n- State what something is, does, or changes. Direct positive construction.\n- Similes rare, exact, and materially specific.\n- Replace every banned construction below with something narratively consistent:\n\n**Banned constructions:** \"not X,\" \"not X but Y,\" \"not quite X,\" synthetic negative parallelisms, flat-affect comparisons to weather or groceries, \"and yet,\" \"a beat,\" \"say that again,\" \"somewhere, X...,\" \"they don't X,\" \"that does it,\" \"that lands,\" \"that lands X,\" \"not a question,\" \"not really a question,\" \"not quite a question,\" \"statement than question,\" \"really looks at,\" \"like a physical blow,\" \"like a stone into still water,\" \"blood rushing,\" \"a sound between X and Y,\" \"dust motes,\" \"predator and prey\" constructions\n\n**Banned tics:** jaw-clenching, jaw-tightening, mouth open-close cycling, breath-catching, knuckle-whitening, knuckles turning pale, cheeks burning\n\n**Banned scents:** ozone, sandalwood, cedar, cardamom\n\n**Banned nicknames:** gremlin, goblin\n\n- If introducing a new unnamed character this turn, their name must start with: {{random::A::B::C::D::E::F::G::H::I::J::K::L::M::N::O::P::R::S::T::V::W::Y}} and/or {{random::A::B::C::D::E::F::G::H::I::J::K::L::M::N::O::P::R::S::T::V::W::Y}}. Create new NPCs sparingly.",
+    "prompt": "### Grounded Prose Rules\n- Each beat must alter pressure, leverage, focus, relation, or access.\n- Write sensory detail only where materially relevant. Focus on visuals and personalities of environment. Messiness or items strewn about are more informative than smells.\n- Scents allowed aside from banned ones.\n- Echoing and parroting any dialogue from any characters is forbidden.\n- Instead of stating what a character doesn't do, just say what they're currently doing. The implication is already in the active action.\n- Replace abstraction and statistical phrasing with observable detail.\n- Sparse dialogue tags when speaker and tone are already legible. After dialogue, move through action, reaction, or a new beat.\n- Default to contractions in dialogue; preserve character-appropriate formality.\n- Fresh, concrete phrasing. Render emphasis through behavior, timing, syntax, and consequence.\n- Similes rare, exact, and materially specific.\n- Replace every banned construction below with something narratively consistent, or skip it entirely:\n\n**Banned constructions:** \"not X,\" \"not X but Y,\" \"not quite X,\" synthetic negative parallelisms, flat-affect comparisons to weather or groceries, \"say that again,\" \"somewhere, X...,\" \"they don't X,\" \"that does it,\" \"that lands,\" \"that lands X,\" \"not a question,\" \"not really a question,\" \"not quite a question,\" \"statement than question,\" \"really looks at,\" \"like a physical blow,\" \"like a stone into still water,\" \"blood rushing,\" \"a sound between X and Y,\" \"dust motes,\" \"predator and prey\" constructions, \"doesn't just X, but Y\", \"doesn't X; Y\"\n\n**Banned tics:** jaw-clenching, jaw-tightening, jaw-shifting, mouth open-close cycling, breath-catching, knuckle-whitening, knuckles turning pale, cheeks burning, specific word repetition. Replace with character-specific quirks, gestures, movements, muttering.\n\n**Banned scents:** ozone, sandalwood, cedar, cardamom\n\n**Banned nicknames:** gremlin, goblin\n\n**Ban animal-esque sounds for humans:** \"they chirp\", \"they purr\", \"they growl\"\n\n**Banned Fillers:** \"A beat\", \"A pause\"\n\n**Banned number counting:** e.g. \"I see,\" Two words.\n\n**Banned combined sounds:** \"between an X and a Y\", \"half X, half Y\", \"makes a/an X sound\"\n\n**Banned environmental details:** \"dust motes\", \"metallic tang of X\"\n\n- If introducing a new unnamed character this turn, their name must start with: {{random::A::B::C::D::E::F::G::H::I::J::K::L::M::N::O::P::R::S::T::V::W::Y}} and/or {{random::A::B::C::D::E::F::G::H::I::J::K::L::M::N::O::P::R::S::T::V::W::Y}}. Create new NPCs sparingly.",
     "phase": "pre",
     "injection": {
       "position": 0,
@@ -530,6 +530,17 @@
       "role": 0,
       "order": 100,
       "scan": false
+    },
+    "preProcess": {
+      "mode": "intercept",
+      "interceptTiming": "post-main-generation",
+      "applyMode": "replace",
+      "wrapPosition": "after",
+      "wrapPrefix": "",
+      "wrapSuffix": "",
+      "patchStartTag": "<context_patch>",
+      "patchEndTag": "</context_patch>",
+      "maxTokens": 32000
     },
     "postProcess": {
       "enabled": false,

--- a/public/scripts/generation-lifecycle/index.js
+++ b/public/scripts/generation-lifecycle/index.js
@@ -5,6 +5,8 @@ export const GENERATION_LIFECYCLE_UI_STATE = Object.freeze({
 
 export const GENERATION_LIFECYCLE_ABORT_REASON = 'Clicked stop button';
 
+const OUTPUT_INTERCEPT_EXCLUDED_TYPES = new Set(['quiet', 'impersonate', 'first_message']);
+
 function normalizeGenerationType(type) {
     const normalizedType = String(type ?? '').trim();
     return normalizedType || null;
@@ -102,6 +104,28 @@ export function resolveStopGenerationState({
 }
 
 /**
+ * Resolves whether main generation output must be buffered before display/storage.
+ * @param {object} options Options.
+ * @param {string|null} [options.type=null] Generation type.
+ * @param {boolean} [options.isStreaming=false] Whether the main model response is streaming.
+ * @param {boolean} [options.hasPostMainInterceptors=false] Whether any post-main intercept agents are active.
+ * @returns {{canInterceptMainOutput: boolean, shouldBuffer: boolean}}
+ */
+export function resolveGenerationOutputBufferState({
+    type = null,
+    isStreaming = false,
+    hasPostMainInterceptors = false,
+} = {}) {
+    const generationType = normalizeGenerationType(type);
+    const canInterceptMainOutput = !OUTPUT_INTERCEPT_EXCLUDED_TYPES.has(generationType);
+
+    return {
+        canInterceptMainOutput,
+        shouldBuffer: Boolean(canInterceptMainOutput && isStreaming && hasPostMainInterceptors),
+    };
+}
+
+/**
  * Creates the compatibility-facing generation lifecycle seam.
  * Runtime call sites should depend on this shape instead of individual helpers.
  * @returns {object}
@@ -116,6 +140,9 @@ export function createGenerationLifecycle() {
         stop: {
             abortReason: GENERATION_LIFECYCLE_ABORT_REASON,
             resolveState: resolveStopGenerationState,
+        },
+        output: {
+            resolveBufferState: resolveGenerationOutputBufferState,
         },
     };
 }

--- a/tests/generation-lifecycle-wiring.test.js
+++ b/tests/generation-lifecycle-wiring.test.js
@@ -7,8 +7,12 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 const scriptSource = readFileSync(path.join(repoRoot, 'public', 'script.js'), 'utf8');
 
 function getFunctionSource(name, { exported = false } = {}) {
-    const marker = `${exported ? 'export ' : ''}function ${name}(`;
-    const start = scriptSource.indexOf(marker);
+    const markers = [
+        `${exported ? 'export ' : ''}function ${name}(`,
+        `${exported ? 'export ' : ''}async function ${name}(`,
+    ];
+    const marker = markers.find(candidate => scriptSource.includes(candidate));
+    const start = marker ? scriptSource.indexOf(marker) : -1;
 
     expect(start).toBeGreaterThanOrEqual(0);
 
@@ -30,9 +34,20 @@ function getFunctionSource(name, { exported = false } = {}) {
     throw new Error(`Unable to find function source for ${name}`);
 }
 
+function getSourceBetween(startMarker, endMarker) {
+    const start = scriptSource.indexOf(startMarker);
+    expect(start).toBeGreaterThanOrEqual(0);
+
+    const end = scriptSource.indexOf(endMarker, start + startMarker.length);
+    expect(end).toBeGreaterThan(start);
+
+    return scriptSource.slice(start, end);
+}
+
 describe('generation lifecycle wiring', () => {
     test('imports generation lifecycle decisions into the script adapter', () => {
         expect(scriptSource).toContain('resolveGenerationUiLockState');
+        expect(scriptSource).toContain('resolveGenerationOutputBufferState');
         expect(scriptSource).toContain('resolveGenerationUnblockState');
         expect(scriptSource).toContain('resolveStopGenerationState');
     });
@@ -85,6 +100,46 @@ describe('generation lifecycle wiring', () => {
 
     test('routes provider-error cleanup through stopped lifecycle semantics', () => {
         expect(scriptSource).toContain('this.markUIGenStopped({ emitGenerationEnded: false, emitGenerationStopped: true });');
-        expect(scriptSource).toContain('eventSource.emit(event_types.GENERATION_STOPPED);\n        unblockGeneration(type, { emitGenerationEnded: false });');
+        expect(scriptSource).toContain('eventSource.emit(event_types.GENERATION_STOPPED);');
+        expect(scriptSource).toContain('unblockGeneration(type, { emitGenerationEnded: false });');
+    });
+
+    test('routes post-main buffering decisions through lifecycle output state', () => {
+        const bufferSource = getFunctionSource('shouldBufferMainGenerationOutput');
+
+        expect(bufferSource).toContain('event_types.GENERATION_OUTPUT_BUFFERING_DECISION');
+        expect(bufferSource).toContain('resolveGenerationOutputBufferState({');
+        expect(bufferSource).toContain('hasPostMainInterceptors: Boolean(eventData.hasPostMainInterceptors)');
+        expect(scriptSource).toContain('await shouldBufferMainGenerationOutput({ type, isStreaming: true })');
+        expect(scriptSource).toContain('await activeStreamingProcessor.generateBuffered()');
+    });
+
+    test('keeps buffered streaming output hidden until post-main intercept completes', () => {
+        const bufferedSource = getSourceBetween('async generateBuffered() {', 'async generate() {');
+        const generateSource = getFunctionSource('Generate', { exported: true });
+        const normalizedGenerateSource = generateSource.replace(/\r\n/g, '\n');
+
+        expect(bufferedSource).toContain('for await (const { text, swipes, logprobs, toolCalls, state } of this.generator())');
+        expect(bufferedSource).toContain('this.result = text;');
+        expect(bufferedSource).not.toContain('this.onStartStreaming');
+        expect(bufferedSource).not.toContain('this.onProgressStreaming');
+        expect(bufferedSource).not.toContain('this.onFinishStreaming');
+
+        expect(generateSource).toContain('const shouldBufferOutput = await shouldBufferMainGenerationOutput({ type, isStreaming: true });');
+        expect(generateSource).toContain('await activeStreamingProcessor.generateBuffered()');
+        expect(normalizedGenerateSource).toContain('const interceptResult = await applyMainGenerationOutputInterceptors({\n                            type,\n                            text: getMessage,\n                            isStreaming: true,');
+        expect(generateSource).toContain('const saveReplyType = originalType !== \'continue\' ? type : \'appendFinal\';');
+        expect(generateSource).toContain('type: saveReplyType,');
+        expect(generateSource).toContain('!shouldBufferOutput && hasToolCalls && !shouldDeleteMessage');
+    });
+
+    test('runs main output intercept event before saveReply stores non-streaming replies', () => {
+        const generateSource = getFunctionSource('Generate', { exported: true });
+        const interceptIndex = generateSource.indexOf('await applyMainGenerationOutputInterceptors({');
+        const saveIndex = generateSource.indexOf('await saveReply({ type, getMessage, title, swipes, reasoning, imageUrls, reasoningSignature, reasoningTokens: data.reasoningTokens })');
+
+        expect(interceptIndex).toBeGreaterThanOrEqual(0);
+        expect(saveIndex).toBeGreaterThanOrEqual(0);
+        expect(interceptIndex).toBeLessThan(saveIndex);
     });
 });

--- a/tests/generation-lifecycle.test.js
+++ b/tests/generation-lifecycle.test.js
@@ -4,6 +4,7 @@ import {
     createGenerationLifecycle,
     GENERATION_LIFECYCLE_ABORT_REASON,
     GENERATION_LIFECYCLE_UI_STATE,
+    resolveGenerationOutputBufferState,
     resolveGenerationUiLockState,
     resolveGenerationUnblockState,
     resolveStopGenerationState,
@@ -114,6 +115,48 @@ describe('generation lifecycle helper', () => {
         });
     });
 
+    test('buffers only streaming main output that has post-main interceptors', () => {
+        expect(resolveGenerationOutputBufferState({
+            type: 'normal',
+            isStreaming: true,
+            hasPostMainInterceptors: true,
+        })).toEqual({
+            canInterceptMainOutput: true,
+            shouldBuffer: true,
+        });
+
+        expect(resolveGenerationOutputBufferState({
+            type: 'normal',
+            isStreaming: false,
+            hasPostMainInterceptors: true,
+        })).toMatchObject({
+            canInterceptMainOutput: true,
+            shouldBuffer: false,
+        });
+
+        expect(resolveGenerationOutputBufferState({
+            type: 'normal',
+            isStreaming: true,
+            hasPostMainInterceptors: false,
+        })).toMatchObject({
+            canInterceptMainOutput: true,
+            shouldBuffer: false,
+        });
+    });
+
+    test('does not intercept auxiliary output types', () => {
+        for (const type of ['quiet', 'impersonate', 'first_message']) {
+            expect(resolveGenerationOutputBufferState({
+                type,
+                isStreaming: true,
+                hasPostMainInterceptors: true,
+            })).toEqual({
+                canInterceptMainOutput: false,
+                shouldBuffer: false,
+            });
+        }
+    });
+
     test('creates a stable lifecycle seam for future runtime wiring', () => {
         const lifecycle = createGenerationLifecycle();
 
@@ -122,5 +165,6 @@ describe('generation lifecycle helper', () => {
         expect(lifecycle.ui.resolveUnblockState).toBe(resolveGenerationUnblockState);
         expect(lifecycle.stop.abortReason).toBe(GENERATION_LIFECYCLE_ABORT_REASON);
         expect(lifecycle.stop.resolveState).toBe(resolveStopGenerationState);
+        expect(lifecycle.output.resolveBufferState).toBe(resolveGenerationOutputBufferState);
     });
 });

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -69,6 +69,8 @@ describe('in-chat agent post-processing runner', () => {
             IMPERSONATE_READY: 'impersonate_ready',
             MESSAGE_SWIPED: 'message_swiped',
             GENERATE_AFTER_COMBINE_PROMPTS: 'generate_after_combine_prompts',
+            GENERATION_OUTPUT_BUFFERING_DECISION: 'generation_output_buffering_decision',
+            MAIN_GENERATION_OUTPUT_READY: 'main_generation_output_ready',
             CHAT_COMPLETION_PROMPT_READY: 'chat_completion_prompt_ready',
             CHAT_COMPLETION_SETTINGS_READY: 'chat_completion_settings_ready',
             WORLDINFO_ENTRIES_LOADED: 'worldinfo_entries_loaded',
@@ -916,6 +918,151 @@ describe('in-chat agent post-processing runner', () => {
         expect(generateQuietPrompt).not.toHaveBeenCalled();
         expect(inactiveEventData.prompt).toBe('inactive prompt');
         expect(dryRunEventData.prompt).toBe('dry run prompt');
+    });
+
+    test('post-main intercept agents do not rewrite outgoing pre-generation prompts', async () => {
+        enabledAgents = [createPreInterceptAgent({
+            preProcess: { interceptTiming: 'post-main-generation' },
+        })];
+
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        const eventData = { prompt: 'Original outgoing prompt', dryRun: false };
+        await eventSource.emit(eventTypes.GENERATE_AFTER_COMBINE_PROMPTS, eventData);
+
+        expect(generateQuietPrompt).not.toHaveBeenCalled();
+        expect(eventData.prompt).toBe('Original outgoing prompt');
+    });
+
+    test('marks streaming output for buffering when post-main intercept agents are active', async () => {
+        enabledAgents = [createPreInterceptAgent({
+            preProcess: { interceptTiming: 'post-main-generation' },
+        })];
+
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        const eventData = { type: 'normal', isStreaming: true, hasPostMainInterceptors: false };
+        await eventSource.emit(eventTypes.GENERATION_OUTPUT_BUFFERING_DECISION, eventData);
+
+        expect(eventData.hasPostMainInterceptors).toBe(true);
+    });
+
+    test('keeps streaming output unbuffered when no post-main intercept agents are active', async () => {
+        enabledAgents = [createPreInterceptAgent()];
+
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        const eventData = { type: 'normal', isStreaming: true, hasPostMainInterceptors: false };
+        await eventSource.emit(eventTypes.GENERATION_OUTPUT_BUFFERING_DECISION, eventData);
+
+        expect(eventData.hasPostMainInterceptors).toBe(false);
+    });
+
+    test('runs post-main intercepts before storing the assistant message', async () => {
+        enabledAgents = [createPreInterceptAgent({
+            preProcess: { interceptTiming: 'post-main-generation', applyMode: 'replace' },
+        })];
+        generateQuietPrompt.mockResolvedValue('intercepted assistant reply');
+
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        const outputData = { type: 'normal', text: 'raw assistant reply', isStreaming: false, cancelled: false };
+        await eventSource.emit(eventTypes.MAIN_GENERATION_OUTPUT_READY, outputData);
+
+        expect(outputData.cancelled).toBe(false);
+        expect(outputData.text).toBe('intercepted assistant reply');
+        expect(generateQuietPrompt.mock.calls[0][0].quietPrompt).toContain('Main model output:');
+        expect(generateQuietPrompt.mock.calls[0][0].quietPrompt).toContain('raw assistant reply');
+
+        chat.push({
+            name: 'Assistant',
+            mes: outputData.text,
+            is_user: false,
+            is_system: false,
+            extra: {},
+        });
+        await eventSource.emit(eventTypes.MESSAGE_RECEIVED, 0, 'normal');
+        await eventSource.emit(eventTypes.GENERATION_ENDED, chat.length);
+        await waitFor(() => Array.isArray(chat[0].extra.inChatAgentPreGenerationInterceptHistory));
+
+        expect(chat[0].mes).toBe('intercepted assistant reply');
+        expect(chat[0].extra.inChatAgentPreGenerationInterceptHistory).toEqual([expect.objectContaining({
+            agentId: 'agent-pre-intercept',
+            timing: 'post-main-generation',
+            beforeText: 'raw assistant reply',
+            outputText: 'intercepted assistant reply',
+            afterText: 'intercepted assistant reply',
+            changed: true,
+            status: 'changed',
+        })]);
+    });
+
+    test('falls back to raw output when a post-main intercept fails', async () => {
+        enabledAgents = [createPreInterceptAgent({
+            preProcess: { interceptTiming: 'post-main-generation' },
+        })];
+        generateQuietPrompt.mockRejectedValue(new Error('post-main failed'));
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        try {
+            const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+            initAgentRunner();
+
+            await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+            const outputData = { type: 'normal', text: 'raw assistant reply', isStreaming: false, cancelled: false };
+            await eventSource.emit(eventTypes.MAIN_GENERATION_OUTPUT_READY, outputData);
+
+            expect(outputData.cancelled).toBe(false);
+            expect(outputData.text).toBe('raw assistant reply');
+
+            chat.push({
+                name: 'Assistant',
+                mes: outputData.text,
+                is_user: false,
+                is_system: false,
+                extra: {},
+            });
+            await eventSource.emit(eventTypes.MESSAGE_RECEIVED, 0, 'normal');
+            await eventSource.emit(eventTypes.GENERATION_ENDED, chat.length);
+            await waitFor(() => Array.isArray(chat[0].extra.inChatAgentPreGenerationInterceptHistory));
+
+            expect(chat[0].extra.inChatAgentPreGenerationInterceptHistory).toEqual([expect.objectContaining({
+                timing: 'post-main-generation',
+                status: 'error',
+                changed: false,
+                beforeText: 'raw assistant reply',
+                afterText: 'raw assistant reply',
+                error: 'post-main failed',
+            })]);
+        } finally {
+            warnSpy.mockRestore();
+        }
+    });
+
+    test('cancels post-main output instead of storing raw text after generation stop', async () => {
+        enabledAgents = [createPreInterceptAgent({
+            preProcess: { interceptTiming: 'post-main-generation' },
+        })];
+
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        await eventSource.emit(eventTypes.GENERATION_STOPPED);
+        const outputData = { type: 'normal', text: 'raw assistant reply', isStreaming: false, cancelled: false };
+        await eventSource.emit(eventTypes.MAIN_GENERATION_OUTPUT_READY, outputData);
+
+        expect(outputData.cancelled).toBe(true);
+        expect(outputData.text).toBe('raw assistant reply');
+        expect(generateQuietPrompt).not.toHaveBeenCalled();
     });
 
     test('exposes pre-generation intercept history for message document UI', async () => {

--- a/tests/in-chat-agents-store.test.js
+++ b/tests/in-chat-agents-store.test.js
@@ -145,6 +145,7 @@ describe('in-chat agent scoped enabled state', () => {
             name: 'Intercept Agent',
             preProcess: {
                 mode: 'intercept',
+                interceptTiming: 'post-main-generation',
                 applyMode: 'patch',
                 wrapPosition: 'before',
                 wrapPrefix: 'prefix',
@@ -157,6 +158,7 @@ describe('in-chat agent scoped enabled state', () => {
 
         expect(store.getAgentById('agent-intercept').preProcess).toEqual(expect.objectContaining({
             mode: 'intercept',
+            interceptTiming: 'post-main-generation',
             applyMode: 'patch',
             wrapPosition: 'before',
             wrapPrefix: 'prefix',
@@ -171,6 +173,7 @@ describe('in-chat agent scoped enabled state', () => {
             name: 'Invalid Intercept Agent',
             preProcess: {
                 mode: 'unknown',
+                interceptTiming: 'after-lunch',
                 applyMode: 'unknown',
                 wrapPosition: 'middle',
                 maxTokens: 'not-a-number',
@@ -179,6 +182,7 @@ describe('in-chat agent scoped enabled state', () => {
 
         expect(store.getAgentById('agent-invalid-intercept').preProcess).toEqual(expect.objectContaining({
             mode: 'inject',
+            interceptTiming: 'pre-generation',
             applyMode: 'replace',
             wrapPosition: 'after',
             maxTokens: store.DEFAULT_AGENT_MAX_TOKENS,


### PR DESCRIPTION
## What?
Fixes #225 by adding an opt-in post-main generation timing for In-Chat Agent intercept mode while preserving the existing pre-generation default.

The change adds the editor timing control, normalizes the new setting in agent storage, wires lifecycle events for output-buffering decisions, and applies post-main intercepts before generated text is rendered or saved.

## Why?
Some agents need to transform the main model output itself. Without post-main timing, those transforms either had to run before the main model saw the prompt or after the raw assistant response was already visible/stored.

## How?
Post-main intercept agents are detected during the generation lifecycle. Non-streaming output is intercepted before `saveReply`; streaming output with active post-main interceptors is buffered through `generateBuffered()` so raw tokens are not shown before the intercept completes.

The default remains `pre-generation`, auxiliary output types are excluded, failed post-main intercepts fall back to raw output unless generation was stopped, `continue` saves through `appendFinal`, and tool-call finalization stays guarded when buffering is active.

## Testing?
- `npm run lint`
- `npm run lint --prefix tests -- generation-lifecycle.test.js generation-lifecycle-wiring.test.js in-chat-agents-runner.test.js in-chat-agents-store.test.js`
- `npm run test:unit --prefix tests -- generation-lifecycle.test.js generation-lifecycle-wiring.test.js in-chat-agents-runner.test.js in-chat-agents-store.test.js chat-render-lifecycle-stream-buffer.test.js`
- Browser smoke on `http://127.0.0.1:5108`: opened the In-Chat Agents editor, confirmed the Timing select defaults to `pre-generation`, includes `post-main-generation`, and becomes visible when intercept mode is selected.
- `git diff --check`

## Anything Else?
Targets `staging`. The streaming path intentionally hides raw tokens until the opted-in post-main intercept finishes.