### PR TITLE
fix: reset prompt order from selected preset

### DIFF
--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -4,7 +4,7 @@ import { DOMPurify } from '../lib.js';
 
 import { event_types, eventSource, is_send_press, main_api, saveSettingsDebounced, substituteParams } from '../script.js';
 import { is_group_generating } from './group-chats.js';
-import { Message, MessageCollection, TokenHandler } from './openai.js';
+import { getCurrentOpenAIPresetPromptOrder, Message, MessageCollection, TokenHandler } from './openai.js';
 import { power_user } from './power-user.js';
 import { debounce, waitUntilCondition, escapeHtml, uuidv4 } from './utils.js';
 import { debounce_timeout } from './constants.js';
@@ -1013,8 +1013,12 @@ class PromptManager {
                 .then(userChoice => {
                     if (!userChoice) return;
 
+                    // SillyBunny: reset to the selected preset's saved order before falling back to the upstream default.
+                    const presetPromptOrder = getCurrentOpenAIPresetPromptOrder(this.activeCharacter?.id);
+                    const resetPromptOrder = presetPromptOrder.length ? presetPromptOrder : promptManagerDefaultPromptOrder;
+
                     this.removePromptOrderForCharacter(this.activeCharacter);
-                    this.addPromptOrderForCharacter(this.activeCharacter, promptManagerDefaultPromptOrder);
+                    this.addPromptOrderForCharacter(this.activeCharacter, resetPromptOrder);
 
                     this.render();
                     this.saveServiceSettings();

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -649,6 +649,27 @@ export let openai_settings;
 /** @type {import('./PromptManager.js').PromptManager} */
 export let promptManager = null;
 
+/**
+ * SillyBunny: prompt order reset needs the selected preset's saved order, not the current modified settings.
+ * Gets the prompt order from the selected OpenAI preset before user edits are applied.
+ * @param {number|string|null} characterId Character/dummy ID to match in the preset prompt order.
+ * @returns {Array<Object>} Prompt order from the selected preset, or an empty array.
+ */
+export function getCurrentOpenAIPresetPromptOrder(characterId) {
+    const presetName = oai_settings.preset_settings_openai;
+    const presetIndex = openai_setting_names?.[presetName];
+    const presetPromptOrder = openai_settings?.[presetIndex]?.prompt_order;
+
+    if (!Array.isArray(presetPromptOrder)) {
+        return [];
+    }
+
+    const promptOrderEntry = presetPromptOrder.find(entry => String(entry?.character_id) === String(characterId))
+        ?? presetPromptOrder.find(entry => Array.isArray(entry?.order));
+
+    return Array.isArray(promptOrderEntry?.order) ? promptOrderEntry.order : [];
+}
+
 async function validateReverseProxy() {
     if (!oai_settings.reverse_proxy) {
         return;


### PR DESCRIPTION
## Summary
- Reset prompt order from the selected OpenAI preset's saved `prompt_order`
- Fall back to the upstream hardcoded order only when the preset has no usable order
- Preserve custom preset-only prompt rows after accidental reset

## Tests
- `node --check public/scripts/openai.js`
- `node --check public/scripts/PromptManager.js`
- `npx --no-install eslint public/scripts/openai.js public/scripts/PromptManager.js`
- `git diff --check`
- `npm run build:frontend`