### PR TITLE
chore: Bump version numbers from 1.6.0 to 1.6.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v1.6.1
+
+Date: 2026-05-31
+
+This maintenance bump separates staging work merged after v1.6.0 so the next stable release changelog can collect it cleanly.
+
+### Release Metadata
+- Updated app, Horde client, bundled extension, package, lockfile, and test metadata to 1.6.1.
+
+### Merged Staging PRs
+- PR #155 (2026-05-24) `fix: chat scroll and prompt manager scroll position issues`
+- PR #158 (2026-05-24) `feat: add mobile navigation customization`
+- PR #159 (2026-05-24) `fix: Make message generation glow theme-aware`
+
 ## v1.6.0
 
 Date: 2026-05-18
@@ -85,11 +99,6 @@ This update consolidates the v1.6.0 staging work since v1.5.3: preset and connec
 - The welcome panel now uses the dynamic current-release label instead of a stale hardcoded 1.4.2 eyebrow.
 - Updated app, Horde client, bundled extension, package, lockfile, and README metadata to 1.6.0.
 - Added a `changelog:merged-prs` script and GitHub workflow so future merged staging PRs are recorded in `changelog.md` automatically.
-
-### Merged Staging PRs
-- PR #155 (2026-05-24) `fix: chat scroll and prompt manager scroll position issues`
-- PR #158 (2026-05-24) `feat: add mobile navigation customization`
-- PR #159 (2026-05-24) `fix: Make message generation glow theme-aware`
 
 ## v1.5.3
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sillybunny",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sillybunny",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "license": "AGPL-3.0",
             "dependencies": {
                 "@adobe/css-tools": "^4.4.4",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
         "type": "git",
         "url": "https://github.com/platberlitz/SillyBunny.git"
     },
-    "version": "1.6.0",
+    "version": "1.6.1",
     "scripts": {
         "start": "bun server.js",
         "start:node": "node --no-warnings server.js",

--- a/public/script.js
+++ b/public/script.js
@@ -501,7 +501,7 @@ export let isChatSaving = false;
 export let firstRun = false;
 export let settingsReady = false;
 let currentVersion = '0.0.0';
-const SILLYBUNNY_UI_VERSION = 'SillyBunny v1.6.0';
+const SILLYBUNNY_UI_VERSION = 'SillyBunny v1.6.1';
 
 export let displayVersion = SILLYBUNNY_UI_VERSION;
 
@@ -544,7 +544,7 @@ export function getSillyBunnyFrontendIconSrc({ absolute = false } = {}) {
 export let system_avatar = getSillyBunnyFrontendIconSrc();
 export const comment_avatar = 'img/quill.png';
 export const default_user_avatar = 'img/user-default.png';
-export let CLIENT_VERSION = 'SillyBunny:v1.6.0:platberlitz'; // For Horde header
+export let CLIENT_VERSION = 'SillyBunny:v1.6.1:platberlitz'; // For Horde header
 
 function applySillyBunnyFrontendIcon(iconId = getStoredSillyBunnyFrontendIcon()) {
     const normalizedIconId = normalizeSillyBunnyFrontendIcon(iconId);

--- a/public/scripts/extensions/gallery/manifest.json
+++ b/public/scripts/extensions/gallery/manifest.json
@@ -7,7 +7,7 @@
     "js": "index.js",
     "css": "style.css",
     "author": "City-Unit",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "homePage": "https://github.com/SillyTavern/SillyTavern",
     "hooks": {
         "activate": "init"

--- a/src/endpoints/horde.js
+++ b/src/endpoints/horde.js
@@ -15,7 +15,7 @@ export const router = express.Router();
  */
 async function getClientAgent() {
     const version = await getVersion();
-    return version?.agent || 'SillyBunny:1.6.0:platberlitz';
+    return version?.agent || 'SillyBunny:1.6.1:platberlitz';
 }
 
 /**

--- a/tests/extensions-disable.test.js
+++ b/tests/extensions-disable.test.js
@@ -44,7 +44,7 @@ function installExtensionModuleMocks() {
     }));
 
     jest.unstable_mockModule('../public/script.js', () => ({
-        CLIENT_VERSION: 'SillyBunny:v1.6.0',
+        CLIENT_VERSION: 'SillyBunny:v1.6.1',
         animation_duration: 0,
         eventSource: { emit: jest.fn(async () => {}) },
         event_types: { EXTENSIONS_FIRST_LOAD: 'extensions_first_load', EXTRAS_CONNECTED: 'extras_connected', EXTENSION_SETTINGS_LOADED: 'extension_settings_loaded' },


### PR DESCRIPTION
Summary: Maintenance bump from 1.6.0 to 1.6.1, including UI version text, Horde client fallback string, package metadata, gallery manifest, test mock, and changelog separation for post-1.6.0 staging PRs. Verification: git diff --check; git grep for stale app/client 1.6.0 strings.