### PR TITLE
fix: close release readiness regressions

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -225,12 +225,29 @@ SillyBunny includes some extras by default to help you get started right away:
 
 ### v1.6.1 (2026-05-31)
 
-This maintenance bump separates staging work merged after v1.6.0 so the next stable release changelog can collect it cleanly.
+This update carries the post-v1.6.0 staging line forward with safer chat rendering, tighter mobile navigation, sturdier preset/profile persistence, more reliable Quick Replies, and a broader cleanup pass across settings, screenshots, and release tooling.
+
+**Added**
+* Desktop vertical navigation settings and clearer mobile navigation customization make the shell easier to tune without changing the default layout.
+* Post-main in-chat agent intercept timing gives agent workflows a cleaner place to process main-model output.
+* OpenAI TTS now supports explicit audio format selection.
+* Current-chat files access, Quick Action icon picking, compact Pathfinder mode controls, and Pathfinder submodule toggles expand the utility surface without crowding first-run defaults.
 
 **Changed**
 * Updated app, Horde client, bundled extension, package, lockfile, and test metadata to 1.6.1.
-* Updated bundled tracker agent templates with Pura's Director Preset 13.3 wording and bumped affected tracker templates to v2 so installed agents can be manually updated from the version pill.
-* Added a script to detect changed bundled agent template content and bump matching template versions across individual template files and the bundled index.
+* Chat rendering now routes bottom scroll, redisplay, show-more, message updates, streaming, swipe replacement, media resize, and mobile viewport handling through lifecycle helpers with proven routes enabled by default.
+* Mobile shell, preset/API sync, generation, extension boot, Prompt Manager, and tooling hydration behavior now sit behind smaller lifecycle seams for easier future syncs and safer bug fixes.
+* Pura Director and bundled tracker templates were refreshed and versioned so installed agents can be manually updated from the version pill.
+* Release automation was refreshed so merged staging work is easier to keep represented in the changelog.
+
+**Fixed**
+* Connection profiles and presets now persist more reliably, including immediate connection-profile preset saves, prompt-order reset from the selected preset, reverse-proxy backend binding, and current chat-completion model fetching.
+* Quick Reply loading, active-set rendering, API listing, auto-execute, settings selectors, and context menus now dedupe duplicate set names without dropping saved chat or character links.
+* OOC and HTML context depth `0` now keeps the active turn while stripping older context messages.
+* Sampler visibility startup now avoids overwriting saved selections when browser storage is slow to respond.
+* Character avatar refresh, imported character selection, desktop Prompt Manager scroll, chat shell wheel routing, shell resize handles, Select2 dropdowns, native chat style headers, bounded rendered messages, and wand message screenshots were tightened.
+* Duplicate agent runner initialization, text-completion close handlers, local generation aborts, LCPP status restore, text-completion reasoning leaks, Guided Generations steering, post-agent provider-error handling, and Pathfinder swipe/settings reuse were hardened.
+* PR checks, changelog automation, frontend asset handling, and upstream touch tracking were cleaned up.
 
 ### v1.6.0 (2026-05-18)
 

--- a/README.md
+++ b/README.md
@@ -223,12 +223,29 @@ SillyBunny includes some extras by default to help you get started right away:
 
 ### v1.6.1 (2026-05-31)
 
-This maintenance bump separates staging work merged after v1.6.0 so the next stable release changelog can collect it cleanly.
+This update carries the post-v1.6.0 staging line forward with safer chat rendering, tighter mobile navigation, sturdier preset/profile persistence, more reliable Quick Replies, and a broader cleanup pass across settings, screenshots, and release tooling.
+
+**Added**
+* Desktop vertical navigation settings and clearer mobile navigation customization make the shell easier to tune without changing the default layout.
+* Post-main in-chat agent intercept timing gives agent workflows a cleaner place to process main-model output.
+* OpenAI TTS now supports explicit audio format selection.
+* Current-chat files access, Quick Action icon picking, compact Pathfinder mode controls, and Pathfinder submodule toggles expand the utility surface without crowding first-run defaults.
 
 **Changed**
 * Updated app, Horde client, bundled extension, package, lockfile, and test metadata to 1.6.1.
-* Updated bundled tracker agent templates with Pura's Director Preset 13.3 wording and bumped affected tracker templates to v2 so installed agents can be manually updated from the version pill.
-* Added a script to detect changed bundled agent template content and bump matching template versions across individual template files and the bundled index.
+* Chat rendering now routes bottom scroll, redisplay, show-more, message updates, streaming, swipe replacement, media resize, and mobile viewport handling through lifecycle helpers with proven routes enabled by default.
+* Mobile shell, preset/API sync, generation, extension boot, Prompt Manager, and tooling hydration behavior now sit behind smaller lifecycle seams for easier future syncs and safer bug fixes.
+* Pura Director and bundled tracker templates were refreshed and versioned so installed agents can be manually updated from the version pill.
+* Release automation was refreshed so merged staging work is easier to keep represented in the changelog.
+
+**Fixed**
+* Connection profiles and presets now persist more reliably, including immediate connection-profile preset saves, prompt-order reset from the selected preset, reverse-proxy backend binding, and current chat-completion model fetching.
+* Quick Reply loading, active-set rendering, API listing, auto-execute, settings selectors, and context menus now dedupe duplicate set names without dropping saved chat or character links.
+* OOC and HTML context depth `0` now keeps the active turn while stripping older context messages.
+* Sampler visibility startup now avoids overwriting saved selections when browser storage is slow to respond.
+* Character avatar refresh, imported character selection, desktop Prompt Manager scroll, chat shell wheel routing, shell resize handles, Select2 dropdowns, native chat style headers, bounded rendered messages, and wand message screenshots were tightened.
+* Duplicate agent runner initialization, text-completion close handlers, local generation aborts, LCPP status restore, text-completion reasoning leaks, Guided Generations steering, post-agent provider-error handling, and Pathfinder swipe/settings reuse were hardened.
+* PR checks, changelog automation, frontend asset handling, and upstream touch tracking were cleaned up.
 
 ### v1.6.0 (2026-05-18)
 

--- a/changelog.md
+++ b/changelog.md
@@ -15,8 +15,118 @@ This maintenance bump separates staging work merged after v1.6.0 so the next sta
 
 ### Merged Staging PRs
 - PR #155 (2026-05-24) `fix: chat scroll and prompt manager scroll position issues`
+- PR #156 (2026-05-22) `fix: improve mobile group and editor spacing`
+- PR #157 (2026-05-22) `chore: remove redundant fork update launcher`
 - PR #158 (2026-05-24) `feat: add mobile navigation customization`
 - PR #159 (2026-05-24) `fix: Make message generation glow theme-aware`
+- PR #160 (2026-05-23) `fix: avoid duplicate text completion close handlers`
+- PR #161 (2026-05-25) `fix: surface moving ui reset for offscreen panels`
+- PR #162 (2026-05-25) `fix: normalize character book positions`
+- PR #163 (2026-05-26) `fix: isolate local prompt cache lanes`
+- PR #165 (2026-05-26) `fix: abort generation on client disconnect`
+- PR #191 (2026-05-26) `Fix local generation aborts after stop`
+- PR #192 (2026-05-27) `fix: restore LCPP status after refresh`
+- PR #193 (2026-05-27) `fix: keep quick reply bar after startup`
+- PR #194 (2026-05-27) `Fix imported character auto-selection`
+- PR #195 (2026-05-27) `fix: respect OpenAI preset link mode`
+- PR #196 (2026-05-27) `Fix iOS group candidate row selection`
+- PR #197 (2026-05-27) `fix: prevent text completion reasoning leaks in agents`
+- PR #198 (2026-05-27) `fix: cover Guided Generations steering commands`
+- PR #199 (2026-05-27) `fix: support oklch message screenshots`
+- PR #200 (2026-05-27) `Fix Prose Polisher for guided impersonate`
+- PR #201 (2026-05-27) `refactor: chat scroll anchor lifecycle`
+- PR #203 (2026-05-27) `refactor: add chat render scroll intent resolver`
+- PR #204 (2026-05-27) `fix: keep input history menu above composer`
+- PR #205 (2026-05-28) `refactor: add chat render lifecycle index seam`
+- PR #206 (2026-05-28) `chore: add chat lifecycle rollout guard`
+- PR #207 (2026-05-27) `fix: stop disabled extensions injecting prompts`
+- PR #208 (2026-05-28) `refactor: route chat bottom scroll through lifecycle`
+- PR #211 (2026-05-29) `Refactor redisplay chat batching through lifecycle`
+- PR #212 (2026-05-29) `Refactor show-more batching through lifecycle`
+- PR #213 (2026-05-29) `Refactor chat lifecycle update queue helper`
+- PR #214 (2026-05-29) `Refactor chat lifecycle message update route`
+- PR #215 (2026-05-29) `Refactor mobile message updates through lifecycle queue`
+- PR #216 (2026-05-29) `Refactor chat lifecycle stream buffer helper`
+- PR #217 (2026-05-29) `Refactor streaming start scroll through lifecycle`
+- PR #218 (2026-05-29) `Refactor streaming progress writes through lifecycle`
+- PR #219 (2026-05-29) `Test replace-message anchor positions`
+- PR #220 (2026-05-29) `Route swipe replacement through lifecycle`
+- PR #221 (2026-05-29) `Add lifecycle resize observer helper`
+- PR #227 (2026-05-29) `Refactor chat lifecycle media resize route`
+- PR #228 (2026-05-29) `Fix Guided Generations GGSystemPrompt cleanup`
+- PR #229 (2026-05-29) `Refactor chat lifecycle mobile viewport helper`
+- PR #230 (2026-05-29) `Refactor chat lifecycle mobile viewport route`
+- PR #231 (2026-05-29) `test: add chat render performance baseline`
+- PR #232 (2026-05-29) `Refactor chat lifecycle route rollout defaults`
+- PR #233 (2026-05-29) `Refactor chat lifecycle bottom scroll default on`
+- PR #234 (2026-05-29) `Refactor chat lifecycle initial load default on`
+- PR #235 (2026-05-29) `Refactor chat lifecycle redisplay batch default on`
+- PR #236 (2026-05-29) `Refactor chat lifecycle show more default on`
+- PR #237 (2026-05-29) `Refactor chat lifecycle message update default on`
+- PR #238 (2026-05-29) `Refactor chat lifecycle streaming start default on`
+- PR #239 (2026-05-29) `Refactor chat lifecycle streaming progress default on`
+- PR #240 (2026-05-29) `Refactor chat lifecycle replace message default on`
+- PR #241 (2026-05-29) `Refactor chat lifecycle media resize default on`
+- PR #242 (2026-05-29) `Refactor chat lifecycle mobile viewport default on`
+- PR #243 (2026-05-29) `Refactor mobile shell lifecycle helper`
+- PR #244 (2026-05-29) `Refactor mobile shell lifecycle wiring`
+- PR #245 (2026-05-29) `Refactor preset API sync lifecycle helper`
+- PR #246 (2026-05-29) `Refactor preset API sync lifecycle wiring`
+- PR #247 (2026-05-29) `Refactor generation lifecycle helper`
+- PR #248 (2026-05-29) `Refactor generation lifecycle wiring`
+- PR #249 (2026-05-29) `Refactor extension boot lifecycle helper`
+- PR #250 (2026-05-29) `Refactor extension boot lifecycle wiring`
+- PR #251 (2026-05-29) `Refactor prompt manager lifecycle helper`
+- PR #252 (2026-05-29) `Refactor prompt manager lifecycle wiring`
+- PR #253 (2026-05-29) `Refactor tooling UI hydration helper`
+- PR #254 (2026-05-29) `Refactor tooling UI hydration wiring`
+- PR #255 (2026-05-29) `Fix bulk preset deletion tooltip copy`
+- PR #256 (2026-05-29) `Add compact Pathfinder mode selector`
+- PR #257 (2026-05-29) `Add Quick Action icon picker`
+- PR #258 (2026-05-29) `Fix character lorebook focus routing`
+- PR #259 (2026-05-29) `Fix first-launch topbar scale default`
+- PR #260 (2026-05-29) `Style boolean radio choices as segmented toggles`
+- PR #261 (2026-05-29) `Fix Workspace Select2 dropdown geometry`
+- PR #262 (2026-05-29) `Fix Quick Image Gen collapsed drawer layout`
+- PR #263 (2026-05-29) `Add Pathfinder submodule toggle`
+- PR #264 (2026-05-29) `Stabilize mobile sampler range rows`
+- PR #265 (2026-05-29) `Add current chat files access`
+- PR #266 (2026-05-29) `Add vertical chat layout setting`
+- PR #267 (2026-05-29) `Preserve Prompt Manager scroll after save`
+- PR #268 (2026-05-29) `Show source prompt token counts before generation`
+- PR #269 (2026-05-29) `fix: encode Google Font family spaces correctly`
+- PR #270 (2026-05-29) `fix: make mobile quick action icons tappable`
+- PR #271 (2026-05-29) `fix: stabilize chat scrolling`
+- PR #272 (2026-05-29) `Fix post agents after provider errors`
+- PR #273 (2026-05-29) `Fix chat vectorization toggle persistence`
+- PR #274 (2026-05-29) `Bind reverse proxy presets to source`
+- PR #275 (2026-05-29) `Fix iOS streaming scroll jitter`
+- PR #276 (2026-05-29) `Fix in-chat agent regex refresh`
+- PR #278 (2026-05-29) `fix: stabilize streaming resize scroll pins`
+- PR #279 (2026-05-29) `feat: add desktop vertical navigation settings`
+- PR #280 (2026-05-31) `fix: chat shell wheel routing`
+- PR #281 (2026-05-31) `feat: add post-main in-chat agent intercept timing`
+- PR #283 (2026-06-02) `fix: persist presets immediately in connection profiles`
+- PR #285 (2026-06-02) `feat: add explicit UI for reverse proxy backend binding`
+- PR #286 (2026-05-31) `chore: Bump version numbers from 1.6.0 to 1.6.1`
+- PR #287 (2026-06-02) `fix: improve server plugin dependency diagnostics`
+- PR #288 (2026-05-31) `chore: update Pura director preset and tracker templates`
+- PR #289 (2026-06-02) `fix: reset prompt order from selected preset`
+- PR #290 (2026-06-02) `fix: make shell resize handles more visible`
+- PR #291 (2026-06-02) `fix: preserve desktop prompt manager scroll`
+- PR #292 (2026-05-31) `fix: prevent duplicate agent runner initialization`
+- PR #293 (2026-05-31) `chore: update Pura Director Preset agents to v2`
+- PR #294 (2026-06-02) `feat(tts): add OpenAI audio format selection`
+- PR #295 (2026-06-02) `fix: bound rendered chat messages`
+- PR #296 (2026-06-02) `chore: align PR checks with SillyBunny`
+- PR #297 (2026-06-02) `fix: fetch current chat completion models`
+- PR #298 (2026-06-02) `fix: refresh edited character avatars`
+- PR #299 (2026-06-02) `fix: align desktop shell tabs with navigation preferences`
+- PR #300 (2026-06-02) `fix: align native chat style headers`
+- PR #301 (2026-06-02) `fix: improve Pathfinder swipe reuse and settings UI`
+- PR #302 (2026-06-02) `fix: harden Select2 dropdown surfaces`
+- PR #303 (2026-06-02) `fix: prevent corrupted wand message screenshots`
+- PR #304 (2026-06-02) `fix: switch backend for bound reverse proxy presets`
 
 ## v1.6.0
 

--- a/docs/upstream-touch-ledger.md
+++ b/docs/upstream-touch-ledger.md
@@ -102,6 +102,58 @@ This ledger tracks intentional SillyBunny divergence in upstream-origin files. I
 | Last reviewed | 2026-05-28 extension boot lifecycle wiring. |
 | Owner | Refactor integrator and extension runtime owner. |
 
+### `public/scripts/extensions/quick-reply/` - active set canonicalization
+| Field | Value |
+| --- | --- |
+| Area | Extension quick replies, settings, and automation. |
+| Divergence reason | SillyBunny needs duplicate Quick Reply set names from saved/imported data to resolve to one canonical active set so buttons, auto-execute, API lookup, settings selectors, and persisted chat/character links do not duplicate or disappear. |
+| Target seam | `public/scripts/extensions/quick-reply/src/quick-reply-set-list.js`. |
+| Adapter shape | Keep call sites using normalized set/link helpers for load, render, API, auto-execute, and settings traversal. |
+| Protecting tests | `tests/quick-reply-set-list.test.js`, `tests/quick-reply-config.test.js`, `tests/quick-reply-button-ui.test.js`, `tests/quick-reply-auto-execute.test.js`, `tests/quick-reply-api.test.js`. |
+| Validation | `npm run test:unit --prefix tests -- quick-reply-set-list.test.js quick-reply-config.test.js quick-reply-button-ui.test.js quick-reply-auto-execute.test.js quick-reply-api.test.js`, `npm run lint`, `npm run check:frontend-budgets`. |
+| Rollback path | Remove helper calls and revert to exact-name set/link traversal if canonicalization regresses saved Quick Reply data. |
+| Last reviewed | 2026-06-02 Quick Replies duplicate fix. |
+| Owner | Refactor integrator and extension runtime owner. |
+
+### `public/scripts/ooc-blocks.js` - prompt context retention
+| Field | Value |
+| --- | --- |
+| Area | Prompt context and settings. |
+| Divergence reason | SillyBunny exposes OOC and raw HTML retention depth where `0` must keep the active turn while stripping older context messages. |
+| Target seam | `public/scripts/ooc-blocks.js`. |
+| Adapter shape | Keep retention-depth normalization and message-depth checks in this module; keep settings copy in `public/index.html` aligned with behavior. |
+| Protecting tests | `tests/ooc-blocks.test.js`. |
+| Validation | `npm run test:unit --prefix tests -- ooc-blocks.test.js`, `npm run lint`, `npm run check:frontend-budgets`. |
+| Rollback path | Revert the comparison and settings copy to previous strip-at-zero behavior. |
+| Last reviewed | 2026-06-02 active-turn retention fix. |
+| Owner | Refactor integrator. |
+
+### `public/scripts/samplerSelect.js` - selected sampler storage
+| Field | Value |
+| --- | --- |
+| Area | Preset/API sync and sampler settings. |
+| Divergence reason | SillyBunny persists text-generation sampler visibility and manual priority while guarding startup from slow IndexedDB reads that could otherwise overwrite saved selections with fallback state. |
+| Target seam | `public/scripts/sampler-storage.js`. |
+| Adapter shape | Keep `samplerSelect.js` as the DOM/settings adapter and delegate timeout-backed storage loading to `sampler-storage.js`. |
+| Protecting tests | `tests/sampler-storage.test.js`. |
+| Validation | `npm run test:unit --prefix tests -- sampler-storage.test.js`, `npm run lint`, `npm run check:frontend-budgets`. |
+| Rollback path | Revert the storage helper import and save guard, returning to direct `localforage.getItem('selectedSamplers')` loading. |
+| Last reviewed | 2026-06-02 sampler storage timeout guard. |
+| Owner | Refactor integrator and preset/API sync owner. |
+
+### `public/index.html` - boot assets and settings copy
+| Field | Value |
+| --- | --- |
+| Area | Settings and frontend boot. |
+| Divergence reason | SillyBunny keeps `script.js` loaded through its canonical URL and keeps OOC/HTML retention settings copy synchronized with active-turn depth behavior. |
+| Target seam | `public/scripts/ooc-blocks.js` for retention behavior; no separate seam for the HTML boot URL. |
+| Adapter shape | Keep HTML changes limited to static boot references and settings labels/tooltips. |
+| Protecting tests | `tests/frontend-assets.test.js`, `tests/ooc-blocks.test.js`. |
+| Validation | `npm run test:unit --prefix tests -- frontend-assets.test.js ooc-blocks.test.js`, `npm run build:frontend`, browser smoke check. |
+| Rollback path | Restore versioned `script.js` references and previous settings copy if cache behavior or settings semantics regress. |
+| Last reviewed | 2026-06-02 frontend asset and OOC settings update. |
+| Owner | Refactor integrator. |
+
 ### `public/scripts/PromptManager.js` - prompt manager lifecycle
 | Field | Value |
 | --- | --- |

--- a/public/index.html
+++ b/public/index.html
@@ -18,7 +18,7 @@
         }
     </style>
     <link rel="preload" as="style" href="style.css?v=20260523b">
-    <link rel="modulepreload" href="script.js?v=20260602a">
+    <link rel="modulepreload" href="script.js">
     <link rel="modulepreload" href="scripts/sillybunny-tabs.js?v=20260602a">
     <link rel="preload" as="font" type="font/woff2" href="webfonts/Figtree/Figtree-Regular.woff2?v=20260422b" crossorigin>
     <link rel="manifest" crossorigin="use-credentials" href="manifest.json">
@@ -5651,16 +5651,16 @@
                                     <small data-i18n="Show tags in responses">Show &lt;tags&gt; in responses</small>
                                 </label>
                                 <div class="flex-container alignitemscenter gap10">
-                                    <label for="ooc_context_depth" class="flex1" title="Keep OOC ((...)) blocks in prompt context. -1 keeps all messages, 0 strips all messages, N keeps the last N messages." data-i18n="[title]Keep OOC blocks in prompt context. -1 keeps all messages, 0 strips all messages, N keeps the last N messages.">
+                                    <label for="ooc_context_depth" class="flex1" title="Keep OOC ((...)) blocks in prompt context. -1 keeps all messages, 0 keeps only the active turn, N keeps through depth N." data-i18n="[title]Keep OOC blocks in prompt context. -1 keeps all messages, 0 keeps only the active turn, N keeps through depth N.">
                                         <small data-i18n="OOC context depth">OOC context depth</small>
-                                        <small class="opacity50p" data-i18n="-1 keeps all OOC blocks; 0 strips all; N keeps the last N messages.">-1 keeps all OOC blocks; 0 strips all; N keeps the last N messages.</small>
+                                        <small class="opacity50p" data-i18n="-1 keeps all OOC blocks; 0 keeps active turn only; N keeps through depth N.">-1 keeps all OOC blocks; 0 keeps active turn only; N keeps through depth N.</small>
                                     </label>
                                     <input id="ooc_context_depth" class="text_pole widthUnset" type="number" min="-1" step="1" value="-1" />
                                 </div>
                                 <div class="flex-container alignitemscenter gap10">
-                                    <label for="html_context_depth" class="flex1" title="Keep raw HTML tags in prompt context. -1 keeps all messages, 0 strips all messages, N keeps the last N messages." data-i18n="[title]Keep raw HTML tags in prompt context. -1 keeps all messages, 0 strips all messages, N keeps the last N messages.">
+                                    <label for="html_context_depth" class="flex1" title="Keep raw HTML tags in prompt context. -1 keeps all messages, 0 keeps only the active turn, N keeps through depth N." data-i18n="[title]Keep raw HTML tags in prompt context. -1 keeps all messages, 0 keeps only the active turn, N keeps through depth N.">
                                         <small data-i18n="HTML tag context depth">HTML tag context depth</small>
-                                        <small class="opacity50p" data-i18n="-1 keeps all HTML tags; 0 strips all; N keeps the last N messages.">-1 keeps all HTML tags; 0 strips all; N keeps the last N messages.</small>
+                                        <small class="opacity50p" data-i18n="-1 keeps all HTML tags; 0 keeps active turn only; N keeps through depth N.">-1 keeps all HTML tags; 0 keeps active turn only; N keeps through depth N.</small>
                                     </label>
                                     <input id="html_context_depth" class="text_pole widthUnset" type="number" min="-1" step="1" value="-1" />
                                 </div>
@@ -8750,7 +8750,7 @@
     <script type="module" src="lib/eventemitter.js"></script>
     <script type="module" src="scripts/i18n.js"></script>
     <script type="module" src="scripts/performance-loader.js"></script>
-    <script type="module" src="script.js?v=20260602a"></script>
+    <script type="module" src="script.js"></script>
     <script type="module" src="scripts/sillybunny-tabs.js?v=20260602a"></script>
     <script>
         window.addEventListener('load', (event) => {

--- a/public/scripts/extensions/quick-reply/api/QuickReplyApi.js
+++ b/public/scripts/extensions/quick-reply/api/QuickReplyApi.js
@@ -4,6 +4,7 @@ import { QuickReplySet } from '../src/QuickReplySet.js';
 import { QuickReplySettings } from '../src/QuickReplySettings.js';
 import { SettingsUi } from '../src/ui/SettingsUi.js';
 import { onlyUnique } from '../../../utils.js';
+import { getUniqueQuickReplySetLinksBySetName, getUniqueQuickReplySetsByName } from '../src/quick-reply-set-list.js';
 
 export class QuickReplyApi {
     /** @type {QuickReplySettings} */ settings;
@@ -56,7 +57,7 @@ export class QuickReplyApi {
      * @returns the return value of the quick reply, or undefined if not found
      */
     async executeQuickReplyByIndex(idx) {
-        const qr = [...this.settings.config.setList, ...(this.settings.chatConfig?.setList ?? [])]
+        const qr = getUniqueQuickReplySetLinksBySetName([...this.settings.config.setList, ...(this.settings.chatConfig?.setList ?? [])])
             .map(it => it.set.qrList)
             .flat()[idx]
         ;
@@ -454,7 +455,7 @@ export class QuickReplyApi {
      * @returns array with the names of all quick reply sets
      */
     listSets() {
-        return QuickReplySet.list.map(it => it.name);
+        return getUniqueQuickReplySetsByName(QuickReplySet.list).map(it => it.name);
     }
     /**
      * Gets a list of all globally active quick reply sets.
@@ -462,7 +463,7 @@ export class QuickReplyApi {
      * @returns array with the names of all quick reply sets
      */
     listGlobalSets() {
-        return this.settings.config.setList.map(it => it.set.name);
+        return getUniqueQuickReplySetLinksBySetName(this.settings.config.setList).map(it => it.set.name);
     }
     /**
      * Gets a list of all quick reply sets activated by the current chat.
@@ -470,7 +471,7 @@ export class QuickReplyApi {
      * @returns array with the names of all quick reply sets
      */
     listChatSets() {
-        return this.settings.chatConfig?.setList?.flatMap(it => it.set.name) ?? [];
+        return getUniqueQuickReplySetLinksBySetName(this.settings.chatConfig?.setList).map(it => it.set.name);
     }
 
     /**

--- a/public/scripts/extensions/quick-reply/index.js
+++ b/public/scripts/extensions/quick-reply/index.js
@@ -5,6 +5,7 @@ import { AutoExecuteHandler } from './src/AutoExecuteHandler.js';
 // QuickReply imported lazily inside loadSets to avoid circular TDZ
 import { QuickReplyConfig } from './src/QuickReplyConfig.js';
 import { QuickReplySet } from './src/QuickReplySet.js';
+import { getUniqueQuickReplySetLinksBySetName, getUniqueQuickReplySetsByName } from './src/quick-reply-set-list.js';
 import { QuickReplySettings } from './src/QuickReplySettings.js';
 import { SlashCommandHandler } from './src/SlashCommandHandler.js';
 import { ButtonUi } from './src/ui/ButtonUi.js';
@@ -60,6 +61,7 @@ const loadSets = async () => {
 
     if (response.ok) {
         const setList = (await response.json()).quickReplyPresets ?? [];
+        const migratedSets = [];
         for (const set of setList) {
             if (set.version !== 2) {
                 // migrate old QR set
@@ -90,13 +92,20 @@ const loadSets = async () => {
                 });
             }
             if (set.version == 2) {
-                QuickReplySet.list.push(QuickReplySet.from(JSON.parse(JSON.stringify(set))));
+                migratedSets.push(set);
             }
         }
+        const uniqueSets = getUniqueQuickReplySetsByName(migratedSets);
+        if (uniqueSets.length !== migratedSets.length) {
+            warn(`Skipped ${migratedSets.length - uniqueSets.length} duplicate Quick Reply set(s) while loading.`);
+        }
+
+        QuickReplySet.list.splice(0, QuickReplySet.list.length, ...uniqueSets.map(set => QuickReplySet.from(JSON.parse(JSON.stringify(set)))));
+
         // need to load QR lists after all sets are loaded to be able to resolve context menu entries
         const { QuickReply } = await import('./src/QuickReply.js');
-        setList.forEach((set, idx) => {
-            QuickReplySet.list[idx].qrList = set.qrList.map(it => QuickReply.from(it));
+        uniqueSets.forEach((set, idx) => {
+            QuickReplySet.list[idx].qrList = (set.qrList ?? []).map(it => QuickReply.from(it));
             QuickReplySet.list[idx].init();
         });
         log('sets: ', QuickReplySet.list);
@@ -196,11 +205,11 @@ async function doInit() {
             ...settings.config.setList,
             ...(settings.chatConfig?.setList ?? []),
             ...(settings.charConfig?.setList ?? []),
-        ]
+        ];
+        qr = getUniqueQuickReplySetLinksBySetName(qr)
             .map(it => it.set.qrList)
             .flat()
-            .find(it => it.label == name)
-            ;
+            .find(it => it.label == name);
         if (!qr) {
             let [setName, ...qrName] = name.split('.');
             qrName = qrName.join('.');

--- a/public/scripts/extensions/quick-reply/src/AutoExecuteHandler.js
+++ b/public/scripts/extensions/quick-reply/src/AutoExecuteHandler.js
@@ -1,6 +1,5 @@
+import { getUniqueQuickReplySetLinksBySetName } from './quick-reply-set-list.js';
 import { warn } from './shared.js';
-import { QuickReply } from './QuickReply.js';
-import { QuickReplySettings } from './QuickReplySettings.js';
 
 export class AutoExecuteHandler {
     /** @type {QuickReplySettings} */ settings;
@@ -33,15 +32,13 @@ export class AutoExecuteHandler {
 
 
     getCommands(eventName) {
-        const getFromConfig = (config) => {
-            // This safely handles cases where a link exists but the set hasn't been loaded (link.set is null)
-            return config?.setList?.map(link => link.set ? link.set.qrList.filter(qr => qr[eventName]) : [])?.flat() ?? [];
-        };
-        return [
-            ...getFromConfig(this.settings.config),
-            ...getFromConfig(this.settings.chatConfig),
-            ...getFromConfig(this.settings.charConfig),
-        ];
+        return getUniqueQuickReplySetLinksBySetName([
+            ...(this.settings.config?.setList ?? []),
+            ...(this.settings.chatConfig?.setList ?? []),
+            ...(this.settings.charConfig?.setList ?? []),
+        ])
+            .map(link => link.set ? link.set.qrList.filter(qr => qr[eventName]) : [])
+            .flat();
     }
 
     async handleStartup() {
@@ -87,17 +84,13 @@ export class AutoExecuteHandler {
         const automationIds = entries.map(entry => entry.automationId).filter(Boolean);
         if (automationIds.length === 0) return;
 
-        const getFromConfig = (config) => {
-            return config?.setList
-                ?.map(link => link.set ? link.set.qrList.filter(qr => qr.automationId && automationIds.includes(qr.automationId)) : [])
-                ?.flat() ?? [];
-        };
-
-        const qrList = [
-            ...getFromConfig(this.settings.config),
-            ...getFromConfig(this.settings.chatConfig),
-            ...getFromConfig(this.settings.charConfig),
-        ];
+        const qrList = getUniqueQuickReplySetLinksBySetName([
+            ...(this.settings.config?.setList ?? []),
+            ...(this.settings.chatConfig?.setList ?? []),
+            ...(this.settings.charConfig?.setList ?? []),
+        ])
+            .map(link => link.set ? link.set.qrList.filter(qr => qr.automationId && automationIds.includes(qr.automationId)) : [])
+            .flat();
 
         await this.performAutoExecute(qrList);
     }

--- a/public/scripts/extensions/quick-reply/src/QuickReply.js
+++ b/public/scripts/extensions/quick-reply/src/QuickReply.js
@@ -15,6 +15,7 @@ import { debounce, delay, getSortableDelay, showFontAwesomePicker } from '../../
 import { log, warn } from './shared.js';
 import { QuickReplyContextLink } from './QuickReplyContextLink.js';
 import { QuickReplySet } from './QuickReplySet.js';
+import { getUniqueQuickReplySetsByName } from './quick-reply-set-list.js';
 import { ContextMenu } from './ui/ctx/ContextMenu.js';
 
 export class QuickReply {
@@ -948,7 +949,7 @@ export class QuickReply {
             const tpl = dom.querySelector('#qr--ctxItem');
             const linkList = dom.querySelector('#qr--ctxEditor');
             const fillQrSetSelect = (/**@type {HTMLSelectElement}*/select, /**@type {QuickReplyContextLink}*/ link) => {
-                [{ name: 'Select a QR set' }, ...QuickReplySet.list.toSorted((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()))].forEach(qrs => {
+                [{ name: 'Select a QR set' }, ...getUniqueQuickReplySetsByName(QuickReplySet.list).toSorted((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()))].forEach(qrs => {
                     const opt = document.createElement('option'); {
                         opt.value = qrs.name;
                         opt.textContent = qrs.name;

--- a/public/scripts/extensions/quick-reply/src/QuickReplyConfig.js
+++ b/public/scripts/extensions/quick-reply/src/QuickReplyConfig.js
@@ -1,6 +1,7 @@
 import { getSortableDelay } from '../../../utils.js';
 import { QuickReplySetLink } from './QuickReplySetLink.js';
 import { QuickReplySet } from './QuickReplySet.js';
+import { getQuickReplySetLinkNameKey, getQuickReplySetNameKey, getUniqueQuickReplySetLinksBySetName, getUniqueQuickReplySetsByName } from './quick-reply-set-list.js';
 
 export class QuickReplyConfig {
     /**@type {QuickReplySetLink[]}*/ setList = [];
@@ -14,7 +15,7 @@ export class QuickReplyConfig {
 
 
     static from(props) {
-        props.setList = props.setList?.map(it => QuickReplySetLink.from(it))?.filter(it => it.set) ?? [];
+        props.setList = getUniqueQuickReplySetLinksBySetName(props.setList?.map(it => QuickReplySetLink.from(it))?.filter(it => it.set) ?? []);
         const instance = Object.assign(new this(), props);
         instance.init();
         return instance;
@@ -27,7 +28,8 @@ export class QuickReplyConfig {
 
 
     hasSet(qrs) {
-        return this.setList.find(it => it.set == qrs) != null;
+        const key = getQuickReplySetNameKey(qrs);
+        return this.setList.find(it => getQuickReplySetLinkNameKey(it) === key) != null;
     }
     addSet(qrs, isVisible = true) {
         if (!this.hasSet(qrs)) {
@@ -41,9 +43,10 @@ export class QuickReplyConfig {
         }
     }
     removeSet(qrs) {
-        const idx = this.setList.findIndex(it => it.set == qrs);
-        if (idx > -1) {
-            this.setList.splice(idx, 1);
+        const key = getQuickReplySetNameKey(qrs);
+        const nextSetList = this.setList.filter(it => getQuickReplySetLinkNameKey(it) !== key);
+        if (nextSetList.length !== this.setList.length) {
+            this.setList = nextSetList;
             this.update();
             this.updateSetListDom();
         }
@@ -54,7 +57,7 @@ export class QuickReplyConfig {
         /**@type {HTMLElement}*/
         this.setListDom = root.querySelector('.qr--setList');
         root.querySelector('.qr--setListAdd').addEventListener('click', () => {
-            const newSet = QuickReplySet.list.find(qr => !this.setList.find(qrl => qrl.set == qr));
+            const newSet = getUniqueQuickReplySetsByName(QuickReplySet.list).find(qr => !this.hasSet(qr));
             if (newSet) {
                 this.addSet(newSet);
             } else {
@@ -70,7 +73,7 @@ export class QuickReplyConfig {
             delay: getSortableDelay(),
             stop: () => this.onSetListSort(),
         });
-        this.setList.filter(it => !it.set.isDeleted).forEach((qrl, idx) => this.setListDom.append(qrl.renderSettings(idx)));
+        getUniqueQuickReplySetLinksBySetName(this.setList).filter(it => !it.set.isDeleted).forEach((qrl, idx) => this.setListDom.append(qrl.renderSettings(idx)));
     }
 
 

--- a/public/scripts/extensions/quick-reply/src/QuickReplySet.js
+++ b/public/scripts/extensions/quick-reply/src/QuickReplySet.js
@@ -5,6 +5,7 @@ import { SlashCommandScope } from '../../../slash-commands/SlashCommandScope.js'
 import { SlashCommandParser } from '../../../slash-commands/SlashCommandParser.js';
 import { debounceAsync, warn } from './shared.js';
 import { QuickReply } from './QuickReply.js';
+import { getQuickReplySetNameKey, getUniqueQuickReplySetsByName } from './quick-reply-set-list.js';
 
 export class QuickReplySet {
     /**@type {QuickReplySet[]}*/ static list = [];
@@ -24,7 +25,8 @@ export class QuickReplySet {
      * @param {string} name - name of the QuickReplySet
      */
     static get(name) {
-        return this.list.find(it => it.name == name);
+        const key = getQuickReplySetNameKey(name);
+        return this.list.find(it => getQuickReplySetNameKey(it) === key);
     }
 
     /**@type {string}*/ name;
@@ -293,7 +295,7 @@ export class QuickReplySet {
                         noOpt.textContent = '-- Select QR Set --';
                         sel.append(noOpt);
                     }
-                    for (const qrs of QuickReplySet.list) {
+                    for (const qrs of getUniqueQuickReplySetsByName(QuickReplySet.list)) {
                         const opt = document.createElement('option'); {
                             opt.value = qrs.name;
                             opt.textContent = qrs.name;
@@ -345,7 +347,7 @@ export class QuickReplySet {
             sel.focus();
             await prom;
             if (dlg.result == POPUP_RESULT.AFFIRMATIVE) {
-                const qrs = QuickReplySet.list.find(it => it.name == sel.value);
+                const qrs = QuickReplySet.get(sel.value);
                 qrs.addQuickReply(qr.toJSON());
                 if (!isCopy) {
                     qr.delete();

--- a/public/scripts/extensions/quick-reply/src/QuickReplySetLink.js
+++ b/public/scripts/extensions/quick-reply/src/QuickReplySetLink.js
@@ -1,4 +1,5 @@
 import { QuickReplySet } from './QuickReplySet.js';
+import { getQuickReplySetLinkNameKey, getQuickReplySetNameKey, getUniqueQuickReplySetsByName } from './quick-reply-set-list.js';
 
 export class QuickReplySetLink {
     static from(props) {
@@ -41,11 +42,11 @@ export class QuickReplySetLink {
                     this.set = QuickReplySet.get(set.value);
                     this.update();
                 });
-                QuickReplySet.list.toSorted((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase())).forEach(qrs => {
+                getUniqueQuickReplySetsByName(QuickReplySet.list).toSorted((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase())).forEach(qrs => {
                     const opt = document.createElement('option'); {
                         opt.value = qrs.name;
                         opt.textContent = qrs.name;
-                        opt.selected = qrs == this.set;
+                        opt.selected = getQuickReplySetNameKey(qrs) === getQuickReplySetLinkNameKey(this);
                         set.append(opt);
                     }
                 });

--- a/public/scripts/extensions/quick-reply/src/quick-reply-set-list.js
+++ b/public/scripts/extensions/quick-reply/src/quick-reply-set-list.js
@@ -1,0 +1,38 @@
+export function getQuickReplySetNameKey(set) {
+    const name = typeof set === 'string' ? set : set?.name;
+    return String(name ?? '').trim().toLowerCase();
+}
+
+export function getUniqueQuickReplySetsByName(sets) {
+    const seen = new Set();
+
+    return (Array.isArray(sets) ? sets : []).filter(set => {
+        const key = getQuickReplySetNameKey(set);
+
+        if (!key || seen.has(key)) {
+            return false;
+        }
+
+        seen.add(key);
+        return true;
+    });
+}
+
+export function getQuickReplySetLinkNameKey(link) {
+    return getQuickReplySetNameKey(link?.set);
+}
+
+export function getUniqueQuickReplySetLinksBySetName(links) {
+    const seen = new Set();
+
+    return (Array.isArray(links) ? links : []).filter(link => {
+        const key = getQuickReplySetLinkNameKey(link);
+
+        if (!key || seen.has(key)) {
+            return false;
+        }
+
+        seen.add(key);
+        return true;
+    });
+}

--- a/public/scripts/extensions/quick-reply/src/ui/ButtonUi.js
+++ b/public/scripts/extensions/quick-reply/src/ui/ButtonUi.js
@@ -1,6 +1,7 @@
 import { animation_duration } from '../../../../../script.js';
 import { dragElement } from '../../../../RossAscends-mods.js';
 import { loadMovingUIState } from '../../../../power-user.js';
+import { getUniqueQuickReplySetLinksBySetName } from '../quick-reply-set-list.js';
 
 export class ButtonUi {
     /** @type {QuickReplySettings} */ settings;
@@ -92,6 +93,14 @@ export class ButtonUi {
         this.placementObserver = null;
     }
 
+    getVisibleSetLinks() {
+        return getUniqueQuickReplySetLinksBySetName([
+            ...this.settings.config.setList,
+            ...(this.settings.chatConfig?.setList ?? []),
+            ...(this.settings.charConfig?.setList ?? []),
+        ].filter(link => link.isVisible));
+    }
+
 
     renderBar() {
         if (!this.dom) {
@@ -124,10 +133,7 @@ export class ButtonUi {
                         root.append(buttons);
                     }
                 }
-                [...this.settings.config.setList, ...(this.settings.chatConfig?.setList ?? []), ...(this.settings.charConfig?.setList ?? [])]
-                    .filter(link => link.isVisible)
-                    .forEach(link => buttonHolder.append(link.set.render()))
-                ;
+                this.getVisibleSetLinks().forEach(link => buttonHolder.append(link.set.render()));
             }
         }
         return this.dom;
@@ -182,10 +188,7 @@ export class ButtonUi {
                             body.append(buttons);
                         }
                     }
-                    [...this.settings.config.setList, ...(this.settings.chatConfig?.setList ?? []), ...(this.settings.charConfig?.setList ?? [])]
-                        .filter(link => link.isVisible)
-                        .forEach(link => buttonHolder.append(link.set.render()))
-                    ;
+                    this.getVisibleSetLinks().forEach(link => buttonHolder.append(link.set.render()));
                     root.append(body);
                 }
             }

--- a/public/scripts/extensions/quick-reply/src/ui/SettingsUi.js
+++ b/public/scripts/extensions/quick-reply/src/ui/SettingsUi.js
@@ -3,6 +3,7 @@ import { getSortableDelay } from '../../../../utils.js';
 import { log, warn } from '../shared.js';
 import { QuickReply } from '../QuickReply.js';
 import { QuickReplySet } from '../QuickReplySet.js';
+import { getQuickReplySetLinkNameKey, getQuickReplySetNameKey, getUniqueQuickReplySetsByName } from '../quick-reply-set-list.js';
 import { QuickReplySettings } from '../QuickReplySettings.js';
 
 export class SettingsUi {
@@ -161,7 +162,7 @@ export class SettingsUi {
         this.qrList = this.dom.querySelector('#qr--set-qrList');
         this.currentSet = this.dom.querySelector('#qr--set');
         this.currentSet.addEventListener('change', () => this.onQrSetChange());
-        QuickReplySet.list.toSorted((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase())).forEach(qrs => {
+        getUniqueQuickReplySetsByName(QuickReplySet.list).toSorted((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase())).forEach(qrs => {
             const opt = document.createElement('option'); {
                 opt.value = qrs.name;
                 opt.textContent = qrs.name;
@@ -308,24 +309,13 @@ export class SettingsUi {
     async doDeleteQrSet(qrs) {
         await qrs.delete();
         //TODO (HACK) should just bubble up from QuickReplySet.delete() but that would require proper or at least more comples onDelete listeners
-        for (let i = this.settings.config.setList.length - 1; i >= 0; i--) {
-            if (this.settings.config.setList[i].set == qrs) {
-                this.settings.config.setList.splice(i, 1);
-            }
-        }
+        const deletedKey = getQuickReplySetNameKey(qrs);
+        this.settings.config.setList = this.settings.config.setList.filter(link => getQuickReplySetLinkNameKey(link) !== deletedKey);
         if (this.settings.chatConfig) {
-            for (let i = this.settings.chatConfig.setList.length - 1; i >= 0; i--) {
-                if (this.settings.chatConfig.setList[i].set == qrs) {
-                    this.settings.chatConfig.setList.splice(i, 1);
-                }
-            }
+            this.settings.chatConfig.setList = this.settings.chatConfig.setList.filter(link => getQuickReplySetLinkNameKey(link) !== deletedKey);
         }
         if (this.settings.charConfig) {
-            for (let i = this.settings.charConfig.setList.length - 1; i >= 0; i--) {
-                if (this.settings.charConfig.setList[i].set == qrs) {
-                    this.settings.charConfig.setList.splice(i, 1);
-                }
-            }
+            this.settings.charConfig.setList = this.settings.charConfig.setList.filter(link => getQuickReplySetLinkNameKey(link) !== deletedKey);
         }
         this.settings.save();
     }
@@ -381,7 +371,7 @@ export class SettingsUi {
         if (name && name.length > 0) {
             const oldQrs = QuickReplySet.get(name);
             if (oldQrs) {
-                const replace = Popup.show.confirm('Replace existing World Info', `A Quick Reply Set named "${name}" already exists.<br>Do you want to overwrite the existing Quick Reply Set?<br>The existing set will be deleted. This cannot be undone.`);
+                const replace = await Popup.show.confirm('Replace existing Quick Reply Set', `A Quick Reply Set named "${name}" already exists.<br>Do you want to overwrite the existing Quick Reply Set?<br>The existing set will be deleted. This cannot be undone.`);
                 if (replace) {
                     const idx = QuickReplySet.list.indexOf(oldQrs);
                     await this.doDeleteQrSet(oldQrs);
@@ -444,7 +434,7 @@ export class SettingsUi {
                 qrs.init();
                 const oldQrs = QuickReplySet.get(props.name);
                 if (oldQrs) {
-                    const replace = Popup.show.confirm('Replace existing World Info', `A Quick Reply Set named "${name}" already exists.<br>Do you want to overwrite the existing Quick Reply Set?<br>The existing set will be deleted. This cannot be undone.`);
+                    const replace = await Popup.show.confirm('Replace existing Quick Reply Set', `A Quick Reply Set named "${props.name}" already exists.<br>Do you want to overwrite the existing Quick Reply Set?<br>The existing set will be deleted. This cannot be undone.`);
                     if (replace) {
                         const idx = QuickReplySet.list.indexOf(oldQrs);
                         await this.doDeleteQrSet(oldQrs);

--- a/public/scripts/ooc-blocks.js
+++ b/public/scripts/ooc-blocks.js
@@ -4,7 +4,7 @@ const OOC_BLOCK_PLACEHOLDER_SUFFIX = '_\uE001';
 
 /**
  * Normalizes prompt-context retention settings.
- * -1 preserves every context message, 0 strips every context message, N preserves the last N messages.
+ * -1 preserves every context message, 0 preserves the active turn, N preserves through depth N.
  * @param {number|string} value Retention setting value.
  * @returns {number} Normalized context depth.
  */
@@ -33,7 +33,7 @@ export function shouldRetainContextAtDepth(messageDepth, retentionDepth) {
         return true;
     }
 
-    return Math.max(0, Number(messageDepth) || 0) < normalizedDepth;
+    return Math.max(0, Number(messageDepth) || 0) <= normalizedDepth;
 }
 
 /**

--- a/public/scripts/sampler-storage.js
+++ b/public/scripts/sampler-storage.js
@@ -1,0 +1,28 @@
+export const SELECTED_SAMPLERS_STORAGE_KEY = 'selectedSamplers';
+export const SELECTED_SAMPLERS_STORAGE_TIMEOUT_MS = 1500;
+
+function normalizeSelectedSamplers(value, fallback = {}) {
+    return value && typeof value === 'object' ? value : fallback;
+}
+
+export async function loadStoredSelectedSamplers(objectStore, {
+    timeoutMs = SELECTED_SAMPLERS_STORAGE_TIMEOUT_MS,
+    fallback = {},
+} = {}) {
+    let timeoutId;
+    const timeoutPromise = new Promise((_, reject) => {
+        timeoutId = setTimeout(() => {
+            reject(new Error(`Timed out loading selected sampler settings after ${timeoutMs}ms`));
+        }, timeoutMs);
+    });
+
+    try {
+        const value = await Promise.race([
+            objectStore.getItem(SELECTED_SAMPLERS_STORAGE_KEY),
+            timeoutPromise,
+        ]);
+        return normalizeSelectedSamplers(value, fallback);
+    } finally {
+        clearTimeout(timeoutId);
+    }
+}

--- a/public/scripts/samplerSelect.js
+++ b/public/scripts/samplerSelect.js
@@ -10,6 +10,7 @@ import { setting_names as TGsamplerNames, showTGSamplerControls, textgenerationw
 import { renderTemplateAsync } from './templates.js';
 import { Popup, POPUP_TYPE } from './popup.js';
 import { localforage } from '../lib.js';
+import { loadStoredSelectedSamplers } from './sampler-storage.js';
 
 const forcedOnColoring = 'color: #89db35;';
 const forcedOffColoring = 'color: #e84f62;';
@@ -21,6 +22,7 @@ const SELECT_SAMPLER = {
 
 const textGenObjectStore = localforage.createInstance({ name: 'SillyTavern_TextCompletions' });
 let selectedSamplers = {};
+let selectedSamplersStorageReady = true;
 
 // Goal 1: show popup with all samplers for active API
 async function showSamplerSelectPopup() {
@@ -316,10 +318,12 @@ export async function validateDisabledSamplers(redraw = false) {
 export async function loadApiSelectedSamplers() {
     try {
         console.debug('Text Completions: loading selected samplers');
-        selectedSamplers = await textGenObjectStore.getItem('selectedSamplers') || {};
+        selectedSamplers = await loadStoredSelectedSamplers(textGenObjectStore);
+        selectedSamplersStorageReady = true;
     } catch (error) {
         console.log('Text Completions: unable to load selected samplers, using default samplers', error);
         selectedSamplers = {};
+        selectedSamplersStorageReady = false;
     }
 }
 
@@ -329,10 +333,17 @@ export async function loadApiSelectedSamplers() {
  */
 export async function saveApiSelectedSamplers() {
     try {
+        if (!selectedSamplersStorageReady) {
+            console.warn('Text Completions: skipping selected sampler save because storage did not finish loading.');
+            return false;
+        }
+
         console.debug('Text Completions: saving selected samplers');
         await textGenObjectStore.setItem('selectedSamplers', selectedSamplers);
+        return true;
     } catch (error) {
         console.log('Text Completions: unable to save selected samplers', error);
+        return false;
     }
 }
 
@@ -350,8 +361,8 @@ export async function resetApiSelectedSamplers(tcApiType = '', silent = false) {
 
         console.debug('Text Completions: resetting selected samplers');
         delete selectedSamplers[tcApiType];
-        await saveApiSelectedSamplers();
-        if (!silent) toastr.success('Selected samplers cleared.');
+        const saved = await saveApiSelectedSamplers();
+        if (saved && !silent) toastr.success('Selected samplers cleared.');
     } catch (error) {
         console.log('Text Completions: unable to reset selected preset samplers', error);
     }
@@ -411,6 +422,7 @@ export function setApiSamplerVisibilityState(state, tcApiType = '') {
     selectedSamplers[tcApiType] = Object.fromEntries(
         Object.entries(state).map(([key, value]) => [key, String(value) === 'true']),
     );
+    selectedSamplersStorageReady = true;
 
     return true;
 }

--- a/releases/sillybunny-v1.6.1-discord-post.md
+++ b/releases/sillybunny-v1.6.1-discord-post.md
@@ -1,0 +1,19 @@
+**SillyBunny version 1.6.1 has released**
+This release carries the post-1.6.0 staging line forward with safer chat rendering, sturdier preset/profile persistence, cleaner mobile navigation, more reliable Quick Replies, and a broad settings/tooling cleanup pass.
+
+**Detailed Changelog**
+- Chat rendering now routes bottom scroll, redisplay, show-more, message updates, streaming, swipe replacement, media resize, and mobile viewport handling through smaller lifecycle helpers.
+- Mobile shell, preset/API sync, generation, extension boot, Prompt Manager, and tooling hydration behavior now have cleaner seams for safer future fixes.
+- Connection profiles and presets now persist more reliably, including immediate preset saves, prompt-order resets, reverse-proxy backend binding, and current model fetching.
+- Quick Replies now dedupe duplicate set names across loading, buttons, API listing, auto-execute, settings selectors, and context menus without dropping saved chat or character links.
+- OOC and HTML context depth `0` now keeps the active turn while stripping older context messages.
+- Sampler visibility startup no longer overwrites saved selections when browser storage is slow to respond.
+- Added desktop vertical navigation settings, post-main agent intercept timing, OpenAI TTS audio format selection, current-chat files access, Quick Action icon picking, and compact Pathfinder controls.
+- Fixed character avatar refresh, imported character selection, desktop Prompt Manager scroll, chat shell wheel routing, shell resize handles, Select2 dropdown surfaces, native chat style headers, bounded rendered messages, and wand message screenshots.
+- Hardened duplicate agent initialization, local generation aborts, text-completion reasoning leaks, Guided Generations steering, post-agent provider-error handling, Pathfinder swipe reuse, and changelog automation.
+
+**How to update**
+- Built-in updater: open Customize > Server and update from there.
+- Git clone: run `git pull`.
+- Launcher users: close and reopen Start.bat, Start.command, or start.sh.
+- ZIP users: grab the new release directly.

--- a/scripts/update-changelog-merged-prs.js
+++ b/scripts/update-changelog-merged-prs.js
@@ -206,6 +206,10 @@ function formatPrEntry(pr) {
     return `- PR #${pr.number} (${date}) \`${escapeInlineCode(pr.title)}\``;
 }
 
+function escapeRegExp(value) {
+    return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function mergePrLines(existingText, prs) {
     const byNumber = new Map();
 
@@ -231,7 +235,7 @@ function mergePrLines(existingText, prs) {
 }
 
 function updateVersionBlock(block, prs) {
-    const sectionPattern = /### Merged Staging PRs\n([\s\S]*?)(?=\n### |\n## |$)/;
+    const sectionPattern = /### Merged Staging PRs\r?\n([\s\S]*?)(?=\r?\n### |\r?\n## |$)/;
     const match = sectionPattern.exec(block);
 
     if (match) {
@@ -252,15 +256,17 @@ function updateVersionBlock(block, prs) {
 }
 
 function updateChangelog(changelog, version, prs) {
-    const versionHeading = `## ${version}\n`;
-    const versionStart = changelog.indexOf(versionHeading);
+    const versionHeadingPattern = new RegExp(`(^|\\r?\\n)## ${escapeRegExp(version)}\\r?\\n`);
+    const versionHeadingMatch = versionHeadingPattern.exec(changelog);
 
-    if (versionStart === -1) {
-        throw new Error(`Could not find changelog section: ${versionHeading.trim()}`);
+    if (!versionHeadingMatch) {
+        throw new Error(`Could not find changelog section: ## ${version}`);
     }
 
-    const nextVersionStart = changelog.indexOf('\n## ', versionStart + versionHeading.length);
-    const versionEnd = nextVersionStart === -1 ? changelog.length : nextVersionStart;
+    const versionStart = versionHeadingMatch.index + versionHeadingMatch[1].length;
+    const versionHeadingEnd = versionStart + versionHeadingMatch[0].length - versionHeadingMatch[1].length;
+    const nextVersionMatch = /\r?\n## /.exec(changelog.slice(versionHeadingEnd));
+    const versionEnd = nextVersionMatch ? versionHeadingEnd + nextVersionMatch.index : changelog.length;
     const block = changelog.slice(versionStart, versionEnd);
     const updatedBlock = updateVersionBlock(block, prs);
 

--- a/tests/frontend-assets.test.js
+++ b/tests/frontend-assets.test.js
@@ -73,6 +73,14 @@ describe('frontend asset manifest rewriting', () => {
         expect(FRONTEND_ASSET_PREFIX).toBe('/frontend-assets/');
     });
 
+    test('loads the main app module through the canonical URL', () => {
+        const indexHtml = fs.readFileSync(path.join(process.cwd(), '..', 'public', 'index.html'), 'utf8');
+
+        expect(indexHtml).toContain('<link rel="modulepreload" href="script.js">');
+        expect(indexHtml).toContain('<script type="module" src="script.js"></script>');
+        expect(indexHtml).not.toMatch(/(?:href|src)="script\.js\?/);
+    });
+
     test('only treats fingerprinted frontend asset names as immutable', () => {
         expect(HASHED_FRONTEND_ASSET_RE.test('script-0123456789ab.js')).toBe(true);
         expect(HASHED_FRONTEND_ASSET_RE.test('scripts/extensions-abcdef123456.js')).toBe(true);

--- a/tests/ooc-blocks.test.js
+++ b/tests/ooc-blocks.test.js
@@ -73,11 +73,24 @@ describe('OOC block handling', () => {
         expect(normalizeContextRetentionDepth(2.9)).toBe(2);
     });
 
-    test('retains context content according to -1, 0, and last-N depths', () => {
+    test('retains context content according to -1, active-turn, and max-depth settings', () => {
         expect(shouldRetainContextAtDepth(50, -1)).toBe(true);
-        expect(shouldRetainContextAtDepth(0, 0)).toBe(false);
+        expect(shouldRetainContextAtDepth(0, 0)).toBe(true);
+        expect(shouldRetainContextAtDepth(1, 0)).toBe(false);
         expect(shouldRetainContextAtDepth(0, 2)).toBe(true);
         expect(shouldRetainContextAtDepth(1, 2)).toBe(true);
-        expect(shouldRetainContextAtDepth(2, 2)).toBe(false);
+        expect(shouldRetainContextAtDepth(2, 2)).toBe(true);
+        expect(shouldRetainContextAtDepth(3, 2)).toBe(false);
+    });
+
+    test('keeps OOC and HTML for the active turn when context depth is zero', () => {
+        expect(stripOocBlocksFromContext('Visible ((active turn note)) text', shouldRetainContextAtDepth(0, 0)))
+            .toBe('Visible ((active turn note)) text');
+        expect(stripOocBlocksFromContext('Visible ((older note)) text', shouldRetainContextAtDepth(1, 0)))
+            .toBe('Visible text');
+        expect(stripHtmlTagsFromContext('Visible <em>active turn tag</em> text', shouldRetainContextAtDepth(0, 0)))
+            .toBe('Visible <em>active turn tag</em> text');
+        expect(stripHtmlTagsFromContext('Visible <em>older tag</em> text', shouldRetainContextAtDepth(1, 0)))
+            .toBe('Visible older tag text');
     });
 });

--- a/tests/quick-reply-api.test.js
+++ b/tests/quick-reply-api.test.js
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+await jest.unstable_mockModule('../public/scripts/extensions/quick-reply/src/QuickReply.js', () => ({
+    QuickReply: class QuickReply {},
+}));
+
+await jest.unstable_mockModule('../public/scripts/extensions/quick-reply/src/QuickReplyContextLink.js', () => ({
+    QuickReplyContextLink: class QuickReplyContextLink {},
+}));
+
+class MockQuickReplySet {
+    static list = [];
+
+    static get(name) {
+        const key = String(name ?? '').trim().toLowerCase();
+        return this.list.find(set => String(set.name ?? '').trim().toLowerCase() === key);
+    }
+}
+
+await jest.unstable_mockModule('../public/scripts/extensions/quick-reply/src/QuickReplySet.js', () => ({
+    QuickReplySet: MockQuickReplySet,
+}));
+
+await jest.unstable_mockModule('../public/scripts/extensions/quick-reply/src/QuickReplySettings.js', () => ({
+    QuickReplySettings: class QuickReplySettings {},
+}));
+
+await jest.unstable_mockModule('../public/scripts/extensions/quick-reply/src/ui/SettingsUi.js', () => ({
+    SettingsUi: class SettingsUi {},
+}));
+
+await jest.unstable_mockModule('../public/scripts/utils.js', () => ({
+    onlyUnique: (value, index, array) => array.indexOf(value) === index,
+}));
+
+const { QuickReplyApi } = await import('../public/scripts/extensions/quick-reply/api/QuickReplyApi.js');
+
+function createQuickReply(label) {
+    return {
+        label,
+        onExecute: jest.fn(async () => label),
+    };
+}
+
+function createSet(name, labels = []) {
+    return {
+        name,
+        qrList: labels.map(createQuickReply),
+    };
+}
+
+function createApi(settings) {
+    return new QuickReplyApi(settings, { rerender: jest.fn() });
+}
+
+beforeEach(() => {
+    MockQuickReplySet.list = [];
+});
+
+describe('Quick Reply API set listing', () => {
+    test('finds sets by normalized display name', () => {
+        const memorySet = createSet('Memory Sharding');
+        MockQuickReplySet.list = [memorySet];
+        const api = createApi({ config: { setList: [] } });
+
+        expect(api.getSetByName(' memory sharding ')).toBe(memorySet);
+    });
+
+    test('deduplicates global and chat set names and ignores unresolved links', () => {
+        const globalSet = createSet('Memory Sharding');
+        const duplicateGlobalSet = createSet(' memory sharding ');
+        const chatSet = createSet('Chat Tools');
+        const api = createApi({
+            config: {
+                setList: [
+                    { set: globalSet },
+                    { set: duplicateGlobalSet },
+                    { set: null },
+                ],
+            },
+            chatConfig: {
+                setList: [
+                    { set: chatSet },
+                    { set: createSet(' chat tools ') },
+                    { set: null },
+                ],
+            },
+        });
+
+        expect(api.listGlobalSets()).toEqual(['Memory Sharding']);
+        expect(api.listChatSets()).toEqual(['Chat Tools']);
+    });
+
+    test('executes quick replies by index from the first active set for duplicate names', async () => {
+        const firstSet = createSet('Memory Sharding', ['first']);
+        const duplicateSet = createSet(' memory sharding ', ['duplicate']);
+        const secondSet = createSet('Chat Tools', ['second']);
+        const api = createApi({
+            config: {
+                setList: [{ set: firstSet }, { set: duplicateSet }],
+            },
+            chatConfig: {
+                setList: [{ set: secondSet }],
+            },
+        });
+
+        await expect(api.executeQuickReplyByIndex(0)).resolves.toBe('first');
+        await expect(api.executeQuickReplyByIndex(1)).resolves.toBe('second');
+        expect(firstSet.qrList[0].onExecute).toHaveBeenCalledTimes(1);
+        expect(duplicateSet.qrList[0].onExecute).not.toHaveBeenCalled();
+        expect(secondSet.qrList[0].onExecute).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/quick-reply-auto-execute.test.js
+++ b/tests/quick-reply-auto-execute.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, jest, test } from '@jest/globals';
+
+await jest.unstable_mockModule('../public/scripts/extensions/quick-reply/src/QuickReply.js', () => ({
+    QuickReply: class QuickReply {},
+}));
+
+await jest.unstable_mockModule('../public/scripts/extensions/quick-reply/src/QuickReplySettings.js', () => ({
+    QuickReplySettings: class QuickReplySettings {},
+}));
+
+await jest.unstable_mockModule('../public/scripts/extensions/quick-reply/src/shared.js', () => ({
+    warn: jest.fn(),
+}));
+
+const { AutoExecuteHandler } = await import('../public/scripts/extensions/quick-reply/src/AutoExecuteHandler.js');
+
+function createQuickReply(label) {
+    return {
+        label,
+        executeOnUser: true,
+        execute: jest.fn(async () => undefined),
+    };
+}
+
+describe('Quick Reply auto-execute handling', () => {
+    test('collects one command when active scopes contain duplicate set names', () => {
+        const firstQr = createQuickReply('first');
+        const duplicateQr = createQuickReply('duplicate');
+        const handler = new AutoExecuteHandler({
+            isEnabled: true,
+            config: {
+                setList: [{ set: { name: 'Memory Sharding', qrList: [firstQr] } }],
+            },
+            chatConfig: {
+                setList: [{ set: { name: ' memory sharding ', qrList: [duplicateQr] } }],
+            },
+        });
+
+        expect(handler.getCommands('executeOnUser')).toEqual([firstQr]);
+    });
+});

--- a/tests/quick-reply-button-ui.test.js
+++ b/tests/quick-reply-button-ui.test.js
@@ -173,8 +173,9 @@ class FakeMutationObserver {
     }
 }
 
-function createVisibleSet(label = 'HELP') {
+function createVisibleSet(label = 'HELP', name = label) {
     return {
+        name,
         render() {
             const button = document.createElement('button');
             button.classList.add('qr--button');
@@ -184,14 +185,14 @@ function createVisibleSet(label = 'HELP') {
     };
 }
 
-function createSettings(label = 'HELP') {
+function createSettings(label = 'HELP', name = label) {
     return {
         isEnabled: true,
         isPopout: false,
         isCombined: false,
         showPopoutButton: false,
         config: {
-            setList: [{ isVisible: true, set: createVisibleSet(label) }],
+            setList: [{ isVisible: true, set: createVisibleSet(label, name) }],
         },
     };
 }
@@ -270,5 +271,36 @@ describe('Quick Reply button bar', () => {
         buttons.refresh();
 
         expect(document.querySelector('#qr--bar')?.querySelector('.qr--button')?.textContent).toBe('Shard Memory');
+    });
+
+    test('renders one visible button set when active scopes contain duplicate set names', () => {
+        appendComposer();
+        const settings = createSettings('Global Help');
+        settings.chatConfig = {
+            setList: [{ isVisible: true, set: createVisibleSet('Chat Help', ' global help ') }],
+        };
+        const buttons = new ButtonUi(settings);
+
+        buttons.show();
+
+        const qrButtons = document.querySelector('#qr--bar')?.querySelectorAll('.qr--button') ?? [];
+        expect(qrButtons).toHaveLength(1);
+        expect(qrButtons[0].textContent).toBe('Global Help');
+    });
+
+    test('lets a visible duplicate render when the earlier matching link is hidden', () => {
+        appendComposer();
+        const settings = createSettings('Hidden Global', 'Memory Sharding');
+        settings.config.setList[0].isVisible = false;
+        settings.chatConfig = {
+            setList: [{ isVisible: true, set: createVisibleSet('Visible Chat', ' memory sharding ') }],
+        };
+        const buttons = new ButtonUi(settings);
+
+        buttons.show();
+
+        const qrButtons = document.querySelector('#qr--bar')?.querySelectorAll('.qr--button') ?? [];
+        expect(qrButtons).toHaveLength(1);
+        expect(qrButtons[0].textContent).toBe('Visible Chat');
     });
 });

--- a/tests/quick-reply-config.test.js
+++ b/tests/quick-reply-config.test.js
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+await jest.unstable_mockModule('../public/script.js', () => ({
+    getRequestHeaders: jest.fn(() => ({})),
+    substituteParams: value => value,
+}));
+
+await jest.unstable_mockModule('../public/scripts/popup.js', () => ({
+    Popup: class Popup {},
+    POPUP_RESULT: { AFFIRMATIVE: 1 },
+    POPUP_TYPE: { CONFIRM: 1 },
+}));
+
+await jest.unstable_mockModule('../public/scripts/slash-commands.js', () => ({
+    executeSlashCommandsOnChatInput: jest.fn(),
+    executeSlashCommandsWithOptions: jest.fn(),
+}));
+
+await jest.unstable_mockModule('../public/scripts/slash-commands/SlashCommandScope.js', () => ({
+    SlashCommandScope: class SlashCommandScope {},
+}));
+
+await jest.unstable_mockModule('../public/scripts/slash-commands/SlashCommandParser.js', () => ({
+    SlashCommandParser: class SlashCommandParser {
+        parse() {
+            return {
+                execute: jest.fn(async () => ({ pipe: undefined })),
+                scope: { setMacro: jest.fn() },
+            };
+        }
+    },
+}));
+
+await jest.unstable_mockModule('../public/scripts/extensions/quick-reply/src/QuickReply.js', () => ({
+    QuickReply: class QuickReply {},
+}));
+
+await jest.unstable_mockModule('../public/scripts/utils.js', () => ({
+    debounceAsync: fn => fn,
+    getSortableDelay: jest.fn(() => 0),
+}));
+
+const { QuickReplyConfig } = await import('../public/scripts/extensions/quick-reply/src/QuickReplyConfig.js');
+const { QuickReplySet } = await import('../public/scripts/extensions/quick-reply/src/QuickReplySet.js');
+
+function createSet(name) {
+    return QuickReplySet.from({
+        name,
+        qrList: [],
+    });
+}
+
+beforeEach(() => {
+    QuickReplySet.list = [];
+});
+
+describe('Quick Reply config persisted set links', () => {
+    test('resolves saved links to the canonical set when duplicate names were skipped on load', () => {
+        const canonicalSet = createSet('Memory Sharding');
+        QuickReplySet.list = [canonicalSet];
+
+        const config = QuickReplyConfig.from({
+            setList: [
+                { set: ' memory sharding ', isVisible: true },
+                { set: 'MEMORY SHARDING', isVisible: false },
+            ],
+        });
+
+        expect(config.setList).toHaveLength(1);
+        expect(config.setList[0].set).toBe(canonicalSet);
+        expect(config.setList[0].isVisible).toBe(true);
+    });
+
+    test('removes all active links matching a normalized set name', () => {
+        const canonicalSet = createSet('Memory Sharding');
+        const duplicateSet = createSet(' memory sharding ');
+        const otherSet = createSet('Other');
+        const config = QuickReplyConfig.from({ setList: [] });
+        config.setList = [
+            { set: canonicalSet },
+            { set: duplicateSet },
+            { set: otherSet },
+        ];
+        config.updateSetListDom = jest.fn();
+        config.onUpdate = jest.fn();
+
+        config.removeSet(canonicalSet);
+
+        expect(config.setList).toEqual([{ set: otherSet }]);
+        expect(config.onUpdate).toHaveBeenCalledTimes(1);
+        expect(config.updateSetListDom).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/quick-reply-set-list.test.js
+++ b/tests/quick-reply-set-list.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, test } from '@jest/globals';
+
+import {
+    getQuickReplySetLinkNameKey,
+    getQuickReplySetNameKey,
+    getUniqueQuickReplySetLinksBySetName,
+    getUniqueQuickReplySetsByName,
+} from '../public/scripts/extensions/quick-reply/src/quick-reply-set-list.js';
+
+describe('Quick Reply set list helpers', () => {
+    test('normalizes set names for duplicate detection', () => {
+        expect(getQuickReplySetNameKey({ name: ' Default ' })).toBe('default');
+        expect(getQuickReplySetNameKey({ name: 'Memory Sharding' })).toBe('memory sharding');
+        expect(getQuickReplySetNameKey(null)).toBe('');
+    });
+
+    test('keeps the first set for each display name', () => {
+        const defaultSet = { name: 'Default', qrList: [{ id: 1 }] };
+        const duplicateDefaultSet = { name: ' default ', qrList: [{ id: 2 }] };
+        const memorySet = { name: 'Memory Sharding', qrList: [{ id: 3 }] };
+        const duplicateMemorySet = { name: 'MEMORY SHARDING', qrList: [{ id: 4 }] };
+
+        expect(getUniqueQuickReplySetsByName([
+            defaultSet,
+            duplicateDefaultSet,
+            memorySet,
+            duplicateMemorySet,
+            { name: '' },
+            {},
+        ])).toEqual([defaultSet, memorySet]);
+    });
+
+    test('keeps the first link for each linked set display name', () => {
+        const defaultLink = { set: { name: 'Default' }, isVisible: true };
+        const duplicateDefaultLink = { set: { name: ' default ' }, isVisible: true };
+        const memoryLink = { set: { name: 'Memory Sharding' }, isVisible: false };
+
+        expect(getQuickReplySetLinkNameKey(defaultLink)).toBe('default');
+        expect(getUniqueQuickReplySetLinksBySetName([
+            defaultLink,
+            duplicateDefaultLink,
+            { set: null },
+            memoryLink,
+        ])).toEqual([defaultLink, memoryLink]);
+    });
+});

--- a/tests/quick-reply-settings-ui.test.js
+++ b/tests/quick-reply-settings-ui.test.js
@@ -1,0 +1,91 @@
+import { describe, expect, jest, test } from '@jest/globals';
+
+await jest.unstable_mockModule('../public/script.js', () => ({
+    getRequestHeaders: jest.fn(() => ({})),
+    substituteParams: value => value,
+}));
+
+await jest.unstable_mockModule('../public/scripts/popup.js', () => ({
+    Popup: { show: { confirm: jest.fn(), input: jest.fn() } },
+    POPUP_RESULT: { AFFIRMATIVE: 1 },
+    POPUP_TYPE: { CONFIRM: 1 },
+}));
+
+await jest.unstable_mockModule('../public/scripts/slash-commands.js', () => ({
+    executeSlashCommandsOnChatInput: jest.fn(),
+    executeSlashCommandsWithOptions: jest.fn(),
+}));
+
+await jest.unstable_mockModule('../public/scripts/slash-commands/SlashCommandScope.js', () => ({
+    SlashCommandScope: class SlashCommandScope {},
+}));
+
+await jest.unstable_mockModule('../public/scripts/slash-commands/SlashCommandParser.js', () => ({
+    SlashCommandParser: class SlashCommandParser {
+        parse() {
+            return {
+                execute: jest.fn(async () => ({ pipe: undefined })),
+                scope: { setMacro: jest.fn() },
+            };
+        }
+    },
+}));
+
+await jest.unstable_mockModule('../public/scripts/utils.js', () => ({
+    debounceAsync: fn => fn,
+    getSortableDelay: jest.fn(() => 0),
+}));
+
+await jest.unstable_mockModule('../public/scripts/extensions/quick-reply/src/QuickReply.js', () => ({
+    QuickReply: class QuickReply {},
+}));
+
+await jest.unstable_mockModule('../public/scripts/extensions/quick-reply/src/QuickReplySettings.js', () => ({
+    QuickReplySettings: class QuickReplySettings {},
+}));
+
+const { SettingsUi } = await import('../public/scripts/extensions/quick-reply/src/ui/SettingsUi.js');
+
+function createLink(name) {
+    return { set: { name } };
+}
+
+describe('Quick Reply settings deletion', () => {
+    test('purges matching links by normalized set name across every active scope', async () => {
+        const settings = {
+            config: {
+                setList: [
+                    createLink('Memory Sharding'),
+                    createLink(' memory sharding '),
+                    createLink('Global Other'),
+                ],
+            },
+            chatConfig: {
+                setList: [
+                    createLink('MEMORY SHARDING'),
+                    createLink('Chat Other'),
+                ],
+            },
+            charConfig: {
+                setList: [
+                    createLink('Memory Sharding'),
+                    createLink('Character Other'),
+                ],
+            },
+            save: jest.fn(),
+        };
+        const deletedSet = {
+            name: 'Memory Sharding',
+            delete: jest.fn(async () => undefined),
+        };
+
+        const ui = new SettingsUi(settings);
+        await ui.doDeleteQrSet(deletedSet);
+
+        expect(deletedSet.delete).toHaveBeenCalledTimes(1);
+        expect(settings.config.setList).toEqual([createLink('Global Other')]);
+        expect(settings.chatConfig.setList).toEqual([createLink('Chat Other')]);
+        expect(settings.charConfig.setList).toEqual([createLink('Character Other')]);
+        expect(settings.save).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/sampler-storage.test.js
+++ b/tests/sampler-storage.test.js
@@ -1,0 +1,170 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import {
+    SELECTED_SAMPLERS_STORAGE_KEY,
+    loadStoredSelectedSamplers,
+} from '../public/scripts/sampler-storage.js';
+
+describe('loadStoredSelectedSamplers', () => {
+    test('loads selected sampler settings from storage', async () => {
+        const storedSamplers = { textgenerationwebui: { temp: true } };
+        const objectStore = {
+            getItem: jest.fn(async key => key === SELECTED_SAMPLERS_STORAGE_KEY ? storedSamplers : null),
+        };
+
+        await expect(loadStoredSelectedSamplers(objectStore)).resolves.toEqual(storedSamplers);
+        expect(objectStore.getItem).toHaveBeenCalledWith(SELECTED_SAMPLERS_STORAGE_KEY);
+    });
+
+    test('falls back to empty selections when storage has no object', async () => {
+        const objectStore = {
+            getItem: jest.fn(async () => null),
+        };
+
+        await expect(loadStoredSelectedSamplers(objectStore)).resolves.toEqual({});
+    });
+
+    test('rejects when storage does not settle before the startup timeout', async () => {
+        jest.useFakeTimers();
+
+        try {
+            const objectStore = {
+                getItem: jest.fn(() => new Promise(() => {})),
+            };
+            const result = loadStoredSelectedSamplers(objectStore, { timeoutMs: 25 });
+            const observedError = result.catch(error => error);
+
+            await jest.advanceTimersByTimeAsync(25);
+            await expect(observedError).resolves.toMatchObject({
+                message: 'Timed out loading selected sampler settings after 25ms',
+            });
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+});
+
+describe('selected sampler save guard', () => {
+    const mockTextGenObjectStore = {
+        getItem: jest.fn(),
+        setItem: jest.fn(),
+    };
+
+    beforeEach(() => {
+        jest.resetModules();
+        mockTextGenObjectStore.getItem.mockReset();
+        mockTextGenObjectStore.setItem.mockReset();
+    });
+
+    async function importSamplerSelect() {
+        await jest.unstable_mockModule('../public/script.js', () => ({
+            main_api: 'textgenerationwebui',
+            saveSettingsDebounced: jest.fn(),
+        }));
+
+        await jest.unstable_mockModule('../public/scripts/textgen-settings.js', () => ({
+            setting_names: ['temperature'],
+            showTGSamplerControls: jest.fn(),
+            textgenerationwebui_settings: { type: 'ooba' },
+        }));
+
+        await jest.unstable_mockModule('../public/scripts/templates.js', () => ({
+            renderTemplateAsync: jest.fn(async () => ''),
+        }));
+
+        await jest.unstable_mockModule('../public/scripts/popup.js', () => ({
+            Popup: class Popup {},
+            POPUP_TYPE: { TEXT: 1 },
+        }));
+
+        await jest.unstable_mockModule('../public/lib.js', () => ({
+            localforage: {
+                createInstance: jest.fn(() => mockTextGenObjectStore),
+            },
+        }));
+
+        return import('../public/scripts/samplerSelect.js');
+    }
+
+    test('does not persist fallback sampler state after storage load timeout', async () => {
+        jest.useFakeTimers();
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        try {
+            mockTextGenObjectStore.getItem.mockReturnValue(new Promise(() => {}));
+            const {
+                loadApiSelectedSamplers,
+                saveApiSelectedSamplers,
+                setApiSamplersState,
+            } = await importSamplerSelect();
+
+            const loadPromise = loadApiSelectedSamplers();
+            await jest.advanceTimersByTimeAsync(1500);
+            await loadPromise;
+
+            setApiSamplersState('temperature', true, 'ooba');
+
+            await expect(saveApiSelectedSamplers()).resolves.toBe(false);
+            expect(mockTextGenObjectStore.setItem).not.toHaveBeenCalled();
+        } finally {
+            jest.useRealTimers();
+            console.log.mockRestore();
+            console.warn.mockRestore();
+        }
+    });
+
+    test('allows explicit preset sampler visibility saves after a storage timeout', async () => {
+        jest.useFakeTimers();
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+
+        try {
+            mockTextGenObjectStore.getItem.mockReturnValue(new Promise(() => {}));
+            const {
+                loadApiSelectedSamplers,
+                saveApiSelectedSamplers,
+                setApiSamplerVisibilityState,
+            } = await importSamplerSelect();
+
+            const loadPromise = loadApiSelectedSamplers();
+            await jest.advanceTimersByTimeAsync(1500);
+            await loadPromise;
+
+            expect(setApiSamplerVisibilityState({ temperature: true }, 'ooba')).toBe(true);
+            await expect(saveApiSelectedSamplers()).resolves.toBe(true);
+            expect(mockTextGenObjectStore.setItem).toHaveBeenCalledWith('selectedSamplers', {
+                ooba: { temperature: true },
+            });
+        } finally {
+            jest.useRealTimers();
+            console.log.mockRestore();
+        }
+    });
+
+    test('does not arm the save guard when reset follows a storage timeout', async () => {
+        jest.useFakeTimers();
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        try {
+            mockTextGenObjectStore.getItem.mockReturnValue(new Promise(() => {}));
+            const {
+                loadApiSelectedSamplers,
+                resetApiSelectedSamplers,
+                setApiSamplersState,
+            } = await importSamplerSelect();
+
+            const loadPromise = loadApiSelectedSamplers();
+            await jest.advanceTimersByTimeAsync(1500);
+            await loadPromise;
+
+            setApiSamplersState('temperature', true, 'ooba');
+            await resetApiSelectedSamplers('ooba', true);
+
+            expect(mockTextGenObjectStore.setItem).not.toHaveBeenCalled();
+        } finally {
+            jest.useRealTimers();
+            console.log.mockRestore();
+            console.warn.mockRestore();
+        }
+    });
+});


### PR DESCRIPTION
## What?
Fixes the remaining release-readiness regressions from the staging PR sweep:

- Deduplicates duplicate Quick Reply set names across loading, active scopes, API lookup, auto-execute, settings selectors, deletion, and context menus.
- Keeps OOC/HTML context depth `0` effective for the active turn while stripping older context messages.
- Prevents slow sampler-storage startup from saving fallback sampler visibility state over previously saved selections.
- Refreshes the v1.6.1 changelog/README/release-note surfaces and upstream touch ledger entries for the validated changes.

## Why?
The release sweep found three user-visible risks after the merged PR batch: duplicate Quick Reply names could render/execute more than once, depth `0` removed OOC before the active turn could use it, and a slow IndexedDB sampler read could allow fallback state to overwrite saved sampler choices.

## How?
Quick Replies now resolve duplicate display names through a small canonical set-list helper and use normalized link removal where active scopes can carry repeated saved names. OOC/HTML retention compares prompt context depth so `0` means active turn only. Sampler selected-state loading now goes through a timeout-aware storage helper, and save/reset paths refuse to persist fallback state unless an explicit preset visibility apply restores storage readiness.

## Testing?
- `git diff --check`
- `npm run lint -- --quiet`
- `npm run lint --prefix tests -- --quiet`
- `npm run test:unit --prefix tests -- sampler-storage.test.js ooc-blocks.test.js frontend-assets.test.js quick-reply-set-list.test.js quick-reply-config.test.js quick-reply-button-ui.test.js quick-reply-auto-execute.test.js quick-reply-api.test.js quick-reply-settings-ui.test.js`
- `npm run check:frontend-budgets`
- `npm run build:frontend`
- `npm run test:unit --prefix tests`
- `bash scripts/sync-readme-mirror.sh --check`
- Built-in browser smoke on a non-default local port: title loaded, `script.js` loaded canonically without a query string, Quick Reply settings DOM present, OOC/HTML setting copy present, 0 console errors, 1 known empty-chat startup warning.

## Screenshots (optional)
Not included; this is behavior/settings validation rather than a visual UI change. The browser smoke covered DOM and console state.

## Anything Else?
No Graphify artifacts or Graphify references are included. The previous clean PR branches were already merged and deleted.