### PR TITLE
feat(tts): add OpenAI audio format selection

### DIFF
--- a/public/scripts/extensions/tts/openai-compatible.js
+++ b/public/scripts/extensions/tts/openai-compatible.js
@@ -4,6 +4,20 @@ import { getPreviewString, saveTtsProviderSettings } from './index.js';
 
 export { OpenAICompatibleTtsProvider };
 
+// SillyBunny: expose OpenAI-compatible response formats instead of forcing MP3.
+const OPENAI_COMPATIBLE_TTS_RESPONSE_FORMATS = [
+    { value: 'wav', label: 'WAV' },
+    { value: 'mp3', label: 'MP3' },
+    { value: 'opus', label: 'Opus' },
+    { value: 'aac', label: 'AAC' },
+    { value: 'flac', label: 'FLAC' },
+];
+
+function getOpenAiCompatibleTtsResponseFormat(value) {
+    const responseFormat = String(value ?? 'wav').toLowerCase();
+    return OPENAI_COMPATIBLE_TTS_RESPONSE_FORMATS.some(format => format.value === responseFormat) ? responseFormat : 'wav';
+}
+
 class OpenAICompatibleTtsProvider {
     settings;
     voices = [];
@@ -15,6 +29,7 @@ class OpenAICompatibleTtsProvider {
         voiceMap: {},
         model: 'tts-1',
         speed: 1,
+        response_format: 'wav',
         available_voices: ['alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer'],
         provider_endpoint: 'http://127.0.0.1:8000/v1/audio/speech',
     };
@@ -33,6 +48,10 @@ class OpenAICompatibleTtsProvider {
         </div>
         <label for="openai_compatible_model">Model:</label>
         <input id="openai_compatible_model" type="text" class="text_pole" maxlength="500" value="${this.defaultSettings.model}"/>
+        <label for="openai_compatible_tts_response_format">Output format:</label>
+        <select id="openai_compatible_tts_response_format">
+            ${OPENAI_COMPATIBLE_TTS_RESPONSE_FORMATS.map(format => `<option value="${format.value}">${format.label}</option>`).join('')}
+        </select>
         <label for="openai_compatible_tts_voices">Available Voices (comma separated):</label>
         <input id="openai_compatible_tts_voices" type="text" class="text_pole" value="${this.defaultSettings.available_voices.join()}"/>
         <label for="openai_compatible_tts_speed">Speed: <span id="openai_compatible_tts_speed_output"></span></label>
@@ -71,11 +90,16 @@ class OpenAICompatibleTtsProvider {
             }
         }
 
+        this.settings.response_format = getOpenAiCompatibleTtsResponseFormat(this.settings.response_format);
+
         $('#openai_compatible_tts_endpoint').val(this.settings.provider_endpoint);
         $('#openai_compatible_tts_endpoint').on('input', () => { this.onSettingsChange(); });
 
-        $('#openai_compatible_model').val(this.defaultSettings.model);
+        $('#openai_compatible_model').val(this.settings.model);
         $('#openai_compatible_model').on('input', () => { this.onSettingsChange(); });
+
+        $('#openai_compatible_tts_response_format').val(this.settings.response_format);
+        $('#openai_compatible_tts_response_format').on('change', () => { this.onSettingsChange(); });
 
         $('#openai_compatible_tts_voices').val(this.settings.available_voices.join());
         $('#openai_compatible_tts_voices').on('input', () => { this.onSettingsChange(); });
@@ -101,6 +125,7 @@ class OpenAICompatibleTtsProvider {
         // Update dynamically
         this.settings.provider_endpoint = String($('#openai_compatible_tts_endpoint').val());
         this.settings.model = String($('#openai_compatible_model').val());
+        this.settings.response_format = getOpenAiCompatibleTtsResponseFormat($('#openai_compatible_tts_response_format').find(':selected').val());
         this.settings.available_voices = String($('#openai_compatible_tts_voices').val()).split(',');
         this.settings.speed = Number($('#openai_compatible_tts_speed').val());
         $('#openai_compatible_tts_speed_output').text(this.settings.speed);
@@ -166,7 +191,7 @@ class OpenAICompatibleTtsProvider {
                 model: this.settings.model,
                 input: inputText,
                 voice: voiceId,
-                response_format: 'mp3',
+                response_format: this.settings.response_format,
                 speed: this.settings.speed,
             }),
         });

--- a/public/scripts/extensions/tts/openai.js
+++ b/public/scripts/extensions/tts/openai.js
@@ -1,19 +1,37 @@
 import { getRequestHeaders, substituteParams } from '../../../script.js';
-import { saveTtsProviderSettings, sanitizeId } from './index.js';
+import { getPreviewString, saveTtsProviderSettings, sanitizeId } from './index.js';
 
 export { OpenAITtsProvider };
+
+// SillyBunny: expose OpenAI's browser-playable response formats instead of forcing MP3.
+const OPENAI_TTS_RESPONSE_FORMATS = [
+    { value: 'wav', label: 'WAV' },
+    { value: 'mp3', label: 'MP3' },
+    { value: 'opus', label: 'Opus' },
+    { value: 'aac', label: 'AAC' },
+    { value: 'flac', label: 'FLAC' },
+];
+
+function getOpenAiTtsResponseFormat(value) {
+    const responseFormat = String(value ?? 'wav').toLowerCase();
+    return OPENAI_TTS_RESPONSE_FORMATS.some(format => format.value === responseFormat) ? responseFormat : 'wav';
+}
 
 class OpenAITtsProvider {
     static voices = [
         { name: 'Alloy', voice_id: 'alloy', lang: 'en-US', preview_url: 'https://cdn.openai.com/API/docs/audio/alloy.wav' },
         { name: 'Ash', voice_id: 'ash', lang: 'en-US', preview_url: 'https://cdn.openai.com/API/docs/audio/ash.wav' },
+        { name: 'Ballad', voice_id: 'ballad', lang: 'en-US', preview_url: false },
         { name: 'Coral', voice_id: 'coral', lang: 'en-US', preview_url: 'https://cdn.openai.com/API/docs/audio/coral.wav' },
         { name: 'Echo', voice_id: 'echo', lang: 'en-US', preview_url: 'https://cdn.openai.com/API/docs/audio/echo.wav' },
         { name: 'Fable', voice_id: 'fable', lang: 'en-US', preview_url: 'https://cdn.openai.com/API/docs/audio/fable.wav' },
+        { name: 'Marin', voice_id: 'marin', lang: 'en-US', preview_url: false },
         { name: 'Onyx', voice_id: 'onyx', lang: 'en-US', preview_url: 'https://cdn.openai.com/API/docs/audio/onyx.wav' },
         { name: 'Nova', voice_id: 'nova', lang: 'en-US', preview_url: 'https://cdn.openai.com/API/docs/audio/nova.wav' },
         { name: 'Sage', voice_id: 'sage', lang: 'en-US', preview_url: 'https://cdn.openai.com/API/docs/audio/sage.wav' },
         { name: 'Shimmer', voice_id: 'shimmer', lang: 'en-US', preview_url: 'https://cdn.openai.com/API/docs/audio/shimmer.wav' },
+        { name: 'Verse', voice_id: 'verse', lang: 'en-US', preview_url: false },
+        { name: 'Cedar', voice_id: 'cedar', lang: 'en-US', preview_url: false },
     ];
 
     settings;
@@ -26,6 +44,7 @@ class OpenAITtsProvider {
         customVoices: [],
         model: 'tts-1',
         speed: 1,
+        response_format: 'wav',
         characterInstructions: {},
     };
 
@@ -45,7 +64,15 @@ class OpenAITtsProvider {
                     <option value="tts-1-1106">tts-1-1106</option>
                     <option value="tts-1-hd-1106">tts-1-hd-1106</option>
                 </optgroup>
-            <select>
+            </select>
+            <small>Ballad, Marin, Verse, and Cedar require gpt-4o-mini-tts.</small>
+        </div>
+        <div>
+            <label for="openai-tts-response-format">Output format:</label>
+            <select id="openai-tts-response-format">
+                ${OPENAI_TTS_RESPONSE_FORMATS.map(format => `<option value="${format.value}">${format.label}</option>`).join('')}
+            </select>
+            <small>WAV is the default. OpenAI also supports raw PCM, but it is not exposed here because browser playback expects an audio container.</small>
         </div>
         <div>
             <label for="openai-tts-speed">Speed: <span id="openai-tts-speed-output"></span></label>
@@ -71,8 +98,15 @@ class OpenAITtsProvider {
             }
         }
 
+        this.settings.response_format = getOpenAiTtsResponseFormat(this.settings.response_format);
+
         $('#openai-tts-model').val(this.settings.model);
         $('#openai-tts-model').on('change', () => {
+            this.onSettingsChange();
+        });
+
+        $('#openai-tts-response-format').val(this.settings.response_format);
+        $('#openai-tts-response-format').on('change', () => {
             this.onSettingsChange();
         });
 
@@ -114,6 +148,7 @@ class OpenAITtsProvider {
     onSettingsChange() {
         // Update dynamically
         this.settings.model = String($('#openai-tts-model').find(':selected').val());
+        this.settings.response_format = getOpenAiTtsResponseFormat($('#openai-tts-response-format').find(':selected').val());
         this.settings.speed = Number($('#openai-tts-speed').val());
         $('#openai-tts-speed-output').text(this.settings.speed);
         this.updateInstructionsUI();
@@ -215,8 +250,17 @@ class OpenAITtsProvider {
         return OpenAITtsProvider.voices;
     }
 
-    async previewTtsVoice(_) {
-        return;
+    async previewTtsVoice(voiceId) {
+        this.audioElement.pause();
+        this.audioElement.currentTime = 0;
+
+        const text = getPreviewString('en-US');
+        const response = await this.fetchTtsGeneration(text, voiceId);
+        const audio = await response.blob();
+        const url = URL.createObjectURL(audio);
+        this.audioElement.src = url;
+        this.audioElement.play();
+        this.audioElement.onended = () => URL.revokeObjectURL(url);
     }
 
     async fetchTtsGeneration(inputText, voiceId, characterName = null) {
@@ -227,6 +271,7 @@ class OpenAITtsProvider {
             'voice': voiceId,
             'model': this.settings.model,
             'speed': this.settings.speed,
+            'response_format': this.settings.response_format,
         };
 
         if (this.settings.model === 'gpt-4o-mini-tts' && characterName) {

--- a/src/endpoints/openai.js
+++ b/src/endpoints/openai.js
@@ -12,6 +12,24 @@ import { AIMLAPI_HEADERS, OPENROUTER_HEADERS, SILICONFLOW_ENDPOINT, ZAI_ENDPOINT
 
 export const router = express.Router();
 
+// SillyBunny: keep OpenAI TTS proxy content types aligned with the requested audio format.
+const OPENAI_TTS_CONTENT_TYPES = {
+    mp3: 'audio/mpeg',
+    opus: 'audio/opus',
+    aac: 'audio/aac',
+    flac: 'audio/flac',
+    wav: 'audio/wav',
+};
+
+function getOpenAiTtsResponseFormat(value) {
+    const responseFormat = String(value ?? 'wav').toLowerCase();
+    return Object.hasOwn(OPENAI_TTS_CONTENT_TYPES, responseFormat) ? responseFormat : 'wav';
+}
+
+function getOpenAiTtsContentType(result, responseFormat) {
+    return result.headers.get('content-type') || OPENAI_TTS_CONTENT_TYPES[responseFormat] || OPENAI_TTS_CONTENT_TYPES.wav;
+}
+
 router.post('/caption-image', async (request, response) => {
     try {
         let key = '';
@@ -289,9 +307,10 @@ router.post('/generate-voice', async (request, response) => {
             return response.sendStatus(400);
         }
 
+        const responseFormat = getOpenAiTtsResponseFormat(request.body.response_format);
         const requestBody = {
             input: request.body.text,
-            response_format: 'mp3',
+            response_format: responseFormat,
             voice: request.body.voice ?? 'alloy',
             speed: request.body.speed ?? 1,
             model: request.body.model ?? 'tts-1',
@@ -319,7 +338,7 @@ router.post('/generate-voice', async (request, response) => {
         }
 
         const buffer = await result.arrayBuffer();
-        response.setHeader('Content-Type', 'audio/mpeg');
+        response.setHeader('Content-Type', getOpenAiTtsContentType(result, responseFormat));
         return response.send(Buffer.from(buffer));
     } catch (error) {
         console.error('OpenAI TTS generation failed', error);
@@ -773,6 +792,7 @@ custom.post('/generate-voice', async (request, response) => {
             return response.sendStatus(400);
         }
 
+        const responseFormat = getOpenAiTtsResponseFormat(response_format);
         const result = await fetch(provider_endpoint, {
             method: 'POST',
             headers: {
@@ -781,7 +801,7 @@ custom.post('/generate-voice', async (request, response) => {
             },
             body: JSON.stringify({
                 input: input ?? '',
-                response_format: response_format ?? 'mp3',
+                response_format: responseFormat,
                 voice: voice ?? 'alloy',
                 speed: speed ?? 1,
                 model: model ?? 'tts-1',
@@ -795,7 +815,7 @@ custom.post('/generate-voice', async (request, response) => {
         }
 
         const buffer = await result.arrayBuffer();
-        response.setHeader('Content-Type', 'audio/mpeg');
+        response.setHeader('Content-Type', getOpenAiTtsContentType(result, responseFormat));
         return response.send(Buffer.from(buffer));
     } catch (error) {
         console.error('OpenAI TTS generation failed', error);


### PR DESCRIPTION
## Summary
- Add output format selectors for OpenAI and OpenAI Compatible TTS with WAV as the default.
- Forward response_format to native and custom OpenAI TTS endpoints and preserve upstream audio Content-Type instead of forcing audio/mpeg.
- Add current OpenAI voices Ballad, Marin, Verse, and Cedar; dynamic preview generation covers voices without static preview clips.
- Preserve saved OpenAI-compatible model settings while adding the format setting.

## Research
- OpenAI TTS supports MP3, Opus, AAC, FLAC, WAV, and raw PCM.
- WAV avoids MP3 decoding overhead and is suitable for lower-latency playback.
- PCM is not exposed because SillyTavern playback expects browser-playable audio blobs.

## Testing
- git diff --check
- ./node_modules/.bin/eslint public/scripts/extensions/tts/openai.js public/scripts/extensions/tts/openai-compatible.js src/endpoints/openai.js