### PR TITLE
feat: add explicit UI for reverse proxy backend binding

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2809,7 +2809,7 @@
                                 Allow context sizes above the model-provided limit.
                             </div>
                         </div>
-                        <div class="inline-drawer wide100p" data-source="openai,claude,mistralai,makersuite,vertexai,deepseek,xai,zai,moonshot">
+                        <div class="inline-drawer wide100p" data-source="openai,openai_responses,claude,mistralai,makersuite,vertexai,deepseek,xai,zai,moonshot">
                             <div class="inline-drawer-toggle inline-drawer-header">
                                 <b data-i18n="Reverse Proxy">Reverse Proxy</b>
                                 <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
@@ -2871,9 +2871,33 @@
                                     <input id="openai_proxy_password" type="password" class="text_pole flex1" placeholder="" form="openai_form" autocomplete="off" />
                                     <div id="openai_proxy_password_show" title="Peek a password" data-i18n="[title]Peek a password" class="menu_button fa-solid fa-eye-slash fa-fw"></div>
                                 </div>
+                                <div class="range-block-title justifyLeft" data-i18n="Bind to Backend">
+                                    Bind to Backend
+                                </div>
+                                <div class="toggle-description justifyLeft">
+                                    <span data-i18n="Switch to this backend when the proxy preset is selected.">
+                                        Switch to this backend when the proxy preset is selected.
+                                    </span>
+                                    <br>
+                                </div>
+                                <div class="wide100p">
+                                    <select id="openai_proxy_source" class="text_pole">
+                                        <option value="" data-i18n="None (Don't switch)">None (Don't switch)</option>
+                                        <option value="openai">OpenAI</option>
+                                        <option value="openai_responses">OpenAI (Responses)</option>
+                                        <option value="claude">Claude</option>
+                                        <option value="mistralai">MistralAI</option>
+                                        <option value="makersuite">Google AI Studio</option>
+                                        <option value="vertexai">Google Vertex AI</option>
+                                        <option value="deepseek">DeepSeek</option>
+                                        <option value="xai">xAI (Grok)</option>
+                                        <option value="zai">Z.AI (GLM)</option>
+                                        <option value="moonshot">Moonshot AI</option>
+                                    </select>
+                                </div>
                             </div>
                         </div>
-                        <div id="ReverseProxyWarningMessage" data-source="openai,claude,mistralai,makersuite,vertexai,deepseek,xai,zai,moonshot">
+                        <div id="ReverseProxyWarningMessage" data-source="openai,openai_responses,claude,mistralai,makersuite,vertexai,deepseek,xai,zai,moonshot">
                             <div class="reverse_proxy_warning">
                                 <b>
                                     <div data-i18n="Using a proxy that you're not running yourself is a risk to your data privacy.">

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -253,6 +253,19 @@ export const REVERSE_PROXY_SUPPORTED_SOURCES = [
     chat_completion_sources.MOONSHOT,
 ];
 
+const REVERSE_PROXY_SOURCE_LABELS = {
+    [chat_completion_sources.OPENAI]: 'OpenAI',
+    [chat_completion_sources.OPENAI_RESPONSES]: 'OpenAI (Responses)',
+    [chat_completion_sources.CLAUDE]: 'Claude',
+    [chat_completion_sources.MISTRALAI]: 'MistralAI',
+    [chat_completion_sources.MAKERSUITE]: 'AI Studio',
+    [chat_completion_sources.VERTEXAI]: 'Vertex AI',
+    [chat_completion_sources.DEEPSEEK]: 'DeepSeek',
+    [chat_completion_sources.XAI]: 'xAI',
+    [chat_completion_sources.ZAI]: 'Z.AI',
+    [chat_completion_sources.MOONSHOT]: 'Moonshot',
+};
+
 const MODEL_ID_SEARCH_CONTROLS = [
     { source: chat_completion_sources.CLAUDE, setting: 'claude_model', input: '#claude_model_id', select: '#model_claude_select', dynamicGroupId: 'claude_other_models' },
     { source: chat_completion_sources.AI21, setting: 'ai21_model', input: '#ai21_model_id', select: '#model_ai21_select', dynamicGroupId: 'ai21_other_models' },
@@ -8363,11 +8376,7 @@ export function loadProxyPresets(settings) {
     $('#openai_proxy_preset').empty();
 
     for (const preset of proxies) {
-        const option = document.createElement('option');
-        option.innerText = preset.name;
-        option.value = preset.name;
-        option.selected = preset.name === 'None';
-        $('#openai_proxy_preset').append(option);
+        appendProxyPresetOption(preset);
     }
     $('#openai_proxy_preset').val(selected_proxy.name);
     setProxyPreset(selected_proxy.name, selected_proxy.url, selected_proxy.password, selected_proxy.source, { applySource: false });
@@ -8375,6 +8384,40 @@ export function loadProxyPresets(settings) {
 
 function normalizeProxyPreset(preset) {
     return normalizeReverseProxyPreset(preset, { supportedSources: REVERSE_PROXY_SUPPORTED_SOURCES });
+}
+
+function getReverseProxySourceLabel(source) {
+    return REVERSE_PROXY_SOURCE_LABELS[source] || '';
+}
+
+function getReverseProxyPresetOptionText(preset) {
+    const normalizedPreset = normalizeProxyPreset(preset);
+    const sourceLabel = getReverseProxySourceLabel(normalizedPreset.source);
+
+    return sourceLabel ? `${normalizedPreset.name} [${sourceLabel}]` : normalizedPreset.name;
+}
+
+function getProxyPresetOption(name) {
+    return $('#openai_proxy_preset option').filter((_, option) => option.value === name);
+}
+
+function appendProxyPresetOption(preset) {
+    const normalizedPreset = normalizeProxyPreset(preset);
+    const option = document.createElement('option');
+    option.innerText = getReverseProxyPresetOptionText(normalizedPreset);
+    option.value = normalizedPreset.name;
+    option.selected = normalizedPreset.name === 'None';
+    $('#openai_proxy_preset').append(option);
+}
+
+function updateProxyPresetOption(preset) {
+    const option = getProxyPresetOption(preset.name);
+
+    if (option.length > 0) {
+        option.text(getReverseProxyPresetOptionText(preset));
+    } else {
+        appendProxyPresetOption(preset);
+    }
 }
 
 function setProxyPreset(name, url, password, source = '', { applySource = true } = {}) {
@@ -8396,6 +8439,7 @@ function setProxyPreset(name, url, password, source = '', { applySource = true }
     $('#openai_reverse_proxy').val(oai_settings.reverse_proxy);
     oai_settings.proxy_password = normalizedPreset.password;
     $('#openai_proxy_password').val(oai_settings.proxy_password);
+    $('#openai_proxy_source').val(normalizedPreset.source || '');
 
     if (applySource && normalizedPreset.source && normalizedPreset.source !== oai_settings.chat_completion_source) {
         $('#chat_completion_source').val(normalizedPreset.source).trigger('change');
@@ -8424,19 +8468,13 @@ $('#save_proxy').on('click', async function () {
         name: presetName,
         url: reverseProxy,
         password: proxyPassword,
-        source: oai_settings.chat_completion_source,
+        source: $('#openai_proxy_source').val() || '',
     }, { supportedSources: REVERSE_PROXY_SUPPORTED_SOURCES });
 
     setProxyPreset(preset.name, preset.url, preset.password, preset.source);
     saveSettingsDebounced();
     toastr.success(t`Proxy Saved`);
-    if ($('#openai_proxy_preset').val() !== preset.name) {
-        const option = document.createElement('option');
-        option.text = preset.name;
-        option.value = preset.name;
-
-        $('#openai_proxy_preset').append(option);
-    }
+    updateProxyPresetOption(preset);
     $('#openai_proxy_preset').val(preset.name);
 });
 
@@ -8446,7 +8484,7 @@ $('#delete_proxy').on('click', async function () {
 
     if (index !== -1) {
         proxies.splice(index, 1);
-        $('#openai_proxy_preset option[value="' + presetName + '"]').remove();
+        getProxyPresetOption(presetName).remove();
 
         if (proxies.length > 0) {
             const newIndex = Math.max(0, index - 1);

--- a/tests/openai-proxy-preset-wiring.test.js
+++ b/tests/openai-proxy-preset-wiring.test.js
@@ -5,6 +5,7 @@ import path from 'node:path';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const openAiSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'openai.js'), 'utf8');
+const indexHtml = readFileSync(path.join(repoRoot, 'public', 'index.html'), 'utf8');
 
 function getFunctionSource(name) {
     const marker = `function ${name}(`;
@@ -31,10 +32,24 @@ function getFunctionSource(name) {
 }
 
 describe('OpenAI proxy preset wiring', () => {
-    test('saves reverse proxy presets with the current Chat Completion source', () => {
+    test('saves reverse proxy presets with the selected backend binding', () => {
         expect(openAiSource).toContain('buildReverseProxyPresetForSave({');
-        expect(openAiSource).toContain('source: oai_settings.chat_completion_source');
+        expect(openAiSource).toContain('source: $(\'#openai_proxy_source\').val() || \'\'');
         expect(openAiSource).toContain('supportedSources: REVERSE_PROXY_SUPPORTED_SOURCES');
+    });
+
+    test('shows an explicit reverse proxy backend selector', () => {
+        expect(indexHtml).toContain('id="openai_proxy_source"');
+        expect(indexHtml).toContain('None (Don\'t switch)');
+        expect(indexHtml).toContain('value="makersuite"');
+    });
+
+    test('renders clean source indicators in proxy preset options', () => {
+        const optionTextSource = getFunctionSource('getReverseProxyPresetOptionText');
+
+        expect(openAiSource).toContain('function getReverseProxySourceLabel(source)');
+        expect(openAiSource).toContain('[chat_completion_sources.MAKERSUITE]: \'AI Studio\'');
+        expect(optionTextSource).toContain('`${normalizedPreset.name} [${sourceLabel}]`');
     });
 
     test('applies proxy credentials before switching Chat Completion source', () => {


### PR DESCRIPTION
Summary:
- Add a Bind to Backend selector to reverse proxy presets with an unbound default.
- Show clean source badges in reverse proxy preset labels.
- Save the selected binding instead of silently using the current Chat Completion source.

Tests:
- npm run test:unit -- openai-preset-utils.test.js openai-proxy-preset-wiring.test.js
- npx eslint public/scripts/openai.js
- npx eslint openai-proxy-preset-wiring.test.js (from tests/)
- git diff --check