### PR TITLE
feat: Add helper prefill fields

### DIFF
--- a/public/scripts/extensions/guided-generations/index.js
+++ b/public/scripts/extensions/guided-generations/index.js
@@ -28,6 +28,7 @@ const defaultSettings = {
     promptGuidedSwipe: '[Take the following into special consideration for your next message: {{input}}]',
     promptGuidedCorrection: '[Apply the following correction to your previous message: {{input}}]',
     promptImpersonate1st: 'Write in first Person perspective from {{user}}. {{input}}',
+    helperPrefillMessages: '',
     depthPromptGuidedResponse: 0,
     depthPromptGuidedSwipe: 0,
     depthPromptGuidedCorrection: 0,

--- a/public/scripts/extensions/guided-generations/scripts/guidedImpersonate.js
+++ b/public/scripts/extensions/guided-generations/scripts/guidedImpersonate.js
@@ -16,6 +16,10 @@ import {
     serializeHelperPrefillForPrompt,
 } from '../../helper-prefill.js';
 
+function escapeSlashCommandDelimiters(value) {
+    return String(value ?? '').replace(/\|/g, '\\|');
+}
+
 async function guidedImpersonate() {
     const textarea = document.getElementById('send_textarea');
     if (!(textarea instanceof HTMLTextAreaElement)) {
@@ -46,7 +50,7 @@ async function guidedImpersonate() {
         .map(value => String(value ?? '').trim())
         .filter(Boolean)
         .join('\n\n');
-    const fullScript = `// Impersonate guide|\n/impersonate await=true ${impersonatePrompt} |`;
+    const fullScript = `// Impersonate guide|\n/impersonate await=true ${escapeSlashCommandDelimiters(impersonatePrompt)} |`;
 
     try {
         await switching.switch();

--- a/public/scripts/extensions/guided-generations/scripts/guidedImpersonate.js
+++ b/public/scripts/extensions/guided-generations/scripts/guidedImpersonate.js
@@ -11,6 +11,10 @@ import {
     setLastImpersonateResult,
     setPreviousImpersonateInput,
 } from './shared.js';
+import {
+    parseHelperPrefillMessages,
+    serializeHelperPrefillForPrompt,
+} from '../../helper-prefill.js';
 
 async function guidedImpersonate() {
     const textarea = document.getElementById('send_textarea');
@@ -37,7 +41,12 @@ async function guidedImpersonate() {
     const switching = await handleSwitching(profileValue, presetValue, originalProfile);
     const promptTemplate = settings.promptImpersonate1st ?? '';
     const filledPrompt = applyPromptTemplate(promptTemplate, currentInputText);
-    const fullScript = `// Impersonate guide|\n/impersonate await=true ${filledPrompt} |`;
+    const helperPrefillPrompt = serializeHelperPrefillForPrompt(parseHelperPrefillMessages(settings.helperPrefillMessages));
+    const impersonatePrompt = [filledPrompt, helperPrefillPrompt]
+        .map(value => String(value ?? '').trim())
+        .filter(Boolean)
+        .join('\n\n');
+    const fullScript = `// Impersonate guide|\n/impersonate await=true ${impersonatePrompt} |`;
 
     try {
         await switching.switch();

--- a/public/scripts/extensions/guided-generations/settings.html
+++ b/public/scripts/extensions/guided-generations/settings.html
@@ -92,6 +92,11 @@
                     <button type="button" id="gg_refreshProfiles" class="menu_button menu_button_icon fa-solid fa-rotate" title="Refresh profiles and presets"></button>
                 </div>
             </div>
+
+            <div class="setting_item">
+                <label for="gg_helperPrefillMessages">Helper prefill messages</label>
+                <textarea id="gg_helperPrefillMessages" name="helperPrefillMessages" class="gg-setting-input text_pole gg-prompt-field" rows="4"></textarea>
+            </div>
         </div>
     </div>
 </div>

--- a/public/scripts/extensions/helper-prefill.js
+++ b/public/scripts/extensions/helper-prefill.js
@@ -1,0 +1,86 @@
+const ROLE_HEADER_RE = /^\s*\[(system|user|assistant)\]\s*$/i;
+const VALID_ROLES = new Set(['system', 'user', 'assistant']);
+
+function normalizeRole(value) {
+    const role = String(value ?? '').trim().toLowerCase();
+    return VALID_ROLES.has(role) ? role : 'assistant';
+}
+
+function normalizeContent(value) {
+    return String(value ?? '').replace(/\r\n/g, '\n').replace(/\r/g, '\n').trim();
+}
+
+/**
+ * Parses textarea role blocks into chat-style helper messages.
+ *
+ * @param {string} value
+ * @returns {{role: 'system'|'user'|'assistant', content: string}[]}
+ */
+export function parseHelperPrefillMessages(value = '') {
+    const lines = String(value ?? '').replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
+    const messages = [];
+    let currentRole = 'assistant';
+    let currentLines = [];
+
+    const flush = () => {
+        const content = normalizeContent(currentLines.join('\n'));
+        if (content) {
+            messages.push({ role: currentRole, content });
+        }
+        currentLines = [];
+    };
+
+    for (const line of lines) {
+        const roleMatch = line.match(ROLE_HEADER_RE);
+        if (roleMatch) {
+            flush();
+            currentRole = normalizeRole(roleMatch[1]);
+            continue;
+        }
+
+        currentLines.push(line);
+    }
+
+    flush();
+    return messages;
+}
+
+/**
+ * Appends configured helper prefill messages to a synthetic helper prompt.
+ *
+ * @param {object[]} messages
+ * @param {string} prefillText
+ * @returns {object[]}
+ */
+export function appendHelperPrefillMessages(messages, prefillText = '') {
+    const baseMessages = Array.isArray(messages)
+        ? messages.filter(message => message && typeof message === 'object').map(message => ({ ...message }))
+        : [];
+    const prefillMessages = parseHelperPrefillMessages(prefillText);
+
+    if (prefillMessages.length === 0) {
+        return baseMessages;
+    }
+
+    return [...baseMessages, ...prefillMessages];
+}
+
+/**
+ * Converts helper prefill messages to labeled prompt text for prompt-only paths.
+ *
+ * @param {{role?: string, content?: unknown}[]} messages
+ * @returns {string}
+ */
+export function serializeHelperPrefillForPrompt(messages = []) {
+    return (Array.isArray(messages) ? messages : [])
+        .map(message => {
+            const content = normalizeContent(message?.content);
+            if (!content) {
+                return '';
+            }
+
+            return `${normalizeRole(message?.role).toUpperCase()}:\n${content}`;
+        })
+        .filter(Boolean)
+        .join('\n\n');
+}

--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -37,6 +37,10 @@ import {
 import { buildFallbackPromptText, extractProfileResponseText } from './llm-utils.js';
 import { getConnectionProfileDisplayName, getConnectionProfileModelName } from './profile-utils.js';
 import {
+    appendHelperPrefillMessages,
+    parseHelperPrefillMessages,
+} from '../helper-prefill.js';
+import {
     getToolAction,
     getToolFormatter,
 } from './tool-action-registry.js';
@@ -2689,7 +2693,27 @@ function consolidateAppendPromptTransformOutputs(baseText, agents, results) {
     };
 }
 
-function getUserFinalPromptTransformMessages(promptMessages) {
+function getConfiguredHelperPrefillText() {
+    return getGlobalSettings()?.helperPrefillMessages ?? '';
+}
+
+function appendConfiguredHelperPrefillMessages(promptMessages) {
+    const helperPrefillText = getConfiguredHelperPrefillText();
+    const helperPrefillMessages = parseHelperPrefillMessages(helperPrefillText);
+    if (helperPrefillMessages.length === 0) {
+        return {
+            promptMessages,
+            allowAssistantPrefillTail: false,
+        };
+    }
+
+    return {
+        promptMessages: appendHelperPrefillMessages(promptMessages, helperPrefillText),
+        allowAssistantPrefillTail: helperPrefillMessages.at(-1)?.role === 'assistant',
+    };
+}
+
+function getUserFinalPromptTransformMessages(promptMessages, options = {}) {
     const messages = (Array.isArray(promptMessages) ? promptMessages : [])
         .filter(message => message && typeof message === 'object')
         .map(message => ({
@@ -2707,6 +2731,10 @@ function getUserFinalPromptTransformMessages(promptMessages) {
         return messages;
     }
 
+    if (options.allowAssistantPrefillTail && lastMessage.role === 'assistant') {
+        return messages;
+    }
+
     // Prompt-transform helper prompts are synthetic requests, not real chat/tool-call tails.
     // Keep providers that reject assistant-prefill tails happy by appending a tiny user turn
     // instead of role-flipping any existing assistant content.
@@ -2720,9 +2748,9 @@ function canUseMainChatCompletionHelper(context) {
     return context?.mainApi === 'openai' && typeof context?.generateRaw === 'function';
 }
 
-async function requestMainChatCompletionPromptTransform(context, promptMessages, maxTokens) {
+async function requestMainChatCompletionPromptTransform(context, promptMessages, maxTokens, options = {}) {
     const output = await context.generateRaw({
-        prompt: getUserFinalPromptTransformMessages(promptMessages),
+        prompt: getUserFinalPromptTransformMessages(promptMessages, options),
         api: 'openai',
         instructOverride: true,
         responseLength: maxTokens,
@@ -2796,7 +2824,7 @@ async function requestProfilePromptTransform(CMRS, profileId, promptMessages, ma
     };
 }
 
-async function requestPromptTransform(agent, promptMessages, maxTokens) {
+async function requestPromptTransform(agent, promptMessages, maxTokens, options = {}) {
     const profileId = resolveAgentConnectionProfile(agent);
     const modelOverride = typeof agent.modelOverride === 'string' ? agent.modelOverride.trim() : '';
     const context = getContext();
@@ -2825,7 +2853,7 @@ async function requestPromptTransform(agent, promptMessages, maxTokens) {
 
     if (canUseMainChatCompletionHelper(context)) {
         return await runAsInternalPromptTransform(async () =>
-            await requestMainChatCompletionPromptTransform(context, promptMessages, maxTokens),
+            await requestMainChatCompletionPromptTransform(context, promptMessages, maxTokens, options),
         );
     }
 
@@ -2913,13 +2941,13 @@ async function runPromptTransformAgent(agent, message, generationType, messageTe
         return result;
     }
 
-    const promptMessages = buildPromptTransformMessages(
+    const helperRequest = appendConfiguredHelperPrefillMessages(buildPromptTransformMessages(
         expandedPrompt,
         currentMessageText,
         String(message?.name ?? '').trim(),
         normalizedGenerationType,
         promptTransformMode,
-    );
+    ));
     const cancelRevision = agentGenerationCancelRevision;
     const runningToast = showNotifications
         ? showPromptTransformRunningToast(agent, promptTransformMode, profileId)
@@ -2927,7 +2955,12 @@ async function runPromptTransformAgent(agent, message, generationType, messageTe
 
     try {
         const maxTokens = normalizePromptTransformMaxTokens(agent.postProcess?.promptTransformMaxTokens);
-        const response = await requestPromptTransform(agent, promptMessages, maxTokens);
+        const response = await requestPromptTransform(
+            agent,
+            helperRequest.promptMessages,
+            maxTokens,
+            { allowAssistantPrefillTail: helperRequest.allowAssistantPrefillTail },
+        );
         const promptOutputText = unwrapAssistantResponseWrapper(response.output).trim();
 
         if (!promptOutputText) {
@@ -3831,7 +3864,9 @@ async function runContextInterceptAgent(agent, currentContextText, generationTyp
         };
     }
 
-    const promptMessages = buildContextInterceptMessages(expandedPrompt, currentContextText, generationType, contextFormat, timing);
+    const helperRequest = appendConfiguredHelperPrefillMessages(
+        buildContextInterceptMessages(expandedPrompt, currentContextText, generationType, contextFormat, timing),
+    );
     const cancelRevision = agentGenerationCancelRevision;
     const runningToast = shouldShowPreInterceptNotifications(agent)
         ? showPromptTransformRunningToast(agent, applyMode, profileId, {
@@ -3843,8 +3878,9 @@ async function runContextInterceptAgent(agent, currentContextText, generationTyp
     try {
         const response = await requestPromptTransform(
             agent,
-            promptMessages,
+            helperRequest.promptMessages,
             normalizePreProcessMaxTokens(agent.preProcess?.maxTokens),
+            { allowAssistantPrefillTail: helperRequest.allowAssistantPrefillTail },
         );
 
         if (agentGenerationCancelRevision !== cancelRevision) {

--- a/public/scripts/extensions/in-chat-agents/agent-store.js
+++ b/public/scripts/extensions/in-chat-agents/agent-store.js
@@ -130,11 +130,12 @@ let globalSettings = {
     connectionProfile: '',
     promptTransformShowNotifications: true,
     appendAgentsExecutionMode: 'parallel',
+    helperPrefillMessages: '',
 };
 
 /**
  * Returns the global settings.
- * @returns {{ enabled: boolean, pathfinderEnabled: boolean, separateRecentChats: boolean, enabledAgentIdsByChatType: Record<string, string[]>, scopedEnabledAgentIdsInitialized: boolean, connectionProfile: string, promptTransformShowNotifications: boolean, appendAgentsExecutionMode: 'parallel'|'sequential' }}
+ * @returns {{ enabled: boolean, pathfinderEnabled: boolean, separateRecentChats: boolean, enabledAgentIdsByChatType: Record<string, string[]>, scopedEnabledAgentIdsInitialized: boolean, connectionProfile: string, promptTransformShowNotifications: boolean, appendAgentsExecutionMode: 'parallel'|'sequential', helperPrefillMessages: string }}
  */
 export function getGlobalSettings() {
     return globalSettings;
@@ -152,6 +153,9 @@ export function setGlobalSettings(update) {
     Object.assign(globalSettings, update);
     globalSettings.pathfinderEnabled = globalSettings.pathfinderEnabled !== false;
     globalSettings.enabledAgentIdsByChatType = normalizeScopedEnabledAgentIds(globalSettings.enabledAgentIdsByChatType);
+    globalSettings.helperPrefillMessages = typeof globalSettings.helperPrefillMessages === 'string'
+        ? globalSettings.helperPrefillMessages
+        : '';
 
     if (!globalSettings.scopedEnabledAgentIdsInitialized) {
         const scopedSetting = update.enabledAgentIdsByChatType;

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -68,6 +68,7 @@ import { initPathfinder, teardownPathfinder } from './pathfinder-init.js';
 import { openPathfinderSettings, isPathfinderAgent } from './pathfinder-settings-ui.js';
 import { getPathfinderToolDefinitions } from './pathfinder/tool-definitions.js';
 import { buildFallbackPromptText, extractProfileResponseText } from './llm-utils.js';
+import { appendHelperPrefillMessages } from '../helper-prefill.js';
 import {
     buildConnectionProfileNameMap,
     getConnectionManagerRequestService,
@@ -3557,6 +3558,10 @@ function populateGlobalExecutionModeDropdown() {
     $('#ica--appendAgentsExecutionMode').val(mode);
 }
 
+function populateGlobalHelperPrefillField() {
+    $('#ica--helperPrefillMessages').val(getGlobalSettings().helperPrefillMessages || '');
+}
+
 /**
  * Makes an LLM call for prompt refinement, using CMRS if a profile is selected.
  * @param {string} systemPrompt
@@ -3565,10 +3570,14 @@ function populateGlobalExecutionModeDropdown() {
  */
 async function refineLLMCall(systemPrompt, userPrompt, connectionProfile = '') {
     const profileId = resolveConnectionProfile(connectionProfile);
+    const messages = appendHelperPrefillMessages([
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userPrompt },
+    ], getGlobalSettings().helperPrefillMessages);
 
     if (!profileId) {
         return await generateQuietPrompt({
-            quietPrompt: systemPrompt + '\n\n' + userPrompt,
+            quietPrompt: buildFallbackPromptText(messages),
             skipWIAN: true,
         });
     }
@@ -3577,15 +3586,10 @@ async function refineLLMCall(systemPrompt, userPrompt, connectionProfile = '') {
 
     if (!CMRS) {
         return await generateQuietPrompt({
-            quietPrompt: systemPrompt + '\n\n' + userPrompt,
+            quietPrompt: buildFallbackPromptText(messages),
             skipWIAN: true,
         });
     }
-
-    const messages = [
-        { role: 'system', content: systemPrompt },
-        { role: 'user', content: userPrompt },
-    ];
 
     try {
         const response = await CMRS.sendRequest(profileId, messages, DEFAULT_AGENT_MAX_TOKENS, {
@@ -4085,6 +4089,7 @@ async function refinePromptWithAI(currentPrompt, category, phase, connectionProf
     populateProfileDropdown();
     populateGlobalNotificationToggle();
     populateGlobalExecutionModeDropdown();
+    populateGlobalHelperPrefillField();
     $('#ica--connectionProfile').on('change', function () {
         setGlobalSettings({ connectionProfile: this.value });
         persistExtensionState();
@@ -4138,6 +4143,10 @@ async function refinePromptWithAI(currentPrompt, category, phase, connectionProf
     });
     $('#ica--appendAgentsExecutionMode').on('change', function () {
         setGlobalSettings({ appendAgentsExecutionMode: this.value });
+        persistExtensionState();
+    });
+    $('#ica--helperPrefillMessages').on('input', function () {
+        setGlobalSettings({ helperPrefillMessages: this.value });
         persistExtensionState();
     });
     $('#ica--resetDefaults').on('click', async () => {

--- a/public/scripts/extensions/in-chat-agents/settings.html
+++ b/public/scripts/extensions/in-chat-agents/settings.html
@@ -120,6 +120,10 @@
                     Order is shown on each agent card.
                 </small>
             </label>
+            <label class="ica--profile-label ica--helper-prefill-label">
+                <span>Helper Prefill Messages</span>
+                <textarea id="ica--helperPrefillMessages" class="text_pole ica--helper-prefill-field" rows="4"></textarea>
+            </label>
             <label class="checkbox_label" title="Keep enabled In-Chat Agents separate between Individual chats and Group chats.">
                 <input type="checkbox" id="ica--separateRecentChats" />
                 <span>Separate Agents Between Individual and Group Chats</span>

--- a/public/scripts/extensions/in-chat-agents/style.css
+++ b/public/scripts/extensions/in-chat-agents/style.css
@@ -835,6 +835,21 @@ button.ica--card-pill--version-update {
     flex: 1;
 }
 
+.ica--helper-prefill-label {
+    align-items: flex-start;
+}
+
+.ica--helper-prefill-label span {
+    padding-top: 8px;
+}
+
+.ica--helper-prefill-field {
+    flex: 1 1 320px;
+    width: 100%;
+    min-height: 92px;
+    resize: vertical;
+}
+
 .ica--profile-help {
     flex-basis: 100%;
     font-size: calc(var(--mainFontSize) * 0.76);

--- a/tests/guided-generations-settings.test.js
+++ b/tests/guided-generations-settings.test.js
@@ -101,4 +101,13 @@ describe('Guided Generations settings migration', () => {
         expect(extensionSettings['guided-generations'].presetImpersonate1st).toBe('My Custom Preset');
         expect(saveSettingsDebounced).not.toHaveBeenCalled();
     });
+
+    test('adds an empty helper prefill setting by default without forcing a save', async () => {
+        const { loadSettings } = await import('../public/scripts/extensions/guided-generations/index.js');
+
+        loadSettings();
+
+        expect(extensionSettings['guided-generations'].helperPrefillMessages).toBe('');
+        expect(saveSettingsDebounced).not.toHaveBeenCalled();
+    });
 });

--- a/tests/guided-generations-steering.test.js
+++ b/tests/guided-generations-steering.test.js
@@ -143,7 +143,7 @@ describe('Guided Generations steering commands', () => {
 Stay terse.
 
 [assistant]
-I`;
+I | begin`;
 
         const { guidedImpersonate } = await import('../public/scripts/extensions/guided-generations/scripts/guidedImpersonate.js');
 
@@ -153,6 +153,6 @@ I`;
         const command = context.executeSlashCommandsWithOptions.mock.calls[0][0];
         expect(command).toContain('/impersonate await=true FIRST PERSON: aim for a colder, suspicious reply');
         expect(command).toContain('SYSTEM:\nStay terse.');
-        expect(command).toContain('ASSISTANT:\nI');
+        expect(command).toContain('ASSISTANT:\nI \\| begin');
     });
 });

--- a/tests/guided-generations-steering.test.js
+++ b/tests/guided-generations-steering.test.js
@@ -136,4 +136,23 @@ describe('Guided Generations steering commands', () => {
         expect(textarea.value).toBe('aim for a colder, suspicious reply');
         expect(textarea.dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'input' }));
     });
+
+    test('guided impersonate appends helper prefill blocks to the impersonate prompt', async () => {
+        extensionSettings['guided-generations'].promptImpersonate1st = 'FIRST PERSON: {{input}}';
+        extensionSettings['guided-generations'].helperPrefillMessages = `[system]
+Stay terse.
+
+[assistant]
+I`;
+
+        const { guidedImpersonate } = await import('../public/scripts/extensions/guided-generations/scripts/guidedImpersonate.js');
+
+        await guidedImpersonate();
+
+        expect(context.executeSlashCommandsWithOptions).toHaveBeenCalledTimes(1);
+        const command = context.executeSlashCommandsWithOptions.mock.calls[0][0];
+        expect(command).toContain('/impersonate await=true FIRST PERSON: aim for a colder, suspicious reply');
+        expect(command).toContain('SYSTEM:\nStay terse.');
+        expect(command).toContain('ASSISTANT:\nI');
+    });
 });

--- a/tests/helper-prefill.test.js
+++ b/tests/helper-prefill.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, test } from '@jest/globals';
+
+import {
+    appendHelperPrefillMessages,
+    parseHelperPrefillMessages,
+    serializeHelperPrefillForPrompt,
+} from '../public/scripts/extensions/helper-prefill.js';
+
+describe('helper prefill role blocks', () => {
+    test('parses role blocks in order with multiline content', () => {
+        const input = `[system]
+Follow the helper rules.
+
+[user]
+Current scene:
+Rain on glass.
+
+[assistant]
+Let me`;
+
+        expect(parseHelperPrefillMessages(input)).toEqual([
+            { role: 'system', content: 'Follow the helper rules.' },
+            { role: 'user', content: 'Current scene:\nRain on glass.' },
+            { role: 'assistant', content: 'Let me' },
+        ]);
+    });
+
+    test('treats unheaded text as assistant prefill and drops empty blocks', () => {
+        const input = `Begin directly here.
+
+[system]
+
+[USER]
+Keep this context.
+
+[assistant]
+`;
+
+        expect(parseHelperPrefillMessages(input)).toEqual([
+            { role: 'assistant', content: 'Begin directly here.' },
+            { role: 'user', content: 'Keep this context.' },
+        ]);
+    });
+
+    test('appends parsed prefill messages without mutating the base messages', () => {
+        const baseMessages = [{ role: 'system', content: 'Base prompt.' }];
+        const result = appendHelperPrefillMessages(baseMessages, '[assistant]\nStart');
+
+        expect(result).toEqual([
+            { role: 'system', content: 'Base prompt.' },
+            { role: 'assistant', content: 'Start' },
+        ]);
+        expect(baseMessages).toEqual([{ role: 'system', content: 'Base prompt.' }]);
+    });
+
+    test('serializes role blocks for prompt-only helpers', () => {
+        const messages = parseHelperPrefillMessages('[system]\nRules\n\n[user]\nContext\n\n[assistant]\nStart');
+
+        expect(serializeHelperPrefillForPrompt(messages)).toBe(
+            'SYSTEM:\nRules\n\nUSER:\nContext\n\nASSISTANT:\nStart',
+        );
+    });
+});

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -779,6 +779,7 @@ describe('in-chat agent post-processing runner', () => {
         enabledAgents = [createPreInterceptAgent({
             preProcess: { applyMode: 'replace', maxTokens: 123 },
         })];
+        globalSettings.helperPrefillMessages = '[system]\nUse the helper prefill.';
 
         const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
         initAgentRunner();
@@ -799,6 +800,7 @@ describe('in-chat agent post-processing runner', () => {
         }));
         expect(generateQuietPrompt.mock.calls[0][0].quietPrompt).toContain('Outgoing context:');
         expect(generateQuietPrompt.mock.calls[0][0].quietPrompt).toContain('Original outgoing prompt');
+        expect(generateQuietPrompt.mock.calls[0][0].quietPrompt).toContain('SYSTEM:\nUse the helper prefill.');
         expect(eventData.prompt).toBe('quiet result');
 
         chat.push({
@@ -1691,6 +1693,67 @@ describe('in-chat agent post-processing runner', () => {
             8192,
             expect.objectContaining({ extractData: true, stream: false }),
         );
+    });
+
+    test('appends global helper prefill messages to profile prompt-transform requests', async () => {
+        usePromptTransformPostAgent();
+        enabledAgents[0].connectionProfile = 'profile-cc';
+        globalSettings.helperPrefillMessages = `[system]
+Helper rule.
+
+[user]
+Helper context.`;
+        connectionManagerRequestService = {
+            getProfile: jest.fn(() => ({ name: 'Agent profile', model: 'helper-model' })),
+            sendRequest: jest.fn(async () => ({ content: 'Profile rewrite' })),
+        };
+
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+
+        chat.push({
+            name: 'Assistant',
+            mes: 'Needs rewrite',
+            is_user: false,
+            is_system: false,
+            extra: {},
+        });
+
+        await eventSource.emit(eventTypes.MESSAGE_RECEIVED, 0, 'normal');
+
+        const sentMessages = connectionManagerRequestService.sendRequest.mock.calls[0][1];
+        expect(sentMessages.slice(-2)).toEqual([
+            { role: 'system', content: 'Helper rule.' },
+            { role: 'user', content: 'Helper context.' },
+        ]);
+        expect(chat[0].mes).toBe('Profile rewrite');
+    });
+
+    test('preserves configured assistant helper prefill as the final direct chat helper message', async () => {
+        usePromptTransformPostAgent();
+        mainApi = 'openai';
+        globalSettings.helperPrefillMessages = '[assistant]\nBegin here';
+        generateRaw.mockResolvedValue('Direct rewrite');
+
+        const { initAgentRunner } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        initAgentRunner();
+
+        chat.push({
+            name: 'Assistant',
+            mes: 'Needs rewrite',
+            is_user: false,
+            is_system: false,
+            extra: {},
+        });
+
+        await eventSource.emit(eventTypes.MESSAGE_RECEIVED, 0, 'normal');
+
+        const sentPrompt = generateRaw.mock.calls[0][0].prompt;
+        expect(sentPrompt.at(-1)).toEqual({ role: 'assistant', content: 'Begin here' });
+        expect(sentPrompt).not.toEqual(expect.arrayContaining([
+            expect.objectContaining({ content: 'Return only the requested transformed text.' }),
+        ]));
+        expect(chat[0].mes).toBe('Direct rewrite');
     });
 
     test('keeps text-completion profile reasoning out of post-transform replacements', async () => {

--- a/tests/in-chat-agents-store.test.js
+++ b/tests/in-chat-agents-store.test.js
@@ -94,6 +94,12 @@ describe('in-chat agent scoped enabled state', () => {
         expect(saveSettingsDebounced).toHaveBeenCalledTimes(1);
     });
 
+    test('exposes an empty helper prefill global setting by default', async () => {
+        const store = await importStore();
+
+        expect(store.getGlobalSettings().helperPrefillMessages).toBe('');
+    });
+
     test('recovers legacy enabled agents missing from initialized scoped settings', async () => {
         const store = await importStore();
         store.setGlobalSettings({


### PR DESCRIPTION
## What?
Adds role-block helper prefill fields for Guided Generations and In-Chat Agents. Users can configure `[system]`, `[user]`, and `[assistant]` blocks outside their prompt/chat-completion presets.

## Why?
Helper generations need their own lightweight prefill control without forcing users to modify the active generation preset. This lets Guided Impersonate and Agent helper requests carry extra role-specific context while preserving normal main-generation preset behavior.

## How?
Introduces a shared helper-prefill parser/formatter, stores a new Guided Generations setting and an In-Chat Agents global setting, and appends parsed helper messages after synthetic helper prompts. Guided Impersonate serializes role blocks into its existing `/impersonate` prompt path. In-Chat Agents preserve explicit assistant-tail helper prefill for direct chat helper requests while leaving the existing user-final guard intact for empty settings.

## Testing?
- `npm run test:unit -- helper-prefill.test.js guided-generations-settings.test.js guided-generations-steering.test.js in-chat-agents-store.test.js in-chat-agents-runner.test.js --runInBand`
- `node --check` on edited JS modules
- `git diff --check` (only normal CRLF notices)

## Screenshots (optional)
No fresh browser screenshot captured. The Agents textarea is placed in the requested footer position, after Append Agents Execution and before the checkbox toggles.

## Anything Else?
Base branch: `staging`.