### PR TITLE
fix: correct underreported thought token counts

### DIFF
--- a/public/scripts/reasoning-token-accounting.js
+++ b/public/scripts/reasoning-token-accounting.js
@@ -33,7 +33,7 @@ function getActiveSwipeExtra(message) {
  * @param {string} [options.reasoning] Reasoning text to count separately.
  * @param {number} [options.reasoningTokens] Provider-reported reasoning token count, if available.
  * @param {boolean} [options.countOutput=true] Whether to refresh the visible output token count.
- * @param {boolean} [options.countReasoning=options.countOutput] Whether to estimate reasoning tokens when the provider did not report them.
+ * @param {boolean} [options.countReasoning=options.countOutput] Whether to count reasoning text locally.
  * @returns {Promise<{outputTokens: number, reasoningTokens: number}>}
  */
 export async function updateReasoningTokenAccounting(
@@ -64,10 +64,12 @@ export async function updateReasoningTokenAccounting(
         message.extra.token_count = outputTokens;
     }
 
-    let countedReasoningTokens = getPositiveTokenCount(reasoningTokens);
+    const providerReasoningTokens = getPositiveTokenCount(reasoningTokens);
+    let countedReasoningTokens = providerReasoningTokens;
     const reasoningText = String(reasoning ?? '');
-    if (!countedReasoningTokens && reasoningText && countReasoning) {
-        countedReasoningTokens = await countTokens(reasoningText);
+    if (reasoningText && countReasoning) {
+        const localReasoningTokens = getPositiveTokenCount(await countTokens(reasoningText));
+        countedReasoningTokens = Math.max(providerReasoningTokens, localReasoningTokens);
     }
 
     message.extra.reasoning_tokens = countedReasoningTokens;

--- a/tests/reasoning-token-accounting.test.js
+++ b/tests/reasoning-token-accounting.test.js
@@ -31,7 +31,7 @@ describe('reasoning token accounting', () => {
         expect(countTokens).toHaveBeenNthCalledWith(2, 'Hidden chain of thought');
     });
 
-    test('preserves provider-reported reasoning tokens', async () => {
+    test('keeps provider-reported reasoning tokens when they exceed local count', async () => {
         const message = {
             mes: 'Visible output',
             extra: {
@@ -50,8 +50,31 @@ describe('reasoning token accounting', () => {
         expect(result).toEqual({ outputTokens: 2, reasoningTokens: 17 });
         expect(message.extra.token_count).toBe(2);
         expect(message.extra.reasoning_tokens).toBe(17);
-        expect(countTokens).toHaveBeenCalledTimes(1);
-        expect(countTokens).toHaveBeenCalledWith('Visible output');
+        expect(countTokens).toHaveBeenNthCalledWith(1, 'Visible output');
+        expect(countTokens).toHaveBeenNthCalledWith(2, 'Provider thought text');
+    });
+
+    test('uses local reasoning count when provider count is lower', async () => {
+        const message = {
+            mes: 'Visible output',
+            extra: {
+                reasoning: 'Locally counted thought text',
+                reasoning_tokens: 1,
+            },
+        };
+        const countTokens = jest.fn(async text => text.split(/\s+/).filter(Boolean).length);
+
+        const result = await updateReasoningTokenAccounting(message, {
+            countTokens,
+            reasoning: message.extra.reasoning,
+            reasoningTokens: message.extra.reasoning_tokens,
+        });
+
+        expect(result).toEqual({ outputTokens: 2, reasoningTokens: 4 });
+        expect(message.extra.token_count).toBe(2);
+        expect(message.extra.reasoning_tokens).toBe(4);
+        expect(countTokens).toHaveBeenNthCalledWith(1, 'Visible output');
+        expect(countTokens).toHaveBeenNthCalledWith(2, 'Locally counted thought text');
     });
 
     test('can avoid local reasoning estimation when token counting is disabled', async () => {


### PR DESCRIPTION
## Summary
- count local reasoning text when available and store the larger of provider-reported and locally counted reasoning tokens
- keep higher provider-reported reasoning counts intact
- add regression coverage for underreported provider counts

## Tests
- `npm ci && node --experimental-vm-modules node_modules/jest/bin/jest.js reasoning-token-accounting.test.js --config jest.config.json` from `tests/`