### PR TITLE
fix: restore character lorebook dropdown visibility

### DIFF
--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -2246,7 +2246,8 @@ input[type='range']::-moz-range-thumb {
     pointer-events: auto;
 }
 
-:is(#select2-world_info-results, #select2-world_editor_select-results) {
+:is(#select2-world_info-results, #select2-world_editor_select-results),
+.sb-world-info-select2-dropdown > .select2-results > .select2-results__options {
     display: block;
     min-height: var(--sb-field-min-height);
     max-height: min(320px, 42vh);
@@ -2256,7 +2257,8 @@ input[type='range']::-moz-range-thumb {
     background-image: linear-gradient(var(--SmartThemeBlurTintColor), var(--SmartThemeBlurTintColor));
 }
 
-:is(#select2-world_info-results, #select2-world_editor_select-results) .select2-results__option {
+:is(#select2-world_info-results, #select2-world_editor_select-results) .select2-results__option,
+.sb-world-info-select2-dropdown .select2-results__option {
     display: block;
     min-height: 32px;
     padding: 8px 12px 8px 30px;
@@ -2267,7 +2269,8 @@ input[type='range']::-moz-range-thumb {
     pointer-events: auto;
 }
 
-:is(#select2-world_info-results, #select2-world_editor_select-results) .select2-results__option--selected {
+:is(#select2-world_info-results, #select2-world_editor_select-results) .select2-results__option--selected,
+.sb-world-info-select2-dropdown .select2-results__option--selected {
     background-color: #11151c;
     background-image: linear-gradient(
         color-mix(in srgb, var(--color-primary, var(--sb-accent)) 18%, var(--SmartThemeBlurTintColor) 82%),
@@ -2275,7 +2278,8 @@ input[type='range']::-moz-range-thumb {
     );
 }
 
-:is(#select2-world_info-results, #select2-world_editor_select-results) .select2-results__option--highlighted[aria-selected] {
+:is(#select2-world_info-results, #select2-world_editor_select-results) .select2-results__option--highlighted[aria-selected],
+.sb-world-info-select2-dropdown .select2-results__option--highlighted[aria-selected] {
     background-color: #11151c;
     background-image: linear-gradient(
         color-mix(in srgb, var(--color-primary, var(--sb-accent)) 28%, var(--SmartThemeBlurTintColor) 72%),

--- a/public/script.js
+++ b/public/script.js
@@ -13923,6 +13923,7 @@ async function openCharacterWorldPopup() {
                 extrasSelect.select2({
                     width: '100%',
                     placeholder: t`No auxiliary Lorebooks set. Click here to select.`,
+                    dropdownCssClass: 'sb-world-info-select2-dropdown',
                     allowClear: true,
                     closeOnSelect: false,
                     dropdownParent: popupDialog,

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -3250,6 +3250,7 @@ function initCharacterFilterSelect2Helper(characterFilter) {
         $(characterFilter).select2({
             width: '100%',
             placeholder: t`Tie this entry to specific characters or characters with specific tags`,
+            dropdownCssClass: 'sb-world-info-select2-dropdown',
             allowClear: true,
             closeOnSelect: false,
         });
@@ -4012,6 +4013,7 @@ export async function getWorldEntry(name, data, entry, options = {}) {
             generationTypeTriggers.select2({
                 placeholder: t`All types (default)`,
                 width: '100%',
+                dropdownCssClass: 'sb-world-info-select2-dropdown',
                 closeOnSelect: false,
                 allowClear: true,
             });


### PR DESCRIPTION
## Summary
- Apply the existing World Info Select2 dropdown visibility styling to the character auxiliary lorebook picker.
- Tag the popup Select2 dropdown with a stable class instead of relying on generated Select2 result IDs.

## Verification
- git diff --check
- node --check public/script.js