### PR TITLE
fix: switch backend for bound reverse proxy presets

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -8405,7 +8405,8 @@ export function loadProxyPresets(settings) {
         appendProxyPresetOption(preset);
     }
     $('#openai_proxy_preset').val(selected_proxy.name);
-    setProxyPreset(selected_proxy.name, selected_proxy.url, selected_proxy.password, selected_proxy.source, { applySource: false });
+    const shouldApplySource = Boolean(selected_proxy.source);
+    setProxyPreset(selected_proxy.name, selected_proxy.url, selected_proxy.password, selected_proxy.source, { applySource: shouldApplySource });
 }
 
 function normalizeProxyPreset(preset) {

--- a/tests/openai-proxy-preset-wiring.test.js
+++ b/tests/openai-proxy-preset-wiring.test.js
@@ -63,4 +63,14 @@ describe('OpenAI proxy preset wiring', () => {
         expect(sourceChangeIndex).toBeGreaterThan(passwordUpdateIndex);
         expect(setProxyPresetSource).toContain('reconnectOpenAi();');
     });
+
+    test('applies selected proxy backend binding when loading presets', () => {
+        const loadProxyPresetsSource = getFunctionSource('loadProxyPresets');
+        const applySourceFlagIndex = loadProxyPresetsSource.indexOf('const shouldApplySource = Boolean(selected_proxy.source);');
+        const setProxyPresetIndex = loadProxyPresetsSource.indexOf('setProxyPreset(selected_proxy.name, selected_proxy.url, selected_proxy.password, selected_proxy.source, { applySource: shouldApplySource });');
+
+        expect(applySourceFlagIndex).toBeGreaterThanOrEqual(0);
+        expect(setProxyPresetIndex).toBeGreaterThan(applySourceFlagIndex);
+        expect(loadProxyPresetsSource).not.toContain('{ applySource: false }');
+    });
 });


### PR DESCRIPTION
## Summary
- apply a selected reverse proxy preset's backend binding during settings load
- keep unbound and None proxy presets from forcing a backend switch
- add a regression assertion for the proxy preset load path

## Tests
- npm run test:unit -- openai-proxy-preset-wiring.test.js openai-preset-utils.test.js
- npm run lint