### PR TITLE
fix: harden streaming disconnect cancellation

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -35,6 +35,7 @@ import {
     flattenSchema,
     summarizeLlmPayloadForLog,
 } from '../../util.js';
+import { isRequestCancellationError } from '../../request-cancellation.js';
 import {
     convertClaudeMessages,
     convertGooglePrompt,
@@ -2450,16 +2451,7 @@ function transformResponsesApiResponse(data) {
 }
 
 function isExpectedStreamAbort(error) {
-    const name = String(error?.name ?? '');
-    const type = String(error?.type ?? '');
-    const code = String(error?.code ?? '');
-    const message = String(error?.message ?? '').toLowerCase();
-
-    return name === 'AbortError' ||
-        type === 'aborted' ||
-        code === 'ABORT_ERR' ||
-        message.includes('operation was aborted') ||
-        message.includes('aborted');
+    return isRequestCancellationError(error);
 }
 
 /**

--- a/src/request-cancellation.js
+++ b/src/request-cancellation.js
@@ -4,6 +4,43 @@ export const REQUEST_CANCELLATION_ABORT_REASON = 'Client disconnected';
 const DEFAULT_ABORT_HOOK_TIMEOUT_MS = 5000;
 const DEFAULT_CONNECTION_POLL_INTERVAL_MS = 150;
 
+function matchesCancellationError(value) {
+    if (!value) {
+        return false;
+    }
+
+    if (value === REQUEST_CANCELLATION_ABORT_REASON) {
+        return true;
+    }
+
+    const name = String(value?.name ?? '');
+    const type = String(value?.type ?? '');
+    const code = String(value?.code ?? '');
+    const message = String(value?.message ?? value).toLowerCase();
+
+    return name === 'AbortError' ||
+        type === 'aborted' ||
+        code === 'ABORT_ERR' ||
+        message.includes('client disconnected') ||
+        message.includes('operation was aborted') ||
+        message.includes('aborted');
+}
+
+/**
+ * Detects request cancellation errors across runtimes and fetch implementations.
+ * Bun can reject fetch with the raw abort reason, while Node/node-fetch usually
+ * rejects with an AbortError-shaped object.
+ * @param {any} error Error-like value from fetch, streams, or abort hooks.
+ * @returns {boolean} Whether this value is an expected client disconnect.
+ */
+export function isRequestCancellationError(error) {
+    return [
+        error,
+        error?.cause,
+        error?.reason,
+    ].some(matchesCancellationError);
+}
+
 function removeEventListener(target, event, handler) {
     if (typeof target?.removeEventListener === 'function') {
         target.removeEventListener(event, handler);

--- a/src/util.js
+++ b/src/util.js
@@ -22,7 +22,7 @@ import { serverDirectory } from './server-directory.js';
 import { sync as writeFileAtomicSync } from 'write-file-atomic';
 import { isFirefox } from './express-common.js';
 import { pollSocketConnection } from './connection-state-checker.js';
-import { observeRequestCancellation } from './request-cancellation.js';
+import { isRequestCancellationError, observeRequestCancellation } from './request-cancellation.js';
 import { isBunRuntime } from './runtime.js';
 
 const DEFAULT_STREAMING_CONNECTION_POLLING_INTERVAL_MS = 150;
@@ -828,8 +828,14 @@ export async function forwardFetchResponse(from, to, request = null, onDisconnec
             to.end();
         });
 
-        from.body.on('error', function () {
+        from.body.on('error', function (error) {
             stopPolling();
+            if (isRequestCancellationError(error) || to.destroyed || to.writableEnded) {
+                if (!to.destroyed && !to.writableEnded) {
+                    to.end();
+                }
+                return;
+            }
         });
     } else {
         to.end();

--- a/tests/request-cancellation.test.js
+++ b/tests/request-cancellation.test.js
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, jest, test } from '@jest/globals';
 import { EventEmitter } from 'node:events';
 
-import { observeRequestCancellation } from '../src/request-cancellation.js';
+import {
+    REQUEST_CANCELLATION_ABORT_REASON,
+    isRequestCancellationError,
+    observeRequestCancellation,
+} from '../src/request-cancellation.js';
 
 function createHttpExchange() {
     const request = new EventEmitter();
@@ -131,5 +135,24 @@ describe('observeRequestCancellation', () => {
         abortedRequest.emit('close');
 
         expect(abortedController.signal.aborted).toBe(true);
+    });
+});
+
+describe('isRequestCancellationError', () => {
+    test('recognizes expected request cancellation errors', () => {
+        const errors = [
+            REQUEST_CANCELLATION_ABORT_REASON,
+            new Error(REQUEST_CANCELLATION_ABORT_REASON),
+            new DOMException(REQUEST_CANCELLATION_ABORT_REASON, 'AbortError'),
+            Object.assign(new Error('operation was aborted'), { code: 'ABORT_ERR' }),
+        ];
+
+        for (const error of errors) {
+            expect(isRequestCancellationError(error)).toBe(true);
+        }
+    });
+
+    test('does not classify unrelated failures as request cancellation', () => {
+        expect(isRequestCancellationError(new Error('upstream exploded'))).toBe(false);
     });
 });

--- a/tests/util.test.js
+++ b/tests/util.test.js
@@ -3,6 +3,7 @@ import { EventEmitter, once } from 'node:events';
 import { PassThrough } from 'node:stream';
 import { Response } from 'node-fetch';
 import { CHAT_COMPLETION_SOURCES } from '../src/constants';
+import { REQUEST_CANCELLATION_ABORT_REASON } from '../src/request-cancellation';
 import { abortOnRequestClose, flattenSchema, forwardFetchResponse } from '../src/util';
 
 function createMockExpressResponse() {
@@ -165,6 +166,19 @@ describe('forwardFetchResponse', () => {
         response.emit('close');
 
         expect(upstreamBody.destroy).toHaveBeenCalled();
+    });
+
+    test('should finish the client response when upstream streaming emits a request cancellation error', async () => {
+        const upstreamBody = new PassThrough();
+        const response = createMockExpressResponse();
+        response.socket = {};
+        const bodyPromise = collectResponseBody(response);
+
+        await forwardFetchResponse(new Response(upstreamBody), response);
+        upstreamBody.emit('error', REQUEST_CANCELLATION_ABORT_REASON);
+
+        await expect(bodyPromise).resolves.toBe('');
+        expect(response.writableEnded).toBe(true);
     });
 
     test('should log JSON error bodies and return the original body for non-2xx streaming responses', async () => {


### PR DESCRIPTION
## What?
Hardens streaming request cancellation after #313 by centralizing expected client-disconnect error detection and using it in the chat-completions stream path. The shared fetch stream bridge now also finishes writable client responses when an upstream body emits the expected cancellation reason.

## Why?
Bun can reject an aborted fetch with the raw abort reason, `Client disconnected`, instead of an AbortError-shaped object. That made a normal Discord/client disconnect look like a provider failure and could produce repeated noisy errors during stream cleanup.

## How?
Adds `isRequestCancellationError()` to the request cancellation helper so Node/node-fetch AbortError objects, Bun raw abort reasons, and nested abort causes are handled consistently. Chat-completions now delegates expected stream-abort classification to that helper, and `forwardFetchResponse()` treats expected upstream body cancellation as cleanup rather than a failure path.

## Testing?
- `npm run test:unit -- request-cancellation.test.js util.test.js connection-state-checker.test.js openai-responses.test.js --runInBand`
- `bun scripts/verify-request-cancellation.js`
- `bunx eslint src/request-cancellation.js src/util.js src/endpoints/backends/chat-completions.js`
- `npx eslint request-cancellation.test.js util.test.js` from `tests/`

## Screenshots (optional)
Not applicable; this is server-side streaming cancellation behavior.

## Anything Else?
Follow-up to #313. This keeps the scope to cancellation classification and stream cleanup; provider-specific abort hooks remain unchanged.