### PR TITLE
fix: persist sampler visibility choices

### DIFF
--- a/public/scripts/samplerSelect.js
+++ b/public/scripts/samplerSelect.js
@@ -21,6 +21,20 @@ const SELECT_SAMPLER = {
 
 const textGenObjectStore = localforage.createInstance({ name: 'SillyTavern_TextCompletions' });
 let selectedSamplers = {};
+const DEFAULT_HIDDEN_TG_SAMPLERS = new Set([
+    'rep_pen',
+    'rep_pen_range',
+    'rep_pen_decay',
+    'rep_pen_slope',
+    'encoder_rep_pen',
+    'freq_pen',
+    'presence_pen',
+    'mirostat_mode',
+    'mirostat_tau',
+    'mirostat_eta',
+    'xtc_probability',
+    'xtc_threshold',
+]);
 
 // Goal 1: show popup with all samplers for active API
 async function showSamplerSelectPopup() {
@@ -52,12 +66,13 @@ async function showSamplerSelectPopup() {
     if (main_api === 'textgenerationwebui') {
         $('#prioritizeManuallySelectedSamplers').show();
         $('#prioritizeManuallySelectedSamplers').toggleClass('toggleEnabled', isSamplerManualPriorityEnabled());
-        $('#prioritizeManuallySelectedSamplers').off('click').on('click', function () {
+        $('#prioritizeManuallySelectedSamplers').off('click').on('click', async function () {
             $(this).toggleClass('toggleEnabled');
 
             const isActive = $(this).hasClass('toggleEnabled');
 
             toggleSamplerManualPriority(isActive);
+            await saveApiSelectedSamplers();
         });
     } else {
         $('#prioritizeManuallySelectedSamplers').hide();
@@ -65,7 +80,9 @@ async function showSamplerSelectPopup() {
     }
 
     await showPromise;
-    if (main_api === 'textgenerationwebui') await saveApiSelectedSamplers();
+    if (main_api === 'textgenerationwebui' && selectedSamplers[textgenerationwebui_settings.type]?.st_manual_priority !== undefined) {
+        await saveApiSelectedSamplers();
+    }
 }
 
 function getRelatedDOMElement(samplerName) {
@@ -199,7 +216,16 @@ function setSamplerListListeners() {
         const shouldDisplay = isChecked ? targetDisplayType : 'none';
         relatedDOMElement.css('display', shouldDisplay);
 
-        if (main_api === 'textgenerationwebui') setApiSamplersState(samplerName, shouldDisplay !== 'none');
+        if (main_api === 'textgenerationwebui') {
+            setApiSamplersState(samplerName, shouldDisplay !== 'none');
+
+            if (!isSamplerManualPriorityEnabled()) {
+                toggleSamplerManualPriority(true);
+                $('#prioritizeManuallySelectedSamplers').toggleClass('toggleEnabled', true);
+            }
+
+            await saveApiSelectedSamplers();
+        }
 
         console.log(samplerName, relatedDOMElement.data(SELECT_SAMPLER.DATA), shouldDisplay);
     });
@@ -321,6 +347,15 @@ export async function loadApiSelectedSamplers() {
         console.log('Text Completions: unable to load selected samplers, using default samplers', error);
         selectedSamplers = {};
     }
+}
+
+/**
+ * Returns whether a Text Completion sampler is hidden by default in automatic mode.
+ * @param {string} samplerName Target sampler key name
+ * @returns {boolean}
+ */
+export function isSamplerHiddenByDefault(samplerName) {
+    return DEFAULT_HIDDEN_TG_SAMPLERS.has(samplerName);
 }
 
 /**

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -20,7 +20,7 @@ import { autoSelectInstructPreset, selectContextPreset, selectInstructPreset } f
 import { BIAS_CACHE, createNewLogitBiasEntry, displayLogitBias, getLogitBiasListResult } from './logit-bias.js';
 
 import { power_user, registerDebugFunction } from './power-user.js';
-import { getActiveManualApiSamplers, loadApiSelectedSamplers, isSamplerManualPriorityEnabled } from './samplerSelect.js';
+import { getActiveManualApiSamplers, loadApiSelectedSamplers, isSamplerManualPriorityEnabled, isSamplerHiddenByDefault } from './samplerSelect.js';
 import { SECRET_KEYS, writeSecret } from './secrets.js';
 import { getEventSourceStream } from './sse-stream.js';
 import { getLocalPromptCacheValue, isLikelyLocalServerUrl } from './local-url-utils.js';
@@ -1175,7 +1175,9 @@ export function initTextGenSettings() {
  * @returns void
  */
 function showSamplerControls(apiType = null) {
-    $('#textgenerationwebui_api-settings [data-tg-samplers], #textgenerationwebui_api [data-tg-samplers], #sb-sampling-textgenerationwebui [data-tg-samplers]').each(function (idx, elem) {
+    const samplerControlsSelector = '#textgenerationwebui_api-settings [data-tg-samplers], #textgenerationwebui_api [data-tg-samplers], #sb-sampling-textgenerationwebui [data-tg-samplers]';
+
+    $(samplerControlsSelector).each(function (idx, elem) {
         const typeSpecificControlled = $(elem).data('tg-type') !== undefined;
 
         if (!typeSpecificControlled) $(this).show();
@@ -1186,20 +1188,34 @@ function showSamplerControls(apiType = null) {
     const prioritizeManualSamplerSelect = isSamplerManualPriorityEnabled(apiType ?? textgenerationwebui_settings.type);
     const samplersActivatedManually = getActiveManualApiSamplers(apiType ?? textgenerationwebui_settings.type);
 
-    if (!samplersActivatedManually?.length || !prioritizeManualSamplerSelect) return;
+    if (!prioritizeManualSamplerSelect) {
+        hideDefaultSamplerControls(samplerControlsSelector);
+        return;
+    }
 
-    $('#textgenerationwebui_api-settings [data-tg-samplers], #textgenerationwebui_api [data-tg-samplers], #sb-sampling-textgenerationwebui [data-tg-samplers]').each(function () {
-        const tgSamplers = $(this).attr('data-tg-samplers').split(',').map(x => x.trim()).filter(str => str !== '');
+    $(samplerControlsSelector).each(function () {
+        const tgSamplers = getSamplerNamesFromElement(this);
+        const shouldShow = tgSamplers.some(tgSampler => samplersActivatedManually.includes(tgSampler));
 
-        for (const tgSampler of tgSamplers) {
-            if (samplersActivatedManually.includes(tgSampler)) {
-                $(this).show();
-                return;
-            } else {
-                $(this).hide();
-            }
+        $(this).toggle(shouldShow);
+    });
+}
+
+function hideDefaultSamplerControls(selector) {
+    $(selector).each(function () {
+        const shouldHide = getSamplerNamesFromElement(this).some(isSamplerHiddenByDefault);
+
+        if (shouldHide) {
+            $(this).hide();
         }
     });
+}
+
+function getSamplerNamesFromElement(element) {
+    return String($(element).attr('data-tg-samplers') ?? '')
+        .split(',')
+        .map(x => x.trim())
+        .filter(str => str !== '');
 }
 
 function showTypeSpecificControls(apiType) {


### PR DESCRIPTION
## Summary
- auto-enable and immediately save manual sampler priority when a Text Completion sampler is toggled
- persist the Prioritize toggle immediately instead of waiting for popup close
- hide repetition/frequency/presence penalties, Mirostat, and XTC controls by default unless manual sampler selection is active

## Testing
- npm run lint -- public/scripts/samplerSelect.js public/scripts/textgen-settings.js
- git diff --check
- npm run build:frontend