### PR TITLE
fix: polish menu layout and mobile dropdowns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,8 @@ yarn.lock
 *.code-workspace
 test-results/
 .playwright-cli/
+.playwright-mcp/
+.local-worklog/
 /output/
 /AGENTS.md
 
@@ -74,3 +76,7 @@ screenshots/layout-mobile-workspace-20260505.png
 screenshots/sillybunny-ui-polish-desktop-ooc.png
 screenshots/sillybunny-ui-polish-desktop-workspace.png
 screenshots/sillybunny-ui-polish-mobile-workspace.png
+
+# Local Agent Skills
+.agents/
+skills-lock.json

--- a/docs/upstream-touch-ledger.md
+++ b/docs/upstream-touch-ledger.md
@@ -154,6 +154,45 @@ This ledger tracks intentional SillyBunny divergence in upstream-origin files. I
 | Last reviewed | 2026-06-02 frontend asset and OOC settings update. |
 | Owner | Refactor integrator. |
 
+### `public/scripts/sillybunny-tabs.js` - menu layout and character drawer
+| Field | Value |
+| --- | --- |
+| Area | Mobile shell and character menu. |
+| Divergence reason | SillyBunny keeps horizontal labeled menu rails as the default, supports vertical rail mode without mixing Workspace and Customize shortcuts, and routes Character Menu controls through the canonical drawer when duplicate runtime nodes exist. |
+| Target seam | `public/scripts/mobile-shell-lifecycle/` for drawer/nav state; no separate seam yet for Character Menu tab copy and canonical DOM targeting. |
+| Adapter shape | Keep shell state updates and DOM routing in `sillybunny-tabs.js`; delegate only viewport/nav open-state decisions to lifecycle helpers where they already exist. |
+| Protecting tests | `tests/mobile-shell-lifecycle.test.js`, `tests/mobile-shell-lifecycle-wiring.test.js`, focused browser smoke for horizontal labels, vertical rail separation, and Character Menu drawer tabs. |
+| Validation | `node --check public/scripts/sillybunny-tabs.js`, `git diff --check`, mobile/desktop browser smoke on Character Menu horizontal labels, vertical rail behavior, and canonical drawer targeting. |
+| Rollback path | Revert the nav default/rail action filtering and Character panel helper calls independently from the shell lifecycle helpers. |
+| Last reviewed | 2026-06-02 PR #315 menu layout polish. |
+| Owner | Refactor integrator and mobile shell owner. |
+
+### `public/scripts/openai.js` and `public/scripts/textgen-models.js` - mobile OpenRouter selects
+| Field | Value |
+| --- | --- |
+| Area | Settings and mobile shell. |
+| Divergence reason | SillyBunny must avoid Select2 keyboard-only behavior on touch/mobile OpenRouter/API model and provider selects while preserving the underlying native select values and existing change handlers. |
+| Target seam | No separate seam yet; future API settings UI helpers can own reusable inline select rendering. |
+| Adapter shape | Keep the inline picker as a thin DOM adapter around existing `<select>` elements; dispatch native `change`/`input` events so current settings logic remains authoritative. |
+| Protecting tests | Existing OpenAI/textgen settings unit coverage where applicable, plus focused browser smoke for OpenRouter model, provider, and quantization menus on mobile and desktop Select2 parity. |
+| Validation | `node --check public/scripts/openai.js`, `node --check public/scripts/textgen-models.js`, `git diff --check`, mobile browser smoke opening OpenRouter model/provider/quantization menus and selecting through native-backed lists. |
+| Rollback path | Remove the inline picker binding and restore Select2/native select initialization to the previous mobile branch if dropdown behavior regresses. |
+| Last reviewed | 2026-06-02 PR #315 mobile dropdown fix. |
+| Owner | Refactor integrator and settings owner. |
+
+### `public/css/sillybunny-tabs.css`, `public/css/sillybunny-mobile-shell.css`, `public/css/select2-overrides.css`, `public/css/welcome.css`, `public/style.css`, `public/script.js`, `public/sw.js`, and `public/index.html` - menu polish assets
+| Field | Value |
+| --- | --- |
+| Area | Mobile shell, settings, cache, and frontend boot. |
+| Divergence reason | SillyBunny UI polish needs responsive Character Menu rail sizing, mobile inline picker styling, Select2 z-layer fixes, welcome card text wrapping, and cache-busted asset references for the updated shell files. |
+| Target seam | CSS remains declarative; frontend asset/cache references stay in the existing boot files. |
+| Adapter shape | Keep CSS changes scoped to SillyBunny shell/select/menu classes and update only the affected boot/cache version strings. |
+| Protecting tests | `tests/frontend-assets.test.js`, frontend asset budget check, focused browser smoke for mobile/desktop menu layout and dropdown layering. |
+| Validation | `git diff --check`, frontend asset check in CI, browser smoke for mobile Character Menu, desktop Character Menu, and OpenRouter dropdown layering. |
+| Rollback path | Revert the cache-bust strings and scoped CSS blocks together if stale assets, menu layout, or dropdown layering regress. |
+| Last reviewed | 2026-06-02 PR #315 menu/layout polish. |
+| Owner | Refactor integrator and mobile shell owner. |
+
 ### `public/scripts/PromptManager.js` - prompt manager lifecycle
 | Field | Value |
 | --- | --- |

--- a/public/css/select2-overrides.css
+++ b/public/css/select2-overrides.css
@@ -4,6 +4,10 @@
     max-width: 100%;
 }
 
+.select2-container--open {
+    z-index: var(--sb-z-critical, 2147483000);
+}
+
 /* Customize the dropdown */
 .select2-dropdown {
     background-color: var(--SmartThemeBlurTintColor);
@@ -16,6 +20,12 @@
     z-index: var(--sb-z-critical);
     user-select: none;
     pointer-events: auto;
+}
+
+#rm_api_block .select2-container--open .select2-dropdown,
+#left-nav-panel.openDrawer .select2-container--open .select2-dropdown,
+#right-nav-panel.openDrawer .select2-container--open .select2-dropdown {
+    max-width: calc(100vw - 24px);
 }
 
 .select2-container .select2-selection.select2-selection--single.select2-selection--clearable .select2-selection__clear {

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -206,7 +206,7 @@
 
     :root[data-sb-mobile-nav-layout='vertical'] #right-nav-panel.openDrawer {
         display: grid !important;
-        grid-template-columns: minmax(0, 1fr) 78px !important;
+        grid-template-columns: minmax(0, 1fr) 84px !important;
         grid-template-rows: auto auto auto auto minmax(0, 1fr) !important;
         grid-template-areas:
             'header nav'
@@ -220,8 +220,8 @@
         display: flex !important;
         flex-direction: column !important;
         grid-area: nav !important;
-        width: 78px !important;
-        min-width: 78px !important;
+        width: 84px !important;
+        min-width: 84px !important;
         height: 100% !important;
         max-height: 100% !important;
         min-height: 0 !important;
@@ -275,7 +275,7 @@
         align-items: stretch !important;
         justify-content: flex-start !important;
         gap: 6px !important;
-        padding: 16px 7px max(16px, var(--sb-mobile-safe-area-bottom, env(safe-area-inset-bottom, 0px))) !important;
+        padding: 16px 8px max(16px, var(--sb-mobile-safe-area-bottom, env(safe-area-inset-bottom, 0px))) !important;
         overflow-x: hidden !important;
         overflow-y: auto !important;
         overscroll-behavior: contain !important;
@@ -320,11 +320,12 @@
         width: 100% !important;
         min-width: 0 !important;
         max-width: 100% !important;
-        min-height: 50px !important;
+        min-height: 54px !important;
         flex-direction: column !important;
         justify-content: center !important;
         gap: 4px !important;
-        padding: 7px 4px !important;
+        padding: 8px 6px !important;
+        border-radius: var(--sb-radius-button, 14px) !important;
         text-align: center !important;
         white-space: normal !important;
     }
@@ -334,9 +335,9 @@
     }
 
     :root[data-sb-mobile-nav-layout='vertical'] #right-nav-panel.openDrawer .sb-character-shell-nav .sb-shell-tab:is(.is-active, .active, .selected, .is-selected, .is-current, [aria-selected='true'], [aria-current]) {
-        background: transparent !important;
-        border-color: transparent !important;
-        box-shadow: none !important;
+        background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 14%, var(--sb-shell-tab-active-bg) 86%) !important;
+        border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 34%, var(--sb-shell-border) 66%) !important;
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--sb-focus-ring) 28%, transparent) !important;
     }
 
     :root[data-sb-mobile-nav-layout='vertical'] #right-nav-panel.openDrawer .sb-character-shell-nav .sb-shell-rail-action {
@@ -362,9 +363,11 @@
     }
 
     :root[data-sb-mobile-nav-layout='vertical'] #right-nav-panel.openDrawer .sb-character-shell-nav .sb-shell-tab-copy strong {
-        font-size: calc(var(--mainFontSize) * 0.62) !important;
-        line-height: 1.1 !important;
+        font-size: calc(var(--mainFontSize) * 0.72) !important;
+        line-height: 1.2 !important;
         white-space: normal !important;
+        hyphens: auto !important;
+        text-wrap: balance !important;
     }
 
     :root[data-sb-mobile-nav-layout='vertical'][data-sb-mobile-nav-mode='icon-only'] #right-nav-panel.openDrawer .sb-character-shell-nav .sb-shell-tab {
@@ -467,7 +470,7 @@
 
     #right-nav-panel.openDrawer > #CharListButtonAndHotSwaps {
         min-height: 34px !important;
-        max-height: 34px !important;
+        max-height: none !important;
         padding: 3px 10px !important;
     }
 
@@ -523,6 +526,7 @@
     }
 
     #right-nav-panel.openDrawer .sb-character-editor-subtabs {
+        justify-content: center !important;
         justify-content: safe center !important;
         gap: 6px !important;
     }
@@ -982,7 +986,7 @@
         --sb-chatbar-button-size-base: 24px;
         --sb-chatbar-field-height-base: 24px;
         --sb-chatbar-field-padding-x-base: 7px;
-        --sb-mobile-toggle-size-base: 34px;
+        --sb-mobile-toggle-size-base: 44px;
         --sb-home-toggle-min-width-base: 34px;
         --sb-mobile-tools-min-size: 34px;
     }
@@ -2464,5 +2468,95 @@
         min-height: 64px !important;
         max-height: 64px !important;
         flex-basis: 64px !important;
+    }
+
+    .sb-model-id-picker-menu {
+        width: 100%;
+        max-height: min(320px, 48dvh);
+        margin-top: 8px;
+        padding: 6px;
+        overflow: auto;
+        border: 1px solid var(--sb-shell-border);
+        border-radius: var(--sb-radius-md);
+        background: var(--sb-surface-elevated);
+        box-shadow: 0 14px 28px color-mix(in srgb, var(--SmartThemeShadowColor) 12%, transparent);
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .sb-model-id-picker-menu[hidden] {
+        display: none !important;
+    }
+
+    .sb-inline-select-picker-control {
+        cursor: pointer;
+        touch-action: manipulation;
+    }
+
+    .sb-inline-select-picker-menu[data-sb-inline-select-multiple] .sb-inline-select-picker-option {
+        gap: 8px;
+    }
+
+    .sb-inline-select-picker-menu[data-sb-inline-select-multiple] .sb-inline-select-picker-option::before {
+        content: '';
+        flex: 0 0 16px;
+        width: 16px;
+        height: 16px;
+        border: 1px solid color-mix(in srgb, var(--SmartThemeBodyColor) 38%, transparent);
+        border-radius: 5px;
+        background: color-mix(in srgb, var(--sb-surface-elevated) 82%, transparent);
+    }
+
+    .sb-inline-select-picker-menu[data-sb-inline-select-multiple] .sb-inline-select-picker-option[aria-selected='true']::before {
+        border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 74%, var(--sb-shell-border) 26%);
+        background: var(--color-primary, var(--sb-accent));
+        box-shadow: inset 0 0 0 3px var(--sb-surface-elevated);
+    }
+
+    .sb-model-id-picker-group {
+        padding: 8px 10px 4px;
+        color: var(--sb-muted-fg);
+        font-size: var(--sb-type-caption);
+        font-weight: var(--sb-weight-label);
+        letter-spacing: var(--sb-tracking-label);
+        text-transform: uppercase;
+    }
+
+    .sb-model-id-picker-empty,
+    .sb-model-id-picker-option {
+        min-height: 44px;
+        width: 100%;
+        border-radius: var(--sb-radius-button);
+        padding: 9px 10px;
+        text-align: left;
+        line-height: 1.25;
+    }
+
+    .sb-model-id-picker-empty {
+        display: flex;
+        align-items: center;
+        color: var(--sb-muted-fg);
+    }
+
+    .sb-model-id-picker-option {
+        display: flex;
+        align-items: center;
+        justify-content: flex-start;
+        border: 1px solid transparent;
+        background: transparent;
+        color: var(--SmartThemeBodyColor);
+        font: inherit;
+        overflow-wrap: anywhere;
+    }
+
+    .sb-model-id-picker-option:is(:hover, :focus-visible) {
+        border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 28%, var(--sb-shell-border) 72%);
+        background: var(--sb-button-hover);
+        outline: none;
+    }
+
+    .sb-model-id-picker-option[aria-selected='true'] {
+        border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 36%, var(--sb-shell-border) 64%);
+        background: var(--sb-shell-tab-active-bg);
+        font-weight: var(--sb-weight-title);
     }
 }

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -104,7 +104,7 @@
     --sb-proxy-label-size: calc(var(--mainFontSize) * var(--sb-proxy-label-scale-base));
     --sb-proxy-underline-inset: var(--sb-proxy-underline-inset-base);
     --sb-proxy-underline-bottom: var(--sb-proxy-underline-bottom-base);
-    --sb-mobile-toggle-size: clamp(34px, calc(var(--sb-mobile-toggle-size-base) * var(--sb-mobile-button-scale)), 56px);
+    --sb-mobile-toggle-size: clamp(44px, calc(var(--sb-mobile-toggle-size-base) * var(--sb-mobile-button-scale)), 56px);
     --sb-home-toggle-min-width: max(44px, calc(var(--sb-home-toggle-min-width-base) * var(--sb-mobile-button-scale)));
     --sb-topbar-compact-icon-size: calc(var(--mainFontSize) * var(--sb-topbar-compact-icon-scale-base));
     --sb-topbar-primary-min-height: max(var(--sb-proxy-button-height), var(--sb-mobile-toggle-size));
@@ -168,7 +168,7 @@
     --sb-proxy-button-height-base: 34px;
     --sb-proxy-button-min-width-base: 88px;
     --sb-proxy-button-gap-base: 6px;
-    --sb-mobile-toggle-size-base: 34px;
+    --sb-mobile-toggle-size-base: 44px;
     --sb-home-toggle-min-width-base: 78px;
     --sb-mobile-tools-padding-top-base: 7px;
     --sb-mobile-tools-padding-x-base: 7px;
@@ -1672,6 +1672,7 @@ body.sb-shell-resizing * {
     border-bottom: 1px solid color-mix(in srgb, var(--sb-shell-border) 88%, transparent);
     overflow-x: auto;
     overflow-y: hidden;
+    scroll-padding-inline: 54px;
     flex-shrink: 0;
     overscroll-behavior: contain;
     -webkit-overflow-scrolling: touch;
@@ -1774,7 +1775,8 @@ body.sb-shell-resizing * {
 }
 
 .sb-shell-tab-copy strong {
-    font-size: calc(var(--mainFontSize) * 0.9);
+    font-size: calc(var(--mainFontSize) * 0.92);
+    line-height: 1.22;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -1862,8 +1864,8 @@ body.sb-shell-resizing * {
 }
 
 #right-nav-panel.openDrawer > .sb-character-shell-header .sb-shell-kicker {
-    font-size: calc(var(--mainFontSize) * 0.62);
-    letter-spacing: 0.14em;
+    font-size: var(--sb-type-caption);
+    letter-spacing: var(--sb-tracking-label);
 }
 
 #right-nav-panel.openDrawer > .sb-character-shell-header .sb-shell-title {
@@ -1872,9 +1874,9 @@ body.sb-shell-resizing * {
 }
 
 #right-nav-panel.openDrawer > .sb-character-shell-header .sb-shell-subtitle {
-    max-width: min(58ch, 100%);
-    font-size: calc(var(--mainFontSize) * 0.78);
-    line-height: 1.25;
+    max-width: min(62ch, 100%);
+    font-size: var(--sb-type-control);
+    line-height: 1.36;
 }
 
 #right-nav-panel.openDrawer > .sb-character-shell-header .sb-shell-description {
@@ -2203,15 +2205,18 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 
 .sb-character-editor-empty-actions {
     display: flex;
-    flex-flow: row nowrap;
+    flex-flow: row wrap;
     justify-content: center;
     gap: 10px;
+    max-width: min(100%, 440px);
 }
 
 .sb-character-editor-empty-actions .menu_button {
     min-height: 42px;
     margin: 0;
     gap: 8px;
+    white-space: normal;
+    text-align: center;
 }
 
 .sb-character-persona-panel[hidden] {
@@ -2430,6 +2435,8 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     font-weight: var(--sb-weight-title);
     line-height: var(--sb-line-title);
     text-align: left;
+    max-width: 100%;
+    overflow-wrap: anywhere;
 }
 
 .sb-shell-title:focus-visible {
@@ -6396,7 +6403,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     }
 
     :root[data-sb-desktop-nav-layout='vertical'] #right-nav-panel.openDrawer {
-        --sb-character-shell-rail-width: 86px;
+        --sb-character-shell-rail-width: 92px;
         display: grid;
         grid-template-columns: var(--sb-character-shell-rail-width) minmax(0, 1fr);
         grid-template-rows: auto auto auto auto minmax(0, 1fr);
@@ -6437,7 +6444,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
         align-items: stretch;
         justify-content: flex-start;
         gap: 6px;
-        padding: 18px 8px;
+        padding: 18px 9px;
         overflow-x: hidden;
         overflow-y: auto;
         border-right: 1px solid color-mix(in srgb, var(--sb-shell-border) 80%, transparent);
@@ -6449,20 +6456,20 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
         width: 100%;
         min-width: 0;
         max-width: 100%;
-        min-height: calc(50px * var(--sb-desktop-button-scale));
+        min-height: calc(54px * var(--sb-desktop-button-scale));
         flex: 0 0 auto;
         flex-direction: column;
         justify-content: center;
         gap: 4px;
-        padding: 7px 4px;
+        padding: 8px 6px;
+        border-radius: var(--sb-radius-button, 14px);
         text-align: center;
         white-space: normal;
     }
 
     :root[data-sb-desktop-nav-layout='vertical'] #right-nav-panel.openDrawer .sb-character-shell-nav > .sb-shell-tab:is(.is-active, .active, .selected, .is-selected, .is-current, [aria-selected='true'], [aria-current]) {
-        background: transparent;
-        border-color: transparent;
-        box-shadow: none;
+        background: var(--sb-shell-tab-active-bg);
+        border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 34%, var(--sb-shell-border) 66%);
     }
 
     :root[data-sb-desktop-nav-layout='vertical'] #right-nav-panel.openDrawer .sb-character-shell-nav > .sb-shell-tab i {
@@ -6477,8 +6484,8 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     }
 
     :root[data-sb-desktop-nav-layout='vertical'] #right-nav-panel.openDrawer .sb-character-shell-nav .sb-shell-tab-copy strong {
-        font-size: calc(var(--mainFontSize) * 0.66 * var(--sb-desktop-button-scale));
-        line-height: 1.1;
+        font-size: calc(var(--mainFontSize) * 0.72 * var(--sb-desktop-button-scale));
+        line-height: 1.2;
         white-space: normal;
     }
 
@@ -7137,6 +7144,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     .sb-shell-search {
         min-height: 42px;
     }
+
 }
 
 @media screen and (max-width: 768px) {
@@ -7461,13 +7469,18 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 }
 
 @media screen and (min-width: 1001px) {
-    #right-nav-panel.openDrawer .sb-character-shell-nav-wrapper {
+    :root:not([data-sb-desktop-nav-layout='vertical']) #right-nav-panel.openDrawer .sb-character-shell-nav-wrapper {
         width: 100%;
     }
 
-    #right-nav-panel.openDrawer .sb-character-shell-nav {
+    :root:not([data-sb-desktop-nav-layout='vertical']) #right-nav-panel.openDrawer .sb-character-shell-nav {
         justify-content: center !important;
         padding-inline: max(var(--sb-shell-panel-padding-inline), 60px) !important;
+    }
+
+    :root[data-sb-desktop-nav-layout='vertical'] #right-nav-panel.openDrawer .sb-character-shell-nav {
+        justify-content: flex-start !important;
+        padding: 18px 9px !important;
     }
 }
 

--- a/public/css/welcome.css
+++ b/public/css/welcome.css
@@ -1991,23 +1991,36 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
     }
 
     .welcomeActionCard {
-        min-height: 72px;
+        height: auto !important;
+        min-height: 72px !important;
+        width: 100% !important;
+        max-width: none;
         padding: 10px 12px;
         gap: 10px;
         border-radius: 18px;
+        white-space: normal !important;
     }
 
     .welcomeActionMeta {
+        flex: 1 1 auto;
         gap: 4px;
+        max-width: 100%;
+        min-height: 0;
+        overflow: hidden;
+        white-space: normal;
     }
 
     .welcomeActionMeta strong {
         font-size: calc(var(--mainFontSize) * 0.86);
+        max-width: 100%;
+        overflow-wrap: anywhere;
     }
 
     .welcomeActionMeta span {
         font-size: calc(var(--mainFontSize) * 0.68);
         line-height: 1.35;
+        max-width: 100%;
+        overflow-wrap: anywhere;
     }
 
     .welcomeHeroScene {

--- a/public/index.html
+++ b/public/index.html
@@ -17,9 +17,9 @@
             background-color: #1d2128;
         }
     </style>
-    <link rel="preload" as="style" href="style.css?v=20260523b">
+    <link rel="preload" as="style" href="style.css?v=20260602f">
     <link rel="modulepreload" href="script.js">
-    <link rel="modulepreload" href="scripts/sillybunny-tabs.js?v=20260602a">
+    <link rel="modulepreload" href="scripts/sillybunny-tabs.js?v=20260602f">
     <link rel="preload" as="font" type="font/woff2" href="webfonts/Figtree/Figtree-Regular.woff2?v=20260422b" crossorigin>
     <link rel="manifest" crossorigin="use-credentials" href="manifest.json">
     <link href="webfonts/Figtree/stylesheet.css?v=20260422b" rel="stylesheet">
@@ -40,14 +40,14 @@
     <link rel="apple-touch-icon" sizes="114x114" href="img/apple-icon-114x114.png" />
     <link rel="apple-touch-icon" sizes="144x144" href="img/apple-icon-144x144.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="img/apple-icon-180x180.png" />
-    <link rel="stylesheet" type="text/css" href="style.css?v=20260523b">
+    <link rel="stylesheet" type="text/css" href="style.css?v=20260602f">
     <link rel="stylesheet" type="text/css" href="css/st-tailwind.css">
     <link rel="stylesheet" type="text/css" href="css/toggle-dependent.css">
-    <link rel="stylesheet" type="text/css" href="css/select2-overrides.css">
+    <link rel="stylesheet" type="text/css" href="css/select2-overrides.css?v=20260602f">
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260516d" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260523a">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260528a">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260523b" media="(max-width: 768px)">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260602f">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260602f">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260602f" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
 </head>
@@ -3056,7 +3056,7 @@
                                     </button>
                                 </div>
                                 <div id="openai_model_picker_hint" class="toggle-description justifyLeft">
-                                    Search with your keyboard. Favorite models stay pinned to the top for faster switching.
+                                    Use the list button to browse models, or type a custom ID. Favorites stay pinned to the top for faster switching.
                                 </div>
                                 <label for="openai_bypass_status_check" class="checkbox_label">
                                     <input id="openai_bypass_status_check" type="checkbox" />
@@ -6300,8 +6300,8 @@
                     </button>
                     <div class="sb-shell-kicker" data-i18n="Characters">Characters</div>
                     <h2 class="sb-shell-title" tabindex="-1" data-i18n="Character Menu">Character Menu</h2>
-                    <p class="sb-shell-subtitle" data-i18n="Create, organize, and tune the cast for your chats from one place.">Create, organize, and tune the cast for your chats from one place.</p>
-                    <p class="sb-shell-description" data-i18n="This area will get dedicated character workflows. The tabs above are placeholders while the final sections are decided.">This area will get dedicated character workflows. The tabs above are placeholders while the final sections are decided.</p>
+                    <p class="sb-shell-subtitle" data-i18n="Browse, create, and tune the cast for your chats from one place.">Browse, create, and tune the cast for your chats from one place.</p>
+                    <p class="sb-shell-description" data-i18n="Move between characters, groups, personas, lore, and imports without leaving the writing workspace.">Move between characters, groups, personas, lore, and imports without leaving the writing workspace.</p>
                 </div>
                 <div id="CharListButtonAndHotSwaps" class="flex-container flexnowrap">
                     <div class="flexFlowColumn flex-container">
@@ -6381,7 +6381,8 @@
                     <div id="sb_character_editor_empty" class="sb-character-editor-empty" hidden>
                         <div class="sb-character-editor-empty-icon fa-solid fa-address-card" aria-hidden="true"></div>
                         <div class="sb-character-editor-empty-copy">
-                            <h3 data-i18n="No character selected. Please select or create a new character.">No character selected. Please select or create a new character.</h3>
+                            <h3 data-i18n="Choose a character to edit">Choose a character to edit</h3>
+                            <p data-i18n="Pick someone from your cast, or start a fresh card with the editor defaults.">Pick someone from your cast, or start a fresh card with the editor defaults.</p>
                         </div>
                         <div class="sb-character-editor-empty-actions">
                             <button id="sb_character_empty_browse" class="menu_button menu_button_icon" type="button">
@@ -6396,6 +6397,10 @@
                     </div>
                     <div id="sb_character_persona_panel" class="sb-character-persona-panel" hidden></div>
                     <div id="sb_character_import_panel" class="sb-character-import-panel" hidden>
+                        <div class="sb-character-import-intro">
+                            <h3 data-i18n="Bring in a character card">Bring in a character card</h3>
+                            <p data-i18n="Use a local file or paste a card link, then review the details before adding it to your cast.">Use a local file or paste a card link, then review the details before adding it to your cast.</p>
+                        </div>
                         <div class="sb-character-import-actions">
                             <button id="sb_character_import_file_action" class="sb-character-import-action" type="button">
                                 <i class="fa-solid fa-file-import" aria-hidden="true"></i>
@@ -8751,7 +8756,7 @@
     <script type="module" src="scripts/i18n.js"></script>
     <script type="module" src="scripts/performance-loader.js"></script>
     <script type="module" src="script.js"></script>
-    <script type="module" src="scripts/sillybunny-tabs.js?v=20260602a"></script>
+    <script type="module" src="scripts/sillybunny-tabs.js?v=20260602f"></script>
     <script>
         window.addEventListener('load', (event) => {
             const documentHeight = () => {

--- a/public/script.js
+++ b/public/script.js
@@ -950,7 +950,7 @@ function registerSillyBunnyServiceWorker() {
     }
 
     const register = () => {
-        navigator.serviceWorker.register('/sw.js?v=20260522g', { updateViaCache: 'none' }).then((registration) => {
+        navigator.serviceWorker.register('/sw.js?v=20260602f', { updateViaCache: 'none' }).then((registration) => {
             return registration.update().catch((error) => {
                 console.warn('Failed to update SillyBunny service worker.', error);
             });

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -278,7 +278,20 @@ const MODEL_ID_SEARCH_CONTROLS = [
     { source: chat_completion_sources.ZAI, setting: 'zai_model', input: '#zai_model_id', select: '#model_zai_select', dynamicGroupId: 'zai_other_models' },
 ];
 
+const INLINE_SELECT_PICKER_CONTROLS = [
+    { source: 'openrouter-model-chat', select: '#model_openrouter_select', label: 'OpenRouter model' },
+    { source: 'openrouter-sort-models', select: '#openrouter_sort_models', label: 'OpenRouter model sorting' },
+    { source: 'openrouter-providers-chat', select: '#openrouter_providers_chat', label: 'OpenRouter providers', multiple: true },
+    { source: 'openrouter-quantizations-chat', select: '#openrouter_quantizations_chat', label: 'OpenRouter quantizations', multiple: true },
+    { source: 'openrouter-model-text', select: '#openrouter_model', label: 'OpenRouter model' },
+    { source: 'openrouter-middleout', select: '#openrouter_middleout', label: 'OpenRouter middle-out transform' },
+    { source: 'openrouter-providers-text', select: '#openrouter_providers_text', label: 'OpenRouter providers', multiple: true },
+    { source: 'openrouter-quantizations-text', select: '#openrouter_quantizations_text', label: 'OpenRouter quantizations', multiple: true },
+];
+
 const modelIdSearchControlState = new Map();
+let modelSelectPickerDocumentListenerBound = false;
+let inlineSelectPickerObserverBound = false;
 
 const character_names_behavior = {
     NONE: -1,
@@ -2215,10 +2228,379 @@ function getPromptManagerSelect2DropdownParent() {
     return promptManagerPopup.length ? promptManagerPopup : getApiSelect2DropdownParent();
 }
 
+function closeModelSelectPickerMenus(exceptMenu = null) {
+    document.querySelectorAll('.sb-model-id-picker-menu').forEach(menu => {
+        if (menu !== exceptMenu) {
+            menu.hidden = true;
+        }
+    });
+}
+
+function bindModelSelectPickerDocumentListener() {
+    if (modelSelectPickerDocumentListenerBound) {
+        return;
+    }
+
+    document.addEventListener('click', event => {
+        if (event.target instanceof Element && event.target.closest('.sb-model-id-search-row, .sb-model-id-picker-menu, .sb-inline-select-picker-control')) {
+            return;
+        }
+
+        closeModelSelectPickerMenus();
+    });
+
+    document.addEventListener('keydown', event => {
+        if (event.key === 'Escape') {
+            closeModelSelectPickerMenus();
+        }
+    });
+
+    modelSelectPickerDocumentListenerBound = true;
+}
+
+function getModelSelectPickerOptionEntries(select) {
+    const entries = [];
+
+    for (const child of select.children) {
+        if (child instanceof HTMLOptGroupElement) {
+            const groupLabel = child.label || '';
+            for (const option of child.children) {
+                if (option instanceof HTMLOptionElement && !option.disabled) {
+                    entries.push({ group: groupLabel, text: option.textContent.trim() || option.value, value: option.value });
+                }
+            }
+            continue;
+        }
+
+        if (child instanceof HTMLOptionElement && !child.disabled) {
+            entries.push({ group: '', text: child.textContent.trim() || child.value, value: child.value });
+        }
+    }
+
+    return entries.filter(entry => entry.value);
+}
+
+function openInlineModelSelectPicker(select, { input = null, source = select.id } = {}) {
+    const row = input instanceof HTMLInputElement && input.parentElement instanceof HTMLElement ? input.parentElement : null;
+    const menuParent = row?.parentElement;
+
+    if (!row || !menuParent) {
+        return false;
+    }
+
+    let menu = menuParent.querySelector(`.sb-model-id-picker-menu[data-sb-model-id-picker-menu-source="${CSS.escape(source)}"]`);
+    if (!(menu instanceof HTMLElement)) {
+        menu = document.createElement('div');
+        menu.className = 'sb-model-id-picker-menu';
+        menu.dataset.sbModelIdPickerMenuSource = source;
+        menu.hidden = true;
+        menu.setAttribute('role', 'listbox');
+        row.insertAdjacentElement('afterend', menu);
+    }
+
+    const entries = getModelSelectPickerOptionEntries(select);
+    const currentValue = select.value || input.value || '';
+    let currentGroup = null;
+
+    menu.innerHTML = '';
+    menu.setAttribute('aria-label', t`Available models`);
+
+    if (entries.length === 0) {
+        const empty = document.createElement('div');
+        empty.className = 'sb-model-id-picker-empty';
+        empty.textContent = t`No models available`;
+        menu.appendChild(empty);
+    }
+
+    for (const entry of entries) {
+        if (entry.group && entry.group !== currentGroup) {
+            currentGroup = entry.group;
+            const heading = document.createElement('div');
+            heading.className = 'sb-model-id-picker-group';
+            heading.textContent = entry.group;
+            menu.appendChild(heading);
+        }
+
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'sb-model-id-picker-option';
+        button.textContent = entry.text;
+        button.dataset.value = entry.value;
+        button.setAttribute('role', 'option');
+        button.setAttribute('aria-selected', String(entry.value === currentValue));
+        button.addEventListener('click', () => {
+            select.value = entry.value;
+            input.value = entry.value;
+            select.dispatchEvent(new Event('change', { bubbles: true }));
+            closeModelSelectPickerMenus();
+        });
+        menu.appendChild(button);
+    }
+
+    bindModelSelectPickerDocumentListener();
+    const willOpen = menu.hidden;
+    closeModelSelectPickerMenus(menu);
+    menu.hidden = !willOpen;
+
+    if (!menu.hidden) {
+        menu.querySelector('[aria-selected="true"]')?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    }
+
+    return true;
+}
+
+function getInlineSelectPickerEntries(select) {
+    const entries = [];
+
+    for (const child of select.children) {
+        if (child instanceof HTMLOptGroupElement) {
+            const groupLabel = child.label || '';
+            for (const option of child.children) {
+                if (option instanceof HTMLOptionElement && !option.disabled) {
+                    entries.push({ group: groupLabel, text: option.textContent.trim() || option.value, value: option.value });
+                }
+            }
+            continue;
+        }
+
+        if (child instanceof HTMLOptionElement && !child.disabled) {
+            entries.push({ group: '', text: child.textContent.trim() || child.value, value: child.value });
+        }
+    }
+
+    return entries;
+}
+
+function getInlineSelectPickerSelectedValues(select) {
+    return new Set(Array.from(select.selectedOptions).map(option => option.value));
+}
+
+function dispatchInlineSelectPickerChange(select) {
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    select.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+function toggleInlineSelectPickerOption(select, value) {
+    if (select.multiple) {
+        for (const option of select.options) {
+            if (option.value === value) {
+                option.selected = !option.selected;
+                break;
+            }
+        }
+    } else {
+        select.value = value;
+    }
+
+    dispatchInlineSelectPickerChange(select);
+}
+
+function openInlineSelectPicker(select, { source = select.id, label = select.id, multiple = select.multiple, forceOpen = false } = {}) {
+    if (!(select instanceof HTMLSelectElement) || !(select.parentElement instanceof HTMLElement) || select.disabled) {
+        return false;
+    }
+
+    const menuParent = select.parentElement;
+    let menu = menuParent.querySelector(`.sb-model-id-picker-menu[data-sb-model-id-picker-menu-source="${CSS.escape(source)}"]`);
+    if (!(menu instanceof HTMLElement)) {
+        menu = document.createElement('div');
+        menu.className = 'sb-model-id-picker-menu sb-inline-select-picker-menu';
+        menu.dataset.sbModelIdPickerMenuSource = source;
+        menu.hidden = true;
+        menu.setAttribute('role', 'listbox');
+        if (multiple) {
+            menu.setAttribute('aria-multiselectable', 'true');
+        }
+        select.insertAdjacentElement('afterend', menu);
+    }
+
+    const entries = getInlineSelectPickerEntries(select);
+    const selectedValues = getInlineSelectPickerSelectedValues(select);
+    let currentGroup = null;
+
+    menu.innerHTML = '';
+    menu.setAttribute('aria-label', label);
+    menu.toggleAttribute('data-sb-inline-select-multiple', Boolean(multiple));
+
+    if (entries.length === 0) {
+        const empty = document.createElement('div');
+        empty.className = 'sb-model-id-picker-empty';
+        empty.textContent = t`No options available`;
+        menu.appendChild(empty);
+    }
+
+    for (const entry of entries) {
+        if (entry.group && entry.group !== currentGroup) {
+            currentGroup = entry.group;
+            const heading = document.createElement('div');
+            heading.className = 'sb-model-id-picker-group';
+            heading.textContent = entry.group;
+            menu.appendChild(heading);
+        }
+
+        const button = document.createElement('button');
+        const selected = selectedValues.has(entry.value);
+        button.type = 'button';
+        button.className = 'sb-model-id-picker-option sb-inline-select-picker-option';
+        button.textContent = entry.text;
+        button.dataset.value = entry.value;
+        button.setAttribute('role', 'option');
+        button.setAttribute('aria-selected', String(selected));
+        if (multiple) {
+            button.setAttribute('aria-pressed', String(selected));
+        }
+        button.addEventListener('click', () => {
+            toggleInlineSelectPickerOption(select, entry.value);
+            if (multiple) {
+                openInlineSelectPicker(select, { source, label, multiple, forceOpen: true });
+            } else {
+                closeModelSelectPickerMenus();
+            }
+        });
+        menu.appendChild(button);
+    }
+
+    bindModelSelectPickerDocumentListener();
+    const willOpen = forceOpen || menu.hidden;
+    closeModelSelectPickerMenus(menu);
+    menu.hidden = !willOpen;
+
+    if (!menu.hidden) {
+        menu.querySelector('[aria-selected="true"]')?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    }
+
+    return true;
+}
+
+function shouldUseInlineModelSelectPicker() {
+    return isMobile() || window.matchMedia('(max-width: 768px)').matches;
+}
+
+function bindInlineSelectPickerSelect(select, control) {
+    if (!(select instanceof HTMLSelectElement) || select.dataset.sbInlineSelectPickerBound === 'true') {
+        return;
+    }
+
+    select.dataset.sbInlineSelectPickerBound = 'true';
+    select.classList.add('sb-inline-select-picker-control');
+
+    const openPicker = event => {
+        if (!shouldUseInlineModelSelectPicker()) {
+            return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        openInlineSelectPicker(select, control);
+    };
+
+    select.addEventListener('pointerdown', openPicker);
+    select.addEventListener('click', event => {
+        if (shouldUseInlineModelSelectPicker()) {
+            event.preventDefault();
+        }
+    });
+    select.addEventListener('keydown', event => {
+        if (!shouldUseInlineModelSelectPicker() || ![' ', 'Enter', 'ArrowDown'].includes(event.key)) {
+            return;
+        }
+
+        openPicker(event);
+    });
+}
+
+function bindInlineSelectPickerControl(control) {
+    document.querySelectorAll(control.select).forEach(select => bindInlineSelectPickerSelect(select, control));
+}
+
+function bindInlineSelectPickerControls() {
+    INLINE_SELECT_PICKER_CONTROLS.forEach(bindInlineSelectPickerControl);
+
+    if (!inlineSelectPickerObserverBound && document.body instanceof HTMLElement) {
+        const observer = new MutationObserver(() => {
+            INLINE_SELECT_PICKER_CONTROLS.forEach(bindInlineSelectPickerControl);
+        });
+        observer.observe(document.body, { childList: true, subtree: true });
+        inlineSelectPickerObserverBound = true;
+    }
+}
+
+function setModelIdPickerTouchTarget(button) {
+    if (!(button instanceof HTMLButtonElement)) {
+        return;
+    }
+
+    for (const property of ['width', 'min-width', 'max-width', 'height', 'min-height', 'max-height', 'flex-basis']) {
+        button.style.setProperty(property, '44px', 'important');
+    }
+    button.style.setProperty('padding', '0', 'important');
+}
+
+function openModelSelectPicker(select, options = {}) {
+    if (!(select instanceof HTMLSelectElement) || select.disabled) {
+        return;
+    }
+
+    select.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+
+    if (shouldUseInlineModelSelectPicker() && openInlineModelSelectPicker(select, options)) {
+        return;
+    }
+
+    if (select.classList.contains('select2-hidden-accessible') && typeof $ === 'function') {
+        try {
+            $(select).select2('open');
+            return;
+        } catch {
+            // Fall back to the native picker below when Select2 is not ready.
+        }
+    }
+
+    select.focus({ preventScroll: true });
+
+    if (typeof select.showPicker === 'function') {
+        try {
+            select.showPicker();
+        } catch {
+            select.focus({ preventScroll: true });
+        }
+    }
+}
+
+function ensureOpenAIModelPickerButton() {
+    const input = document.querySelector('#openai_model_id');
+    const select = document.querySelector('#model_openai_select');
+
+    if (!(input instanceof HTMLInputElement) || !(select instanceof HTMLSelectElement) || !(input.parentElement instanceof HTMLElement)) {
+        return;
+    }
+
+    const row = input.parentElement;
+    row.classList.add('sb-model-id-search-row');
+    input.classList.add('sb-model-id-search-input');
+
+    let button = row.querySelector('#model_openai_picker_toggle');
+    if (!(button instanceof HTMLButtonElement)) {
+        button = document.createElement('button');
+        button.id = 'model_openai_picker_toggle';
+        button.type = 'button';
+        button.className = 'menu_button menu_button_icon sb-model-id-picker-toggle';
+        button.innerHTML = '<i class="fa-solid fa-list-ul" aria-hidden="true"></i>';
+        button.addEventListener('click', () => openModelSelectPicker(select, { input, source: chat_completion_sources.OPENAI }));
+        input.insertAdjacentElement('afterend', button);
+    }
+
+    button.title = t`Open model list`;
+    button.setAttribute('aria-label', t`Open model list`);
+    button.disabled = select.disabled || select.options.length === 0;
+    setModelIdPickerTouchTarget(button);
+}
+
 function initOpenAIModelSearch() {
     const $modelSelect = $('#model_openai_select');
+    ensureOpenAIModelPickerButton();
 
-    if (isMobile() || $modelSelect.length === 0) {
+    if (shouldUseInlineModelSelectPicker() || $modelSelect.length === 0) {
         return;
     }
 
@@ -2739,6 +3121,7 @@ function ensureModelIdSearchFavoriteButton(control) {
 
     let button = row.querySelector(`[data-sb-model-id-favorite-source="${CSS.escape(control.source)}"]`);
     if (button instanceof HTMLButtonElement) {
+        setModelIdPickerTouchTarget(button);
         return;
     }
 
@@ -2748,7 +3131,56 @@ function ensureModelIdSearchFavoriteButton(control) {
     button.dataset.sbModelIdFavoriteSource = control.source;
     button.innerHTML = '<i class="fa-solid fa-star" aria-hidden="true"></i>';
     button.addEventListener('click', () => toggleModelIdSearchFavorite(control));
-    input.insertAdjacentElement('afterend', button);
+
+    const pickerButton = row.querySelector(`[data-sb-model-id-picker-source="${CSS.escape(control.source)}"]`);
+    if (pickerButton instanceof HTMLButtonElement) {
+        pickerButton.insertAdjacentElement('afterend', button);
+    } else {
+        input.insertAdjacentElement('afterend', button);
+    }
+    setModelIdPickerTouchTarget(button);
+}
+
+function openModelIdSearchSelect(control) {
+    const input = document.querySelector(control.input);
+    const select = document.querySelector(control.select);
+
+    if (!(input instanceof HTMLInputElement) || !(select instanceof HTMLSelectElement)) {
+        return;
+    }
+
+    getModelIdSearchState(control.source).query = '';
+    rebuildModelIdSearchControl(control);
+    openModelSelectPicker(select, { input, source: control.source });
+}
+
+function ensureModelIdSearchPickerButton(control) {
+    const input = document.querySelector(control.input);
+    const select = document.querySelector(control.select);
+
+    if (!(input instanceof HTMLInputElement) || !(select instanceof HTMLSelectElement) || !(input.parentElement instanceof HTMLElement)) {
+        return;
+    }
+
+    const row = input.parentElement;
+    row.classList.add('sb-model-id-search-row');
+    input.classList.add('sb-model-id-search-input');
+
+    let button = row.querySelector(`[data-sb-model-id-picker-source="${CSS.escape(control.source)}"]`);
+    if (!(button instanceof HTMLButtonElement)) {
+        button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'menu_button menu_button_icon sb-model-id-picker-toggle';
+        button.dataset.sbModelIdPickerSource = control.source;
+        button.innerHTML = '<i class="fa-solid fa-list-ul" aria-hidden="true"></i>';
+        button.addEventListener('click', () => openModelIdSearchSelect(control));
+        input.insertAdjacentElement('afterend', button);
+    }
+
+    button.title = t`Open model list`;
+    button.setAttribute('aria-label', t`Open model list`);
+    button.disabled = select.disabled || select.options.length === 0;
+    setModelIdPickerTouchTarget(button);
 }
 
 function initModelIdSearchControl(control) {
@@ -2760,6 +3192,7 @@ function initModelIdSearchControl(control) {
     }
 
     getModelIdSearchStaticEntries(control);
+    ensureModelIdSearchPickerButton(control);
     ensureModelIdSearchFavoriteButton(control);
 
     if (input.dataset.sbModelIdSearchBound !== 'true') {
@@ -3465,6 +3898,7 @@ function scheduleOpenAIUiRefresh() {
         updateServerChatCompletionConfigSourceVisibility();
         updateOpenAISettingsGroupVisibility();
         updateOpenAIModelFavoriteButton();
+        bindInlineSelectPickerControls();
     });
 
     window.setTimeout(() => {
@@ -3472,6 +3906,7 @@ function scheduleOpenAIUiRefresh() {
         updateServerChatCompletionConfigSourceVisibility();
         updateOpenAISettingsGroupVisibility();
         updateOpenAIModelFavoriteButton();
+        bindInlineSelectPickerControls();
     }, 200);
 }
 
@@ -9533,7 +9968,7 @@ export function initOpenAI() {
         });
     }
 
-    if (!isMobile()) {
+    if (!shouldUseInlineModelSelectPicker()) {
         $('#model_openai_select').select2({
             dropdownParent: getApiSelect2DropdownParent(),
             placeholder: t`Select a model`,
@@ -9638,6 +10073,7 @@ export function initOpenAI() {
     groupOpenAISettingsIntoDrawers();
     injectServerChatCompletionConfigCard();
     cacheOpenAIStaticModelGroups();
+    bindInlineSelectPickerControls();
     rebuildOpenAIModelSelect();
     initModelIdSearchControls();
     updateAdvancedFormattingVisibility();

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -289,6 +289,8 @@ const INLINE_SELECT_PICKER_CONTROLS = [
     { source: 'openrouter-quantizations-text', select: '#openrouter_quantizations_text', label: 'OpenRouter quantizations', multiple: true },
 ];
 
+// SillyBunny: touch browsers can open Select2 search as a keyboard-only field.
+// Keep mobile OpenRouter/API selects backed by native values while rendering an inline list.
 const modelIdSearchControlState = new Map();
 let modelSelectPickerDocumentListenerBound = false;
 let inlineSelectPickerObserverBound = false;

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -394,18 +394,18 @@ const SB_MESSAGE_STYLES = Object.freeze([
 const SB_CHARACTER_TAB_COPY = Object.freeze({
     characters: {
         title: 'Character Menu',
-        subtitle: 'Browse, create, and sort locally-stored character cards.',
-        description: 'Manage your personal character cards, groups, and personas here.',
+        subtitle: 'Browse, create, and tune the cast for your chats from one place.',
+        description: 'Move between characters, groups, personas, lore, and imports without leaving the writing workspace.',
     },
     groups: {
         title: 'Group Menu',
-        subtitle: 'Browse, create, and sort locally-stored group chats here, using multiple character cards.',
-        description: 'Manage your personal character cards, groups, and personas here.',
+        subtitle: 'Build and organize group casts for multi-character scenes.',
+        description: 'Sort group chats, check members, and return to character cards without losing your place.',
     },
     editor: {
         title: 'Card Editor',
-        subtitle: 'Edit or make changes to your selected character card or group chat here.',
-        description: 'Manage your personal character cards, groups, and personas here.',
+        subtitle: 'Shape the selected card details, prompts, greetings, and metadata.',
+        description: 'Use the subtabs to keep core identity, definitions, greetings, and metadata separated.',
     },
     'world-info': {
         title: 'World Info',
@@ -414,13 +414,13 @@ const SB_CHARACTER_TAB_COPY = Object.freeze({
     },
     persona: {
         title: 'Persona',
-        subtitle: 'Manage your in-chat persona details and other configuration options.',
-        description: 'Manage your personal character cards, groups, and personas here.',
+        subtitle: 'Choose how you appear in chat and connect personas to characters.',
+        description: 'Edit persona details, locks, and defaults in the same flow as your character work.',
     },
     import: {
         title: 'Import',
-        subtitle: 'Import character cards from files, search a website for uploaded character cards, or import them directly from a URL.',
-        description: 'Manage your personal character cards, groups, and personas here.',
+        subtitle: 'Add cards from files or links, then fold them into your local cast.',
+        description: 'PNG, JSON, YAML, CHARX, BYAF, and supported URL imports stay one tab away.',
     },
 });
 
@@ -695,7 +695,7 @@ const sbState = {
         quickActionSection: null,
         quickActionDivider: null,
         layout: normalizeMobileNavLayout(safeGetItem(SB_STORAGE_KEYS.mobileNavLayout)),
-        iconOnly: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.mobileNavIconOnly), true),
+        iconOnly: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.mobileNavIconOnly), false),
         showCustomize: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.mobileNavShowCustomize), true),
         showQuickActions: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.mobileNavShowQuickActions), false),
         replaceQuickActions: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.mobileNavReplaceQuickActions), false),
@@ -703,7 +703,7 @@ const sbState = {
     },
     desktopNav: {
         layout: normalizeMobileNavLayout(safeGetItem(SB_STORAGE_KEYS.desktopNavLayout)),
-        iconOnly: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.desktopNavIconOnly), true),
+        iconOnly: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.desktopNavIconOnly), false),
         showCustomize: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.desktopNavShowCustomize), true),
         showQuickActions: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.desktopNavShowQuickActions), false),
         replaceQuickActions: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.desktopNavReplaceQuickActions), false),
@@ -878,7 +878,7 @@ function normalizeStoredBoolean(value, fallback = false) {
 
 function normalizeMobileNavLayout(value) {
     const normalizedValue = normalizeText(value);
-    return SB_MOBILE_NAV_LAYOUTS.includes(normalizedValue) ? normalizedValue : 'vertical';
+    return SB_MOBILE_NAV_LAYOUTS.includes(normalizedValue) ? normalizedValue : 'horizontal';
 }
 
 function getNavState(mode) {
@@ -896,7 +896,7 @@ function getActiveShellRailMode() {
 function getMobileNavCustomizeLocationLabel(mode = 'mobile') {
     return getNavState(mode).layout === 'horizontal'
         ? 'Show Workspace and Customize buttons in top bar'
-        : 'Show Workspace and Customize buttons in side rail';
+        : 'Show section shortcuts in each side rail';
 }
 
 function normalizeMobileNavReplacementTarget(value) {
@@ -1501,8 +1501,9 @@ function setMobileButtonScale(value, { persist = true } = {}) {
 
 function applyMobileNavPreferences() {
     const quickActionsShown = sbState.mobileNav.showQuickActions;
+    const useIconOnly = sbState.mobileNav.layout === 'vertical' && sbState.mobileNav.iconOnly;
     document.documentElement.dataset.sbMobileNavLayout = sbState.mobileNav.layout;
-    document.documentElement.dataset.sbMobileNavMode = sbState.mobileNav.iconOnly ? 'icon-only' : 'labeled';
+    document.documentElement.dataset.sbMobileNavMode = useIconOnly ? 'icon-only' : 'labeled';
     document.documentElement.dataset.sbMobileNavCustomize = sbState.mobileNav.showCustomize ? 'shown' : 'hidden';
     document.documentElement.dataset.sbMobileNavQuickActions = quickActionsShown ? 'shown' : 'hidden';
     document.documentElement.dataset.sbMobileNavReplacement = sbState.mobileNav.replaceQuickActions ? 'shown' : 'hidden';
@@ -1510,8 +1511,9 @@ function applyMobileNavPreferences() {
 
 function applyDesktopNavPreferences() {
     const quickActionsShown = sbState.desktopNav.showQuickActions;
+    const useIconOnly = sbState.desktopNav.layout === 'vertical' && sbState.desktopNav.iconOnly;
     document.documentElement.dataset.sbDesktopNavLayout = sbState.desktopNav.layout;
-    document.documentElement.dataset.sbDesktopNavMode = sbState.desktopNav.iconOnly ? 'icon-only' : 'labeled';
+    document.documentElement.dataset.sbDesktopNavMode = useIconOnly ? 'icon-only' : 'labeled';
     document.documentElement.dataset.sbDesktopNavCustomize = sbState.desktopNav.showCustomize ? 'shown' : 'hidden';
     document.documentElement.dataset.sbDesktopNavQuickActions = quickActionsShown ? 'shown' : 'hidden';
     document.documentElement.dataset.sbDesktopNavReplacement = sbState.desktopNav.replaceQuickActions ? 'shown' : 'hidden';
@@ -1801,7 +1803,7 @@ function syncCharacterDrawerLockButton() {
 }
 
 function syncCharacterDrawerLockPosition() {
-    const panel = document.getElementById('right-nav-panel');
+    const panel = getCharacterPanel();
     if (!(panel instanceof HTMLElement)) {
         return;
     }
@@ -2491,7 +2493,7 @@ function syncDesktopShellSizing() {
 
     for (const shellKey of ['left', 'right', 'characters']) {
         const root = shellKey === 'characters'
-            ? document.getElementById('right-nav-panel')
+            ? getCharacterPanel()
             : document.getElementById(getShellConfig(shellKey).rootPanelId);
         if (!(root instanceof HTMLElement)) {
             continue;
@@ -2547,7 +2549,7 @@ function syncDesktopShellSizing() {
 
 function getResizableShellRoot(shellKey) {
     if (shellKey === 'characters') {
-        return document.getElementById('right-nav-panel');
+        return getCharacterPanel();
     }
 
     return document.getElementById(getShellConfig(shellKey).rootPanelId);
@@ -6012,14 +6014,53 @@ function bindChatbarEvents() {
     scheduleChatbarRefresh(0);
 }
 
-function triggerDrawerToggle(selector) {
-    const toggle = document.querySelector(selector);
+function getCanonicalTopSettingsHolder() {
+    return Array.from(document.querySelectorAll('#top-settings-holder'))
+        .find(element => element instanceof HTMLElement && element.parentElement === document.body)
+        ?? document.getElementById('top-settings-holder');
+}
+
+function getCharacterDrawerHost() {
+    const topSettingsHolder = getCanonicalTopSettingsHolder();
+    const hosts = Array.from(document.querySelectorAll('#rightNavHolder')).filter(element => element instanceof HTMLElement);
+    const host = hosts.find(element => element.classList.contains('sb-drawer-host') && element.closest('#top-settings-holder') === topSettingsHolder)
+        ?? hosts.find(element => element.classList.contains('sb-drawer-host'))
+        ?? hosts.find(element => element.closest('#top-settings-holder') === topSettingsHolder)
+        ?? document.getElementById('rightNavHolder');
+
+    if (host instanceof HTMLElement && topSettingsHolder instanceof HTMLElement && host.parentElement === topSettingsHolder && topSettingsHolder.firstElementChild !== host) {
+        topSettingsHolder.insertBefore(host, topSettingsHolder.firstElementChild);
+    }
+
+    return host instanceof HTMLElement ? host : null;
+}
+
+function getCharacterDrawerToggle() {
+    return getCharacterDrawerHost()?.querySelector(':scope > .drawer-toggle') ?? null;
+}
+
+function getCharacterPanel() {
+    const panel = getCharacterDrawerHost()?.querySelector(':scope > #right-nav-panel')
+        ?? document.querySelector('#right-nav-panel.sb-character-drawer-root')
+        ?? document.getElementById('right-nav-panel');
+
+    return panel instanceof HTMLElement ? panel : null;
+}
+
+function triggerDrawerToggle(selectorOrElement) {
+    const toggle = typeof selectorOrElement === 'string'
+        ? document.querySelector(selectorOrElement)
+        : selectorOrElement;
     if (toggle instanceof HTMLElement) {
         toggle.click();
     }
 }
 
 function getDrawerRoot(drawerRootOrId) {
+    if (drawerRootOrId === 'right-nav-panel') {
+        return getCharacterPanel();
+    }
+
     return typeof drawerRootOrId === 'string'
         ? document.getElementById(drawerRootOrId)
         : drawerRootOrId;
@@ -6082,7 +6123,7 @@ function getMobileModalRootCandidates() {
     return [
         document.getElementById(getShellConfig('left').rootPanelId),
         document.getElementById(getShellConfig('right').rootPanelId),
-        document.getElementById('right-nav-panel'),
+        getCharacterPanel(),
         document.getElementById('sb-mobile-nav'),
         chatTools,
     ].filter(element => element instanceof HTMLElement);
@@ -6348,7 +6389,7 @@ function ensureCharacterListToolbarLayout() {
     if (bulkEditButton instanceof HTMLElement && bulkEditButton.dataset.sbGroupsGuardBound !== 'true') {
         bulkEditButton.dataset.sbGroupsGuardBound = 'true';
         bulkEditButton.addEventListener('click', (event) => {
-            const panel = document.getElementById('right-nav-panel');
+            const panel = getCharacterPanel();
             if (panel instanceof HTMLElement && panel.dataset.menuType === 'groups') {
                 event.preventDefault();
                 event.stopImmediatePropagation();
@@ -6363,7 +6404,7 @@ async function showCharacterListView(view = 'characters') {
     setCharacterPersonaPanelVisible(false);
     setCharacterImportPanelVisible(false);
     setCharacterWorldInfoPanelVisible(false);
-    const panel = document.getElementById('right-nav-panel');
+    const panel = getCharacterPanel();
     const normalizedView = view === 'groups' ? 'groups' : 'characters';
     sbState.characterDrawer.lastTab = normalizedView;
 
@@ -6390,7 +6431,7 @@ async function showCharacterListView(view = 'characters') {
 }
 
 function showCharacterEditorEmptyState() {
-    const panel = document.getElementById('right-nav-panel');
+    const panel = getCharacterPanel();
     const infoPanel = document.getElementById('result_info');
     const pinAndTabs = document.getElementById('rm_PinAndTabs');
     const characterEditor = document.getElementById('rm_ch_create_block');
@@ -6447,7 +6488,7 @@ function setCharacterEditorEmptyState(visible) {
 }
 
 function syncCharacterTitlebarVisibility() {
-    const panel = document.getElementById('right-nav-panel');
+    const panel = getCharacterPanel();
     const pinAndTabs = document.getElementById('rm_PinAndTabs');
 
     if (!(panel instanceof HTMLElement) || !(pinAndTabs instanceof HTMLElement)) {
@@ -6605,7 +6646,7 @@ function setCharacterEditorSubTab(tabId, { focusButton = false } = {}) {
 }
 
 function setCharacterEditorFullscreenState(expanded, { focusButton = false } = {}) {
-    const panel = document.getElementById('right-nav-panel');
+    const panel = getCharacterPanel();
     const toggleButton = document.getElementById('sb_character_editor_fullscreen_toggle');
     const wasExpanded = panel instanceof HTMLElement && panel.classList.contains('sb-character-editor-fullscreen');
     const canExpand = panel instanceof HTMLElement
@@ -6653,7 +6694,7 @@ function setCharacterPanelMenuType(panel, menuType) {
 }
 
 function toggleCharacterEditorFullscreen() {
-    const panel = document.getElementById('right-nav-panel');
+    const panel = getCharacterPanel();
     if (!(panel instanceof HTMLElement) || !panel.classList.contains('openDrawer') || !isCharacterEditorMenuType(panel.dataset.menuType)) {
         return;
     }
@@ -6662,7 +6703,7 @@ function toggleCharacterEditorFullscreen() {
 }
 
 function syncCharacterEditorFullscreenAvailability() {
-    const panel = document.getElementById('right-nav-panel');
+    const panel = getCharacterPanel();
     const toggleButton = document.getElementById('sb_character_editor_fullscreen_toggle');
     const canUseFullscreen = panel instanceof HTMLElement
         && isCharacterEditorMenuType(panel.dataset.menuType)
@@ -6686,7 +6727,7 @@ function bindCharacterEditorFullscreenToggle() {
     toggleButton.dataset.sbBound = 'true';
     toggleButton.addEventListener('click', () => toggleCharacterEditorFullscreen());
 
-    const panel = document.getElementById('right-nav-panel');
+    const panel = getCharacterPanel();
     if (panel instanceof HTMLElement && panel.dataset.sbEditorFullscreenKeyBound !== 'true') {
         panel.dataset.sbEditorFullscreenKeyBound = 'true';
         panel.addEventListener('keydown', (event) => {
@@ -6805,7 +6846,7 @@ function hideCharacterMainPanels() {
 }
 
 function openCharacterWorldInfoTab() {
-    const panel = document.getElementById('right-nav-panel');
+    const panel = getCharacterPanel();
     sbState.characterDrawer.lastTab = 'world-info';
 
     closeMobileNav();
@@ -6827,7 +6868,7 @@ function openCharacterWorldInfoTab() {
 }
 
 function openCharacterPersonaTab() {
-    const panel = document.getElementById('right-nav-panel');
+    const panel = getCharacterPanel();
     sbState.characterDrawer.lastTab = 'persona';
 
     setCharacterPanelMenuType(panel, 'persona');
@@ -6843,7 +6884,7 @@ function openCharacterPersonaTab() {
 }
 
 function openCharacterImportTab() {
-    const panel = document.getElementById('right-nav-panel');
+    const panel = getCharacterPanel();
     sbState.characterDrawer.lastTab = 'import';
 
     setCharacterPanelMenuType(panel, 'import');
@@ -6859,7 +6900,7 @@ function openCharacterImportTab() {
 }
 
 function preserveCharacterImportTab() {
-    const panel = document.getElementById('right-nav-panel');
+    const panel = getCharacterPanel();
 
     if (panel instanceof HTMLElement && panel.dataset.menuType !== 'import') {
         return;
@@ -6896,7 +6937,7 @@ function openCharacterPanelTab(tabId) {
     }
 
     const activateRequestedTab = () => {
-        const panel = document.getElementById('right-nav-panel');
+        const panel = getCharacterPanel();
         if (normalizedTabId === 'persona') {
             setCharacterPanelMenuType(panel, 'persona');
             openCharacterPersonaTab();
@@ -6958,7 +6999,7 @@ function openCharacterEditorTab() {
 }
 
 function syncCharacterShellTabs(activeTab = null) {
-    const panel = document.getElementById('right-nav-panel');
+    const panel = getCharacterPanel();
     const menuType = panel?.dataset.menuType;
     const normalizedTab = activeTab
         ?? (menuType === 'persona'
@@ -7059,7 +7100,7 @@ function showActiveCharacterEditor() {
 }
 
 function resetCharacterPanelView() {
-    const panel = document.getElementById('right-nav-panel');
+    const panel = getCharacterPanel();
     const listButton = document.getElementById('rm_button_characters');
     const selectedTitle = document.querySelector('#rm_button_selected_ch h2');
 
@@ -7106,7 +7147,7 @@ function resetCharacterPanelView() {
 }
 
 function setCharacterDrawerHostOverflow(shouldOpen) {
-    const host = document.getElementById('rightNavHolder');
+    const host = getCharacterDrawerHost();
 
     if (host instanceof HTMLElement) {
         host.style.overflow = shouldOpen ? 'visible' : '';
@@ -7114,7 +7155,7 @@ function setCharacterDrawerHostOverflow(shouldOpen) {
 }
 
 function syncCharacterDrawerStateFromDom({ force = false } = {}) {
-    const panel = document.getElementById('right-nav-panel');
+    const panel = getCharacterPanel();
 
     if (!(panel instanceof HTMLElement)) {
         return;
@@ -7140,7 +7181,7 @@ function syncCharacterDrawerStateFromDom({ force = false } = {}) {
 }
 
 function bindCharacterDrawerStateObserver() {
-    const panel = document.getElementById('right-nav-panel');
+    const panel = getCharacterPanel();
 
     if (!(panel instanceof HTMLElement)) {
         return;
@@ -7168,7 +7209,7 @@ function bindCharacterDrawerStateObserver() {
 }
 
 function closeCharacterPanel() {
-    const panel = document.getElementById('right-nav-panel');
+    const panel = getCharacterPanel();
 
     setCharacterEditorFullscreenState(false);
 
@@ -7185,7 +7226,7 @@ function closeCharacterPanel() {
 }
 
 function ensureCharacterResizeHandle() {
-    const panel = document.getElementById('right-nav-panel');
+    const panel = getCharacterPanel();
     if (!(panel instanceof HTMLElement)) {
         return null;
     }
@@ -7231,7 +7272,7 @@ function toggleCharacterPanel({ preferredTab = null } = {}) {
     // Temporarily allow overflow on the parent so the panel renders.
     setCharacterDrawerHostOverflow(true);
 
-    triggerDrawerToggle('#rightNavHolder > .drawer-toggle');
+    triggerDrawerToggle(getCharacterDrawerToggle());
 
     // Fallback: if the jQuery drawer-toggle handler didn't fire, force-open
     window.requestAnimationFrame(() => {
@@ -7686,7 +7727,7 @@ function hideHostToggles() {
         hostToggle?.classList.add('sb-hidden-toggle');
     }
 
-    const characterDrawer = document.getElementById('rightNavHolder');
+    const characterDrawer = getCharacterDrawerHost();
     characterDrawer?.classList.add('sb-drawer-host');
     characterDrawer?.querySelector(':scope > .drawer-toggle')?.classList.add('sb-hidden-toggle');
 
@@ -10836,7 +10877,7 @@ function createNavigationSettingsGroup(mode = 'mobile') {
         id: `sb-${modePrefix}-nav-show-quick-actions-input`,
         type: 'checkbox',
         value: 'show-quick-actions',
-        label: 'Show Custom Quick Actions below Customize',
+        label: 'Show Custom Quick Actions in the side rail',
         icon: 'fa-bolt',
         onChange: input => isDesktop ? setDesktopNavShowQuickActions(input.checked) : setMobileNavShowQuickActions(input.checked),
     });
@@ -12535,29 +12576,30 @@ function createMobileShellRailButton(item, actionHandler, className = '') {
     return button;
 }
 
-function createCustomizeGroup() {
-    const customizeGroup = createElement('div', {
-        className: 'sb-shell-rail-group sb-shell-rail-group-customize',
+function createRailActionGroup(actions, groupLabel, className = '') {
+    const railGroup = createElement('div', {
+        className: ['sb-shell-rail-group', className].filter(Boolean).join(' '),
         attrs: {
-            'aria-label': 'Customize',
+            'aria-label': groupLabel,
         },
     });
 
-    let previousShellKey = '';
-    for (const action of SB_MOBILE_RAIL_CUSTOMIZE_ACTIONS) {
-        if (previousShellKey && action.shellKey !== previousShellKey) {
-            customizeGroup.appendChild(createMobileShellRailDivider('Settings'));
-        }
-
+    for (const action of actions) {
         const button = createMobileShellRailButton(action, activateMobileNavAction, 'sb-shell-rail-customize-action');
         if (button) {
-            customizeGroup.appendChild(button);
+            railGroup.appendChild(button);
         }
-
-        previousShellKey = action.shellKey;
     }
 
-    return customizeGroup;
+    return railGroup;
+}
+
+function getBuiltInRailActionsForShell(shellKey) {
+    return SB_MOBILE_RAIL_CUSTOMIZE_ACTIONS.filter(action => action.shellKey === shellKey);
+}
+
+function getBuiltInRailLabelForShell(shellKey) {
+    return shellKey === 'right' ? 'Customize' : 'Workspace';
 }
 
 function syncMobileShellRailActionState(activeShellKey = '', activeTabId = '') {
@@ -12630,8 +12672,9 @@ function syncMobileShellRailActions(shellKey = null) {
             continue;
         }
 
-        const builtInRailActionKeys = showCustomize
-            ? new Set(SB_MOBILE_RAIL_CUSTOMIZE_ACTIONS.map(getMobileQuickActionKey))
+        const builtInRailActions = showCustomize ? getBuiltInRailActionsForShell(currentShellKey) : [];
+        const builtInRailActionKeys = builtInRailActions.length
+            ? new Set(builtInRailActions.map(getMobileQuickActionKey))
             : new Set();
         const replacementAction = railMode === 'desktop' && navState.replaceQuickActions
             ? createNavReplacementQuickAction(navState.replacementTarget)
@@ -12666,9 +12709,14 @@ function syncMobileShellRailActions(shellKey = null) {
 
         const beforeBlock = createRailBlock('before');
 
-        if (showCustomize) {
-            beforeBlock.appendChild(createMobileShellRailDivider('Workspace'));
-            beforeBlock.appendChild(createCustomizeGroup());
+        if (builtInRailActions.length) {
+            const builtInRailLabel = getBuiltInRailLabelForShell(currentShellKey);
+            beforeBlock.appendChild(createMobileShellRailDivider(builtInRailLabel));
+            beforeBlock.appendChild(createRailActionGroup(
+                builtInRailActions,
+                builtInRailLabel,
+                `sb-shell-rail-group-${builtInRailLabel.toLowerCase()}`,
+            ));
         }
 
         if (beforeBlock.children.length > 0) {
@@ -12804,7 +12852,7 @@ function bindWorldInfoRoute() {
             event.preventDefault();
             event.stopImmediatePropagation();
 
-            const characterPanel = document.getElementById('right-nav-panel');
+            const characterPanel = getCharacterPanel();
             const worldInfoVisible = characterPanel instanceof HTMLElement
                 && characterPanel.classList.contains('openDrawer')
                 && characterPanel.dataset.menuType === 'world-info';
@@ -13115,7 +13163,7 @@ function closeMobileNav() {
 }
 
 function injectCharacterDrawerControls() {
-    document.getElementById('right-nav-panel')?.classList.add('sb-character-drawer-root');
+    getCharacterPanel()?.classList.add('sb-character-drawer-root');
     ensureCharacterListToolbarLayout();
     bindCharacterEditorFullscreenToggle();
 
@@ -13433,7 +13481,7 @@ function getInlineDrawerPersistenceRoots() {
         document.getElementById('left-nav-panel'),
         document.getElementById('user-settings-block-content'),
         document.getElementById('WorldInfo'),
-        document.getElementById('right-nav-panel'),
+        getCharacterPanel(),
     ].filter(element => element instanceof HTMLElement);
 }
 

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -2083,8 +2083,10 @@ function normalizeCharacterPanelTab(tabId) {
 }
 
 function getCharacterPanelSearchEntries() {
+    const panel = getCharacterPanel();
+
     return SB_CHARACTER_PANEL_TABS.map((tab) => {
-        const button = document.querySelector(`#right-nav-panel [data-sb-character-tab="${CSS.escape(tab.id)}"]`);
+        const button = panel?.querySelector(`[data-sb-character-tab="${CSS.escape(tab.id)}"]`);
         const searchText = normalizeText([tab.label, tab.id, 'characters'].join(' '));
 
         return {
@@ -6746,7 +6748,7 @@ function bindCharacterEditorFullscreenToggle() {
 
 function focusCharacterPanelTab(tabId) {
     const normalizedTabId = normalizeCharacterPanelTab(tabId);
-    const button = document.querySelector(`#right-nav-panel [data-sb-character-tab="${CSS.escape(normalizedTabId)}"]`);
+    const button = getCharacterPanel()?.querySelector(`[data-sb-character-tab="${CSS.escape(normalizedTabId)}"]`);
 
     if (button instanceof HTMLElement) {
         button.focus({ preventScroll: true });
@@ -7020,7 +7022,7 @@ function syncCharacterShellTabs(activeTab = null) {
 
     syncCharacterHeaderCopy(normalizedTab);
 
-    document.querySelectorAll('#right-nav-panel [data-sb-character-tab]').forEach(tab => {
+    panel?.querySelectorAll('[data-sb-character-tab]').forEach(tab => {
         if (!(tab instanceof HTMLElement)) {
             return;
         }
@@ -7059,9 +7061,10 @@ function syncCharacterShellTabs(activeTab = null) {
 
 function syncCharacterHeaderCopy(activeTab = 'characters') {
     const copy = SB_CHARACTER_TAB_COPY[activeTab] ?? SB_CHARACTER_TAB_COPY.characters;
-    const title = document.querySelector('#right-nav-panel .sb-character-shell-header .sb-shell-title');
-    const subtitle = document.querySelector('#right-nav-panel .sb-character-shell-header .sb-shell-subtitle');
-    const description = document.querySelector('#right-nav-panel .sb-character-shell-header .sb-shell-description');
+    const panel = getCharacterPanel();
+    const title = panel?.querySelector('.sb-character-shell-header .sb-shell-title');
+    const subtitle = panel?.querySelector('.sb-character-shell-header .sb-shell-subtitle');
+    const description = panel?.querySelector('.sb-character-shell-header .sb-shell-description');
 
     if (title instanceof HTMLElement) {
         title.textContent = '';

--- a/public/scripts/textgen-models.js
+++ b/public/scripts/textgen-models.js
@@ -19,6 +19,10 @@ let tabbyModels = [];
 let llamacppModels = [];
 export let openRouterModels = [];
 
+function shouldUseNativeApiSelects() {
+    return window.matchMedia?.('(max-width: 768px)').matches ?? false;
+}
+
 /**
  * List of OpenRouter providers.
  * @type {string[]}
@@ -1363,6 +1367,10 @@ export function initTextGenModels() {
             value: provider.id,
             text: provider.label,
         }));
+    }
+
+    if (shouldUseNativeApiSelects()) {
+        return;
     }
 
     // Keep API Select2 dropdowns inside the scrolling API drawer so they move with the control.

--- a/public/scripts/textgen-models.js
+++ b/public/scripts/textgen-models.js
@@ -7,6 +7,7 @@ import { POPUP_TYPE, callGenericPopup } from './popup.js';
 import { t } from './i18n.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { localizePagination, PAGINATION_TEMPLATE, textValueMatcher } from './utils.js';
+import { isMobile } from './RossAscends-mods.js';
 
 let mancerModels = [];
 let togetherModels = [];
@@ -20,7 +21,7 @@ let llamacppModels = [];
 export let openRouterModels = [];
 
 function shouldUseNativeApiSelects() {
-    return window.matchMedia?.('(max-width: 768px)').matches ?? false;
+    return isMobile() || (window.matchMedia?.('(max-width: 768px)').matches ?? false);
 }
 
 /**

--- a/public/style.css
+++ b/public/style.css
@@ -10,7 +10,7 @@
 @import url(css/accounts.css);
 @import url(css/tags.css);
 @import url(css/scrollable-button.css?v=20260517a);
-@import url(css/welcome.css?v=20260425a);
+@import url(css/welcome.css?v=20260602f);
 @import url(css/data-maid.css);
 @import url(css/secrets.css);
 @import url(css/backgrounds.css?v=20260425a);

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const SB_SW_CACHE_VERSION = 'sillybunny-cache-v20260602a';
+const SB_SW_CACHE_VERSION = 'sillybunny-cache-v20260602f';
 const SB_STATIC_CACHE = `${SB_SW_CACHE_VERSION}-static`;
 const SB_SHELL_CACHE = `${SB_SW_CACHE_VERSION}-shell`;
 const SB_FRONTEND_ASSET_PREFIX = '/frontend-assets/';


### PR DESCRIPTION
## What?
Polishes SillyBunny's Character Menu and adjacent menu surfaces, with emphasis on the mobile Character drawer, horizontal/vertical tab behavior, and OpenRouter API dropdowns.

## Why?
The Character Menu had rough layout and copy issues, horizontal mobile nav was no longer the default, vertical rails mixed Workspace and Customize shortcuts, and OpenRouter dropdowns could focus the keyboard without showing a usable model/provider list on narrow screens.

## How?
- Restores horizontal labeled mobile navigation defaults while keeping icon-only mode available for vertical rails.
- Separates Workspace and Customize shortcuts by active rail so vertical layout stays consistent.
- Adds canonical Character drawer resolution so hidden duplicate drawer nodes do not steal Character Menu sizing, tab, lock, or state updates.
- Adds mobile inline pickers for OpenRouter model/provider/quantization controls and binds duplicate or later-injected select controls safely.
- Tightens Character Menu copy, empty/import states, tab labels, touch sizing, Select2 layering, and cache-busted frontend assets.
- Keeps local agent worklogs and browser artifacts ignored.

## Testing?
- `node --check public/scripts/openai.js`
- `node --check public/scripts/sillybunny-tabs.js`
- `node --check public/scripts/textgen-models.js`
- `git diff --check`
- Browser validation at mobile viewport `390x844`:
  - Character Menu opens full-width with horizontal labeled tabs: Characters, Groups, Editor, World Info, Persona, Import.
  - OpenRouter model picker opens with 344 options.
  - OpenRouter provider picker opens as a multi-select menu.
  - OpenRouter quantization picker opens with 9 options.
- CI: ESLint, unit tests, frontend assets, Bun runtime, metadata, merge-conflict, and label checks are passing.
- Note: a CRLF checkout reports blocking CSS at `801.3 KiB` vs the `800.0 KiB` budget, while the CI LF checkout passes the frontend asset budget.

## Screenshots (optional)
Not attached. Validation used live browser probes at the target mobile viewport.

## Anything Else?
None.