### PR TITLE
fix: preserve desktop prompt manager scroll

### DIFF
--- a/public/scripts/PromptManager.js
+++ b/public/scripts/PromptManager.js
@@ -1164,11 +1164,20 @@ class PromptManager {
     }
 
     #readScrollPosition() {
-        // SillyBunny: prefer .sb-shell-panel-scroller (the actual scroll container inside
-        // the SillyBunny shell) before falling back to upstream .scrollableInner, which is
-        // set to overflow:visible inside the shell and always reports scrollTop 0.
-        return document.getElementById(this.configuration.prefix + 'prompt_manager')
-            ?.closest('.sb-shell-panel-scroller, .scrollableInner')?.scrollTop;
+        return this.#getScrollContainer()?.scrollTop;
+    }
+
+    #getScrollContainer() {
+        const promptManager = document.getElementById(this.configuration.prefix + 'prompt_manager');
+        const listElement = this.listElement ?? promptManager?.querySelector(`#${this.configuration.prefix}prompt_manager_list`);
+
+        // SillyBunny: desktop split scrolls the constrained prompt list itself; mobile
+        // still scrolls through the shell/upstream panel container.
+        if (this.isDesktopSplitLayout() && listElement instanceof HTMLElement) {
+            return listElement;
+        }
+
+        return promptManager?.closest('.sb-shell-panel-scroller, .scrollableInner') ?? null;
     }
 
     #queuePromptManagerScrollRestore() {
@@ -1183,8 +1192,7 @@ class PromptManager {
     #setScrollPosition(scrollPosition) {
         const restoreState = resolvePromptManagerScrollRestore({ scrollPosition });
         if (!restoreState.shouldRestore) return;
-        const container = document.getElementById(this.configuration.prefix + 'prompt_manager')
-            ?.closest('.sb-shell-panel-scroller, .scrollableInner');
+        const container = this.#getScrollContainer();
         if (!container) return;
         container.scrollTo(0, restoreState.scrollPosition);
         // Defer a second restore to handle the reflow that occurs when renderPromptManager

--- a/tests/prompt-manager-lifecycle-wiring.test.js
+++ b/tests/prompt-manager-lifecycle-wiring.test.js
@@ -46,6 +46,14 @@ describe('prompt manager lifecycle wiring', () => {
         expect(source).not.toContain('scrollPosition === undefined || scrollPosition === null');
     });
 
+    test('preserves desktop prompt list scroll before shell fallback', () => {
+        const source = getMethodSource('#getScrollContainer');
+
+        expect(source).toContain('this.isDesktopSplitLayout()');
+        expect(source).toContain('prompt_manager_list');
+        expect(source.indexOf('return listElement;')).toBeLessThan(source.indexOf('closest(\'.sb-shell-panel-scroller, .scrollableInner\')'));
+    });
+
     test('captures prompt manager scroll before save-triggered render', () => {
         const saveStart = promptManagerSource.indexOf('this.handleSavePrompt = (event) => {');
         const saveEnd = promptManagerSource.indexOf('// Reset prompt should it be a system prompt', saveStart);


### PR DESCRIPTION
## Summary
- Preserve the desktop split prompt list scroll container when Prompt Manager rerenders.
- Keep the existing shell/upstream scroller fallback for mobile layouts.
- Add a Prompt Manager wiring regression test for the desktop scroll-container preference.

## Testing
- `./node_modules/.bin/eslint public/scripts/PromptManager.js tests/prompt-manager-lifecycle-wiring.test.js`
- `npm run test:unit -- prompt-manager-lifecycle-wiring.test.js prompt-manager-lifecycle.test.js --runInBand` from `tests/`