### PR TITLE
feat: clarify helper prefill role syntax

### DIFF
--- a/public/scripts/extensions/guided-generations/settings.html
+++ b/public/scripts/extensions/guided-generations/settings.html
@@ -95,7 +95,8 @@
 
             <div class="setting_item">
                 <label for="gg_helperPrefillMessages">Helper prefill messages</label>
-                <textarea id="gg_helperPrefillMessages" name="helperPrefillMessages" class="gg-setting-input text_pole gg-prompt-field" rows="4"></textarea>
+                <textarea id="gg_helperPrefillMessages" name="helperPrefillMessages" class="gg-setting-input text_pole gg-prompt-field" rows="4" placeholder="[assistant] Start of helper response&#10;&#10;[system] Extra instruction"></textarea>
+                <small class="gg-setting-help">Use [system], [user], or [assistant] blocks. Text before any header is treated as [assistant].</small>
             </div>
         </div>
     </div>

--- a/public/scripts/extensions/guided-generations/style.css
+++ b/public/scripts/extensions/guided-generations/style.css
@@ -56,6 +56,11 @@
     resize: vertical;
 }
 
+.guided-generations-settingslist .gg-setting-help {
+    font-size: calc(var(--mainFontSize) * 0.76);
+    opacity: 0.72;
+}
+
 .gg-profile-row {
     display: grid;
     grid-template-columns: max-content minmax(160px, 1fr) max-content minmax(160px, 1fr) max-content;

--- a/public/scripts/extensions/in-chat-agents/settings.html
+++ b/public/scripts/extensions/in-chat-agents/settings.html
@@ -122,7 +122,8 @@
             </label>
             <label class="ica--profile-label ica--helper-prefill-label">
                 <span>Helper Prefill Messages</span>
-                <textarea id="ica--helperPrefillMessages" class="text_pole ica--helper-prefill-field" rows="4"></textarea>
+                <textarea id="ica--helperPrefillMessages" class="text_pole ica--helper-prefill-field" rows="4" placeholder="[assistant] Start of helper response&#10;&#10;[system] Extra instruction"></textarea>
+                <small class="ica--profile-help">Use [system], [user], or [assistant] blocks. Text before any header is treated as [assistant].</small>
             </label>
             <label class="checkbox_label" title="Keep enabled In-Chat Agents separate between Individual chats and Group chats.">
                 <input type="checkbox" id="ica--separateRecentChats" />


### PR DESCRIPTION
## What?
Adds visible role-syntax guidance to the Helper Prefill Messages fields in Guided Generations and In-Chat Agents. The fields now show a placeholder example and a short helper line explaining that `[system]`, `[user]`, and `[assistant]` blocks are supported.

## Why?
The role behavior was only discoverable from the parser: unheaded text defaults to `[assistant]`. The settings UI now makes that default clear where users configure helper prefill messages.

## How?
The change adds concise helper text below both helper prefill textareas and a placeholder example in each textarea. Guided Generations gets a small matching helper-text style; In-Chat Agents reuses the existing footer helper-text style.

## Testing?
- `git diff --check`

## Screenshots (optional)
Not included; this is a small settings copy/placeholder clarification.

## Anything Else?
Targets `staging` as a follow-up to the helper prefill fields change.