### PR TITLE
fix: improve Pathfinder swipe reuse and settings UI

### DIFF
--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -53,10 +53,13 @@ const PROMPT_KEY_PREFIX = 'inchat_agent_';
 const PATHFINDER_AUTO_SUMMARY_PROMPT_KEY = 'pathfinder_zz_auto_summary';
 const MESSAGE_EXTRA_KEY = 'inChatAgents';
 const POST_PROCESSING_RUNS_EXTRA_KEY = 'inChatAgentPostRuns';
+const PATHFINDER_RETRIEVAL_CACHE_EXTRA_KEY = 'pathfinderRetrievalCache';
 export const PROMPT_RUNS_EXTRA_KEY = 'inChatAgentPromptRuns';
 export const PROMPT_TRANSFORM_HISTORY_KEY = 'inChatAgentTransformHistory';
 export const PRE_GENERATION_INTERCEPT_HISTORY_KEY = 'inChatAgentPreGenerationInterceptHistory';
 const MAX_TRANSFORM_HISTORY = 10;
+const MAX_PATHFINDER_RETRIEVAL_CACHE = 6;
+const PATHFINDER_RETRIEVAL_CONTEXT_MESSAGE_LIMIT = 10;
 const pendingRefreshTimeouts = new Map();
 const pendingRegexSnapshotSaves = new WeakSet();
 const GREETING_GENERATION_TYPE = 'first_message';
@@ -957,6 +960,218 @@ function getMessageRevisionKey(message) {
         normalizeMessageRunValue(swipeInfo?.send_date ?? message?.send_date),
         normalizeMessageRunValue(message?.swipe_id),
     ].join('|');
+}
+
+function getPathfinderRetrievalCacheTarget(generationType) {
+    if (normalizeGenerationType(generationType) !== 'normal') {
+        return null;
+    }
+
+    if (generationStartLastAssistantIndex < 0 || generationStartLastAssistantIndex !== chat.length - 1) {
+        return null;
+    }
+
+    const message = chat[generationStartLastAssistantIndex];
+    if (!message || message !== generationStartLastAssistantMessage || message.is_user || message.is_system) {
+        return null;
+    }
+
+    return {
+        message,
+        messageIndex: generationStartLastAssistantIndex,
+    };
+}
+
+function getPathfinderCacheMessageRole(message) {
+    if (message?.is_system) {
+        return 'system';
+    }
+
+    return message?.is_user ? 'user' : 'assistant';
+}
+
+function getPathfinderRetrievalContextSnapshot(targetMessageIndex) {
+    const endIndex = Math.max(0, Number(targetMessageIndex));
+    const startIndex = Math.max(0, endIndex - PATHFINDER_RETRIEVAL_CONTEXT_MESSAGE_LIMIT);
+
+    return chat.slice(startIndex, endIndex).map((message, offset) => ({
+        index: startIndex + offset,
+        role: getPathfinderCacheMessageRole(message),
+        name: normalizeMessageRunValue(message?.name),
+        mes: normalizeMessageRunValue(message?.mes),
+        swipeId: normalizeMessageRunValue(message?.swipe_id),
+        sendDate: normalizeMessageRunValue(message?.send_date),
+        genStarted: normalizeMessageRunValue(message?.gen_started),
+        genFinished: normalizeMessageRunValue(message?.gen_finished),
+    }));
+}
+
+function normalizePathfinderCacheValue(value, seen = new WeakSet()) {
+    if (value instanceof Date) {
+        return value.toISOString();
+    }
+
+    if (Array.isArray(value)) {
+        return value.map(item => normalizePathfinderCacheValue(item, seen));
+    }
+
+    if (value && typeof value === 'object') {
+        if (seen.has(value)) {
+            return '[Circular]';
+        }
+
+        seen.add(value);
+        const normalized = {};
+        for (const key of Object.keys(value).sort()) {
+            const item = value[key];
+            if (typeof item === 'function' || item === undefined) {
+                continue;
+            }
+
+            normalized[key] = normalizePathfinderCacheValue(item, seen);
+        }
+        seen.delete(value);
+        return normalized;
+    }
+
+    if (typeof value === 'bigint') {
+        return String(value);
+    }
+
+    return value ?? null;
+}
+
+function getPathfinderRetrievalSettingsSnapshot(pathfinderAgent) {
+    let runtimeSettings = {};
+    try {
+        runtimeSettings = getPathfinderRuntimeSettings() ?? {};
+    } catch {
+        runtimeSettings = {};
+    }
+
+    return normalizePathfinderCacheValue({
+        agentId: pathfinderAgent?.id ?? '',
+        settings: pathfinderAgent?.settings ?? {},
+        runtimeSettings,
+    });
+}
+
+function buildPathfinderRetrievalCacheSignature(pathfinderAgent, activationSnapshot, generationType, cacheTarget) {
+    if (!cacheTarget) {
+        return '';
+    }
+
+    const signaturePayload = normalizePathfinderCacheValue({
+        version: 1,
+        chatId: normalizeSnapshotChatId(activationSnapshot?.chatId ?? getCurrentSnapshotChatId()),
+        generationType: normalizeGenerationType(generationType),
+        targetMessageIndex: cacheTarget.messageIndex,
+        promptKeys: PATHFINDER_RETRIEVAL_PROMPT_KEYS,
+        context: getPathfinderRetrievalContextSnapshot(cacheTarget.messageIndex),
+        pathfinder: getPathfinderRetrievalSettingsSnapshot(pathfinderAgent),
+    });
+
+    try {
+        return JSON.stringify(signaturePayload);
+    } catch {
+        return '';
+    }
+}
+
+function isPathfinderRetrievalCacheEntry(value) {
+    return Boolean(
+        value &&
+        typeof value === 'object' &&
+        typeof value.signature === 'string' &&
+        Array.isArray(value.prompts),
+    );
+}
+
+function appendPathfinderRetrievalCaches(target, value) {
+    if (Array.isArray(value)) {
+        target.push(...value.filter(isPathfinderRetrievalCacheEntry));
+    }
+}
+
+function getStoredPathfinderRetrievalCaches(message) {
+    const caches = [];
+    appendPathfinderRetrievalCaches(caches, message?.extra?.[PATHFINDER_RETRIEVAL_CACHE_EXTRA_KEY]);
+
+    if (Array.isArray(message?.swipe_info)) {
+        for (const swipeInfo of message.swipe_info) {
+            appendPathfinderRetrievalCaches(caches, swipeInfo?.extra?.[PATHFINDER_RETRIEVAL_CACHE_EXTRA_KEY]);
+        }
+    }
+
+    const deduped = new Map();
+    for (const cache of caches) {
+        deduped.set(cache.signature, cache);
+    }
+
+    return [...deduped.values()];
+}
+
+function findPathfinderRetrievalCache(message, signature) {
+    if (!signature) {
+        return null;
+    }
+
+    return getStoredPathfinderRetrievalCaches(message).find(cache => cache.signature === signature) ?? null;
+}
+
+function getPathfinderPromptValue(key) {
+    const prompt = extension_prompts[key];
+    if (!prompt || prompt.value === undefined || prompt.value === null) {
+        return '';
+    }
+
+    return String(prompt.value);
+}
+
+function capturePathfinderRetrievalPromptSnapshot() {
+    return PATHFINDER_RETRIEVAL_PROMPT_KEYS
+        .map(key => ({ key, value: getPathfinderPromptValue(key) }))
+        .filter(prompt => prompt.value.trim());
+}
+
+function restorePathfinderRetrievalPromptSnapshot(cache) {
+    if (!isPathfinderRetrievalCacheEntry(cache)) {
+        return false;
+    }
+
+    for (const prompt of cache.prompts) {
+        if (!PATHFINDER_RETRIEVAL_PROMPT_KEYS.includes(prompt?.key) || typeof prompt.value !== 'string' || !prompt.value.trim()) {
+            continue;
+        }
+
+        setExtensionPrompt(
+            prompt.key,
+            prompt.value,
+            extension_prompt_types.IN_PROMPT,
+            4,
+            false,
+            extension_prompt_roles.SYSTEM,
+        );
+    }
+
+    return true;
+}
+
+function storePathfinderRetrievalCache(message, signature) {
+    if (!message || !signature) {
+        return;
+    }
+
+    const cacheEntry = {
+        signature,
+        prompts: capturePathfinderRetrievalPromptSnapshot(),
+        savedAt: Date.now(),
+    };
+    const caches = getStoredPathfinderRetrievalCaches(message).filter(cache => cache.signature !== signature);
+    caches.push(cacheEntry);
+
+    setAgentExtraValue(message, PATHFINDER_RETRIEVAL_CACHE_EXTRA_KEY, caches.slice(-MAX_PATHFINDER_RETRIEVAL_CACHE));
+    saveChatDebounced();
 }
 
 function hasProcessedPostProcessingRun(message, runKey, messageIndex = null, indexRunKey = '') {
@@ -3146,21 +3361,34 @@ async function onGenerationAfterCommands(generationType, _options, dryRun) {
 
     if (!dryRun && pathfinderAgent) {
         const retrievalCancelRevision = agentGenerationCancelRevision;
-        const retrievalAbortController = new AbortController();
         syncPathfinderRuntimeSettings(pathfinderAgent);
-        activePathfinderRetrievalAbortControllers.add(retrievalAbortController);
+        const retrievalCacheTarget = getPathfinderRetrievalCacheTarget(normalizedGenerationType);
+        const retrievalCacheSignature = buildPathfinderRetrievalCacheSignature(pathfinderAgent, activationSnapshot, normalizedGenerationType, retrievalCacheTarget);
+        const cachedRetrieval = findPathfinderRetrievalCache(retrievalCacheTarget?.message, retrievalCacheSignature);
+        let retrievalAbortController = null;
 
-        try {
-            if (shouldShowPathfinderRetrievalToast(pathfinderAgent)) {
-                showPathfinderRetrievalToast();
+        if (cachedRetrieval) {
+            restorePathfinderRetrievalPromptSnapshot(cachedRetrieval);
+        } else {
+            retrievalAbortController = new AbortController();
+            activePathfinderRetrievalAbortControllers.add(retrievalAbortController);
+
+            try {
+                if (shouldShowPathfinderRetrievalToast(pathfinderAgent)) {
+                    showPathfinderRetrievalToast();
+                }
+                await runSidecarRetrieval(setExtensionPrompt, extension_prompt_types, extension_prompt_roles, retrievalAbortController.signal);
+            } finally {
+                clearPathfinderRetrievalToast();
+                activePathfinderRetrievalAbortControllers.delete(retrievalAbortController);
             }
-            await runSidecarRetrieval(setExtensionPrompt, extension_prompt_types, extension_prompt_roles, retrievalAbortController.signal);
-        } finally {
-            clearPathfinderRetrievalToast();
-            activePathfinderRetrievalAbortControllers.delete(retrievalAbortController);
+
+            if (!generationStopRequested && agentGenerationCancelRevision === retrievalCancelRevision && !retrievalAbortController.signal.aborted) {
+                storePathfinderRetrievalCache(retrievalCacheTarget?.message, retrievalCacheSignature);
+            }
         }
 
-        if (generationStopRequested || agentGenerationCancelRevision !== retrievalCancelRevision || retrievalAbortController.signal.aborted) {
+        if (generationStopRequested || agentGenerationCancelRevision !== retrievalCancelRevision || retrievalAbortController?.signal.aborted) {
             return;
         }
 

--- a/public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js
@@ -36,6 +36,7 @@ import { createSeparateSummaryMemoryEntry, createSummaryMemoryEntry, deriveSumma
 const MODULE_NAME = 'in-chat-agents';
 const PATHFINDER_LOG_PREFIX = '[Pathfinder]';
 const PATHFINDER_LOG_MODE_KEY = 'pathfinder-retrieval-log-mode';
+const PATHFINDER_QUICKSTART_DISMISSED_KEY = 'pathfinder-quickstart-dismissed';
 const DEFAULT_PIPELINE_MAX_TOKENS = 32000;
 
 let settingsEl = null;
@@ -45,6 +46,16 @@ let summaryMemoryUnsubscribe = null;
 
 function logPathfinder(message, ...details) {
     console.log(`${PATHFINDER_LOG_PREFIX} ${message}`, ...details);
+}
+
+function isQuickstartDismissed() {
+    return localStorage.getItem(PATHFINDER_QUICKSTART_DISMISSED_KEY) === 'true';
+}
+
+function applyQuickstartDismissalState() {
+    if (isQuickstartDismissed()) {
+        settingsEl.find('#pf--quickstart').hide();
+    }
 }
 
 function ensureEnabledLorebooks(settings) {
@@ -253,6 +264,7 @@ export async function openPathfinderSettings(agent) {
 
     // Initialize UI
     await refreshLorebookList();
+    applyQuickstartDismissalState();
     loadSettingsIntoUI();
     bindEvents();
     settingsEl.find('#pf--log-mode').val(retrievalLogMode);
@@ -532,46 +544,6 @@ function readPromptMaxTokens() {
     return Math.min(200000, Math.max(100, value));
 }
 
-const PATHFINDER_MODE_LABELS = {
-    off: 'Off',
-    tool: 'Tool',
-    pipeline: 'Pipeline',
-    both: 'Both',
-};
-
-function normalizePathfinderModeValue(value) {
-    const mode = String(value || '').trim().toLowerCase();
-    return Object.hasOwn(PATHFINDER_MODE_LABELS, mode) ? mode : 'off';
-}
-
-function getPathfinderModeValue(settings = getPathfinderSettings()) {
-    const toolEnabled = Boolean(settings?.sidecarEnabled);
-    const pipelineEnabled = Boolean(settings?.pipelineEnabled);
-
-    if (toolEnabled && pipelineEnabled) {
-        return 'both';
-    }
-
-    if (toolEnabled) {
-        return 'tool';
-    }
-
-    if (pipelineEnabled) {
-        return 'pipeline';
-    }
-
-    return 'off';
-}
-
-function applyPathfinderModeValue(settings, value) {
-    const mode = normalizePathfinderModeValue(value);
-
-    settings.sidecarEnabled = mode === 'tool' || mode === 'both';
-    settings.pipelineEnabled = mode === 'pipeline' || mode === 'both';
-
-    return mode;
-}
-
 /**
  * Load current settings into UI elements
  */
@@ -596,7 +568,6 @@ function loadSettingsIntoUI() {
     settingsEl.find('#pf--dedupe-natural-activation').prop('checked', s.dedupeNaturalActivation !== false);
     settingsEl.find('#pf--auto-summary').prop('checked', s.autoSummary || false);
     settingsEl.find('#pf--auto-summary-interval').val(s.autoSummaryInterval ?? 20);
-    settingsEl.find('#pf--mode-selector').val(getPathfinderModeValue(s));
 
     settingsEl.find('#pf--enable-summarize-tool').prop('checked', isPathfinderToolEnabled('Pathfinder_Summarize'));
 
@@ -788,6 +759,12 @@ ${recentChat}`;
  * Bind all event handlers
  */
 function bindEvents() {
+    settingsEl.find('#pf--quickstart-dismiss').on('click', () => {
+        localStorage.setItem(PATHFINDER_QUICKSTART_DISMISSED_KEY, 'true');
+        settingsEl.find('#pf--quickstart').slideUp(180);
+        logPathfinder('Dismissed Pathfinder introduction card.');
+    });
+
     settingsEl.find('#pf--master-enable').on('change', async function () {
         if (!currentAgent) {
             return;
@@ -840,21 +817,6 @@ function bindEvents() {
     });
 
     // Mode toggles
-    settingsEl.find('#pf--mode-selector').on('change', function () {
-        const s = getPathfinderSettings();
-        const previousToolEnabled = Boolean(s.sidecarEnabled);
-        const mode = applyPathfinderModeValue(s, $(this).val());
-        setPathfinderSettings(s);
-        logPathfinder(`Pathfinder mode set to ${PATHFINDER_MODE_LABELS[mode]}.`);
-        updateModeCardStates();
-        updateStatusBanner();
-        updateAgentSettings();
-
-        if (previousToolEnabled !== Boolean(s.sidecarEnabled)) {
-            syncToolAgentRegistrations();
-        }
-    });
-
     settingsEl.find('#pf--enable-tools').on('change', function () {
         const enabled = $(this).prop('checked');
         const s = getPathfinderSettings();
@@ -1510,7 +1472,6 @@ function updateModeCardStates() {
     const toolCard = settingsEl.find('.pf--mode-card[data-mode="tools"]');
     const pipelineCard = settingsEl.find('.pf--mode-card[data-mode="pipeline"]');
 
-    settingsEl.find('#pf--mode-selector').val(getPathfinderModeValue(s));
     settingsEl.find('#pf--enable-tools').prop('checked', toolEnabled);
     settingsEl.find('#pf--enable-pipeline').prop('checked', pipelineEnabled);
 

--- a/public/scripts/extensions/in-chat-agents/pathfinder-settings.html
+++ b/public/scripts/extensions/in-chat-agents/pathfinder-settings.html
@@ -21,8 +21,13 @@
     <!-- Quick Start Guide -->
     <div id="pf--quickstart" class="pf--quickstart">
         <div class="pf--quickstart-header">
-            <i class="fa-solid fa-route"></i>
-            <strong>What is Pathfinder?</strong>
+            <div class="pf--quickstart-title">
+                <i class="fa-solid fa-route"></i>
+                <strong>What is Pathfinder?</strong>
+            </div>
+            <button type="button" id="pf--quickstart-dismiss" class="pf--quickstart-close" aria-label="Hide Pathfinder explanation" title="Hide Pathfinder explanation">
+                <i class="fa-solid fa-xmark"></i>
+            </button>
         </div>
         <div class="pf--quickstart-body">
             <p>Pathfinder gives the AI <b>intelligent access to your lorebooks</b>. Instead of relying on keywords, it uses AI to predict which lore entries are relevant to the current scene.</p>
@@ -35,40 +40,43 @@
     </div>
 
     <!-- Step 1: Select Lorebooks -->
-    <div class="pf--section pf--section-primary">
-        <div class="pf--section-header">
+    <div id="pf--lorebook-section" class="pf--section pf--section-primary pf--section-collapsible">
+        <div class="pf--section-header pf--collapsible-header">
+            <i class="fa-solid fa-chevron-down pf--chevron"></i>
             <span class="pf--step-badge">1</span>
             <strong>Select Lorebooks</strong>
             <span class="pf--required">(Required)</span>
         </div>
-        <div class="pf--section-desc">
-            Choose which lorebooks Pathfinder can access. These must be lorebooks attached to your current character or chat.
-        </div>
-        <div id="pf--lorebook-list" class="pf--lorebook-list">
-            <div class="pf--empty-state">
-                <i class="fa-solid fa-book-open"></i>
-                <span>No lorebooks found. Attach a lorebook to your character first.</span>
+        <div class="pf--section-body">
+            <div class="pf--section-desc">
+                Choose which lorebooks Pathfinder can access. These must be lorebooks attached to your current character or chat.
             </div>
-        </div>
-        <div class="pf--lorebook-actions">
-            <button type="button" id="pf--refresh-lorebooks" class="menu_button menu_button_icon">
-                <i class="fa-solid fa-rotate"></i>
-                <span>Refresh List</span>
-            </button>
-        </div>
-        <div class="pf--setting-group pf--lorebook-toggle">
-            <label class="checkbox_label">
-                <input type="checkbox" id="pf--auto-use-attached" />
-                <span>Automatically use attached character/chat lorebooks</span>
-            </label>
-            <div class="pf--setting-help">When enabled, Pathfinder auto-selects lorebooks attached to the active character card or chat.</div>
-        </div>
-        <div class="pf--setting-group pf--lorebook-toggle">
-            <label class="checkbox_label">
-                <input type="checkbox" id="pf--auto-sync-lorebooks" />
-                <span>Reset selections to the current chat/character lorebooks on chat change</span>
-            </label>
-            <div class="pf--setting-help">Prevents a previous chat's lorebook from staying selected when the new chat has no attached lorebook.</div>
+            <div id="pf--lorebook-list" class="pf--lorebook-list">
+                <div class="pf--empty-state">
+                    <i class="fa-solid fa-book-open"></i>
+                    <span>No lorebooks found. Attach a lorebook to your character first.</span>
+                </div>
+            </div>
+            <div class="pf--lorebook-actions">
+                <button type="button" id="pf--refresh-lorebooks" class="menu_button menu_button_icon">
+                    <i class="fa-solid fa-rotate"></i>
+                    <span>Refresh List</span>
+                </button>
+            </div>
+            <div class="pf--setting-group pf--lorebook-toggle">
+                <label class="checkbox_label">
+                    <input type="checkbox" id="pf--auto-use-attached" />
+                    <span>Automatically use attached character/chat lorebooks</span>
+                </label>
+                <div class="pf--setting-help">When enabled, Pathfinder auto-selects lorebooks attached to the active character card or chat.</div>
+            </div>
+            <div class="pf--setting-group pf--lorebook-toggle">
+                <label class="checkbox_label">
+                    <input type="checkbox" id="pf--auto-sync-lorebooks" />
+                    <span>Reset selections to the current chat/character lorebooks on chat change</span>
+                </label>
+                <div class="pf--setting-help">Prevents a previous chat's lorebook from staying selected when the new chat has no attached lorebook.</div>
+            </div>
         </div>
     </div>
 
@@ -77,19 +85,6 @@
         <div class="pf--section-header">
             <span class="pf--step-badge">2</span>
             <strong>Choose How Pathfinder Works</strong>
-        </div>
-
-        <div class="pf--mode-selector-row">
-            <label class="pf--setting-label" for="pf--mode-selector">
-                <i class="fa-solid fa-route"></i>
-                <span>Mode</span>
-            </label>
-            <select id="pf--mode-selector" class="text_pole" aria-label="Pathfinder mode">
-                <option value="off">Off</option>
-                <option value="tool">Tool</option>
-                <option value="pipeline">Pipeline</option>
-                <option value="both">Both</option>
-            </select>
         </div>
 
         <!-- Warning banner when both modes enabled -->
@@ -569,6 +564,7 @@
 .pf--quickstart-header {
     display: flex;
     align-items: center;
+    justify-content: space-between;
     gap: 8px;
     padding: 10px 14px;
     background: color-mix(in srgb, var(--pf-surface-strong) 92%, var(--pf-accent) 8%);
@@ -576,8 +572,38 @@
     font-size: 14px;
 }
 
-.pf--quickstart-header i {
+.pf--quickstart-title {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+}
+
+.pf--quickstart-title i {
     color: var(--pf-accent);
+}
+
+.pf--quickstart-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: 30px;
+    height: 30px;
+    margin: -4px -6px -4px 8px;
+    border: 1px solid color-mix(in srgb, var(--pf-border) 72%, transparent);
+    border-radius: var(--pf-radius-sm);
+    background: color-mix(in srgb, var(--pf-surface-strong) 88%, var(--pf-text) 4%);
+    color: var(--pf-text-muted);
+    cursor: pointer;
+    transition: background 0.18s var(--pf-ease), border-color 0.18s var(--pf-ease), color 0.18s var(--pf-ease);
+}
+
+.pf--quickstart-close:hover,
+.pf--quickstart-close:focus-visible {
+    background: var(--pf-surface-hover);
+    border-color: color-mix(in srgb, var(--pf-border) 66%, var(--pf-accent) 20%);
+    color: var(--pf-text);
 }
 
 .pf--quickstart-body {
@@ -805,37 +831,6 @@
 }
 
 /* Mode Cards */
-.pf--mode-selector-row {
-    display: grid;
-    grid-template-columns: max-content minmax(160px, 260px);
-    align-items: center;
-    gap: 10px;
-    margin-bottom: 12px;
-    padding: 10px 12px;
-    background: color-mix(in srgb, var(--pf-surface-strong) 90%, var(--pf-accent) 6%);
-    border: 1px solid color-mix(in srgb, var(--pf-border) 80%, transparent);
-    border-radius: var(--pf-radius-md);
-}
-
-.pf--mode-selector-row .pf--setting-label {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    margin: 0;
-    font-size: 12px;
-    font-weight: 700;
-    color: var(--pf-text);
-}
-
-.pf--mode-selector-row .pf--setting-label i {
-    color: var(--pf-accent);
-}
-
-#pf--mode-selector {
-    width: 100%;
-    min-width: 0;
-}
-
 .pf--mode-cards {
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -1197,11 +1192,6 @@
 @media (max-width: 600px) {
     .pf--settings {
         max-height: calc(100dvh - 120px);
-    }
-
-    .pf--mode-selector-row {
-        grid-template-columns: 1fr;
-        align-items: stretch;
     }
 
     .pf--mode-cards {

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -292,7 +292,7 @@ describe('in-chat agent post-processing runner', () => {
         }));
 
         await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/sidecar-retrieval.js', () => ({
-            PATHFINDER_RETRIEVAL_PROMPT_KEYS: [],
+            PATHFINDER_RETRIEVAL_PROMPT_KEYS: ['pathfinder_sidecar_retrieval', 'pathfinder_pipeline_retrieval'],
             runSidecarRetrieval,
         }));
 
@@ -659,6 +659,76 @@ describe('in-chat agent post-processing runner', () => {
         resolveRetrieval();
         await generationPromise;
 
+        expect(extensionPrompts.pathfinder_pipeline_retrieval).toEqual({ value: 'retrieved lore' });
+        expect(extensionPrompts['inchat_agent_agent-pre-prompt']).toEqual({ value: 'Use the current scene style.' });
+    });
+
+    test('reuses cached Pathfinder retrieval when swiping the same assistant message', async () => {
+        usePrePromptAgent();
+        enabledAgents.unshift({
+            id: 'agent-pathfinder',
+            name: 'Pathfinder',
+            category: 'tool',
+            sourceTemplateId: 'tpl-pathfinder',
+            phase: 'both',
+            prompt: '',
+            injection: { order: 0 },
+            settings: { pipelineEnabled: true, sidecarEnabled: false, pipelineId: 'default' },
+            tools: [],
+            conditions: {
+                triggerKeywords: [],
+                triggerProbability: 100,
+                generationTypes: ['normal'],
+            },
+        });
+        chat.push(
+            {
+                name: 'User',
+                mes: 'Which lore applies here?',
+                is_user: true,
+                is_system: false,
+                send_date: 'user-1',
+                extra: {},
+            },
+            {
+                name: 'Assistant',
+                mes: 'First swipe',
+                is_user: false,
+                is_system: false,
+                send_date: 'assistant-0',
+                gen_started: 'started-0',
+                gen_finished: 'finished-0',
+                swipe_id: 0,
+                swipes: ['First swipe', 'Second swipe'],
+                swipe_info: [
+                    { send_date: 'assistant-0', gen_started: 'started-0', gen_finished: 'finished-0', extra: {} },
+                    { send_date: 'assistant-1', gen_started: 'started-1', gen_finished: 'finished-1', extra: {} },
+                ],
+                extra: {},
+            },
+        );
+        runSidecarRetrieval.mockImplementation(async (setPrompt, promptTypes, promptRoles) => {
+            setPrompt('pathfinder_pipeline_retrieval', 'retrieved lore', promptTypes.IN_PROMPT, 4, false, promptRoles.SYSTEM);
+        });
+
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        await eventSource.emit(eventTypes.GENERATION_AFTER_COMMANDS, 'normal', {}, false);
+
+        expect(runSidecarRetrieval).toHaveBeenCalledTimes(1);
+        expect(extensionPrompts.pathfinder_pipeline_retrieval).toEqual({ value: 'retrieved lore' });
+        expect(chat[1].swipe_info[0].extra.pathfinderRetrievalCache).toHaveLength(1);
+
+        switchToSwipe(chat[1], 1);
+
+        await eventSource.emit(eventTypes.GENERATION_STARTED, 'normal', {}, false);
+        expect(extensionPrompts.pathfinder_pipeline_retrieval).toBeUndefined();
+
+        await eventSource.emit(eventTypes.GENERATION_AFTER_COMMANDS, 'normal', {}, false);
+
+        expect(runSidecarRetrieval).toHaveBeenCalledTimes(1);
         expect(extensionPrompts.pathfinder_pipeline_retrieval).toEqual({ value: 'retrieved lore' });
         expect(extensionPrompts['inchat_agent_agent-pre-prompt']).toEqual({ value: 'Use the current scene style.' });
     });


### PR DESCRIPTION
## Summary
- Cache Pathfinder retrieval prompts per assistant-message swipe so revisiting the same swiped message can skip sidecar reprocessing.
- Remove the redundant Pathfinder Mode dropdown while keeping the existing mode cards as controls.
- Make Select Lorebooks collapsible and add a persistent close button for the What is Pathfinder intro card.

## Verification
- NODE_OPTIONS=--experimental-vm-modules npx --yes jest@29.7.0 --config tests/jest.config.json tests/in-chat-agents-runner.test.js --runInBand
- npx --no-install eslint public/scripts/extensions/in-chat-agents/agent-runner.js public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js tests/in-chat-agents-runner.test.js