### PR TITLE
chore: release v1.6.2

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -56,6 +56,7 @@ These screenshots show the graphical shell UI across Workspace, Customize, Agent
 * [Project Goals](#project-goals-aka-why-we-made-this-fork)
 * [Changes Compared to SillyTavern](#changes-vs-sillytavern)
 * [Latest Update](#latest-update)
+    * [v1.6.2 (2026-06-03)](#v162-2026-06-03)
     * [v1.6.1 (2026-06-02)](#v161-2026-06-02)
     * [v1.6.0 (2026-05-18)](#v160-2026-05-18)
     * [v1.5.3 (2026-05-03)](#v153-2026-05-03)
@@ -222,6 +223,31 @@ SillyBunny includes some extras by default to help you get started right away:
 ---
 
 ## Latest Update
+
+### v1.6.2 (2026-06-03)
+
+This update tightens Bun/client-disconnect cancellation, mobile API/model picking, mobile shell scaling, reasoning token accounting, and Server Admin branch reporting for the 1.6 line.
+
+**Fixed**
+* Bun-safe request cancellation now aborts upstream generation, image, and provider work when the request, response, or socket disconnects without logging expected disconnects as provider failures.
+* Streaming disconnect cleanup now handles Bun raw abort reasons cleanly.
+* Thought and reasoning token totals now use the higher of provider-reported and locally counted reasoning tokens.
+* Server Admin now shows the tracked branch when Git reports an unresolved local branch.
+* Mobile shell rail buttons now scale with the Mobile Button Size slider.
+
+**Added**
+* Mobile-friendly inline and native picker controls for OpenRouter models, sorts, providers, quantizations, middle-out behavior, and searchable model ID rows.
+* Request-cancellation verification and regression coverage for cancellation, mobile shell button scaling, reasoning token accounting, and branch fallback behavior.
+
+**Removed**
+* No user-facing features were removed in this release.
+
+**Improved**
+* Touch and narrow-screen API/model dropdowns avoid Select2 keyboard traps by using inline or native picker behavior where appropriate.
+* Character drawer routing, header copy, empty editor copy, and import intro text are clearer across mobile and desktop panel layouts.
+* Navigation defaults return to a labeled horizontal layout, while vertical icon-only navigation remains opt-in.
+* Side rails can derive shortcuts from all registered Workspace and Customize tabs when rail shortcuts are enabled.
+* Updated app, Horde client, bundled extension, package, lockfile, README mirror, release notes, Discord summary, and test metadata to 1.6.2.
 
 ### v1.6.1 (2026-06-02)
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ These screenshots show the graphical shell UI across Workspace, Customize, Agent
 * [Project Goals](#project-goals-aka-why-we-made-this-fork)
 * [Changes Compared to SillyTavern](#changes-vs-sillytavern)
 * [Latest Update](#latest-update)
+    * [v1.6.2 (2026-06-03)](#v162-2026-06-03)
     * [v1.6.1 (2026-06-02)](#v161-2026-06-02)
     * [v1.6.0 (2026-05-18)](#v160-2026-05-18)
     * [v1.5.3 (2026-05-03)](#v153-2026-05-03)
@@ -220,6 +221,31 @@ SillyBunny includes some extras by default to help you get started right away:
 ---
 
 ## Latest Update
+
+### v1.6.2 (2026-06-03)
+
+This update tightens Bun/client-disconnect cancellation, mobile API/model picking, mobile shell scaling, reasoning token accounting, and Server Admin branch reporting for the 1.6 line.
+
+**Fixed**
+* Bun-safe request cancellation now aborts upstream generation, image, and provider work when the request, response, or socket disconnects without logging expected disconnects as provider failures.
+* Streaming disconnect cleanup now handles Bun raw abort reasons cleanly.
+* Thought and reasoning token totals now use the higher of provider-reported and locally counted reasoning tokens.
+* Server Admin now shows the tracked branch when Git reports an unresolved local branch.
+* Mobile shell rail buttons now scale with the Mobile Button Size slider.
+
+**Added**
+* Mobile-friendly inline and native picker controls for OpenRouter models, sorts, providers, quantizations, middle-out behavior, and searchable model ID rows.
+* Request-cancellation verification and regression coverage for cancellation, mobile shell button scaling, reasoning token accounting, and branch fallback behavior.
+
+**Removed**
+* No user-facing features were removed in this release.
+
+**Improved**
+* Touch and narrow-screen API/model dropdowns avoid Select2 keyboard traps by using inline or native picker behavior where appropriate.
+* Character drawer routing, header copy, empty editor copy, and import intro text are clearer across mobile and desktop panel layouts.
+* Navigation defaults return to a labeled horizontal layout, while vertical icon-only navigation remains opt-in.
+* Side rails can derive shortcuts from all registered Workspace and Customize tabs when rail shortcuts are enabled.
+* Updated app, Horde client, bundled extension, package, lockfile, README mirror, release notes, Discord summary, and test metadata to 1.6.2.
 
 ### v1.6.1 (2026-06-02)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## v1.6.2
+
+Date: 2026-06-03
+
+This update tightens Bun/client-disconnect cancellation, mobile navigation scaling, mobile API/model selection, reasoning token accounting, and Server Admin branch reporting for the 1.6 line.
+
+### Fixed
+- Bun-safe request cancellation now aborts upstream generation, image, and provider requests when the request, response, or socket disconnects without reporting expected client disconnects as provider failures.
+- Streaming disconnect cleanup now treats Bun raw abort reasons as expected cancellation, keeping provider logs quieter after users stop or leave a stream.
+- Thought and reasoning token totals now use the higher of provider-reported reasoning tokens and locally counted reasoning text so counts are no longer underreported.
+- Server Admin now shows the tracked remote branch when Git reports an empty branch, `HEAD`, or a runtime branch prefix.
+- Mobile shell rail buttons now scale down correctly with the Mobile Button Size slider instead of staying pinned to hardcoded rail dimensions.
+
+### Added
+- A reusable request-cancellation observer, verification script, and regression tests for request, response, and socket disconnect paths.
+- Mobile-friendly inline and native picker controls for OpenRouter models, sorts, providers, quantizations, middle-out behavior, and searchable model ID rows on touch or narrow screens.
+- Regression coverage for request cancellation, mobile shell button scaling, reasoning token accounting, and Server Admin branch fallback behavior.
+
+### Removed
+- No user-facing features were removed in this release.
+
+### Improved
+- Touch and narrow-screen API/model dropdowns now avoid Select2 keyboard traps by preferring inline or native picker behavior where appropriate.
+- Character drawer routing, header copy, empty editor copy, and import intro text are clearer and more resilient across mobile and desktop panel layouts.
+- Mobile and desktop navigation defaults return to a labeled horizontal layout, while vertical icon-only navigation remains opt-in.
+- Side rails can derive shortcuts from all registered Workspace and Customize tabs when rail shortcuts are enabled.
+- Shell cache keys and release metadata were refreshed for the 1.6.2 assets.
+
+### Merged Staging PRs
+- PR #313 (2026-06-02) `fix: Bun request cancellation propagation`
+- PR #314 (2026-06-02) `fix: harden streaming disconnect cancellation`
+- PR #316 (2026-06-03) `fix: scale mobile shell buttons with Mobile Button Size slider`
+- PR #317 (2026-06-03) `fix: correct underreported thought token counts`
+- PR #318 (2026-06-03) `fix: show tracked branch when local branch is unresolved`
+
+### Local Staging Commits
+- 1f828ed (2026-06-03) `fix: polish menu layout and mobile dropdowns`
+
+### Release Metadata
+- Updated app, Horde client, bundled extension, package, lockfile, README mirror, release notes, Discord summary, and test metadata to 1.6.2.
+
 ## v1.6.1
 
 Date: 2026-06-02
@@ -135,12 +176,6 @@ This update keeps the 1.6 series moving with safer chat lifecycle defaults, stro
 - PR #310 (2026-06-02) `fix: sync reverse proxy preset when chat completion source changes`
 - PR #311 (2026-06-02) `chore: sync Quick Image Gen v2.0.10`
 - PR #312 (2026-06-02) `fix: close release readiness blockers`
-- PR #313 (2026-06-02) `fix: Bun request cancellation propagation`
-- PR #314 (2026-06-02) `fix: harden streaming disconnect cancellation`
-- PR #316 (2026-06-03) `fix: scale mobile shell buttons with Mobile Button Size slider`
-- PR #317 (2026-06-03) `fix: correct underreported thought token counts`
-- PR #318 (2026-06-03) `fix: show tracked branch when local branch is unresolved`
-
 ## v1.6.0
 
 Date: 2026-05-18

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sillybunny",
-    "version": "1.6.1",
+    "version": "1.6.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sillybunny",
-            "version": "1.6.1",
+            "version": "1.6.2",
             "license": "AGPL-3.0",
             "dependencies": {
                 "@adobe/css-tools": "^4.4.4",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
         "type": "git",
         "url": "https://github.com/platberlitz/SillyBunny.git"
     },
-    "version": "1.6.1",
+    "version": "1.6.2",
     "scripts": {
         "start": "bun server.js",
         "start:node": "node --no-warnings server.js",

--- a/public/script.js
+++ b/public/script.js
@@ -505,7 +505,7 @@ export let isChatSaving = false;
 export let firstRun = false;
 export let settingsReady = false;
 let currentVersion = '0.0.0';
-const SILLYBUNNY_UI_VERSION = 'SillyBunny v1.6.1';
+const SILLYBUNNY_UI_VERSION = 'SillyBunny v1.6.2';
 
 export let displayVersion = SILLYBUNNY_UI_VERSION;
 
@@ -548,7 +548,7 @@ export function getSillyBunnyFrontendIconSrc({ absolute = false } = {}) {
 export let system_avatar = getSillyBunnyFrontendIconSrc();
 export const comment_avatar = 'img/quill.png';
 export const default_user_avatar = 'img/user-default.png';
-export let CLIENT_VERSION = 'SillyBunny:v1.6.1:platberlitz'; // For Horde header
+export let CLIENT_VERSION = 'SillyBunny:v1.6.2:platberlitz'; // For Horde header
 
 function applySillyBunnyFrontendIcon(iconId = getStoredSillyBunnyFrontendIcon()) {
     const normalizedIconId = normalizeSillyBunnyFrontendIcon(iconId);

--- a/public/scripts/extensions/gallery/manifest.json
+++ b/public/scripts/extensions/gallery/manifest.json
@@ -7,7 +7,7 @@
     "js": "index.js",
     "css": "style.css",
     "author": "City-Unit",
-    "version": "1.6.1",
+    "version": "1.6.2",
     "homePage": "https://github.com/SillyTavern/SillyTavern",
     "hooks": {
         "activate": "init"

--- a/public/scripts/extensions/in-chat-agents/manifest.json
+++ b/public/scripts/extensions/in-chat-agents/manifest.json
@@ -6,6 +6,6 @@
     "js": "index.js",
     "css": "style.css",
     "author": "SillyBunny",
-    "version": "1.6.1",
+    "version": "1.6.2",
     "homePage": "https://github.com/platberlitz/SillyBunny"
 }

--- a/public/scripts/extensions/input-history/manifest.json
+++ b/public/scripts/extensions/input-history/manifest.json
@@ -6,7 +6,7 @@
     "js": "index.js",
     "css": "style.css",
     "author": "LenAnderson",
-    "version": "1.6.1",
+    "version": "1.6.2",
     "homePage": "https://github.com/LenAnderson/SillyTavern-InputHistory",
     "manifest_version": 3
 }

--- a/releases/sillybunny-v1.6.2-discord-post.md
+++ b/releases/sillybunny-v1.6.2-discord-post.md
@@ -1,0 +1,19 @@
+**SillyBunny version 1.6.2 has released**
+This release tightens Bun/client-disconnect cancellation, mobile API and model picking, mobile shell scaling, reasoning token accounting, and Server Admin branch reporting for the 1.6 line.
+
+**Detailed Changelog**
+- Bun-safe request cancellation now aborts upstream generation, image, and provider work when the request, response, or socket disconnects without logging expected disconnects as provider failures.
+- Streaming disconnect cleanup now handles Bun raw abort reasons cleanly.
+- Thought and reasoning token totals now use the higher of provider-reported and locally counted reasoning tokens.
+- Server Admin now shows the tracked branch when Git reports an unresolved local branch.
+- Mobile shell rail buttons now scale with the Mobile Button Size slider.
+- Mobile-friendly inline and native picker controls improve OpenRouter model, sort, provider, quantization, middle-out, and searchable model ID selection on touch or narrow screens.
+- Character drawer routing, header copy, empty editor copy, and import intro text are clearer across mobile and desktop panel layouts.
+- Navigation defaults return to a labeled horizontal layout, while vertical icon-only navigation remains opt-in.
+- Side rails can derive shortcuts from all registered Workspace and Customize tabs when rail shortcuts are enabled.
+
+**How to update**
+- Built-in updater: open Customize > Server and update from there.
+- Git clone: run `git pull`.
+- Launcher users: close and reopen Start.bat, Start.command, or start.sh.
+- ZIP users: grab the new release directly.

--- a/src/endpoints/horde.js
+++ b/src/endpoints/horde.js
@@ -15,7 +15,7 @@ export const router = express.Router();
  */
 async function getClientAgent() {
     const version = await getVersion();
-    return version?.agent || 'SillyBunny:1.6.1:platberlitz';
+    return version?.agent || 'SillyBunny:1.6.2:platberlitz';
 }
 
 /**

--- a/tests/extensions-disable.test.js
+++ b/tests/extensions-disable.test.js
@@ -44,7 +44,7 @@ function installExtensionModuleMocks() {
     }));
 
     jest.unstable_mockModule('../public/script.js', () => ({
-        CLIENT_VERSION: 'SillyBunny:v1.6.1',
+        CLIENT_VERSION: 'SillyBunny:v1.6.2',
         animation_duration: 0,
         eventSource: { emit: jest.fn(async () => {}) },
         event_types: { EXTENSIONS_FIRST_LOAD: 'extensions_first_load', EXTRAS_CONNECTED: 'extras_connected', EXTENSION_SETTINGS_LOADED: 'extension_settings_loaded' },


### PR DESCRIPTION
## Summary
- Bump app-owned SillyBunny version metadata to 1.6.2.
- Add the v1.6.2 changelog from post-v1.6.1 staging work to changelog.md and README.md.
- Sync the GitHub README mirror and add the Discord release post.

## Testing
- bash scripts/sync-readme-mirror.sh check
- git diff --check
- node -e "const fs = require('fs'); for (const f of ['package.json','package-lock.json','public/scripts/extensions/gallery/manifest.json','public/scripts/extensions/in-chat-agents/manifest.json','public/scripts/extensions/input-history/manifest.json']) JSON.parse(fs.readFileSync(f, 'utf8'));"
- npm run lint