### PR TITLE
fix: align native chat style headers

### DIFF
--- a/public/css/sillybunny-chat-styles.css
+++ b/public/css/sillybunny-chat-styles.css
@@ -1173,6 +1173,24 @@ body:is(.echostyle, .whisperstyle, .hushstyle, .tidestyle) #chat .mes .ch_name .
         margin-bottom: 0 !important;
     }
 }
+
+@media screen and (min-width: 1001px) {
+    body:is(.echostyle, .whisperstyle, .hushstyle, .tidestyle) #chat .mes:not(.smallSysMes) .mesAvatarWrapper {
+        flex: 0 0 auto;
+        inline-size: auto;
+        min-inline-size: 0;
+        width: auto;
+    }
+
+    body:is(.echostyle, .whisperstyle, .hushstyle, .tidestyle) #chat .mes[is_user="false"]:not(.smallSysMes) .mesAvatarWrapper {
+        flex-direction: row;
+    }
+
+    body:is(.echostyle, .whisperstyle, .hushstyle, .tidestyle) #chat .mes:not(.smallSysMes) .mes_block .ch_name {
+        align-items: center;
+    }
+}
+
 body.big-avatars.echostyle #chat {
     .ch_name {
         margin-top: -22px !important;


### PR DESCRIPTION
## Summary
- Align Echo, Whisper, Hush, and Tide desktop chat headers by restoring the avatar metadata wrapper to a desktop row layout.
- Center the native chat style header row so message action icons align with the character name.
- Keep the existing max-width 1000px mobile layout untouched.

## Testing
- git diff --check