### PR TITLE
fix: restore desktop lorebook selection surfaces

### DIFF
--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -6617,7 +6617,12 @@ export function initWorldInfo() {
 
     // Not needed on mobile
     if (!isMobile()) {
+        // SillyBunny: keep embedded World Info dropdowns anchored to the desktop shell surface.
+        const worldInfoDropdownParent = $('#WorldInfo');
+        const select2DropdownParent = worldInfoDropdownParent.length ? worldInfoDropdownParent : $(document.body);
+
         $('#world_editor_select').select2({
+            dropdownParent: select2DropdownParent,
             placeholder: t`--- Pick to Edit ---`,
             searchInputPlaceholder: t`Search...`,
             allowClear: true,
@@ -6626,6 +6631,7 @@ export function initWorldInfo() {
         });
 
         $('#world_info').select2({
+            dropdownParent: select2DropdownParent,
             width: '100%',
             placeholder: t`No Worlds active. Click here to select.`,
             allowClear: true,


### PR DESCRIPTION
## Summary

Fixes the desktop World Info lorebook selectors rendering transparent and unselectable when the World Info panel is embedded as a Characters tab in the SillyBunny shell.

The two lorebook Select2 controls (`#world_info` "Active World(s) for all chats" and `#world_editor_select` "Pick to Edit") were initialized without a `dropdownParent`, so Select2 appended their dropdowns to `document.body`. The desktop shell host (`#right-nav-panel.sb-shell-root`) uses `isolation: isolate` and transforms, which breaks the positioning and stacking of `body`-anchored dropdowns — the dropdown surface ends up effectively invisible/unclickable.

This change anchors both dropdowns to the embedded `#WorldInfo` container, matching the existing SillyBunny pattern already used for API model selectors in `openai.js`, `horde.js`, and `textgen-models.js`. A SillyBunny divergence comment documents why the upstream init differs.

## Changes

- `public/scripts/world-info.js`: pass `dropdownParent` (the embedded `#WorldInfo` node, falling back to `document.body`) to the desktop `#world_editor_select` and `#world_info` Select2 inits.

## Testing

- `npx eslint public/scripts/world-info.js` — clean.
- Local desktop run (`bun server.js --listen`): opened Characters → World Info tab, confirmed both lorebook dropdowns now render inside the `#WorldInfo` panel (DOM selector resolves to `div#WorldInfo > span > span`) instead of floating under `body`.
- Mobile path unaffected: the change is inside the existing `if (!isMobile())` desktop-only branch.

## Notes

- CSS-only surface hardening was explored but reverted as redundant: PR #302 already paints `.select2-container--default .select2-dropdown` opaque, so once the dropdown is correctly anchored it reads normally. Keeping the fix scoped to the root cause.