### PR TITLE
fix: avoid forced reconnect when loading bound reverse proxy presets

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -8406,7 +8406,7 @@ export function loadProxyPresets(settings) {
     }
     $('#openai_proxy_preset').val(selected_proxy.name);
     const shouldApplySource = Boolean(selected_proxy.source);
-    setProxyPreset(selected_proxy.name, selected_proxy.url, selected_proxy.password, selected_proxy.source, { applySource: shouldApplySource });
+    setProxyPreset(selected_proxy.name, selected_proxy.url, selected_proxy.password, selected_proxy.source, { applySource: shouldApplySource, silent: true });
 }
 
 function normalizeProxyPreset(preset) {
@@ -8447,7 +8447,7 @@ function updateProxyPresetOption(preset) {
     }
 }
 
-function setProxyPreset(name, url, password, source = '', { applySource = true } = {}) {
+function setProxyPreset(name, url, password, source = '', { applySource = true, silent = false } = {}) {
     const normalizedPreset = normalizeProxyPreset({ name, url, password, source });
     const preset = proxies.find(p => p.name === normalizedPreset.name);
     if (preset) {
@@ -8468,7 +8468,21 @@ function setProxyPreset(name, url, password, source = '', { applySource = true }
     $('#openai_proxy_password').val(oai_settings.proxy_password);
     $('#openai_proxy_source').val(normalizedPreset.source || '');
 
-    if (applySource && normalizedPreset.source && normalizedPreset.source !== oai_settings.chat_completion_source) {
+    const shouldSwitchSource = applySource && normalizedPreset.source && normalizedPreset.source !== oai_settings.chat_completion_source;
+
+    // SillyBunny: when applying a bound preset during settings load (silent), switch the backend
+    // and refresh source-dependent UI without triggering a reconnect or the proxy confirmation modal,
+    // which would otherwise block the startup loader and freeze the settings panel. See #304 regression.
+    if (silent) {
+        if (shouldSwitchSource) {
+            oai_settings.chat_completion_source = normalizedPreset.source;
+            $('#chat_completion_source').val(normalizedPreset.source);
+            toggleChatCompletionForms();
+        }
+        return;
+    }
+
+    if (shouldSwitchSource) {
         $('#chat_completion_source').val(normalizedPreset.source).trigger('change');
     } else {
         reconnectOpenAi();

--- a/tests/openai-proxy-preset-wiring.test.js
+++ b/tests/openai-proxy-preset-wiring.test.js
@@ -67,10 +67,30 @@ describe('OpenAI proxy preset wiring', () => {
     test('applies selected proxy backend binding when loading presets', () => {
         const loadProxyPresetsSource = getFunctionSource('loadProxyPresets');
         const applySourceFlagIndex = loadProxyPresetsSource.indexOf('const shouldApplySource = Boolean(selected_proxy.source);');
-        const setProxyPresetIndex = loadProxyPresetsSource.indexOf('setProxyPreset(selected_proxy.name, selected_proxy.url, selected_proxy.password, selected_proxy.source, { applySource: shouldApplySource });');
+        const setProxyPresetIndex = loadProxyPresetsSource.indexOf('setProxyPreset(selected_proxy.name, selected_proxy.url, selected_proxy.password, selected_proxy.source, { applySource: shouldApplySource, silent: true });');
 
         expect(applySourceFlagIndex).toBeGreaterThanOrEqual(0);
         expect(setProxyPresetIndex).toBeGreaterThan(applySourceFlagIndex);
         expect(loadProxyPresetsSource).not.toContain('{ applySource: false }');
+    });
+
+    test('switches backend on silent load without triggering a reconnect', () => {
+        const setProxyPresetSource = getFunctionSource('setProxyPreset');
+        const silentBranchIndex = setProxyPresetSource.indexOf('if (silent) {');
+        const silentSourceAssignIndex = setProxyPresetSource.indexOf('oai_settings.chat_completion_source = normalizedPreset.source;');
+        const silentValIndex = setProxyPresetSource.indexOf('$(\'#chat_completion_source\').val(normalizedPreset.source);');
+        const silentRefreshIndex = setProxyPresetSource.indexOf('toggleChatCompletionForms();');
+        const silentReturnIndex = setProxyPresetSource.indexOf('return;', silentBranchIndex);
+        const reconnectIndex = setProxyPresetSource.indexOf('reconnectOpenAi();');
+
+        // Silent branch applies the source and refreshes UI before returning early.
+        expect(silentBranchIndex).toBeGreaterThanOrEqual(0);
+        expect(silentSourceAssignIndex).toBeGreaterThan(silentBranchIndex);
+        expect(silentValIndex).toBeGreaterThan(silentSourceAssignIndex);
+        expect(silentRefreshIndex).toBeGreaterThan(silentValIndex);
+        expect(silentReturnIndex).toBeGreaterThan(silentRefreshIndex);
+
+        // Silent branch must short-circuit before the reconnect path.
+        expect(reconnectIndex).toBeGreaterThan(silentReturnIndex);
     });
 });


### PR DESCRIPTION
## Summary
- Loading settings with a bound reverse proxy preset selected triggered a synchronous `#chat_completion_source` `change` during startup (via `loadProxyPresets` → `setProxyPreset`), which fired `reconnectOpenAi()` and the blocking "Connecting To Proxy" confirmation modal.
- The leftover modal/overlay during the startup loader froze the settings panel, making the Reverse Proxy drawer (and other dropdowns) unresponsive. Regression from #304.
- Add a `silent` option to `setProxyPreset`. On the load path it now applies the bound backend and refreshes source-dependent UI via `toggleChatCompletionForms()` **without** reconnecting or showing the proxy modal. Manual preset selection keeps the full switch + reconnect behavior.

## Why
#304 intended bound presets to auto-switch the backend. That intent is preserved: the backend still switches on load and on manual selection. Only the disruptive load-time reconnect/modal is removed.

## Tests
- `npm run test:unit --prefix tests` — 837 passed (includes updated `openai-proxy-preset-wiring.test.js` with a new assertion that the silent load path applies the source and short-circuits before `reconnectOpenAi()`).
- `npm run lint` — clean on changed files.