### PR TITLE
fix: bind text sampler visibility to presets

### DIFF
--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -35,6 +35,7 @@ import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
 import { checkForSystemPromptInInstructTemplate, system_prompts } from './sysprompt.js';
 import { renderTemplateAsync } from './templates.js';
 import {
+    getTextCompletionPresetSettings,
     textgenerationwebui_settings as textgen_settings,
     textgenerationwebui_preset_names,
     textgenerationwebui_presets,
@@ -954,7 +955,7 @@ class PresetManager {
                 case 'novel':
                     return nai_settings;
                 case 'textgenerationwebui':
-                    return textgen_settings;
+                    return getTextCompletionPresetSettings();
                 case 'openai':
                     return getChatCompletionPreset(oai_settings);
                 case 'context': {

--- a/public/scripts/samplerSelect.js
+++ b/public/scripts/samplerSelect.js
@@ -387,6 +387,35 @@ export function getAllManualApiSamplers(tcApiType = '') {
 }
 
 /**
+ * Returns a copy of the sampler visibility state for the active/selected TC API Type.
+ * @param {string?} tcApiType Name of the target API Type - It picks the currently active TC API type name by default
+ * @returns {Record<string, boolean>} Sampler visibility state
+ */
+export function getApiSamplerVisibilityState(tcApiType = '') {
+    return Object.fromEntries(
+        Object.entries(getAllManualApiSamplers(tcApiType)).map(([key, value]) => [key, String(value) === 'true']),
+    );
+}
+
+/**
+ * Replaces the sampler visibility state for the active/selected TC API Type.
+ * @param {Record<string, any>} state Sampler visibility state
+ * @param {string?} tcApiType Name of the target API Type - It picks the currently active TC API type name by default
+ * @returns {boolean} Whether the sampler visibility state was applied
+ */
+export function setApiSamplerVisibilityState(state, tcApiType = '') {
+    if (!state || typeof state !== 'object' || Array.isArray(state)) return false;
+    if (!textgenerationwebui_settings?.type && !tcApiType) return false;
+    if (!tcApiType) tcApiType = textgenerationwebui_settings.type;
+
+    selectedSamplers[tcApiType] = Object.fromEntries(
+        Object.entries(state).map(([key, value]) => [key, String(value) === 'true']),
+    );
+
+    return true;
+}
+
+/**
  * Returns the key names of all the manually activated API Type samplers.
  * @param {string?} tcApiType Name of the target API Type - It picks the currently active TC API type name by default
  * @returns {string[]} Array of sampler key names

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -21,7 +21,14 @@ import { autoSelectInstructPreset, selectContextPreset, selectInstructPreset } f
 import { BIAS_CACHE, createNewLogitBiasEntry, displayLogitBias, getLogitBiasListResult } from './logit-bias.js';
 
 import { power_user, registerDebugFunction } from './power-user.js';
-import { getActiveManualApiSamplers, loadApiSelectedSamplers, isSamplerManualPriorityEnabled } from './samplerSelect.js';
+import {
+    getActiveManualApiSamplers,
+    getApiSamplerVisibilityState,
+    isSamplerManualPriorityEnabled,
+    loadApiSelectedSamplers,
+    saveApiSelectedSamplers,
+    setApiSamplerVisibilityState,
+} from './samplerSelect.js';
 import { SECRET_KEYS, writeSecret } from './secrets.js';
 import { getEventSourceStream } from './sse-stream.js';
 import { getLocalPromptCacheValue, isLikelyLocalServerUrl } from './local-url-utils.js';
@@ -149,6 +156,7 @@ export const APHRODITE_DEFAULT_ORDER = [
     'xtc',
 ];
 const BIAS_KEY = '#textgenerationwebui_api-settings';
+const SAMPLER_VISIBILITY_EXTENSION_KEY = 'samplerVisibility';
 
 // Maybe let it be configurable in the future?
 // (7 days later) The future has come.
@@ -424,7 +432,35 @@ async function selectPreset(name) {
     setGenerationParamsFromPreset(preset);
     BIAS_CACHE.delete(BIAS_KEY);
     displayLogitBias(preset.logit_bias, BIAS_KEY);
+    await applyPresetSamplerVisibility(preset);
     await saveSettings();
+}
+
+function getPresetSamplerVisibility(preset) {
+    const samplerVisibility = preset?.extensions?.[SAMPLER_VISIBILITY_EXTENSION_KEY];
+    return samplerVisibility && typeof samplerVisibility === 'object' && !Array.isArray(samplerVisibility)
+        ? samplerVisibility
+        : null;
+}
+
+async function applyPresetSamplerVisibility(preset) {
+    const samplerVisibility = getPresetSamplerVisibility(preset);
+
+    if (!samplerVisibility) {
+        return;
+    }
+
+    if (setApiSamplerVisibilityState(samplerVisibility)) {
+        await saveApiSelectedSamplers();
+        showSamplerControls();
+    }
+}
+
+export function getTextCompletionPresetSettings() {
+    const settings = structuredClone(textgenerationwebui_settings);
+    settings.extensions = settings.extensions || {};
+    settings.extensions[SAMPLER_VISIBILITY_EXTENSION_KEY] = getApiSamplerVisibilityState();
+    return settings;
 }
 
 export function formatTextGenURL(value) {


### PR DESCRIPTION
## Summary
- save the active Text Completion sampler visibility map into preset extensions as `samplerVisibility`
- restore that sampler visibility map when a Text Completion preset is selected
- keep IndexedDB as the live cache while newly saved presets become the source of truth for sampler visibility

Stacked after #283 so this PR only reviews the sampler visibility binding changes.

## Testing
- npm run lint -- public/scripts/preset-manager.js public/scripts/samplerSelect.js public/scripts/textgen-settings.js
- git diff --check
- npm run build:frontend