### PR TITLE
fix: sync reverse proxy preset when chat completion source changes

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -8501,6 +8501,43 @@ function onProxyPresetChange() {
     saveSettingsDebounced();
 }
 
+// SillyBunny: reverse direction of the reverse-proxy backend binding. Selecting a bound preset already
+// switches the backend (forward); this keeps the binding two-way by selecting a preset bound to the
+// newly chosen backend. Guarded against re-entrancy so it can't feed back into the source change handler.
+let isSyncingProxyBinding = false;
+
+/**
+ * Selects the reverse proxy preset bound to the given Chat Completion source, when one exists.
+ * @param {string} source Chat Completion source value
+ */
+function syncProxyPresetToBoundSource(source) {
+    if (isSyncingProxyBinding) {
+        return;
+    }
+    if (!source || !REVERSE_PROXY_SUPPORTED_SOURCES.includes(source)) {
+        return;
+    }
+    // Already on a preset bound to this source; nothing to switch.
+    if (selected_proxy && selected_proxy.name !== 'None' && selected_proxy.source === source) {
+        return;
+    }
+    const boundPreset = proxies.find(preset => preset.name !== 'None' && preset.source === source);
+    if (!boundPreset || boundPreset.name === selected_proxy?.name) {
+        return;
+    }
+
+    isSyncingProxyBinding = true;
+    try {
+        $('#openai_proxy_preset').val(boundPreset.name);
+        // applySource: false avoids re-triggering the source change we are already handling;
+        // silent: true applies the proxy URL/password without a redundant reconnect.
+        setProxyPreset(boundPreset.name, boundPreset.url, boundPreset.password, boundPreset.source, { applySource: false, silent: true });
+        saveSettingsDebounced();
+    } finally {
+        isSyncingProxyBinding = false;
+    }
+}
+
 $('#save_proxy').on('click', async function () {
     const presetName = $('#openai_reverse_proxy_name').val();
     const reverseProxy = $('#openai_reverse_proxy').val();
@@ -9166,6 +9203,7 @@ export function initOpenAI() {
         syncMaxContextUnlockedControl(oai_settings);
         toggleChatCompletionForms();
         applyConfigurableContextLimit();
+        syncProxyPresetToBoundSource(oai_settings.chat_completion_source);
         saveSettingsDebounced();
         reconnectOpenAi();
         forceCharacterEditorTokenize();

--- a/tests/openai-proxy-preset-wiring.test.js
+++ b/tests/openai-proxy-preset-wiring.test.js
@@ -93,4 +93,33 @@ describe('OpenAI proxy preset wiring', () => {
         // Silent branch must short-circuit before the reconnect path.
         expect(reconnectIndex).toBeGreaterThan(silentReturnIndex);
     });
+
+    test('keeps the backend binding two-way by syncing the proxy preset on source change', () => {
+        const syncSource = getFunctionSource('syncProxyPresetToBoundSource');
+
+        // Re-entrancy guard prevents feeding back into the source change handler.
+        expect(openAiSource).toContain('let isSyncingProxyBinding = false;');
+        expect(syncSource).toContain('if (isSyncingProxyBinding) {');
+        expect(syncSource).toContain('isSyncingProxyBinding = true;');
+        expect(syncSource).toContain('isSyncingProxyBinding = false;');
+
+        // Only acts on supported sources and finds a preset bound to that source.
+        expect(syncSource).toContain('REVERSE_PROXY_SUPPORTED_SOURCES.includes(source)');
+        expect(syncSource).toContain('proxies.find(preset => preset.name !== \'None\' && preset.source === source)');
+
+        // Applies the bound preset without re-triggering the source change or a redundant reconnect.
+        expect(syncSource).toContain('{ applySource: false, silent: true }');
+    });
+
+    test('invokes the reverse binding sync from the chat completion source change handler', () => {
+        const initSource = getFunctionSource('initOpenAI');
+        const sourceChangeIndex = initSource.indexOf('$(\'#chat_completion_source\').on(\'change\'');
+        const syncCallIndex = initSource.indexOf('syncProxyPresetToBoundSource(oai_settings.chat_completion_source);');
+        const reconnectIndex = initSource.indexOf('reconnectOpenAi();', sourceChangeIndex);
+
+        expect(sourceChangeIndex).toBeGreaterThanOrEqual(0);
+        expect(syncCallIndex).toBeGreaterThan(sourceChangeIndex);
+        // Proxy preset must be applied before reconnecting so the reconnect uses the bound proxy.
+        expect(reconnectIndex).toBeGreaterThan(syncCallIndex);
+    });
 });


### PR DESCRIPTION
## Summary
- The reverse proxy backend binding only worked one way: selecting a bound proxy preset switched the Chat Completion source. Changing the source directly (e.g. to Z.AI/GLM) did **not** select the proxy preset bound to that source, so the binding felt broken.
- Add `syncProxyPresetToBoundSource()`, called from the `#chat_completion_source` change handler **before** `reconnectOpenAi()`, so picking a backend selects a proxy preset bound to it and the reconnect uses that proxy's URL/password.
- The sync applies the preset with `{ applySource: false, silent: true }` (no redundant reconnect, no re-trigger of the source change) and is wrapped in a re-entrancy guard (`isSyncingProxyBinding`) so it cannot loop back into the source change handler.

## Result
The binding is now two-way: selecting a bound preset switches the backend (existing), and switching the backend selects the bound preset (new).

## Tests
- `npm run test:unit --prefix tests` — 839 passed (2 new assertions in `openai-proxy-preset-wiring.test.js` covering the reverse sync and its invocation order before reconnect).
- `npm run lint` — clean on changed files.