### PR TITLE
fix: Sentencepiece token overcounting at large context sizes

### DIFF
--- a/src/endpoints/tokenizers.js
+++ b/src/endpoints/tokenizers.js
@@ -526,10 +526,13 @@ async function countSentencepieceTokens(tokenizer, text) {
  * @returns {Promise<number>} Number of tokens
  */
 async function countSentencepieceArrayTokens(tokenizer, array) {
-    const jsonBody = array.flatMap(x => Object.values(x)).join('\n\n');
-    const result = await countSentencepieceTokens(tokenizer, jsonBody);
-    const num_tokens = result.count;
-    return num_tokens;
+    // SillyBunny: Use convertClaudePrompt for consistent token counting across all tokenizers.
+    // The previous implementation using Object.values().join('\n\n') overcounted tokens by
+    // including metadata (role, name, tool_calls) and adding separators between every value.
+    // This caused false "Pre-generation intercepts exceed context" errors at large context sizes.
+    const convertedPrompt = convertClaudePrompt(array, false, '', false, false, '', false);
+    const result = await countSentencepieceTokens(tokenizer, convertedPrompt);
+    return result.count;
 }
 
 async function getTiktokenChunks(tokenizer, ids) {


### PR DESCRIPTION
## Summary

Fixes false "Pre-generation intercepts exceed context" errors when using Google AI Studio (MAKERSUITE) backend at 80k+ context sizes, even when agents are disabled or no pre-generation intercepts are configured.

## Root Cause

The `countSentencepieceArrayTokens` function in `src/endpoints/tokenizers.js` was overcounting tokens by:

1. Extracting **all** message object values via `Object.values(x)` — including `role`, `name`, `content`, `tool_calls`, `signature`, `reasoning`
2. Joining everything with `\n\n` separators, adding ~2 tokens per message

At large context sizes with hundreds of messages, this caused significant token inflation compared to the initial budget accounting, triggering false budget exceeded errors.

## Why Only Google AI Studio

- MAKERSUITE source → returns `"gemma"` tokenizer → uses `countSentencepieceArrayTokens`
- Custom OpenAI endpoints → may use tiktoken fallback or different counting logic

## Fix

Align `countSentencepieceArrayTokens` with `countWebTokenizerTokens` (used by Claude, Llama3, DeepSeek, Qwen2, etc.) by using `convertClaudePrompt()` to properly structure messages before counting.

This affects all Sentencepiece tokenizers: **gemma**, **llama**, **mistral**, **yi**, and **jamba**.

## Testing

- Gemini 2.5 Flash on Google AI Studio at 80k+ context
- iOS and Desktop

## Checklist

- [x] I have explained the issue clearly and included all relevant info
- [x] I have checked that this issue hasn't already been raised
- [x] I have checked the docs
- [x] I confirm this is not related to third-party content or unofficial extensions