### PR TITLE
fix: close release polish regressions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -8,7 +8,7 @@ body:
     id: environment
     attributes:
       label: Environment
-      description: Where are you running SillyTavern?
+      description: Where are you running SillyBunny?
       options:
         - 🪟 Windows
         - 🐧 Linux
@@ -33,7 +33,7 @@ body:
     id: version
     attributes:
       label: Version
-      description: What version of SillyTavern are you running?
+      description: What version of SillyBunny are you running?
       placeholder: (check User Settings to see the version)
     validations:
       required: true
@@ -77,7 +77,7 @@ body:
       options:
         - label: I have explained the issue clearly, and I included all relevant info
           required: true
-        - label: I have checked that this [issue hasn't already been raised](https://github.com/SillyTavern/SillyTavern/issues?q=is%3Aissue)
+        - label: I have checked that this [issue hasn't already been raised](https://github.com/platberlitz/SillyBunny/issues?q=is%3Aissue)
           required: true
         - label: I have checked the [docs](https://docs.sillytavern.app/) ![important](https://img.shields.io/badge/Important!-F6094E)
           required: true
@@ -88,6 +88,6 @@ body:
     attributes:
       value: |-
         ## Thanks 🙏
-        Thank you for raising this ticket - in doing so you are helping to make SillyTavern better for everyone.
+        Thank you for raising this ticket - in doing so you are helping to make SillyBunny better for everyone.
     validations:
       required: false

--- a/.github/readme.md
+++ b/.github/readme.md
@@ -223,7 +223,7 @@ SillyBunny includes some extras by default to help you get started right away:
 
 ## Latest Update
 
-### v1.6.1 (2026-05-31)
+### v1.6.1 (2026-06-02)
 
 This update carries the post-v1.6.0 staging line forward with safer chat rendering, tighter mobile navigation, sturdier preset/profile persistence, more reliable Quick Replies, and a broader cleanup pass across settings, screenshots, and release tooling.
 
@@ -247,7 +247,7 @@ This update carries the post-v1.6.0 staging line forward with safer chat renderi
 * Sampler visibility startup now avoids overwriting saved selections when browser storage is slow to respond.
 * Character avatar refresh, imported character selection, desktop Prompt Manager scroll, chat shell wheel routing, shell resize handles, Select2 dropdowns, native chat style headers, bounded rendered messages, and wand message screenshots were tightened.
 * Duplicate agent runner initialization, text-completion close handlers, local generation aborts, LCPP status restore, text-completion reasoning leaks, Guided Generations steering, post-agent provider-error handling, and Pathfinder swipe/settings reuse were hardened.
-* PR checks, changelog automation, frontend asset handling, and upstream touch tracking were cleaned up.
+* Changelog automation, frontend asset handling, and compatibility tracking were cleaned up.
 
 ### v1.6.0 (2026-05-18)
 
@@ -309,8 +309,8 @@ This update adds the Black Orange theme and desktop character drawer tiles, impr
 **In-Chat Agents**
 * Synced the Achievements Tracker and Scene Tracker template catalog entries with their updated source wording, and made bundled template reset recognize saved bundled agents after prompt wording changes.
 
-**PR #13 SillyTavern 1.18.0 Sync**
-Merged PR #13 from `codex/sync-118-compatibility` into `staging` on 2026-05-05. GitHub and the local merge both reported the PR as conflict-free.
+**SillyTavern 1.18.0 Compatibility Sync**
+SillyBunny incorporates the 1.18.0 compatibility updates while preserving the fork's Bun-first runtime and custom shell.
 
 * Kept SillyBunny's Bun-first defaults and port `4444` while updating Node-compatible dependency and lockfile state for the SillyTavern 1.18.0 surface.
 * Updated launcher and Electron package files for the new runtime layout.

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ SillyBunny includes some extras by default to help you get started right away:
 
 ## Latest Update
 
-### v1.6.1 (2026-05-31)
+### v1.6.1 (2026-06-02)
 
 This update carries the post-v1.6.0 staging line forward with safer chat rendering, tighter mobile navigation, sturdier preset/profile persistence, more reliable Quick Replies, and a broader cleanup pass across settings, screenshots, and release tooling.
 
@@ -245,7 +245,7 @@ This update carries the post-v1.6.0 staging line forward with safer chat renderi
 * Sampler visibility startup now avoids overwriting saved selections when browser storage is slow to respond.
 * Character avatar refresh, imported character selection, desktop Prompt Manager scroll, chat shell wheel routing, shell resize handles, Select2 dropdowns, native chat style headers, bounded rendered messages, and wand message screenshots were tightened.
 * Duplicate agent runner initialization, text-completion close handlers, local generation aborts, LCPP status restore, text-completion reasoning leaks, Guided Generations steering, post-agent provider-error handling, and Pathfinder swipe/settings reuse were hardened.
-* PR checks, changelog automation, frontend asset handling, and upstream touch tracking were cleaned up.
+* Changelog automation, frontend asset handling, and compatibility tracking were cleaned up.
 
 ### v1.6.0 (2026-05-18)
 
@@ -307,8 +307,8 @@ This update adds the Black Orange theme and desktop character drawer tiles, impr
 **In-Chat Agents**
 * Synced the Achievements Tracker and Scene Tracker template catalog entries with their updated source wording, and made bundled template reset recognize saved bundled agents after prompt wording changes.
 
-**PR #13 SillyTavern 1.18.0 Sync**
-Merged PR #13 from `codex/sync-118-compatibility` into `staging` on 2026-05-05. GitHub and the local merge both reported the PR as conflict-free.
+**SillyTavern 1.18.0 Compatibility Sync**
+SillyBunny incorporates the 1.18.0 compatibility updates while preserving the fork's Bun-first runtime and custom shell.
 
 * Kept SillyBunny's Bun-first defaults and port `4444` while updating Node-compatible dependency and lockfile state for the SillyTavern 1.18.0 surface.
 * Updated launcher and Electron package files for the new runtime layout.

--- a/Update-Instructions.txt
+++ b/Update-Instructions.txt
@@ -1,71 +1,68 @@
 How to Update SillyBunny
 
-The most recent version can be found here: https://docs.sillytavern.app/usage/update/
+This guide assumes you already have a working SillyBunny install. If you are
+installing for the first time, follow the installation instructions for your
+platform first, then return here when you need to update.
 
-This is not an installation guide. If you need installation instructions, look here:
-https://docs.sillytavern.app/installation/windows/
+Before updating
 
-This guide assumes you have already installed SillyBunny once, and know how to run it on your OS.
+1. Close SillyBunny.
+2. Back up your data folder if you have important characters, chats, presets,
+   themes, or secrets.
+3. If you run multiple user accounts, back up the whole data directory instead
+   of only data/default-user.
 
-Linux/Termux:
+Git installs
 
-You definitely installed via git, so just 'git pull' inside the SillyBunny directory.
+Git is the recommended update method.
 
-Windows/MacOS:
+1. Open a terminal in your SillyBunny folder.
+2. Run:
 
-Method 1 - GIT
+   git pull --ff-only
 
-We always recommend users install using 'git'. Here's why:
+3. If dependencies changed, run:
 
-When you have installed via `git clone`, all you have to do to update is type `git pull` in a command line in the ST folder.
-Alternatively, if the command prompt gives you problems (and you have GitHub Desktop installed), you can use the 'Repository' menu and select 'Pull'.
-The updates are applied automatically and safely.
+   bun install
 
-Method 2 - ZIP
+4. Start SillyBunny normally.
 
-If you insist on installing via a zip, here is the tedious process for doing the update:
+If Git reports local changes, review them before updating. Keep changes you made
+intentionally, or move them out of the way before pulling the update.
 
-1. Download the new release zip.
-2. Unzip it into a folder OUTSIDE of your current ST installation.
-3. Do the usual setup procedure for your OS to install Bun and the required packages.
+ZIP installs
 
-4a. Updating 1.12.0 and above
+ZIP updates require copying your user data into a fresh download.
 
-Copy the user data directory from your data root into the data root of the new install.
+1. Download the new SillyBunny release ZIP.
+2. Extract it into a new folder, outside your current SillyBunny install.
+3. Install or refresh the required packages for the new folder:
 
-By default: /data/default-user
+   bun install
 
-4a. Migrating from <1.12.0 to >=1.20.0
-Copy the following files/folders as necessary(*) from your old ST installation:
+4. Copy your user data from the old install into the new install.
 
-  - Assets
-  - Backgrounds
-  - Characters
-  - Chats
-  - Context
-  - Groups
-  - Group chats
-  - Instruct
-  - movingUI
-  - KoboldAI Settings
-  - NovelAI Settings
-  - OpenAI Settings (Chat Completion API)
-  - TextGen Settings (Text Completion API)
-  - QuickReplies
-  - Themes
-  - User Avatars
-  - Worlds
-  - User
-  - settings.json
-  - secrets.json <---- This one is in the base folder, not /public/
+   For current installs, copy:
 
-  (*) 'As necessary' = "If you made any custom content related to those folders".
-  None of the folders are mandatory, so only copy what you need.
+   data/default-user
 
-  **NB: DO NOT COPY THE ENTIRE /PUBLIC/ FOLDER.**
-  Doing so could break the new install and prevent new features from being present.
-  Paste those items into the /data/default-user folder of the new install.
+   If you use multiple accounts, copy the full data directory instead.
 
-5. Start SillyBunny once again with the method appropriate to your OS, and pray you got it right.
+5. Current installs keep secrets with the user data you copied above. If your
+   old install still has a legacy root-level secrets.json file, copy that file
+   into the matching location in the new install too.
+6. Start SillyBunny from the new folder and confirm your characters, chats,
+   presets, and settings appear correctly.
+7. After the new install is working, you can archive or delete the old folder.
 
-6. If everything shows up, you can safely delete the old ST folder.
+Do not copy the entire public folder from an old ZIP install into a new one.
+That can overwrite updated app files and hide new fixes.
+
+Troubleshooting
+
+- If SillyBunny does not start after an update, run bun install again in the
+  SillyBunny folder and restart.
+- If your data is missing after a ZIP update, confirm it was copied into the
+  new data folder, not into public.
+- If you need help with a SillyBunny-specific update issue, open an issue at:
+  https://github.com/platberlitz/SillyBunny/issues

--- a/changelog.md
+++ b/changelog.md
@@ -2,9 +2,9 @@
 
 ## v1.6.1
 
-Date: 2026-05-31
+Date: 2026-06-02
 
-This maintenance bump separates staging work merged after v1.6.0 so the next stable release changelog can collect it cleanly.
+This update keeps the 1.6 series moving with safer chat lifecycle defaults, stronger preset/profile persistence, more reliable Quick Replies, and cleaner release automation.
 
 ### Release Metadata
 - Updated app, Horde client, bundled extension, package, lockfile, and test metadata to 1.6.1.
@@ -127,6 +127,10 @@ This maintenance bump separates staging work merged after v1.6.0 so the next sta
 - PR #302 (2026-06-02) `fix: harden Select2 dropdown surfaces`
 - PR #303 (2026-06-02) `fix: prevent corrupted wand message screenshots`
 - PR #304 (2026-06-02) `fix: switch backend for bound reverse proxy presets`
+- PR #305 (2026-06-02) `chore: remove stale semantic map artifacts`
+- PR #306 (2026-06-02) `fix: close release readiness regressions`
+- PR #307 (2026-06-02) `fix: avoid forced reconnect when loading bound reverse proxy presets`
+- PR #308 (2026-06-02) `fix: restore desktop lorebook selection surfaces`
 
 ## v1.6.0
 
@@ -247,8 +251,8 @@ This update adds the Black Orange theme and desktop character drawer tiles, impr
 ### In-Chat Agents
 - Synced the Achievements Tracker and Scene Tracker template catalog entries with their updated source wording, and made bundled template reset recognize saved bundled agents after prompt wording changes.
 
-### PR #13 SillyTavern 1.18.0 Sync
-Merged PR #13 from `codex/sync-118-compatibility` into `staging` on 2026-05-05. GitHub and the local merge both reported the PR as conflict-free.
+### SillyTavern 1.18.0 Compatibility Sync
+SillyBunny incorporates the 1.18.0 compatibility updates while preserving the fork's Bun-first runtime and custom shell.
 
 - Kept SillyBunny's Bun-first defaults and port `4444` while updating Node-compatible dependency and lockfile state for the SillyTavern 1.18.0 surface.
 - Updated launcher and Electron package files for the new runtime layout.

--- a/public/scripts/extensions/quick-reply/api/QuickReplyApi.js
+++ b/public/scripts/extensions/quick-reply/api/QuickReplyApi.js
@@ -4,7 +4,7 @@ import { QuickReplySet } from '../src/QuickReplySet.js';
 import { QuickReplySettings } from '../src/QuickReplySettings.js';
 import { SettingsUi } from '../src/ui/SettingsUi.js';
 import { onlyUnique } from '../../../utils.js';
-import { getUniqueQuickReplySetLinksBySetName, getUniqueQuickReplySetsByName } from '../src/quick-reply-set-list.js';
+import { getUniqueQuickReplySetLinksBySetName, getUniqueQuickReplySetsByName, removeQuickReplySetLinksByName } from '../src/quick-reply-set-list.js';
 
 export class QuickReplyApi {
     /** @type {QuickReplySettings} */ settings;
@@ -445,6 +445,14 @@ export class QuickReplyApi {
             throw new Error(`No quick reply set with name "${name}" found.`);
         }
         await set.delete();
+        this.settings.config.setList = removeQuickReplySetLinksByName(this.settings.config.setList, set);
+        if (this.settings.chatConfig) {
+            this.settings.chatConfig.setList = removeQuickReplySetLinksByName(this.settings.chatConfig.setList, set);
+        }
+        if (this.settings.charConfig) {
+            this.settings.charConfig.setList = removeQuickReplySetLinksByName(this.settings.charConfig.setList, set);
+        }
+        this.settings.save();
         this.settingsUi.rerender();
     }
 

--- a/public/scripts/extensions/quick-reply/src/quick-reply-set-list.js
+++ b/public/scripts/extensions/quick-reply/src/quick-reply-set-list.js
@@ -36,3 +36,13 @@ export function getUniqueQuickReplySetLinksBySetName(links) {
         return true;
     });
 }
+
+export function removeQuickReplySetLinksByName(links, setOrName) {
+    const deletedKey = getQuickReplySetNameKey(setOrName);
+
+    if (!Array.isArray(links) || !deletedKey) {
+        return Array.isArray(links) ? links : [];
+    }
+
+    return links.filter(link => getQuickReplySetLinkNameKey(link) !== deletedKey);
+}

--- a/public/scripts/extensions/quick-reply/src/ui/ButtonUi.js
+++ b/public/scripts/extensions/quick-reply/src/ui/ButtonUi.js
@@ -98,7 +98,7 @@ export class ButtonUi {
             ...this.settings.config.setList,
             ...(this.settings.chatConfig?.setList ?? []),
             ...(this.settings.charConfig?.setList ?? []),
-        ].filter(link => link.isVisible));
+        ].filter(link => link.isVisible && !link.set?.isDeleted));
     }
 
 

--- a/public/scripts/extensions/quick-reply/src/ui/SettingsUi.js
+++ b/public/scripts/extensions/quick-reply/src/ui/SettingsUi.js
@@ -3,7 +3,7 @@ import { getSortableDelay } from '../../../../utils.js';
 import { log, warn } from '../shared.js';
 import { QuickReply } from '../QuickReply.js';
 import { QuickReplySet } from '../QuickReplySet.js';
-import { getQuickReplySetLinkNameKey, getQuickReplySetNameKey, getUniqueQuickReplySetsByName } from '../quick-reply-set-list.js';
+import { getUniqueQuickReplySetsByName, removeQuickReplySetLinksByName } from '../quick-reply-set-list.js';
 import { QuickReplySettings } from '../QuickReplySettings.js';
 
 export class SettingsUi {
@@ -309,13 +309,12 @@ export class SettingsUi {
     async doDeleteQrSet(qrs) {
         await qrs.delete();
         //TODO (HACK) should just bubble up from QuickReplySet.delete() but that would require proper or at least more comples onDelete listeners
-        const deletedKey = getQuickReplySetNameKey(qrs);
-        this.settings.config.setList = this.settings.config.setList.filter(link => getQuickReplySetLinkNameKey(link) !== deletedKey);
+        this.settings.config.setList = removeQuickReplySetLinksByName(this.settings.config.setList, qrs);
         if (this.settings.chatConfig) {
-            this.settings.chatConfig.setList = this.settings.chatConfig.setList.filter(link => getQuickReplySetLinkNameKey(link) !== deletedKey);
+            this.settings.chatConfig.setList = removeQuickReplySetLinksByName(this.settings.chatConfig.setList, qrs);
         }
         if (this.settings.charConfig) {
-            this.settings.charConfig.setList = this.settings.charConfig.setList.filter(link => getQuickReplySetLinkNameKey(link) !== deletedKey);
+            this.settings.charConfig.setList = removeQuickReplySetLinksByName(this.settings.charConfig.setList, qrs);
         }
         this.settings.save();
     }

--- a/public/scripts/samplerSelect.js
+++ b/public/scripts/samplerSelect.js
@@ -59,7 +59,7 @@ async function showSamplerSelectPopup() {
 
             const isActive = $(this).hasClass('toggleEnabled');
 
-            toggleSamplerManualPriority(isActive);
+            toggleSamplerManualPriority(isActive, '', true);
         });
     } else {
         $('#prioritizeManuallySelectedSamplers').hide();
@@ -201,7 +201,7 @@ function setSamplerListListeners() {
         const shouldDisplay = isChecked ? targetDisplayType : 'none';
         relatedDOMElement.css('display', shouldDisplay);
 
-        if (main_api === 'textgenerationwebui') setApiSamplersState(samplerName, shouldDisplay !== 'none');
+        if (main_api === 'textgenerationwebui') setApiSamplersState(samplerName, shouldDisplay !== 'none', '', true);
 
         console.log(samplerName, relatedDOMElement.data(SELECT_SAMPLER.DATA), shouldDisplay);
     });
@@ -373,15 +373,17 @@ export async function resetApiSelectedSamplers(tcApiType = '', silent = false) {
  * @param {string} samplerName Target sampler key name
  * @param {string|boolean} state Visibility state of the target sampler
  * @param {string?} tcApiType Name of the target API Type - It picks the currently active TC API type name by default
+ * @param {boolean} explicitSave Whether this write comes from a user/API action that should re-enable saving after a startup timeout
  * @returns void
  */
-export function setApiSamplersState(samplerName, state, tcApiType = '') {
+export function setApiSamplersState(samplerName, state, tcApiType = '', explicitSave = false) {
     if (!textgenerationwebui_settings?.type && !tcApiType) return;
     if (!tcApiType) tcApiType = textgenerationwebui_settings.type;
     if (!selectedSamplers[tcApiType]) selectedSamplers[tcApiType] = {};
 
     const presetSamplers = selectedSamplers[tcApiType];
     presetSamplers[samplerName] = String(state) === 'true';
+    if (explicitSave) selectedSamplersStorageReady = true;
 }
 
 /**
@@ -452,15 +454,17 @@ export function getActiveManualApiSamplers(tcApiType = '') {
 /**
  * @param {string|boolean} state Target state of the feature
  * @param {string?} tcApiType Name of the target API Type - It picks the currently active TC API type name by default
+ * @param {boolean} explicitSave Whether this write comes from a user/API action that should re-enable saving after a startup timeout
  * @returns void
  */
-export function toggleSamplerManualPriority(state = false, tcApiType = '') {
+export function toggleSamplerManualPriority(state = false, tcApiType = '', explicitSave = false) {
     if (!textgenerationwebui_settings?.type && !tcApiType) return;
     if (!tcApiType) tcApiType = textgenerationwebui_settings.type;
     if (!selectedSamplers[tcApiType]) selectedSamplers[tcApiType] = {};
 
     const presetSamplers = selectedSamplers[tcApiType];
     presetSamplers.st_manual_priority = String(state) === 'true';
+    if (explicitSave) selectedSamplersStorageReady = true;
 }
 
 /**

--- a/scripts/update-changelog-merged-prs.js
+++ b/scripts/update-changelog-merged-prs.js
@@ -4,7 +4,7 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, '..');
@@ -109,15 +109,21 @@ function readEventPrNumbers() {
     return prNumbers;
 }
 
-function extractMergedPrNumbers(message) {
-    const numbers = [];
-    const pattern = /^Merge pull request #(\d+)\b/gm;
+export function extractMergedPrNumbers(message) {
+    const numbers = new Set();
+    const text = String(message || '');
 
-    for (const match of String(message || '').matchAll(pattern)) {
-        numbers.push(match[1]);
+    for (const match of text.matchAll(/^Merge pull request #(\d+)\b/gm)) {
+        numbers.add(match[1]);
     }
 
-    return numbers;
+    const [subject = ''] = text.split(/\r?\n/, 1);
+    const squashMatch = /\(#(\d+)\)\s*$/.exec(subject);
+    if (squashMatch) {
+        numbers.add(squashMatch[1]);
+    }
+
+    return [...numbers];
 }
 
 function normalizePrNumbers(values) {
@@ -321,4 +327,6 @@ function main() {
     }
 }
 
-main();
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main();
+}

--- a/src/endpoints/extensions.js
+++ b/src/endpoints/extensions.js
@@ -29,6 +29,7 @@ const CORE_EXTENSIONS = new Set([
 ]);
 const BUNDLED_THIRD_PARTY_EXTENSIONS = new Set([
     'BunnyPresetTools',
+    'ChatCompletionTabs',
 ]);
 const MANUAL_SYNC_EXTENSIONS = new Map([
     ['quick-image-gen', {
@@ -185,7 +186,7 @@ async function ensureExtensionRepo(extensionPath, isGlobal = false) {
     }
 }
 
-function isBundledThirdPartyExtension(extensionName) {
+export function isBundledThirdPartyExtension(extensionName) {
     return BUNDLED_THIRD_PARTY_EXTENSIONS.has(sanitize(extensionName));
 }
 
@@ -194,7 +195,7 @@ function getBuiltInExtensionType(extensionName) {
     return CORE_EXTENSIONS.has(sanitizedName) ? 'core' : 'system';
 }
 
-function rejectBundledThirdPartyExtension(extensionName, response, action) {
+export function rejectBundledThirdPartyExtension(extensionName, response, action) {
     if (!isBundledThirdPartyExtension(extensionName)) {
         return false;
     }

--- a/tests/extensions-bundled-third-party.test.js
+++ b/tests/extensions-bundled-third-party.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, jest, test } from '@jest/globals';
+
+jest.unstable_mockModule('../src/util.js', () => ({
+    getConfigValue: jest.fn((_, fallback) => fallback),
+    isValidUrl: jest.fn(() => true),
+}));
+
+const { isBundledThirdPartyExtension, rejectBundledThirdPartyExtension } = await import('../src/endpoints/extensions.js');
+
+describe('bundled third-party extensions', () => {
+    test('classifies tracked bundled third-party extensions as bundled', () => {
+        expect(isBundledThirdPartyExtension('BunnyPresetTools')).toBe(true);
+        expect(isBundledThirdPartyExtension('ChatCompletionTabs')).toBe(true);
+        expect(isBundledThirdPartyExtension('CommunityExtension')).toBe(false);
+    });
+
+    test('rejects updater mutations for bundled third-party extensions', () => {
+        const response = {
+            status: jest.fn(() => response),
+            send: jest.fn(),
+        };
+
+        expect(rejectBundledThirdPartyExtension('ChatCompletionTabs', response, 'deleted')).toBe(true);
+        expect(response.status).toHaveBeenCalledWith(400);
+        expect(response.send).toHaveBeenCalledWith(expect.stringContaining('ChatCompletionTabs is bundled with SillyBunny'));
+    });
+});

--- a/tests/quick-reply-api.test.js
+++ b/tests/quick-reply-api.test.js
@@ -46,6 +46,10 @@ function createSet(name, labels = []) {
     return {
         name,
         qrList: labels.map(createQuickReply),
+        isDeleted: false,
+        async delete() {
+            this.isDeleted = true;
+        },
     };
 }
 
@@ -109,5 +113,45 @@ describe('Quick Reply API set listing', () => {
         expect(firstSet.qrList[0].onExecute).toHaveBeenCalledTimes(1);
         expect(duplicateSet.qrList[0].onExecute).not.toHaveBeenCalled();
         expect(secondSet.qrList[0].onExecute).toHaveBeenCalledTimes(1);
+    });
+
+    test('deletes sets through the API and purges matching active links across scopes', async () => {
+        const targetSet = createSet('Memory Sharding');
+        const duplicateLinkedSet = createSet(' memory sharding ');
+        const otherSet = createSet('Chat Tools');
+        MockQuickReplySet.list = [targetSet, otherSet];
+        const settings = {
+            save: jest.fn(),
+            config: {
+                setList: [
+                    { set: targetSet },
+                    { set: duplicateLinkedSet },
+                    { set: otherSet },
+                ],
+            },
+            chatConfig: {
+                setList: [
+                    { set: duplicateLinkedSet },
+                    { set: otherSet },
+                ],
+            },
+            charConfig: {
+                setList: [
+                    { set: duplicateLinkedSet },
+                    { set: otherSet },
+                ],
+            },
+        };
+        const settingsUi = { rerender: jest.fn() };
+        const api = new QuickReplyApi(settings, settingsUi);
+
+        await api.deleteSet(' memory sharding ');
+
+        expect(targetSet.isDeleted).toBe(true);
+        expect(settings.config.setList).toEqual([{ set: otherSet }]);
+        expect(settings.chatConfig.setList).toEqual([{ set: otherSet }]);
+        expect(settings.charConfig.setList).toEqual([{ set: otherSet }]);
+        expect(settings.save).toHaveBeenCalledTimes(1);
+        expect(settingsUi.rerender).toHaveBeenCalledTimes(1);
     });
 });

--- a/tests/quick-reply-button-ui.test.js
+++ b/tests/quick-reply-button-ui.test.js
@@ -303,4 +303,20 @@ describe('Quick Reply button bar', () => {
         expect(qrButtons).toHaveLength(1);
         expect(qrButtons[0].textContent).toBe('Visible Chat');
     });
+
+    test('does not render stale visible links to deleted sets', () => {
+        appendComposer();
+        const settings = createSettings('Deleted Help');
+        settings.config.setList[0].set.isDeleted = true;
+        settings.chatConfig = {
+            setList: [{ isVisible: true, set: createVisibleSet('Active Chat') }],
+        };
+        const buttons = new ButtonUi(settings);
+
+        buttons.show();
+
+        const qrButtons = document.querySelector('#qr--bar')?.querySelectorAll('.qr--button') ?? [];
+        expect(qrButtons).toHaveLength(1);
+        expect(qrButtons[0].textContent).toBe('Active Chat');
+    });
 });

--- a/tests/quick-reply-set-list.test.js
+++ b/tests/quick-reply-set-list.test.js
@@ -5,6 +5,7 @@ import {
     getQuickReplySetNameKey,
     getUniqueQuickReplySetLinksBySetName,
     getUniqueQuickReplySetsByName,
+    removeQuickReplySetLinksByName,
 } from '../public/scripts/extensions/quick-reply/src/quick-reply-set-list.js';
 
 describe('Quick Reply set list helpers', () => {
@@ -42,5 +43,17 @@ describe('Quick Reply set list helpers', () => {
             { set: null },
             memoryLink,
         ])).toEqual([defaultLink, memoryLink]);
+    });
+
+    test('removes links by normalized set display name', () => {
+        const defaultLink = { set: { name: 'Default' }, isVisible: true };
+        const duplicateDefaultLink = { set: { name: ' default ' }, isVisible: true };
+        const memoryLink = { set: { name: 'Memory Sharding' }, isVisible: false };
+
+        expect(removeQuickReplySetLinksByName([
+            defaultLink,
+            duplicateDefaultLink,
+            memoryLink,
+        ], 'DEFAULT')).toEqual([memoryLink]);
     });
 });

--- a/tests/sampler-storage.test.js
+++ b/tests/sampler-storage.test.js
@@ -140,6 +140,62 @@ describe('selected sampler save guard', () => {
         }
     });
 
+    test('allows explicit popup sampler changes after a storage timeout', async () => {
+        jest.useFakeTimers();
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+
+        try {
+            mockTextGenObjectStore.getItem.mockReturnValue(new Promise(() => {}));
+            const {
+                loadApiSelectedSamplers,
+                saveApiSelectedSamplers,
+                setApiSamplersState,
+            } = await importSamplerSelect();
+
+            const loadPromise = loadApiSelectedSamplers();
+            await jest.advanceTimersByTimeAsync(1500);
+            await loadPromise;
+
+            setApiSamplersState('temperature', true, 'ooba', true);
+
+            await expect(saveApiSelectedSamplers()).resolves.toBe(true);
+            expect(mockTextGenObjectStore.setItem).toHaveBeenCalledWith('selectedSamplers', {
+                ooba: { temperature: true },
+            });
+        } finally {
+            jest.useRealTimers();
+            console.log.mockRestore();
+        }
+    });
+
+    test('allows explicit manual priority changes after a storage timeout', async () => {
+        jest.useFakeTimers();
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+
+        try {
+            mockTextGenObjectStore.getItem.mockReturnValue(new Promise(() => {}));
+            const {
+                loadApiSelectedSamplers,
+                saveApiSelectedSamplers,
+                toggleSamplerManualPriority,
+            } = await importSamplerSelect();
+
+            const loadPromise = loadApiSelectedSamplers();
+            await jest.advanceTimersByTimeAsync(1500);
+            await loadPromise;
+
+            toggleSamplerManualPriority(true, 'ooba', true);
+
+            await expect(saveApiSelectedSamplers()).resolves.toBe(true);
+            expect(mockTextGenObjectStore.setItem).toHaveBeenCalledWith('selectedSamplers', {
+                ooba: { st_manual_priority: true },
+            });
+        } finally {
+            jest.useRealTimers();
+            console.log.mockRestore();
+        }
+    });
+
     test('does not arm the save guard when reset follows a storage timeout', async () => {
         jest.useFakeTimers();
         jest.spyOn(console, 'log').mockImplementation(() => {});

--- a/tests/update-changelog-merged-prs.test.js
+++ b/tests/update-changelog-merged-prs.test.js
@@ -1,0 +1,21 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { extractMergedPrNumbers } from '../scripts/update-changelog-merged-prs.js';
+
+describe('update changelog merged PR extraction', () => {
+    test('extracts classic merge commit pull request numbers', () => {
+        expect(extractMergedPrNumbers('Merge pull request #305 from owner/branch')).toEqual(['305']);
+    });
+
+    test('extracts squash merge pull request numbers from commit subjects', () => {
+        expect(extractMergedPrNumbers('fix: close release readiness regressions (#306)')).toEqual(['306']);
+    });
+
+    test('ignores pull-request-shaped references outside the subject line', () => {
+        expect(extractMergedPrNumbers('fix: release polish\n\nRefs cleanup note (#999)')).toEqual([]);
+    });
+
+    test('deduplicates pull request numbers found through multiple merge styles', () => {
+        expect(extractMergedPrNumbers('Merge pull request #306 from owner/branch\nfix: close release readiness regressions (#306)')).toEqual(['306']);
+    });
+});


### PR DESCRIPTION
## What?
- Hardens sampler visibility/manual-priority saves so explicit popup actions still persist after a slow-storage startup timeout, while fallback/reset paths stay guarded.
- Purges Quick Reply active links when sets are deleted through settings or the API, and filters stale deleted links from the visible button bar.
- Treats `ChatCompletionTabs` as a bundled third-party extension so updater delete/update/move actions cannot mutate the checked-in bundle.
- Tightens changelog automation for squash-merged PR subjects and refreshes the v1.6.1 release/docs surface, including bug-report wording, update instructions, README mirror sync, and merged PR entries through #308.

## Why?
The release sweep found a few remaining readiness gaps: user sampler changes could still be lost after a storage timeout, deleted Quick Reply sets could leave stale active links, a bundled extension was exposed as mutable third-party content, and the release docs/changelog could drift after squash merges. This closes those before the next version bump.

## How?
- Adds explicit-save paths for sampler popup/manual-priority interactions without changing startup/reset fallback behavior.
- Adds normalized Quick Reply link removal helpers and uses them across settings deletion and API deletion.
- Adds bundled extension classification coverage for `ChatCompletionTabs`.
- Updates changelog extraction to read PR numbers from classic merge commits and squash commit subjects only, with deduplication and body-line false-positive coverage.
- Refreshes public docs so release/update/issue copy is SillyBunny-facing and the README mirror remains generated from the root README.

## Testing?
- `git diff --check origin/staging..HEAD`
- `npm run lint -- --quiet`
- `npm run lint --prefix tests -- --quiet`
- `npm run check:frontend-budgets`
- `npm run test:unit --prefix tests` — 88 suites, 848 tests passed
- `npm run build:frontend`
- `bash scripts/sync-readme-mirror.sh --check`
- `node scripts/update-changelog-merged-prs.js --dry-run --pr 305 --pr 306 --pr 307 --pr 308`
- Browser smoke on a temporary non-default port: title loaded, canonical `script.js` loaded without query string, main chat/composer nodes visible, Quick Reply and `ChatCompletionTabs` extension scripts loaded, and no console errors.

## Screenshots (optional)
Not included; this is a logic/docs hardening pass. The browser smoke verified rendered DOM and console state instead.

## Anything Else?
PRs #307 and #308 were reviewed, marked ready, squash-merged, and their branches deleted before this branch was rebased onto the updated `staging` tip. The release changelog includes entries through #308.
