### PR TITLE
feat: add aggressive DOM unloading for low-memory devices

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5448,6 +5448,24 @@
                                 </label>
                             </div>
 
+                            <!-- SillyBunny: aggressive DOM unloading for low-memory devices -->
+                            <div name="AggressiveDomUnloadToggles">
+                                <h4><span data-i18n="Aggressive DOM Unloading">Aggressive DOM Unloading</span></h4>
+                                <small data-i18n="Aggressive DOM Unloading_desc">Drastically reduces rendered messages to prevent crashes on low-memory devices during long streams.</small>
+                                <label class="checkbox_label" for="aggressive_dom_unload" title="Enable aggressive DOM unloading to keep only a minimal number of messages rendered. Useful for devices that crash during long streaming generations." data-i18n="[title]Enable aggressive DOM unloading to keep only a minimal number of messages rendered. Useful for devices that crash during long streaming generations.">
+                                    <input id="aggressive_dom_unload" type="checkbox" />
+                                    <small data-i18n="Enable aggressive unloading">Enable aggressive unloading</small>
+                                </label>
+                                <div class="alignitemscenter flex-container flexFlowColumn flexBasis48p flexGrow flexShrink gap0">
+                                    <small>
+                                        <span data-i18n="Messages to keep">Messages to keep</span>
+                                        <div class="fa-solid fa-circle-info opacity50p" data-i18n="[title]Number of messages to keep rendered when aggressive unloading is enabled. Lower values use less memory." title="Number of messages to keep rendered when aggressive unloading is enabled. Lower values use less memory."></div>
+                                    </small>
+                                    <input class="neo-range-slider" type="range" id="aggressive_dom_window_size" name="aggressive_dom_window_size" min="1" max="25" step="1">
+                                    <input class="neo-range-input" type="number" min="1" max="25" step="1" data-for="aggressive_dom_window_size" id="aggressive_dom_window_size_counter">
+                                </div>
+                            </div>
+
                             <label for="play_message_sound" class="checkbox_label" title="Play a sound when a message generation finishes." data-i18n="[title]Play a sound when a message generation finishes">
                                 <input id="play_message_sound" type="checkbox" />
                                 <audio id="audio_message_sound" src="sounds/message.mp3" hidden></audio>

--- a/public/script.js
+++ b/public/script.js
@@ -2679,6 +2679,11 @@ const CHAT_HISTORY_NEWER_BUTTON_ID = 'show_newer_messages';
 const CHAT_HISTORY_WINDOW_CONTROL_SELECTOR = `#${CHAT_HISTORY_OLDER_BUTTON_ID}, #${CHAT_HISTORY_NEWER_BUTTON_ID}`;
 
 function getChatRenderWindowSize(requestedSize = power_user.chat_truncation) {
+    // SillyBunny: aggressive DOM unloading for low-memory devices (e.g., iPhones crashing on long streams)
+    if (power_user.aggressive_dom_unload) {
+        const aggressiveSize = power_user.aggressive_dom_window_size || 5;
+        return normalizeChatRenderWindowSize(aggressiveSize, { maxSize: aggressiveSize });
+    }
     // SillyBunny: prevent long chats from using 0/huge truncation values to render every message into the DOM.
     return normalizeChatRenderWindowSize(requestedSize);
 }

--- a/public/scripts/chat-render-lifecycle/index.js
+++ b/public/scripts/chat-render-lifecycle/index.js
@@ -28,6 +28,7 @@ import {
 import {
     CHAT_RENDER_WINDOW_DEFAULT,
     CHAT_RENDER_WINDOW_MAX,
+    CHAT_RENDER_WINDOW_AGGRESSIVE_DEFAULT,
     getChatHistoryPageSize,
     getChatRenderWindowStartIndex,
     normalizeChatRenderWindowSize,
@@ -52,6 +53,7 @@ export {
     CHAT_RENDER_LIFECYCLE_ROUTE_DEFAULTS,
     CHAT_RENDER_WINDOW_DEFAULT,
     CHAT_RENDER_WINDOW_MAX,
+    CHAT_RENDER_WINDOW_AGGRESSIVE_DEFAULT,
     CHAT_SCROLL_ACTION,
     CHAT_SCROLL_INTENT,
     captureVisibleMessageAnchor,

--- a/public/scripts/chat-render-lifecycle/render-window.js
+++ b/public/scripts/chat-render-lifecycle/render-window.js
@@ -1,5 +1,7 @@
 export const CHAT_RENDER_WINDOW_DEFAULT = 100;
 export const CHAT_RENDER_WINDOW_MAX = 200;
+// SillyBunny: aggressive DOM unloading for low-memory devices (e.g., iPhones crashing on long streams)
+export const CHAT_RENDER_WINDOW_AGGRESSIVE_DEFAULT = 5;
 
 /**
  * Keeps chat DOM windows bounded even when older settings used 0 as "render everything".

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -274,6 +274,10 @@ export const power_user = {
     ios_webkit_disable_smooth_streaming: true,
     ios_webkit_disable_stream_fade_in: true,
 
+    // SillyBunny: aggressive DOM unloading for low-memory devices
+    aggressive_dom_unload: false,
+    aggressive_dom_window_size: 5,
+
     fast_ui_mode: true,
     avatar_style: avatar_styles.ROUND,
     chat_display: chat_styles.DEFAULT,
@@ -1964,6 +1968,9 @@ export async function loadPowerUserSettings(settings, data) {
     $('#ios_webkit_reduce_streaming_work').prop('checked', power_user.ios_webkit_reduce_streaming_work);
     $('#ios_webkit_disable_smooth_streaming').prop('checked', power_user.ios_webkit_disable_smooth_streaming);
     $('#ios_webkit_disable_stream_fade_in').prop('checked', power_user.ios_webkit_disable_stream_fade_in);
+    $('#aggressive_dom_unload').prop('checked', power_user.aggressive_dom_unload);
+    $('#aggressive_dom_window_size').val(power_user.aggressive_dom_window_size);
+    $('#aggressive_dom_window_size_counter').val(power_user.aggressive_dom_window_size);
 
     $('#font_scale').val(power_user.font_scale);
     $('#font_scale_counter').val(power_user.font_scale);
@@ -3792,6 +3799,18 @@ jQuery(async () => {
 
     $('#ios_webkit_disable_stream_fade_in').on('input', function () {
         power_user.ios_webkit_disable_stream_fade_in = !!$(this).prop('checked');
+        saveSettingsDebounced();
+    });
+
+    // SillyBunny: aggressive DOM unloading for low-memory devices
+    $('#aggressive_dom_unload').on('input', function () {
+        power_user.aggressive_dom_unload = !!$(this).prop('checked');
+        saveSettingsDebounced();
+    });
+
+    $('#aggressive_dom_window_size').on('input', function () {
+        power_user.aggressive_dom_window_size = Number($(this).val());
+        $('#aggressive_dom_window_size_counter').val(power_user.aggressive_dom_window_size);
         saveSettingsDebounced();
     });
 


### PR DESCRIPTION
## Summary

Adds a new **Aggressive DOM Unloading** feature to prevent crashes on low-memory devices (e.g., iPhones) during long streaming generations.

## Problem

When streaming long messages on devices with limited memory (particularly iPhones), the page can crash because too many messages remain rendered in the DOM. The existing iOS WebKit safeguards focus on streaming work (update intervals, smooth streaming bypass) but don't address the render window size itself.

## Solution

When enabled, only a minimal number of messages (default: 5) are kept rendered in the DOM at any time, immediately pruning older messages as new content arrives.

### New Settings

Located in User Settings, below the iOS Streaming Stability section:

- **Enable aggressive unloading** (checkbox, default: off)
- **Messages to keep** (slider: 1-25, default: 5)

## Changes

| File | Change |
|------|--------|
| `public/scripts/power-user.js` | Add `aggressive_dom_unload` and `aggressive_dom_window_size` settings with event handlers |
| `public/scripts/chat-render-lifecycle/render-window.js` | Add `CHAT_RENDER_WINDOW_AGGRESSIVE_DEFAULT` constant |
| `public/scripts/chat-render-lifecycle/index.js` | Export the new constant |
| `public/script.js` | Modify `getChatRenderWindowSize()` to use aggressive window when enabled |
| `public/index.html` | Add UI controls in User Settings |

## Testing

- [x] Syntax check passes on all modified JS files
- [ ] Manual testing on iOS device with long streaming generation

## Notes

- This feature is platform-agnostic (available to all devices, not just iOS)
- Works alongside existing iOS WebKit safeguards
- Uses the existing render window infrastructure, just with a much smaller cap