### PR TITLE
fix: prevent duplicate agent runner initialization

### DIFF
--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -88,6 +88,7 @@ let latestAssistantPostProcessingFallbackTimeout = null;
 let latestAssistantPostProcessingFallbackDeadline = 0;
 let postGenerationRecoveryTimeout = null;
 let missedGenerationEndRecoveryTimeout = null;
+let agentRunnerInitialized = false;
 let postGenerationRecoveryHooksInitialized = false;
 let postGenerationRecoveryObserver = null;
 const activePromptTransformToasts = new Set();
@@ -4008,6 +4009,11 @@ export async function redoPromptTransform(messageIndex) {
  * Registers all event listeners for the agent runner.
  */
 export function initAgentRunner() {
+    if (agentRunnerInitialized) {
+        return;
+    }
+
+    agentRunnerInitialized = true;
     initPostGenerationRecoveryHooks();
 
     eventSource.on(event_types.GENERATION_STARTED, onGenerationStarted);

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -573,6 +573,22 @@ describe('in-chat agent post-processing runner', () => {
         message.swipe_info[message.swipe_id].extra = structuredClone(message.extra);
     }
 
+    test('does not register duplicate event listeners when initialized twice', async () => {
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+
+        initAgentRunner();
+        initAgentRunner();
+
+        const listenerCount = (eventName) => eventSource.on.mock.calls.filter(([event]) => event === eventName).length;
+
+        expect(listenerCount(eventTypes.GENERATION_STARTED)).toBe(1);
+        expect(listenerCount(eventTypes.MESSAGE_RECEIVED)).toBe(1);
+        expect(listenerCount(eventTypes.GENERATION_ENDED)).toBe(1);
+        expect(listenerCount(eventTypes.WORLDINFO_UPDATED)).toBe(1);
+        expect(document.addEventListener).toHaveBeenCalledTimes(2);
+        expect(globalThis.addEventListener).toHaveBeenCalledTimes(2);
+    });
+
     test('does not mark normal chat generation as active agent generation', async () => {
         const { initAgentRunner, isAgentGenerationActive } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
         initAgentRunner();


### PR DESCRIPTION
## Summary
- Add a module-level idempotency guard to `initAgentRunner()` so event listeners are only registered once per module instance.
- Add focused coverage for calling `initAgentRunner()` twice without duplicating generation/message listeners or recovery hooks.

## Investigation
- `initAgentRunner()` was the only unguarded runner initialization path, while `initPostGenerationRecoveryHooks()` already had an idempotency guard.
- `in-chat-agents` has no manifest hooks, so the `callExtensionHook()` dynamic-import path is not the trigger for this extension.
- Extension activation skips already-active extensions; this fix keeps the runner safe if initialization is still entered more than once in the same module instance.

## Testing
- `npm run test:unit -- in-chat-agents-runner.test.js`
- `bun run test:unit -- in-chat-agents-runner.test.js`
- `npx eslint public/scripts/extensions/in-chat-agents/agent-runner.js`
- `npx eslint in-chat-agents-runner.test.js`