### PR TITLE
fix: Bun request cancellation propagation

### DIFF
--- a/scripts/verify-request-cancellation.js
+++ b/scripts/verify-request-cancellation.js
@@ -1,0 +1,105 @@
+import http from 'node:http';
+import process from 'node:process';
+
+import express from 'express';
+
+import { observeRequestCancellation } from '../src/request-cancellation.js';
+
+const RUNTIME_LABEL = process.versions?.bun ? `Bun ${process.versions.bun}` : `Node ${process.version}`;
+const ABORT_TIMEOUT_MS = 2000;
+
+function waitForAbort(signal) {
+    if (signal.aborted) {
+        return Promise.resolve();
+    }
+
+    return new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => {
+            reject(new Error(`Server-side upstream request was not aborted within ${ABORT_TIMEOUT_MS}ms`));
+        }, ABORT_TIMEOUT_MS);
+        timeout.unref?.();
+
+        signal.addEventListener('abort', () => {
+            clearTimeout(timeout);
+            resolve();
+        }, { once: true });
+    });
+}
+
+function waitForRequestStarted() {
+    let resolveStarted;
+    const promise = new Promise(resolve => {
+        resolveStarted = resolve;
+    });
+
+    return { promise, resolveStarted };
+}
+
+async function listen(server) {
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+        throw new Error('Unable to resolve test server address');
+    }
+
+    return `http://127.0.0.1:${address.port}`;
+}
+
+async function close(server) {
+    await new Promise(resolve => server.close(resolve));
+}
+
+async function main() {
+    const app = express();
+    const started = waitForRequestStarted();
+    let upstreamAbortPromise = null;
+
+    app.use(express.json());
+    app.post('/generate', async (request, response) => {
+        const controller = new AbortController();
+        observeRequestCancellation(request, response, {
+            controller,
+            pollConnection: Boolean(process.versions?.bun),
+            pollIntervalMs: 50,
+        });
+
+        upstreamAbortPromise = waitForAbort(controller.signal);
+        started.resolveStarted();
+
+        try {
+            await upstreamAbortPromise;
+            if (!response.writableEnded) {
+                response.status(499).end();
+            }
+        } catch (error) {
+            if (!response.writableEnded) {
+                response.status(500).send(error.message);
+            }
+        }
+    });
+
+    const server = http.createServer(app);
+    const baseUrl = await listen(server);
+    const clientController = new AbortController();
+    const clientRequest = fetch(`${baseUrl}/generate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: 'slow generation' }),
+        signal: clientController.signal,
+    }).catch(error => error);
+
+    try {
+        await started.promise;
+        clientController.abort();
+        await upstreamAbortPromise;
+        await clientRequest;
+        console.info(`[request-cancellation] PASS under ${RUNTIME_LABEL}`);
+    } finally {
+        await close(server);
+    }
+}
+
+main().catch(error => {
+    console.error(`[request-cancellation] FAIL under ${RUNTIME_LABEL}:`, error);
+    process.exitCode = 1;
+});

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -311,7 +311,7 @@ async function sendClaudeRequest(request, response) {
 
     try {
         const controller = new AbortController();
-        abortOnRequestClose(request, controller);
+        abortOnRequestClose(request, controller, response);
         const additionalHeaders = {};
         const betaHeaders = ['output-128k-2025-02-19', 'context-1m-2025-08-07'];
         const useTools = Array.isArray(request.body.tools) && request.body.tools.length > 0;
@@ -715,7 +715,7 @@ async function sendMakerSuiteRequest(request, response) {
 
     try {
         const controller = new AbortController();
-        abortOnRequestClose(request, controller);
+        abortOnRequestClose(request, controller, response);
 
         const apiVersion = getConfigValue('gemini.apiVersion', 'v1beta');
         const responseType = (stream ? 'streamGenerateContent' : 'generateContent');
@@ -851,7 +851,7 @@ async function sendAI21Request(request, response) {
 
     const bodyParams = {};
     const controller = new AbortController();
-    abortOnRequestClose(request, controller);
+    abortOnRequestClose(request, controller, response);
     // Hack to support JSON schema
     if (request.body.json_schema) {
         bodyParams.response_format = {
@@ -930,7 +930,7 @@ async function sendMistralAIRequest(request, response) {
     try {
         const messages = convertMistralMessages(request.body.messages, getPromptNames(request));
         const controller = new AbortController();
-        abortOnRequestClose(request, controller);
+        abortOnRequestClose(request, controller, response);
 
         const requestBody = {
             'model': request.body.model,
@@ -1008,7 +1008,7 @@ async function sendMistralAIRequest(request, response) {
 async function sendCohereRequest(request, response) {
     const apiKey = readSecret(request.user.directories, SECRET_KEYS.COHERE);
     const controller = new AbortController();
-    abortOnRequestClose(request, controller);
+    abortOnRequestClose(request, controller, response);
 
     if (!apiKey) {
         console.warn('Cohere API key is missing.');
@@ -1112,7 +1112,7 @@ async function sendDeepSeekRequest(request, response) {
     }
 
     const controller = new AbortController();
-    abortOnRequestClose(request, controller);
+    abortOnRequestClose(request, controller, response);
 
     try {
         let bodyParams = {};
@@ -1226,7 +1226,7 @@ async function sendXaiRequest(request, response) {
     }
 
     const controller = new AbortController();
-    abortOnRequestClose(request, controller);
+    abortOnRequestClose(request, controller, response);
 
     try {
         let bodyParams = {};
@@ -1331,7 +1331,7 @@ async function sendAimlapiRequest(request, response) {
     }
 
     const controller = new AbortController();
-    abortOnRequestClose(request, controller);
+    abortOnRequestClose(request, controller, response);
 
     try {
         let bodyParams = {};
@@ -1433,7 +1433,7 @@ async function sendElectronHubRequest(request, response) {
     }
 
     const controller = new AbortController();
-    abortOnRequestClose(request, controller);
+    abortOnRequestClose(request, controller, response);
 
     try {
         let bodyParams = {};
@@ -1542,7 +1542,7 @@ async function sendChutesRequest(request, response) {
     }
 
     const controller = new AbortController();
-    abortOnRequestClose(request, controller);
+    abortOnRequestClose(request, controller, response);
 
     try {
         let bodyParams = {};
@@ -1641,7 +1641,7 @@ async function sendMinimaxRequest(request, response) {
     }
 
     const controller = new AbortController();
-    abortOnRequestClose(request, controller);
+    abortOnRequestClose(request, controller, response);
 
     try {
         // MiniMax does not allow consecutive messages with the same role.
@@ -1757,7 +1757,7 @@ async function sendAzureOpenAIRequest(request, response) {
         : undefined;
 
     const controller = new AbortController();
-    abortOnRequestClose(request, controller);
+    abortOnRequestClose(request, controller, response);
 
     const config = {
         method: 'POST',
@@ -2652,7 +2652,7 @@ async function sendOpenAIResponsesRequest(request, response) {
     }
 
     const controller = new AbortController();
-    abortOnRequestClose(request, controller);
+    abortOnRequestClose(request, controller, response);
 
     try {
         const { input, instructions } = convertMessagesToResponsesFormat(request.body.messages);
@@ -3111,7 +3111,7 @@ router.post('/generate', async function (request, response) {
             `${apiUrl}/chat/completions`;
 
         const controller = new AbortController();
-        abortOnRequestClose(request, controller);
+        abortOnRequestClose(request, controller, response);
 
         if (!isTextCompletion && Array.isArray(request.body.tools) && request.body.tools.length > 0) {
             bodyParams['tools'] = request.body.tools;

--- a/src/endpoints/backends/kobold.js
+++ b/src/endpoints/backends/kobold.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import express from 'express';
 import fetch from 'node-fetch';
 
-import { forwardFetchResponse, delay, summarizeLlmPayloadForLog } from '../../util.js';
+import { abortOnRequestClose, forwardFetchResponse, delay, summarizeLlmPayloadForLog } from '../../util.js';
 import { getOverrideHeaders, setAdditionalHeaders, setAdditionalHeadersByType } from '../../additional-headers.js';
 import { TEXTGEN_TYPES } from '../../constants.js';
 
@@ -17,9 +17,12 @@ router.post('/generate', async function (request, response_generate) {
 
     const request_prompt = request.body.prompt;
     const controller = new AbortController();
-    request.socket.removeAllListeners('close');
-    request.socket.on('close', async function () {
-        if (request.body.can_abort && !response_generate.writableEnded) {
+    abortOnRequestClose(request, controller, response_generate, {
+        onAbort: async () => {
+            if (!request.body.can_abort || response_generate.writableEnded) {
+                return;
+            }
+
             try {
                 console.info('Aborting Kobold generation...');
                 // send abort signal to koboldcpp
@@ -33,8 +36,7 @@ router.post('/generate', async function (request, response_generate) {
             } catch (error) {
                 console.error(error);
             }
-        }
-        controller.abort();
+        },
     });
 
     let this_settings = {

--- a/src/endpoints/backends/text-completions.js
+++ b/src/endpoints/backends/text-completions.js
@@ -12,7 +12,7 @@ import {
     FEATHERLESS_KEYS,
     OPENAI_KEYS,
 } from '../../constants.js';
-import { forwardFetchResponse, trimV1, getConfigValue, pollStreamingRequestConnection, summarizeLlmPayloadForLog } from '../../util.js';
+import { abortOnRequestClose, forwardFetchResponse, trimV1, getConfigValue, pollStreamingRequestConnection, summarizeLlmPayloadForLog } from '../../util.js';
 import { setAdditionalHeaders } from '../../additional-headers.js';
 import { createHash } from 'node:crypto';
 
@@ -316,14 +316,15 @@ router.post('/generate', async function (request, response) {
         console.debug('Text completion request:', summarizeLlmPayloadForLog(request.body));
 
         const controller = new AbortController();
-        request.socket.removeAllListeners('close');
-        request.socket.on('close', async function () {
-            // SillyBunny: KoboldCpp needs its own upstream abort endpoint; other backends use the shared fetch abort/stream destroy path.
-            if (request.body.api_type === TEXTGEN_TYPES.KOBOLDCPP && !response.writableEnded) {
-                await abortKoboldCppRequest(request, trimV1(baseUrl));
-            }
+        abortOnRequestClose(request, controller, response, {
+            onAbort: async () => {
+                // SillyBunny: KoboldCpp needs its own upstream abort endpoint; other backends use the shared fetch abort/stream destroy path.
+                if (request.body.api_type !== TEXTGEN_TYPES.KOBOLDCPP || response.writableEnded) {
+                    return;
+                }
 
-            controller.abort();
+                await abortKoboldCppRequest(request, trimV1(baseUrl));
+            },
         });
 
         let url = trimV1(baseUrl);

--- a/src/endpoints/google.js
+++ b/src/endpoints/google.js
@@ -9,7 +9,7 @@ import lodash from 'lodash';
 
 import { readSecret, SECRET_KEYS } from './secrets.js';
 import { GEMINI_SAFETY, VERTEX_SAFETY } from '../constants.js';
-import { delay, getConfigValue, trimTrailingSlash } from '../util.js';
+import { abortOnRequestClose, delay, getConfigValue, trimTrailingSlash } from '../util.js';
 
 const API_MAKERSUITE = 'https://generativelanguage.googleapis.com';
 const API_VERTEX_AI = 'https://us-central1-aiplatform.googleapis.com';
@@ -536,10 +536,7 @@ router.post('/generate-image', async (request, response) => {
 router.post('/generate-video', async (request, response) => {
     try {
         const controller = new AbortController();
-        request.socket.removeAllListeners('close');
-        request.socket.on('close', function () {
-            controller.abort();
-        });
+        abortOnRequestClose(request, controller, response);
 
         const model = request.body.model || 'veo-3.1-generate-preview';
         const { url, headers, apiName, baseUrl } = await getGoogleApiConfig(request, model, 'predictLongRunning');

--- a/src/endpoints/horde.js
+++ b/src/endpoints/horde.js
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch';
 import express from 'express';
 import { AIHorde, ModelGenerationInputStableSamplers, ModelInterrogationFormTypes, HordeAsyncRequestStates } from '@zeldafan0225/ai_horde';
-import { getVersion, delay, Cache } from '../util.js';
+import { abortOnRequestClose, getVersion, delay, Cache } from '../util.js';
 import { readSecret, SECRET_KEYS } from './secrets.js';
 
 const ANONYMOUS_KEY = '0000000000';
@@ -370,11 +370,13 @@ router.post('/generate-image', async (request, response) => {
         console.info('Horde image generation request:', generation);
 
         const controller = new AbortController();
-        request.socket.removeAllListeners('close');
-        request.socket.on('close', function () {
-            console.warn('Horde image generation request aborted.');
-            controller.abort();
-            if (generation.id) ai_horde.deleteImageGenerationRequest(generation.id);
+        abortOnRequestClose(request, controller, response, {
+            onAbort: () => {
+                console.warn('Horde image generation request aborted.');
+                if (generation.id) {
+                    return ai_horde.deleteImageGenerationRequest(generation.id);
+                }
+            },
         });
 
         for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {

--- a/src/endpoints/novelai.js
+++ b/src/endpoints/novelai.js
@@ -5,7 +5,7 @@ import fetch from 'node-fetch';
 import express from 'express';
 
 import { readSecret, SECRET_KEYS } from './secrets.js';
-import { readAllChunks, extractFileFromZipBuffer, forwardFetchResponse } from '../util.js';
+import { abortOnRequestClose, readAllChunks, extractFileFromZipBuffer, forwardFetchResponse } from '../util.js';
 
 const API_NOVELAI = 'https://api.novelai.net';
 const TEXT_NOVELAI = 'https://text.novelai.net';
@@ -175,10 +175,7 @@ router.post('/generate', async function (req, res) {
     }
 
     const controller = new AbortController();
-    req.socket.removeAllListeners('close');
-    req.socket.on('close', function () {
-        controller.abort();
-    });
+    abortOnRequestClose(req, controller, res);
 
     // Add customized bad words for Clio, Kayra, and Erato
     const badWordsList = getBadWordsList(req.body.model);

--- a/src/endpoints/openai.js
+++ b/src/endpoints/openai.js
@@ -5,7 +5,7 @@ import fetch from 'node-fetch';
 import FormData from 'form-data';
 import express from 'express';
 
-import { getConfigValue, mergeObjectWithYaml, excludeKeysByYaml, trimV1, delay } from '../util.js';
+import { abortOnRequestClose, getConfigValue, mergeObjectWithYaml, excludeKeysByYaml, trimV1, delay } from '../util.js';
 import { setAdditionalHeaders } from '../additional-headers.js';
 import { readSecret, SECRET_KEYS } from './secrets.js';
 import { AIMLAPI_HEADERS, OPENROUTER_HEADERS, SILICONFLOW_ENDPOINT, ZAI_ENDPOINT } from '../constants.js';
@@ -682,10 +682,7 @@ router.post('/generate-image', async (request, response) => {
 router.post('/generate-video', async (request, response) => {
     try {
         const controller = new AbortController();
-        request.socket.removeAllListeners('close');
-        request.socket.on('close', function () {
-            controller.abort();
-        });
+        abortOnRequestClose(request, controller, response);
 
         const key = readSecret(request.user.directories, SECRET_KEYS.OPENAI);
 

--- a/src/endpoints/stable-diffusion.js
+++ b/src/endpoints/stable-diffusion.js
@@ -9,7 +9,7 @@ import urlJoin from 'url-join';
 import _ from 'lodash';
 import mime from 'mime-types';
 
-import { delay, getBasicAuthHeader, isValidUrl, tryParse } from '../util.js';
+import { abortOnRequestClose, delay, getBasicAuthHeader, isValidUrl, tryParse } from '../util.js';
 import { readSecret, SECRET_KEYS } from './secrets.js';
 import { getFileNameValidationFunction } from '../middleware/validateFileName.js';
 import { AIMLAPI_HEADERS } from '../constants.js';
@@ -313,14 +313,16 @@ router.post('/generate', async (request, response) => {
         }
 
         const controller = new AbortController();
-        request.socket.removeAllListeners('close');
-        request.socket.on('close', function () {
-            if (!response.writableEnded) {
+        abortOnRequestClose(request, controller, response, {
+            onAbort: () => {
+                if (response.writableEnded) {
+                    return;
+                }
+
                 const interruptUrl = new URL(request.body.url);
                 interruptUrl.pathname = '/sdapi/v1/interrupt';
-                fetch(interruptUrl, { method: 'POST', headers: { 'Authorization': getBasicAuthHeader(request.body.auth) } });
-            }
-            controller.abort();
+                return fetch(interruptUrl, { method: 'POST', headers: { 'Authorization': getBasicAuthHeader(request.body.auth) } });
+            },
         });
 
         console.debug('SD WebUI request:', request.body);
@@ -565,13 +567,15 @@ comfy.post('/generate', async (request, response) => {
         const url = new URL(urlJoin(request.body.url, '/prompt'));
 
         const controller = new AbortController();
-        request.socket.removeAllListeners('close');
-        request.socket.on('close', function () {
-            if (!response.writableEnded && !item) {
+        abortOnRequestClose(request, controller, response, {
+            onAbort: () => {
+                if (response.writableEnded || item) {
+                    return;
+                }
+
                 const interruptUrl = new URL(urlJoin(request.body.url, '/interrupt'));
-                fetch(interruptUrl, { method: 'POST', headers: { 'Authorization': getBasicAuthHeader(request.body.auth) } });
-            }
-            controller.abort();
+                return fetch(interruptUrl, { method: 'POST', headers: { 'Authorization': getBasicAuthHeader(request.body.auth) } });
+            },
         });
 
         const promptResult = await fetch(url, {
@@ -678,13 +682,15 @@ comfyRunPod.post('/generate', async (request, response) => {
         const url = new URL(urlJoin(request.body.url, '/run'));
 
         const controller = new AbortController();
-        request.socket.removeAllListeners('close');
-        request.socket.on('close', function () {
-            if (!response.writableEnded && !item) {
+        abortOnRequestClose(request, controller, response, {
+            onAbort: () => {
+                if (response.writableEnded || item) {
+                    return;
+                }
+
                 const interruptUrl = new URL(urlJoin(request.body.url, `/cancel/${jobId}`));
-                fetch(interruptUrl, { method: 'POST', headers: { 'Authorization': `Bearer ${key}` } });
-            }
-            controller.abort();
+                return fetch(interruptUrl, { method: 'POST', headers: { 'Authorization': `Bearer ${key}` } });
+            },
         });
         const workflow = JSON.parse(request.body.prompt).prompt;
         const wrappedWorkflow = workflow?.input?.workflow ? workflow : ({ input: { workflow: workflow } });
@@ -1950,10 +1956,7 @@ zai.post('/generate', async (request, response) => {
 zai.post('/generate-video', async (request, response) => {
     try {
         const controller = new AbortController();
-        request.socket.removeAllListeners('close');
-        request.socket.on('close', function () {
-            controller.abort();
-        });
+        abortOnRequestClose(request, controller, response);
 
         const key = readSecret(request.user.directories, SECRET_KEYS.ZAI);
 

--- a/src/request-cancellation.js
+++ b/src/request-cancellation.js
@@ -1,0 +1,181 @@
+import { pollSocketConnection } from './connection-state-checker.js';
+
+export const REQUEST_CANCELLATION_ABORT_REASON = 'Client disconnected';
+const DEFAULT_ABORT_HOOK_TIMEOUT_MS = 5000;
+const DEFAULT_CONNECTION_POLL_INTERVAL_MS = 150;
+
+function removeEventListener(target, event, handler) {
+    if (typeof target?.removeEventListener === 'function') {
+        target.removeEventListener(event, handler);
+        return;
+    }
+
+    if (typeof target?.removeListener === 'function') {
+        target.removeListener(event, handler);
+        return;
+    }
+
+    if (typeof target?.off === 'function') {
+        target.off(event, handler);
+    }
+}
+
+function once(target, event, handler) {
+    if (typeof target?.addEventListener === 'function') {
+        target.addEventListener(event, handler, { once: true });
+        return () => removeEventListener(target, event, handler);
+    }
+
+    if (typeof target?.once !== 'function') {
+        return () => undefined;
+    }
+
+    target.once(event, handler);
+    return () => removeEventListener(target, event, handler);
+}
+
+function normalizePositiveNumber(value, fallback) {
+    const number = Number(value);
+    return Number.isFinite(number) && number > 0 ? number : fallback;
+}
+
+function runAbortHook(onAbort, context, timeoutMs) {
+    if (typeof onAbort !== 'function') {
+        return;
+    }
+
+    try {
+        const result = onAbort(context);
+        if (!result || typeof result.then !== 'function') {
+            return;
+        }
+
+        let settled = false;
+        const timeout = normalizePositiveNumber(timeoutMs, DEFAULT_ABORT_HOOK_TIMEOUT_MS);
+        const timer = setTimeout(() => {
+            if (!settled) {
+                console.warn(`Request cancellation hook timed out after ${timeout}ms from ${context.source}`);
+            }
+        }, timeout);
+        timer.unref?.();
+
+        result.then(
+            () => {
+                settled = true;
+                clearTimeout(timer);
+            },
+            error => {
+                settled = true;
+                clearTimeout(timer);
+                console.warn('Error handling request cancellation:', error);
+            },
+        );
+    } catch (error) {
+        console.warn('Error handling request cancellation:', error);
+    }
+}
+
+function isRequestAborted(request) {
+    return Boolean(
+        request?.aborted
+        || request?.readableAborted
+        || (request?.destroyed && request?.complete !== true),
+    );
+}
+
+/**
+ * Observes client disconnect signals for an HTTP request and aborts upstream work once.
+ * @param {import('express').Request} request Express request.
+ * @param {import('express').Response|null} response Express response.
+ * @param {object} options Cancellation options.
+ * @param {AbortController} [options.controller] Upstream abort controller.
+ * @param {({request: import('express').Request, response: import('express').Response|null, signal: AbortSignal, source: string}) => void | Promise<void>} [options.onAbort] Provider-specific abort hook.
+ * @param {number} [options.abortHookTimeoutMs] Timeout for async abort hook diagnostics.
+ * @param {boolean} [options.pollConnection] Whether to poll the socket as a disconnect fallback.
+ * @param {number} [options.pollIntervalMs] Socket polling interval.
+ * @param {(socket: import('node:net').Socket, intervalMs: number, onDisconnect: () => void) => () => void} [options.startConnectionPolling] Polling starter.
+ * @param {any} [options.reason] Abort reason.
+ * @returns {{controller: AbortController, signal: AbortSignal, abort: (source?: string) => void, cleanup: () => void, isAborted: boolean}}
+ */
+export function observeRequestCancellation(request, response = null, {
+    abortHookTimeoutMs = DEFAULT_ABORT_HOOK_TIMEOUT_MS,
+    controller = new AbortController(),
+    onAbort = null,
+    pollConnection = false,
+    pollIntervalMs = DEFAULT_CONNECTION_POLL_INTERVAL_MS,
+    reason = REQUEST_CANCELLATION_ABORT_REASON,
+    startConnectionPolling = pollSocketConnection,
+} = {}) {
+    const cleanupCallbacks = [];
+    let cancelled = false;
+    let cleanedUp = false;
+
+    function cleanup() {
+        if (cleanedUp) {
+            return;
+        }
+
+        cleanedUp = true;
+        for (const removeListener of cleanupCallbacks.splice(0)) {
+            removeListener();
+        }
+    }
+
+    function abort(source = 'manual') {
+        if (cancelled || controller.signal.aborted) {
+            return;
+        }
+
+        cancelled = true;
+        controller.abort(reason);
+        runAbortHook(onAbort, {
+            request,
+            response,
+            signal: controller.signal,
+            source,
+        }, abortHookTimeoutMs);
+        cleanup();
+    }
+
+    function handleRequestClose() {
+        if (isRequestAborted(request)) {
+            abort('request-close');
+        }
+    }
+
+    function handleResponseClose() {
+        if (response?.writableEnded) {
+            cleanup();
+            return;
+        }
+
+        abort('response-close');
+    }
+
+    cleanupCallbacks.push(
+        once(request, 'aborted', () => abort('request-aborted')),
+        once(request, 'close', handleRequestClose),
+        once(response, 'close', handleResponseClose),
+        once(response, 'finish', cleanup),
+        once(request?.socket, 'close', () => abort('socket-close')),
+        once(controller.signal, 'abort', cleanup),
+    );
+
+    if (pollConnection && request?.socket && typeof startConnectionPolling === 'function') {
+        cleanupCallbacks.push(startConnectionPolling(
+            request.socket,
+            normalizePositiveNumber(pollIntervalMs, DEFAULT_CONNECTION_POLL_INTERVAL_MS),
+            () => abort('socket-poll'),
+        ));
+    }
+
+    return {
+        controller,
+        signal: controller.signal,
+        abort,
+        cleanup,
+        get isAborted() {
+            return cancelled || controller.signal.aborted;
+        },
+    };
+}

--- a/src/util.js
+++ b/src/util.js
@@ -22,6 +22,8 @@ import { serverDirectory } from './server-directory.js';
 import { sync as writeFileAtomicSync } from 'write-file-atomic';
 import { isFirefox } from './express-common.js';
 import { pollSocketConnection } from './connection-state-checker.js';
+import { observeRequestCancellation } from './request-cancellation.js';
+import { isBunRuntime } from './runtime.js';
 
 const DEFAULT_STREAMING_CONNECTION_POLLING_INTERVAL_MS = 150;
 
@@ -838,11 +840,17 @@ export async function forwardFetchResponse(from, to, request = null, onDisconnec
  * Aborts an upstream request if the client connection closes early.
  * @param {import('express').Request} request The Express request to observe.
  * @param {AbortController} controller Abort controller for the upstream request.
+ * @param {import('express').Response|null} [response] The Express response to observe.
+ * @param {object} [options] Additional cancellation options.
  */
-export function abortOnRequestClose(request, controller) {
-    request.socket.removeAllListeners('close');
-    request.socket.on('close', () => {
-        controller.abort();
+export function abortOnRequestClose(request, controller, response = null, options = {}) {
+    const pollIntervalMs = getStreamingConnectionPollingInterval();
+
+    return observeRequestCancellation(request, response, {
+        controller,
+        pollConnection: Boolean(isBunRuntime() && pollIntervalMs),
+        pollIntervalMs,
+        ...options,
     });
 }
 

--- a/tests/request-cancellation.test.js
+++ b/tests/request-cancellation.test.js
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, jest, test } from '@jest/globals';
+import { EventEmitter } from 'node:events';
+
+import { observeRequestCancellation } from '../src/request-cancellation.js';
+
+function createHttpExchange() {
+    const request = new EventEmitter();
+    request.socket = new EventEmitter();
+
+    const response = new EventEmitter();
+    response.writableEnded = false;
+    response.destroyed = false;
+
+    return { request, response };
+}
+
+describe('observeRequestCancellation', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+        jest.useRealTimers();
+    });
+
+    test('aborts the upstream controller on socket close without replacing existing listeners', () => {
+        const { request, response } = createHttpExchange();
+        const existingCloseListener = jest.fn();
+        const controller = new AbortController();
+
+        request.socket.on('close', existingCloseListener);
+        observeRequestCancellation(request, response, { controller });
+        request.socket.emit('close');
+
+        expect(controller.signal.aborted).toBe(true);
+        expect(existingCloseListener).toHaveBeenCalledTimes(1);
+    });
+
+    test('runs the abort hook once across duplicate disconnect signals', () => {
+        const { request, response } = createHttpExchange();
+        const controller = new AbortController();
+        const onAbort = jest.fn();
+
+        observeRequestCancellation(request, response, { controller, onAbort });
+        request.emit('aborted');
+        response.emit('close');
+        response.emit('close');
+        request.socket.emit('close');
+
+        expect(controller.signal.aborted).toBe(true);
+        expect(onAbort).toHaveBeenCalledTimes(1);
+        expect(onAbort).toHaveBeenCalledWith(expect.objectContaining({
+            request,
+            response,
+            signal: controller.signal,
+            source: 'request-aborted',
+        }));
+    });
+
+    test('warns when an async abort hook exceeds its timeout without delaying abort', () => {
+        jest.useFakeTimers();
+        const { request, response } = createHttpExchange();
+        const controller = new AbortController();
+        const onAbort = jest.fn(() => new Promise(() => undefined));
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        observeRequestCancellation(request, response, {
+            controller,
+            onAbort,
+            abortHookTimeoutMs: 25,
+        });
+        response.emit('close');
+
+        expect(controller.signal.aborted).toBe(true);
+
+        jest.advanceTimersByTime(25);
+
+        expect(warnSpy).toHaveBeenCalledWith('Request cancellation hook timed out after 25ms from response-close');
+    });
+
+    test('can abort through a socket polling fallback and stop polling during cleanup', () => {
+        const { request, response } = createHttpExchange();
+        const controller = new AbortController();
+        const stopPolling = jest.fn();
+        let pollDisconnect = null;
+        const startConnectionPolling = jest.fn((socket, intervalMs, onDisconnect) => {
+            pollDisconnect = onDisconnect;
+            return stopPolling;
+        });
+
+        observeRequestCancellation(request, response, {
+            controller,
+            pollConnection: true,
+            pollIntervalMs: 25,
+            startConnectionPolling,
+        });
+
+        expect(startConnectionPolling).toHaveBeenCalledWith(request.socket, 25, expect.any(Function));
+
+        pollDisconnect();
+
+        expect(controller.signal.aborted).toBe(true);
+        expect(stopPolling).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not abort after the response finishes normally', () => {
+        const { request, response } = createHttpExchange();
+        const controller = new AbortController();
+
+        observeRequestCancellation(request, response, { controller });
+        response.writableEnded = true;
+        response.emit('finish');
+        request.socket.emit('close');
+
+        expect(controller.signal.aborted).toBe(false);
+    });
+
+    test('only treats request close as cancellation when the request is marked aborted', () => {
+        const { request, response } = createHttpExchange();
+        const completedController = new AbortController();
+        const abortedController = new AbortController();
+
+        request.complete = true;
+        observeRequestCancellation(request, response, { controller: completedController });
+        request.emit('close');
+
+        expect(completedController.signal.aborted).toBe(false);
+
+        const abortedRequest = new EventEmitter();
+        abortedRequest.socket = new EventEmitter();
+        abortedRequest.aborted = true;
+
+        observeRequestCancellation(abortedRequest, response, { controller: abortedController });
+        abortedRequest.emit('close');
+
+        expect(abortedController.signal.aborted).toBe(true);
+    });
+});

--- a/tests/util.test.js
+++ b/tests/util.test.js
@@ -211,7 +211,7 @@ describe('abortOnRequestClose', () => {
         expect(controller.signal.aborted).toBe(true);
     });
 
-    test('should replace existing socket close listeners before registering the abort handler', () => {
+    test('should preserve existing socket close listeners when registering the abort handler', () => {
         const request = createMockExpressRequest();
         const existingListener = jest.fn();
 
@@ -219,6 +219,18 @@ describe('abortOnRequestClose', () => {
         abortOnRequestClose(request, new AbortController());
         request.socket.emit('close');
 
-        expect(existingListener).not.toHaveBeenCalled();
+        expect(existingListener).toHaveBeenCalledTimes(1);
+    });
+
+    test('should abort the upstream controller when the client response closes', () => {
+        const request = new EventEmitter();
+        request.socket = new EventEmitter();
+        const response = new EventEmitter();
+        const controller = new AbortController();
+
+        abortOnRequestClose(request, controller, response);
+        response.emit('close');
+
+        expect(controller.signal.aborted).toBe(true);
     });
 });


### PR DESCRIPTION
## What?
Adds a shared request-cancellation seam for server-side generation routes and migrates the scattered socket-close abort handlers to use it.

## Why?
Under Bun, aborting generation from the frontend can clear the UI while the backend keeps generating because the server was relying on a single `request.socket.close` signal. That signal is not robust enough under Bun and the old helper also removed unrelated close listeners.

## How?
The new cancellation seam observes request aborts, guarded request closes, guarded response closes, socket closes, and a Bun-only socket polling fallback. It aborts upstream work once, cleans up listeners on normal response completion, preserves existing listeners, and supports provider-specific abort hooks with timeout diagnostics. Generation providers with extra cleanup, such as KoboldCpp, Horde, SD WebUI, ComfyUI, and RunPod cancellation, now attach those actions through the shared seam.

## Testing?
- `node scripts/verify-request-cancellation.js`
- `bun scripts/verify-request-cancellation.js`
- `npm run test:unit -- request-cancellation.test.js util.test.js connection-state-checker.test.js --runInBand`
- `npm run test:unit -- --runInBand`
- `npm run lint -- src/request-cancellation.js src/util.js src/endpoints/backends/kobold.js src/endpoints/backends/text-completions.js src/endpoints/backends/chat-completions.js src/endpoints/google.js src/endpoints/horde.js src/endpoints/novelai.js src/endpoints/openai.js src/endpoints/stable-diffusion.js scripts/verify-request-cancellation.js`
- `npm run lint -- request-cancellation.test.js util.test.js connection-state-checker.test.js` reported only existing warnings in `quick-reply-button-ui.test.js`; no errors.

## Screenshots (optional)
Not applicable; this is backend cancellation behavior.

## Anything Else?
The Bun harness uses a temporary port assigned by the OS and closes the server before exiting. Node behavior is preserved while Bun gets the additional polling fallback.
