### PR TITLE
fix: show tracked branch when local branch is unresolved

### DIFF
--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -8850,9 +8850,13 @@ function renderServerAdminStatus(data) {
         className: 'text_pole',
         attrs: { style: 'width: 100%; max-width: 200px;' },
     });
-    const currentBranch = repository?.displayBranch || repository?.branch || version?.gitBranch || 'Unknown';
-    const currentOption = createElement('option', { attrs: { value: currentBranch, selected: 'selected' } });
-    currentOption.textContent = currentBranch;
+    const currentBranch = repository?.displayBranch || repository?.branch || version?.gitBranch || '';
+    const currentOptionAttributes = { value: currentBranch, selected: 'selected' };
+    if (!currentBranch) {
+        currentOptionAttributes.disabled = 'disabled';
+    }
+    const currentOption = createElement('option', { attrs: currentOptionAttributes });
+    currentOption.textContent = currentBranch || 'Unknown';
     branchSelect.appendChild(currentOption);
     branchValue.appendChild(branchSelect);
     branchContainer.append(branchLabel, branchValue);

--- a/src/server-admin-git.js
+++ b/src/server-admin-git.js
@@ -27,7 +27,7 @@ export function getStatusDisplayBranch(branch, trackingBranch) {
     const currentBranch = String(branch ?? '').trim();
     const upstreamBranch = String(trackingBranch ?? '').trim();
 
-    if (currentBranch.startsWith(RUNTIME_BRANCH_PREFIX) && upstreamBranch) {
+    if ((!currentBranch || currentBranch === 'HEAD' || currentBranch.startsWith(RUNTIME_BRANCH_PREFIX)) && upstreamBranch) {
         return getRemoteBranchDisplayName(upstreamBranch);
     }
 

--- a/tests/server-admin-git.test.js
+++ b/tests/server-admin-git.test.js
@@ -24,6 +24,12 @@ describe('server admin git helpers', () => {
         expect(getStatusDisplayBranch('feature/admin-git', 'origin/feature/admin-git')).toBe('feature/admin-git');
     });
 
+    test('uses the tracked remote when Git cannot report a local branch name', () => {
+        expect(getStatusDisplayBranch('HEAD', 'origin/staging')).toBe('staging');
+        expect(getStatusDisplayBranch('', 'origin/main')).toBe('main');
+        expect(getStatusDisplayBranch('HEAD', '')).toBe('HEAD');
+    });
+
     test('lists display names from remote branch summaries', () => {
         const remoteBranches = getRemoteBranchesFromSummary({
             branches: {


### PR DESCRIPTION
## Summary
- Show the tracked remote branch when Git reports an unresolved local branch name like HEAD or an empty value
- Keep runtime worktree display behavior intact
- Avoid treating Unknown as a selectable branch when repository metadata is unavailable

## Tests
- bun test tests/server-admin-git.test.js
- npm run lint
- git diff --check

Note: npx jest --config tests/jest.config.json tests/server-admin-git.test.js was not usable because this repo does not declare Jest and transient npx Jest failed with an incompatible runtime error.