### PR TITLE
fix: harden shell menu sizing and search focus

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -1270,9 +1270,10 @@
         max-width: calc(100vw - 16px) !important;
         left: 8px !important;
         right: 8px !important;
-        top: calc(var(--sb-topbar-layout-offset) + var(--sb-mobile-shell-gap)) !important;
-        height: calc(100dvh - var(--sb-topbar-layout-offset) - var(--sb-mobile-shell-gap)) !important;
-        max-height: calc(100dvh - var(--sb-topbar-layout-offset) - var(--sb-mobile-shell-gap)) !important;
+        top: calc(var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) + var(--sb-mobile-shell-gap)) !important;
+        bottom: env(safe-area-inset-bottom, 0px) !important;
+        height: calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) - var(--sb-mobile-shell-gap) - env(safe-area-inset-bottom, 0px)) !important;
+        max-height: calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) - var(--sb-mobile-shell-gap) - env(safe-area-inset-bottom, 0px)) !important;
         min-width: 0 !important;
         margin-top: 0 !important;
         border-radius: 22px 22px 0 0 !important;
@@ -2558,5 +2559,22 @@
         border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 36%, var(--sb-shell-border) 64%);
         background: var(--sb-shell-tab-active-bg);
         font-weight: var(--sb-weight-title);
+    }
+}
+
+@media screen and (max-width: 768px) {
+    #left-nav-panel.openDrawer,
+    #user-settings-block.openDrawer,
+    .sb-shell-root.openDrawer,
+    .sb-shell-root.fillLeft.openDrawer,
+    .sb-shell-root.fillRight.openDrawer,
+    #right-nav-panel.openDrawer,
+    #top-settings-holder #right-nav-panel.openDrawer,
+    :root[data-sb-character-drawer-lock='right'] #right-nav-panel.openDrawer {
+        top: calc(var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) + var(--sb-mobile-shell-gap, 0px)) !important;
+        bottom: auto !important;
+        box-sizing: border-box !important;
+        height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset))) - var(--sb-mobile-shell-gap, 0px) - env(safe-area-inset-bottom, 0px)) !important;
+        max-height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset))) - var(--sb-mobile-shell-gap, 0px) - env(safe-area-inset-bottom, 0px)) !important;
     }
 }

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -438,7 +438,8 @@ body.sb-topbar-compact #sb-chatbar-layer {
     padding: 0 14px;
     border: 1px solid color-mix(in srgb, var(--sb-shell-border) 88%, transparent);
     border-radius: 999px;
-    background: transparent;
+    background-color: var(--SmartThemeBlurTintColor);
+    background-image: linear-gradient(180deg, color-mix(in srgb, var(--SmartThemeBodyColor) 4%, transparent), transparent);
     color: var(--SmartThemeBodyColor);
     box-shadow: 0 12px 24px color-mix(in srgb, var(--SmartThemeShadowColor) 10%, transparent);
     cursor: text;
@@ -451,11 +452,7 @@ body.sb-topbar-compact #sb-chatbar-layer {
     z-index: -1;
     border-radius: inherit;
     pointer-events: none;
-    background: color-mix(
-        in srgb,
-        rgb(from var(--SmartThemeBlurTintColor) r g b / 1) 98%,
-        rgb(from var(--SmartThemeBodyColor) r g b / 1) 2%
-    );
+    background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 96%, var(--SmartThemeBodyColor) 4%);
     opacity: 1;
 }
 
@@ -2605,15 +2602,18 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 }
 
 .sb-search-results {
+    position: relative;
+    isolation: isolate;
     display: none;
     flex-direction: column;
     gap: 8px;
-    max-height: min(340px, 42vh);
+    max-height: min(340px, calc(100dvh - var(--sb-topbar-layout-offset) - var(--sb-topbar-search-row-height) - 28px));
     padding: 12px;
     overflow-y: auto;
     border-radius: var(--sb-radius-md, 16px);
     border: 1px solid color-mix(in srgb, var(--sb-shell-border) 88%, transparent);
-    background: transparent;
+    background-color: var(--SmartThemeBlurTintColor);
+    background-image: linear-gradient(180deg, color-mix(in srgb, var(--SmartThemeBodyColor) 4%, transparent), transparent);
     box-shadow: 0 16px 36px color-mix(in srgb, var(--SmartThemeShadowColor) 24%, transparent);
 }
 
@@ -2624,11 +2624,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     z-index: -1;
     border-radius: inherit;
     pointer-events: none;
-    background: color-mix(
-        in srgb,
-        rgb(from var(--SmartThemeBlurTintColor) r g b / 1) 97%,
-        rgb(from var(--SmartThemeBodyColor) r g b / 1) 3%
-    );
+    background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 96%, var(--SmartThemeBodyColor) 4%);
     opacity: 1;
 }
 
@@ -2659,9 +2655,13 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 
 .sb-search-result,
 .sb-search-empty {
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
     border-radius: var(--sb-radius-md, 16px);
     border: 1px solid color-mix(in srgb, var(--sb-shell-border) 80%, transparent);
-    background: transparent;
+    background-color: var(--SmartThemeBlurTintColor);
+    background-image: linear-gradient(180deg, color-mix(in srgb, var(--SmartThemeBodyColor) 3%, transparent), transparent);
 }
 
 .sb-search-result::before,
@@ -2672,11 +2672,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     z-index: -1;
     border-radius: inherit;
     pointer-events: none;
-    background: color-mix(
-        in srgb,
-        rgb(from var(--SmartThemeChatTintColor) r g b / 1) 94%,
-        rgb(from var(--SmartThemeBodyColor) r g b / 1) 6%
-    );
+    background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 94%, var(--SmartThemeBodyColor) 6%);
     opacity: 1;
 }
 
@@ -2710,11 +2706,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 
 .sb-search-result.is-active::before,
 .sb-search-result:focus-visible::before {
-    background: color-mix(
-        in srgb,
-        rgb(from var(--SmartThemeChatTintColor) r g b / 1) 88%,
-        rgb(from var(--SmartThemeBodyColor) r g b / 1) 12%
-    );
+    background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 88%, var(--SmartThemeBodyColor) 12%);
 }
 
 .sb-search-result span,

--- a/public/index.html
+++ b/public/index.html
@@ -17,9 +17,9 @@
             background-color: #1d2128;
         }
     </style>
-    <link rel="preload" as="style" href="style.css?v=20260602f">
+    <link rel="preload" as="style" href="style.css?v=20260603e">
     <link rel="modulepreload" href="script.js">
-    <link rel="modulepreload" href="scripts/sillybunny-tabs.js?v=20260602f">
+    <link rel="modulepreload" href="scripts/sillybunny-tabs.js?v=20260603e">
     <link rel="preload" as="font" type="font/woff2" href="webfonts/Figtree/Figtree-Regular.woff2?v=20260422b" crossorigin>
     <link rel="manifest" crossorigin="use-credentials" href="manifest.json">
     <link href="webfonts/Figtree/stylesheet.css?v=20260422b" rel="stylesheet">
@@ -40,14 +40,14 @@
     <link rel="apple-touch-icon" sizes="114x114" href="img/apple-icon-114x114.png" />
     <link rel="apple-touch-icon" sizes="144x144" href="img/apple-icon-144x144.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="img/apple-icon-180x180.png" />
-    <link rel="stylesheet" type="text/css" href="style.css?v=20260602f">
+    <link rel="stylesheet" type="text/css" href="style.css?v=20260603e">
     <link rel="stylesheet" type="text/css" href="css/st-tailwind.css">
     <link rel="stylesheet" type="text/css" href="css/toggle-dependent.css">
-    <link rel="stylesheet" type="text/css" href="css/select2-overrides.css?v=20260602f">
+    <link rel="stylesheet" type="text/css" href="css/select2-overrides.css?v=20260603e">
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260516d" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260602f">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260602f">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260602f" media="(max-width: 768px)">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260603e">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260603e">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260603e" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
 </head>
@@ -8774,7 +8774,7 @@
     <script type="module" src="scripts/i18n.js"></script>
     <script type="module" src="scripts/performance-loader.js"></script>
     <script type="module" src="script.js"></script>
-    <script type="module" src="scripts/sillybunny-tabs.js?v=20260602f"></script>
+    <script type="module" src="scripts/sillybunny-tabs.js?v=20260603e"></script>
     <script>
         window.addEventListener('load', (event) => {
             const documentHeight = () => {

--- a/public/script.js
+++ b/public/script.js
@@ -950,7 +950,7 @@ function registerSillyBunnyServiceWorker() {
     }
 
     const register = () => {
-        navigator.serviceWorker.register('/sw.js?v=20260602f', { updateViaCache: 'none' }).then((registration) => {
+        navigator.serviceWorker.register('/sw.js?v=20260603e', { updateViaCache: 'none' }).then((registration) => {
             return registration.update().catch((error) => {
                 console.warn('Failed to update SillyBunny service worker.', error);
             });

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -14,6 +14,7 @@ const SB_STORAGE_KEYS = Object.freeze({
     rightTab: 'sb-right-tab',
     leftShellSize: 'sb-left-shell-size',
     rightShellSize: 'sb-right-shell-size',
+    desktopShellSnapToChatWidth: 'sb-desktop-shell-snap-to-chat-width',
     characterDrawerRightLocked: 'sb-character-drawer-right-locked',
     theme: 'sb-theme',
     surfaceTransparency: 'sb-surface-transparency',
@@ -587,6 +588,8 @@ const SB_UNIVERSAL_SEARCH_RESULT_LIMIT = 10;
 const SB_MOBILE_QUICK_ACTION_LIMIT = 12;
 const SB_MOBILE_QUICK_ACTION_LABEL_MAX_LENGTH = 36;
 const SB_MOBILE_QUICK_ACTION_ICON_FALLBACK = 'fa-bolt';
+const SB_MOBILE_NAV_CLOSED_ICON = 'fa-compass';
+const SB_MOBILE_VIEWPORT_RESET_FOLLOWUP_MS = 180;
 const SB_FONT_AWESOME_STYLE_CLASSES = Object.freeze(new Set(['fa-solid', 'fa-regular', 'fa-brands']));
 const SB_MOBILE_NAV_LAYOUTS = Object.freeze(['horizontal', 'vertical']);
 const SB_MOBILE_DEFAULT_QUICK_ACTIONS = Object.freeze([
@@ -666,6 +669,7 @@ const sbState = {
             left: normalizeShellSize(safeGetItem(SB_STORAGE_KEYS.leftShellSize)),
             right: normalizeShellSize(safeGetItem(SB_STORAGE_KEYS.rightShellSize)),
         },
+        snapToChatWidth: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.desktopShellSnapToChatWidth), false),
         activeResize: null,
     },
     characterDrawer: {
@@ -1357,6 +1361,10 @@ function restorePersistedTopbarState() {
     sbState.chatbar.visible = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.chatbarVisible), sbState.chatbar.visible);
     sbState.chatbar.topbarOffset = normalizeTopbarOffset(safeGetItem(SB_STORAGE_KEYS.topbarOffset));
     sbState.compactMode = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.compactMode), sbState.compactMode);
+    sbState.shellSizing.snapToChatWidth = normalizeStoredBoolean(
+        safeGetItem(SB_STORAGE_KEYS.desktopShellSnapToChatWidth),
+        sbState.shellSizing.snapToChatWidth,
+    );
     sbState.mobileNav.layout = normalizeMobileNavLayout(safeGetItem(SB_STORAGE_KEYS.mobileNavLayout));
     sbState.mobileNav.iconOnly = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.mobileNavIconOnly), sbState.mobileNav.iconOnly);
     sbState.mobileNav.showCustomize = normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.mobileNavShowCustomize), sbState.mobileNav.showCustomize);
@@ -1778,6 +1786,19 @@ function setCompactMode(enabled, { persist = true } = {}) {
     updateThemePickerUi();
 }
 
+function setDesktopShellSnapToChatWidth(enabled, { persist = true } = {}) {
+    const nextEnabled = Boolean(enabled);
+    sbState.shellSizing.snapToChatWidth = nextEnabled;
+    document.documentElement.dataset.sbDesktopShellSnapToChatWidth = String(nextEnabled);
+
+    if (persist) {
+        safeSetItem(SB_STORAGE_KEYS.desktopShellSnapToChatWidth, String(nextEnabled));
+    }
+
+    syncDesktopShellSizing();
+    updateThemePickerUi();
+}
+
 function syncCharacterDrawerLockButton() {
     const button = document.getElementById('sb-character-right-lock');
     if (!(button instanceof HTMLButtonElement)) {
@@ -1999,12 +2020,43 @@ function renderSearchEmptyState(container, title, detail) {
     container.appendChild(empty);
 }
 
+function focusUniversalSearchInput(input) {
+    if (!(input instanceof HTMLInputElement)) {
+        return;
+    }
+
+    const applyFocus = () => {
+        input.focus({ preventScroll: true });
+        input.select();
+    };
+
+    applyFocus();
+    window.requestAnimationFrame(applyFocus);
+}
+
+function requestMobileViewportReset() {
+    if (!isMobileViewport() || typeof window === 'undefined' || typeof window.dispatchEvent !== 'function') {
+        return;
+    }
+
+    const dispatchReset = () => window.dispatchEvent(new Event('sb-mobile-viewport-reset'));
+
+    if (typeof window.requestAnimationFrame === 'function') {
+        window.requestAnimationFrame(dispatchReset);
+    } else {
+        dispatchReset();
+    }
+
+    window.setTimeout(dispatchReset, SB_MOBILE_VIEWPORT_RESET_FOLLOWUP_MS);
+}
+
 function setUniversalSearchOpenState(isOpen, { focusInput = false } = {}) {
     const searchState = getUniversalSearchState();
     const row = searchState.row;
     const root = searchState.root;
     const input = searchState.input;
     const nextOpenState = Boolean(isOpen);
+    const wasOpen = Boolean(searchState.expanded);
 
     searchState.expanded = nextOpenState;
     row?.classList.toggle('is-open', nextOpenState);
@@ -2018,14 +2070,18 @@ function setUniversalSearchOpenState(isOpen, { focusInput = false } = {}) {
 
     if (!nextOpenState) {
         searchState.results?.classList.remove('is-visible');
+        if (wasOpen) {
+            requestMobileViewportReset();
+        }
     } else {
         renderUniversalSearchResults(input?.value ?? '');
     }
 
     if (focusInput && input instanceof HTMLInputElement) {
-        input.focus({ preventScroll: true });
+        focusUniversalSearchInput(input);
     }
 
+    queueMobileShellDrawerBoundsSync();
     syncShortcutButtonActiveStates();
 }
 
@@ -2213,6 +2269,113 @@ function canResizeDesktopShells() {
     return !isMobileViewport() && !isTouchOnlyDesktopViewport();
 }
 
+function readFiniteViewportNumber(value, fallback = 0) {
+    const number = Number(value);
+    return Number.isFinite(number) ? number : fallback;
+}
+
+function getShellViewportSize() {
+    const doc = document.documentElement;
+    const visualViewport = window.visualViewport;
+    const fallbackWidth = window.innerWidth || doc?.clientWidth || 0;
+    const fallbackHeight = window.innerHeight || doc?.clientHeight || 0;
+    const width = Math.max(0, Math.round(readFiniteViewportNumber(visualViewport?.width, fallbackWidth)));
+    const height = Math.max(0, Math.round(readFiniteViewportNumber(visualViewport?.height, fallbackHeight)));
+
+    return {
+        width,
+        height,
+        left: 0,
+        top: 0,
+        right: width,
+        bottom: height,
+    };
+}
+
+function syncShellViewportBounds() {
+    const root = document.documentElement;
+    const viewportSize = getShellViewportSize();
+    const topOffset = Math.max(0, Math.round(getResolvedShellTopbarOffset()));
+
+    root.style.setProperty('--sb-shell-viewport-height', `${viewportSize.height}px`);
+    root.style.setProperty('--sb-shell-measured-top-offset', `${topOffset}px`);
+    root.style.setProperty('--sb-shell-available-height', `${Math.max(0, viewportSize.height - topOffset)}px`);
+}
+
+function getMobileShellBoundDrawers() {
+    return Array.from(new Set([
+        ...document.querySelectorAll('#left-nav-panel, #user-settings-block, .sb-shell-root, #right-nav-panel'),
+        ...document.querySelectorAll('#top-settings-holder #right-nav-panel'),
+    ])).filter(drawer => drawer instanceof HTMLElement);
+}
+
+function clearMobileShellDrawerBounds(drawer) {
+    if (!(drawer instanceof HTMLElement) || drawer.dataset.sbMobileViewportBound !== 'true') {
+        return;
+    }
+
+    drawer.style.removeProperty('top');
+    drawer.style.removeProperty('bottom');
+    drawer.style.removeProperty('height');
+    drawer.style.removeProperty('max-height');
+    drawer.style.removeProperty('box-sizing');
+    delete drawer.dataset.sbMobileViewportBound;
+}
+
+function syncMobileShellDrawerBounds() {
+    const drawers = getMobileShellBoundDrawers();
+
+    if (!drawers.length) {
+        return;
+    }
+
+    if (!isMobileViewport()) {
+        drawers.forEach(clearMobileShellDrawerBounds);
+        return;
+    }
+
+    const viewportSize = getShellViewportSize();
+    const baseTopOffset = Math.max(0, Math.round(getResolvedShellTopbarOffset()));
+
+    for (const drawer of drawers) {
+        if (!drawer.classList.contains('openDrawer')) {
+            clearMobileShellDrawerBounds(drawer);
+            continue;
+        }
+
+        const drawerStyles = window.getComputedStyle(drawer);
+        const shellGap = Number.parseFloat(drawerStyles.getPropertyValue('--sb-mobile-shell-gap')) || 0;
+        const topOffset = clampNumber(Math.round(baseTopOffset + shellGap), 0, viewportSize.height);
+        const availableHeight = Math.max(0, viewportSize.height - topOffset);
+
+        drawer.dataset.sbMobileViewportBound = 'true';
+        drawer.style.setProperty('top', `${topOffset}px`, 'important');
+        drawer.style.setProperty('bottom', 'auto', 'important');
+        drawer.style.setProperty('box-sizing', 'border-box', 'important');
+        drawer.style.setProperty('height', `${availableHeight}px`, 'important');
+        drawer.style.setProperty('max-height', `${availableHeight}px`, 'important');
+    }
+}
+
+function queueMobileShellDrawerBoundsSync() {
+    if (!isMobileViewport()) {
+        return;
+    }
+
+    const sync = () => {
+        syncShellViewportBounds();
+        syncMobileShellDrawerBounds();
+    };
+
+    if (typeof window.requestAnimationFrame === 'function') {
+        window.requestAnimationFrame(sync);
+    } else {
+        sync();
+    }
+
+    window.setTimeout(sync, SB_MOBILE_VIEWPORT_RESET_FOLLOWUP_MS);
+}
+
 function isMovingUIActive() {
     return document.body?.classList.contains('movingUI') ?? false;
 }
@@ -2308,6 +2471,75 @@ function hydratePersistedShellSizes() {
     }
 }
 
+function getResolvedShellTopbarOffset() {
+    const chatShell = document.getElementById('sheld');
+    if (chatShell instanceof HTMLElement && chatShell.getClientRects().length > 0) {
+        const chatRect = chatShell.getBoundingClientRect();
+        if (Number.isFinite(chatRect.top) && chatRect.top > 0) {
+            return chatRect.top;
+        }
+    }
+
+    const topBar = document.getElementById('top-bar');
+    if (topBar instanceof HTMLElement && topBar.getClientRects().length > 0) {
+        const topBarRect = topBar.getBoundingClientRect();
+        if (Number.isFinite(topBarRect.bottom) && topBarRect.bottom > 0) {
+            return topBarRect.bottom;
+        }
+    }
+
+    const topbarOffset = Number.parseFloat(
+        window.getComputedStyle(document.documentElement).getPropertyValue('--sb-topbar-layout-offset'),
+    );
+
+    return Number.isFinite(topbarOffset) ? topbarOffset : 0;
+}
+
+function getShellViewportTop(root, viewportSize = getShellViewportSize()) {
+    let top = getResolvedShellTopbarOffset();
+
+    if (root instanceof HTMLElement && root.classList.contains('openDrawer') && root.getClientRects().length > 0) {
+        const rect = root.getBoundingClientRect();
+        if (Number.isFinite(rect.top)) {
+            top = rect.top;
+        }
+    }
+
+    return clampNumber(Math.round(top), viewportSize.top, viewportSize.bottom);
+}
+
+function getChatViewportWidth(viewportSize = getShellViewportSize()) {
+    const chatShell = document.getElementById('sheld');
+
+    if (chatShell instanceof HTMLElement && chatShell.getClientRects().length > 0) {
+        const rect = chatShell.getBoundingClientRect();
+        const visibleWidth = Math.min(rect.right, viewportSize.right) - Math.max(rect.left, viewportSize.left);
+
+        if (Number.isFinite(visibleWidth) && visibleWidth > 0) {
+            return Math.round(visibleWidth);
+        }
+    }
+
+    const sheldWidthStr = window.getComputedStyle(document.documentElement).getPropertyValue('--sheldWidth').trim();
+    const sheldWidthValue = Number.parseFloat(sheldWidthStr);
+
+    if (!Number.isFinite(sheldWidthValue)) {
+        return viewportSize.width;
+    }
+
+    if (sheldWidthStr.endsWith('px')) {
+        return Math.round(sheldWidthValue);
+    }
+
+    return Math.round((sheldWidthValue / 100) * viewportSize.width);
+}
+
+function isShellSnapToChatWidthEnabled(shellKey) {
+    return Boolean(sbState.shellSizing.snapToChatWidth)
+        && isDesktopResizableShell(shellKey)
+        && !isMobileViewport();
+}
+
 function getShellSizeStorageKey(shellKey) {
     const sizingKey = getShellSizingKey(shellKey);
 
@@ -2323,9 +2555,23 @@ function getShellSizeStorageKey(shellKey) {
 }
 
 function getDesktopShellDimensions(shellKey = '') {
-    const viewportWidth = window.innerWidth;
-    const viewportHeight = window.innerHeight;
+    const viewportSize = getShellViewportSize();
+    const viewportWidth = viewportSize.width;
+    const viewportHeight = viewportSize.height;
     const maxShellWidth = shellKey === 'right' ? Math.min(SB_DESKTOP_SHELL_LAYOUT.maxWidth, 760) : SB_DESKTOP_SHELL_LAYOUT.maxWidth;
+
+    if (isShellSnapToChatWidthEnabled(shellKey)) {
+        const snappedWidth = clampNumber(
+            getChatViewportWidth(viewportSize),
+            Math.min(SB_DESKTOP_SHELL_LAYOUT.minWidth, viewportWidth),
+            viewportWidth,
+        );
+
+        return {
+            width: snappedWidth,
+            maxWidth: snappedWidth,
+        };
+    }
 
     if (
         ['left', 'right'].includes(shellKey)
@@ -2386,19 +2632,21 @@ function getDesktopShellDimensions(shellKey = '') {
 }
 
 function getDesktopShellResizeBounds(shellKey = '') {
-    const viewportWidth = Math.max(0, Math.round(window.innerWidth));
-    const topbarOffset = Number.parseFloat(
-        window.getComputedStyle(document.documentElement).getPropertyValue('--sb-topbar-layout-offset'),
-    );
-    const resolvedTopbarOffset = Number.isFinite(topbarOffset) ? topbarOffset : 0;
+    const viewportSize = getShellViewportSize();
+    const viewportWidth = Math.max(0, Math.round(viewportSize.width));
+    const viewportHeight = Math.max(0, Math.round(viewportSize.height));
+    const root = isDesktopResizableShell(shellKey) ? getResizableShellRoot(shellKey) : null;
+    const shellTop = getShellViewportTop(root, viewportSize);
     const defaultDimensions = getDesktopShellDimensions(shellKey);
-    const maxHeight = Math.max(0, Math.round(window.innerHeight - resolvedTopbarOffset - SB_DESKTOP_SHELL_RESIZE.bottomGap));
+    const defaultWidth = Math.max(0, Math.min(Math.round(defaultDimensions.width), viewportWidth));
+    const snapWidth = isShellSnapToChatWidthEnabled(shellKey) ? defaultWidth : null;
+    const maxHeight = Math.max(0, Math.round(viewportHeight - shellTop - SB_DESKTOP_SHELL_RESIZE.bottomGap));
 
     return {
-        defaultWidth: Math.max(0, Math.round(defaultDimensions.width)),
+        defaultWidth,
         defaultHeight: maxHeight,
-        minWidth: Math.min(SB_DESKTOP_SHELL_RESIZE.minWidth, viewportWidth),
-        maxWidth: viewportWidth,
+        minWidth: snapWidth ?? Math.min(SB_DESKTOP_SHELL_RESIZE.minWidth, viewportWidth),
+        maxWidth: snapWidth ?? viewportWidth,
         minHeight: Math.min(SB_DESKTOP_SHELL_RESIZE.minHeight, maxHeight),
         maxHeight,
     };
@@ -2432,7 +2680,7 @@ function setShellSizeOverride(shellKey, size, { persist = true } = {}) {
         return null;
     }
 
-    const nextSize = clampShellSize(size);
+    const nextSize = clampShellSize(size, getDesktopShellResizeBounds(shellKey));
 
     sbState.shellSizing.overrides.left = nextSize;
     sbState.shellSizing.overrides.right = nextSize;
@@ -7201,6 +7449,8 @@ function bindCharacterDrawerStateObserver() {
 
 function closeCharacterPanel() {
     const panel = getCharacterPanel();
+    const shouldResetViewport = panel instanceof HTMLElement
+        && (panel.classList.contains('openDrawer') || (document.activeElement instanceof HTMLElement && panel.contains(document.activeElement)));
 
     setCharacterEditorFullscreenState(false);
 
@@ -7213,7 +7463,13 @@ function closeCharacterPanel() {
     syncDrawerIconState('#WIDrawerIcon', false);
     setCharacterDrawerHostOverflow(false);
     syncChatbarVisibilityState();
+    syncMobileShellDrawerBounds();
+    queueMobileShellDrawerBoundsSync();
     queueMobileModalStateSync();
+
+    if (shouldResetViewport) {
+        requestMobileViewportReset();
+    }
 }
 
 function ensureCharacterResizeHandle() {
@@ -7264,6 +7520,8 @@ function toggleCharacterPanel({ preferredTab = null } = {}) {
     setCharacterDrawerHostOverflow(true);
 
     triggerDrawerToggle(getCharacterDrawerToggle());
+    syncMobileShellDrawerBounds();
+    queueMobileShellDrawerBoundsSync();
 
     // Fallback: if the jQuery drawer-toggle handler didn't fire, force-open
     window.requestAnimationFrame(() => {
@@ -7274,6 +7532,8 @@ function toggleCharacterPanel({ preferredTab = null } = {}) {
         restoreLastCharacterPanelView();
 
         syncChatbarVisibilityState();
+        syncMobileShellDrawerBounds();
+        queueMobileShellDrawerBoundsSync();
         syncDesktopShellSizing();
         queueMobileModalStateSync();
     });
@@ -7614,7 +7874,7 @@ function buildTopBar() {
             'aria-expanded': 'false',
         },
     });
-    mobileButton.innerHTML = '<i class="fa-solid fa-bars" aria-hidden="true"></i>';
+    mobileButton.innerHTML = `<i class="fa-solid ${SB_MOBILE_NAV_CLOSED_ICON}" aria-hidden="true"></i>`;
     stopProxyPointerPropagation(mobileButton);
     mobileButton.addEventListener('click', toggleMobileNav);
 
@@ -10958,6 +11218,30 @@ function createDesktopNavLayoutSettingsGroup() {
     return createNavigationSettingsGroup('desktop');
 }
 
+function createDesktopShellSizingSettingsGroup() {
+    const group = createElement('section', {
+        className: 'sb-theme-slider-group sb-desktop-shell-sizing-group sb-desktop-setting',
+    });
+    const header = createElement('div', { className: 'sb-mobile-nav-settings-header' });
+    const title = createElement('strong', { text: 'Panel Sizing' });
+    const description = createElement('p', {
+        className: 'sb-theme-slider-caption',
+        text: 'Keep Workspace, Customize, and Characters aligned with the active chat width.',
+    });
+    const snapChoice = createMobileNavChoice({
+        id: 'sb-desktop-shell-snap-to-chat-input',
+        type: 'checkbox',
+        value: 'snap-to-chat-width',
+        label: 'Snap to chat width',
+        icon: 'fa-arrows-left-right-to-line',
+        onChange: input => setDesktopShellSnapToChatWidth(input.checked),
+    });
+
+    header.append(title, description);
+    group.append(header, snapChoice);
+    return group;
+}
+
 function createFrontendIconSettingsGroup() {
     const group = createElement('section', {
         className: 'sb-theme-slider-group sb-frontend-icon-group',
@@ -11171,6 +11455,7 @@ function injectThemePicker() {
     });
     const topbarLabelSettingsGroup = createTopbarLabelSettingsGroup();
     const desktopNavLayoutSettingsGroup = createDesktopNavLayoutSettingsGroup();
+    const desktopShellSizingSettingsGroup = createDesktopShellSizingSettingsGroup();
     const mobileNavLayoutSettingsGroup = createMobileNavLayoutSettingsGroup();
     const desktopSettingsDivider = createMobileNavDivider();
     const mobileSettingsDivider = createMobileNavDivider();
@@ -11209,6 +11494,7 @@ function injectThemePicker() {
         desktopSettingsOutlet.replaceChildren(
             desktopNavLayoutSettingsGroup,
             desktopSettingsDivider,
+            desktopShellSizingSettingsGroup,
             desktopButtonSliderGroup,
             desktopCompactModeSettingsGroup,
             desktopQuickActionSettingsGroup,
@@ -11230,6 +11516,7 @@ function injectThemePicker() {
         card.append(
             desktopNavLayoutSettingsGroup,
             desktopSettingsDivider,
+            desktopShellSizingSettingsGroup,
             desktopButtonSliderGroup,
             desktopCompactModeSettingsGroup,
             desktopQuickActionSettingsGroup,
@@ -11266,6 +11553,7 @@ function updateThemePickerUi() {
     const desktopNavShowQuickActionsInput = document.getElementById('sb-desktop-nav-show-quick-actions-input');
     const desktopNavReplaceQuickActionsInput = document.getElementById('sb-desktop-nav-replace-quick-actions-input');
     const desktopNavReplacementSelect = document.getElementById('sb-desktop-nav-replacement-select');
+    const desktopShellSnapToChatInput = document.getElementById('sb-desktop-shell-snap-to-chat-input');
     const mobileNavIconOnlyInput = document.getElementById('sb-mobile-nav-icon-only-input');
     const mobileNavShowCustomizeInput = document.getElementById('sb-mobile-nav-show-customize-input');
     const mobileNavShowQuickActionsInput = document.getElementById('sb-mobile-nav-show-quick-actions-input');
@@ -11414,6 +11702,12 @@ function updateThemePickerUi() {
         desktopNavReplacementSelect.value = normalizeMobileNavReplacementTarget(sbState.desktopNav.replacementTarget);
         desktopNavReplacementSelect.disabled = !sbState.desktopNav.replaceQuickActions;
         desktopNavReplacementSelect.closest('.sb-mobile-nav-replacement-field')?.classList.toggle('is-disabled', !sbState.desktopNav.replaceQuickActions);
+    }
+
+    if (desktopShellSnapToChatInput instanceof HTMLInputElement) {
+        desktopShellSnapToChatInput.checked = sbState.shellSizing.snapToChatWidth;
+        const choice = desktopShellSnapToChatInput.closest('.sb-mobile-nav-choice');
+        choice?.classList.toggle('is-selected', sbState.shellSizing.snapToChatWidth);
     }
 
     if (mobileNavIconOnlyInput instanceof HTMLInputElement) {
@@ -12071,22 +12365,33 @@ function openShell(shellKey, tabId = null) {
     shellState.lastOpenedAt = performance.now();
 
     if (isDrawerActuallyOpen(shellRoot)) {
+        syncMobileShellDrawerBounds();
+        queueMobileShellDrawerBoundsSync();
+        syncDesktopShellSizing();
         window.requestAnimationFrame(() => focusShellPanel(shellKey));
         return;
     }
 
     if (shellRoot.classList.contains('openDrawer')) {
         forceDrawerState(shellRoot, true, shellConfig.hostIconSelector);
+        syncMobileShellDrawerBounds();
+        queueMobileShellDrawerBoundsSync();
+        syncDesktopShellSizing();
         window.requestAnimationFrame(() => focusShellPanel(shellKey));
         return;
     }
 
     if (!shellRoot.classList.contains('openDrawer')) {
         forceDrawerState(shellRoot, true, shellConfig.hostIconSelector);
+        syncMobileShellDrawerBounds();
+        queueMobileShellDrawerBoundsSync();
         window.requestAnimationFrame(() => {
             if (!isDrawerActuallyOpen(shellRoot)) {
                 forceDrawerState(shellRoot, true, shellConfig.hostIconSelector);
             }
+            syncMobileShellDrawerBounds();
+            queueMobileShellDrawerBoundsSync();
+            syncDesktopShellSizing();
             focusShellPanel(shellKey);
         });
     }
@@ -12105,6 +12410,9 @@ function closeShell(shellKey) {
 
     if (!isDrawerActuallyOpen(shellRoot)) {
         forceDrawerState(shellRoot, false, shellConfig.hostIconSelector);
+        syncMobileShellDrawerBounds();
+        queueMobileShellDrawerBoundsSync();
+        requestMobileViewportReset();
         return;
     }
 
@@ -12115,6 +12423,9 @@ function closeShell(shellKey) {
 
     // Managed shells do not need the legacy drawer toggle close animation.
     forceDrawerState(shellRoot, false, shellConfig.hostIconSelector);
+    syncMobileShellDrawerBounds();
+    queueMobileShellDrawerBoundsSync();
+    requestMobileViewportReset();
     if (shouldRestoreFocus) {
         window.requestAnimationFrame(() => restoreShellFocus(shellKey));
     } else {
@@ -12350,6 +12661,7 @@ function buildShell(shellKey) {
             if (isMobileViewport()) {
                 closeMobileNav();
             }
+            syncDesktopShellSizing();
             const activeTab = shellState.tabs.get(shellState.activeTabId);
             activeTab?.onActivate?.();
             dispatchShellTabActivated(shellKey, activeTab);
@@ -12608,6 +12920,34 @@ function getBuiltInRailActionsForShell(shellKey) {
     return actions;
 }
 
+function getAllBuiltInRailActionKeys() {
+    const actionKeys = new Set();
+
+    for (const [shellKey, shellConfig] of Object.entries(SB_SHELLS)) {
+        const tabConfigs = [
+            shellConfig.baseTab,
+            ...(Array.isArray(shellConfig.embeddedTabs) ? shellConfig.embeddedTabs : []),
+            ...(Array.isArray(shellConfig.customTabs) ? shellConfig.customTabs : []),
+        ];
+
+        for (const tabConfig of tabConfigs) {
+            if (!tabConfig?.id) {
+                continue;
+            }
+
+            actionKeys.add(getMobileQuickActionKey({
+                type: 'tab',
+                shellKey,
+                tabId: tabConfig.id,
+                icon: tabConfig.icon,
+                label: tabConfig.label,
+            }));
+        }
+    }
+
+    return actionKeys;
+}
+
 function getBuiltInRailLabelForShell(shellKey) {
     return shellKey === 'right' ? 'Customize' : 'Workspace';
 }
@@ -12675,9 +13015,7 @@ function syncMobileShellRailActions(shellKey = null) {
         }
 
         const builtInRailActions = showCustomize ? getBuiltInRailActionsForShell(currentShellKey) : [];
-        const builtInRailActionKeys = builtInRailActions.length
-            ? new Set(builtInRailActions.map(getMobileQuickActionKey))
-            : new Set();
+        const builtInRailActionKeys = showCustomize ? getAllBuiltInRailActionKeys() : new Set();
         const replacementAction = railMode === 'desktop' && navState.replaceQuickActions
             ? createNavReplacementQuickAction(navState.replacementTarget)
             : null;
@@ -13112,10 +13450,14 @@ function setMobileNavOpenState(isOpen) {
     button.setAttribute('aria-expanded', navState.buttonExpanded);
     button.innerHTML = navState.buttonIcon === 'close'
         ? '<i class="fa-solid fa-xmark" aria-hidden="true"></i>'
-        : '<i class="fa-solid fa-bars" aria-hidden="true"></i>';
+        : `<i class="fa-solid ${SB_MOBILE_NAV_CLOSED_ICON}" aria-hidden="true"></i>`;
     updateMobileNavButtonLabel();
 
     queueMobileModalStateSync();
+
+    if (wasOpen && !navState.shouldOpen) {
+        requestMobileViewportReset();
+    }
 
     if (navState.shouldRefreshQuickActions) {
         refreshMobileNavQuickActions();
@@ -13517,9 +13859,13 @@ function applyDefaultDrawerStates() {
 }
 
 function syncMobileViewportState() {
+    syncShellViewportBounds();
+    syncMobileShellDrawerBounds();
+
     if (!isMobileViewport()) {
         closeMobileNav();
         closeMobileChatTools();
+        syncMobileShellDrawerBounds();
     }
 
     syncMobileShellRailActions();
@@ -14187,6 +14533,7 @@ function initAll() {
     setFrontendIconPreference(sbState.frontendIcon, { persist: false });
     setSurfaceTransparency(sbState.surfaceTransparency, { persist: false });
     setCompactMode(sbState.compactMode, { persist: false });
+    setDesktopShellSnapToChatWidth(sbState.shellSizing.snapToChatWidth, { persist: false });
     setCharacterDrawerRightLock(sbState.characterDrawer.rightLocked, { persist: false });
     setTopbarScale('desktop', sbState.topbarScale.desktop, { persist: false });
     setTopbarScale('mobile', sbState.topbarScale.mobile, { persist: false });
@@ -14220,6 +14567,10 @@ function initAll() {
 
     window.addEventListener('resize', syncMobileViewportState, { passive: true });
     window.addEventListener('orientationchange', syncMobileViewportState);
+    window.visualViewport?.addEventListener('resize', syncMobileViewportState, { passive: true });
+    window.visualViewport?.addEventListener('scroll', syncMobileViewportState, { passive: true });
+    window.visualViewport?.addEventListener('resize', syncDesktopShellSizing, { passive: true });
+    window.visualViewport?.addEventListener('scroll', syncDesktopShellSizing, { passive: true });
 
     // SillyBunny: re-sync shell width when the chat width slider changes so settings
     // panels narrow alongside the chat container (matches standard ST behaviour).
@@ -14283,6 +14634,9 @@ function initAll() {
         },
         setCompactMode(value) {
             setCompactMode(value);
+        },
+        setDesktopShellSnapToChatWidth(value) {
+            setDesktopShellSnapToChatWidth(value);
         },
         setMessageStyle,
         openChatTools() {

--- a/public/style.css
+++ b/public/style.css
@@ -10,7 +10,7 @@
 @import url(css/accounts.css);
 @import url(css/tags.css);
 @import url(css/scrollable-button.css?v=20260517a);
-@import url(css/welcome.css?v=20260602f);
+@import url(css/welcome.css?v=20260603e);
 @import url(css/data-maid.css);
 @import url(css/secrets.css);
 @import url(css/backgrounds.css?v=20260425a);

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const SB_SW_CACHE_VERSION = 'sillybunny-cache-v20260602f';
+const SB_SW_CACHE_VERSION = 'sillybunny-cache-v20260603e';
 const SB_STATIC_CACHE = `${SB_SW_CACHE_VERSION}-static`;
 const SB_SHELL_CACHE = `${SB_SW_CACHE_VERSION}-shell`;
 const SB_FRONTEND_ASSET_PREFIX = '/frontend-assets/';

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -5,6 +5,8 @@ import path from 'node:path';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const tabsSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'sillybunny-tabs.js'), 'utf8');
+const tabsCssSource = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-tabs.css'), 'utf8');
+const mobileShellCssSource = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-mobile-shell.css'), 'utf8');
 
 function getFunctionSource(name) {
     const marker = `function ${name}(`;
@@ -12,7 +14,26 @@ function getFunctionSource(name) {
 
     expect(start).toBeGreaterThanOrEqual(0);
 
-    const bodyStart = tabsSource.indexOf('{', start);
+    const paramsStart = tabsSource.indexOf('(', start);
+    let parenDepth = 0;
+    let paramsEnd = -1;
+
+    for (let index = paramsStart; index < tabsSource.length; index++) {
+        const char = tabsSource[index];
+        if (char === '(') {
+            parenDepth++;
+        } else if (char === ')') {
+            parenDepth--;
+            if (parenDepth === 0) {
+                paramsEnd = index;
+                break;
+            }
+        }
+    }
+
+    expect(paramsEnd).toBeGreaterThan(paramsStart);
+
+    const bodyStart = tabsSource.indexOf('{', paramsEnd);
     let depth = 0;
 
     for (let index = bodyStart; index < tabsSource.length; index++) {
@@ -81,6 +102,102 @@ describe('mobile shell lifecycle wiring', () => {
         expect(setMobileNavOpenStateSource).toContain('overlay.setAttribute(\'aria-hidden\', navState.overlayAriaHidden);');
         expect(setMobileNavOpenStateSource).toContain('button.setAttribute(\'aria-expanded\', navState.buttonExpanded);');
         expect(setMobileNavOpenStateSource).toContain('navState.shouldRestoreButtonFocus');
+    });
+
+    test('uses a distinct closed mobile nav icon from the Workspace proxy', () => {
+        const buildTopBarSource = getFunctionSource('buildTopBar');
+        const setMobileNavOpenStateSource = getFunctionSource('setMobileNavOpenState');
+
+        expect(tabsSource).toContain('const SB_MOBILE_NAV_CLOSED_ICON = \'fa-compass\';');
+        expect(buildTopBarSource).toContain('SB_MOBILE_NAV_CLOSED_ICON');
+        expect(setMobileNavOpenStateSource).toContain('SB_MOBILE_NAV_CLOSED_ICON');
+        expect(setMobileNavOpenStateSource).not.toContain('fa-solid fa-bars');
+    });
+
+    test('requests a mobile viewport reset when search and mobile panels close', () => {
+        const searchOpenStateSource = getFunctionSource('setUniversalSearchOpenState');
+        const closeShellSource = getFunctionSource('closeShell');
+        const closeCharacterPanelSource = getFunctionSource('closeCharacterPanel');
+        const setMobileNavOpenStateSource = getFunctionSource('setMobileNavOpenState');
+
+        expect(tabsSource).toContain('function requestMobileViewportReset(');
+        expect(searchOpenStateSource).toContain('requestMobileViewportReset();');
+        expect(closeShellSource).toContain('requestMobileViewportReset();');
+        expect(closeCharacterPanelSource).toContain('requestMobileViewportReset();');
+        expect(setMobileNavOpenStateSource).toContain('requestMobileViewportReset();');
+    });
+
+    test('dedupes rail quick actions against all built-in rail actions', () => {
+        const syncMobileShellRailActionsSource = getFunctionSource('syncMobileShellRailActions');
+
+        expect(tabsSource).toContain('function getAllBuiltInRailActionKeys(');
+        expect(syncMobileShellRailActionsSource).toContain('getAllBuiltInRailActionKeys()');
+        expect(syncMobileShellRailActionsSource).not.toContain('builtInRailActions.map(getMobileQuickActionKey)');
+    });
+
+    test('clamps resizable shell panels against the visual viewport and panel top', () => {
+        const getResolvedShellTopbarOffsetSource = getFunctionSource('getResolvedShellTopbarOffset');
+        const getDesktopShellResizeBoundsSource = getFunctionSource('getDesktopShellResizeBounds');
+        const setShellSizeOverrideSource = getFunctionSource('setShellSizeOverride');
+        const openShellSource = getFunctionSource('openShell');
+        const closeShellSource = getFunctionSource('closeShell');
+        const syncMobileViewportStateSource = getFunctionSource('syncMobileViewportState');
+
+        expect(tabsSource).toContain('function getShellViewportSize(');
+        expect(tabsSource).toContain('function syncShellViewportBounds(');
+        expect(tabsSource).toContain('function syncMobileShellDrawerBounds(');
+        expect(tabsSource).toContain('function queueMobileShellDrawerBoundsSync(');
+        expect(tabsSource).toContain('root.style.setProperty(\'--sb-shell-available-height\'');
+        expect(tabsSource).toContain('drawer.style.setProperty(\'height\', `${availableHeight}px`, \'important\')');
+        expect(tabsSource).toContain('window.visualViewport');
+        expect(tabsSource).toContain('function getShellViewportTop(');
+        expect(getResolvedShellTopbarOffsetSource).toContain('document.getElementById(\'sheld\')');
+        expect(getResolvedShellTopbarOffsetSource).toContain('document.getElementById(\'top-bar\')');
+        expect(getDesktopShellResizeBoundsSource).toContain('getShellViewportSize()');
+        expect(getDesktopShellResizeBoundsSource).toContain('getShellViewportTop(root, viewportSize)');
+        expect(getDesktopShellResizeBoundsSource).toContain('viewportHeight - shellTop - SB_DESKTOP_SHELL_RESIZE.bottomGap');
+        expect(setShellSizeOverrideSource).toContain('clampShellSize(size, getDesktopShellResizeBounds(shellKey))');
+        expect(openShellSource).toContain('syncDesktopShellSizing();');
+        expect(openShellSource).toContain('syncMobileShellDrawerBounds();');
+        expect(openShellSource).toContain('queueMobileShellDrawerBoundsSync();');
+        expect(closeShellSource).toContain('syncMobileShellDrawerBounds();');
+        expect(closeShellSource).toContain('queueMobileShellDrawerBoundsSync();');
+        expect(syncMobileViewportStateSource).toContain('syncMobileShellDrawerBounds();');
+        expect(tabsSource).toContain('window.visualViewport?.addEventListener(\'resize\', syncMobileViewportState, { passive: true });');
+        expect(tabsSource).toContain('window.visualViewport?.addEventListener(\'scroll\', syncMobileViewportState, { passive: true });');
+        expect(tabsSource).toContain('window.visualViewport?.addEventListener(\'resize\', syncDesktopShellSizing, { passive: true });');
+        expect(tabsSource).toContain('window.visualViewport?.addEventListener(\'scroll\', syncDesktopShellSizing, { passive: true });');
+        expect(mobileShellCssSource).toMatch(/#left-nav-panel\.openDrawer,[\s\S]*#right-nav-panel\.openDrawer\s*\{[\s\S]*top:\s*calc\(var\(--sb-shell-measured-top-offset,[\s\S]*bottom:\s*auto\s*!important;[\s\S]*box-sizing:\s*border-box\s*!important;[\s\S]*height:\s*calc\(var\(--sb-shell-available-height/);
+        expect(mobileShellCssSource.lastIndexOf('bottom: auto !important;')).toBeGreaterThan(
+            mobileShellCssSource.lastIndexOf('bottom: env(safe-area-inset-bottom, 0px) !important;'),
+        );
+    });
+
+    test('offers snap-to-chat-width as a persistent desktop shell sizing mode', () => {
+        const getDesktopShellDimensionsSource = getFunctionSource('getDesktopShellDimensions');
+        const createDesktopShellSizingSettingsGroupSource = getFunctionSource('createDesktopShellSizingSettingsGroup');
+        const updateThemePickerUiSource = getFunctionSource('updateThemePickerUi');
+
+        expect(tabsSource).toContain('desktopShellSnapToChatWidth: \'sb-desktop-shell-snap-to-chat-width\'');
+        expect(tabsSource).toContain('snapToChatWidth: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.desktopShellSnapToChatWidth), false)');
+        expect(tabsSource).toContain('function setDesktopShellSnapToChatWidth(');
+        expect(tabsSource).toContain('safeSetItem(SB_STORAGE_KEYS.desktopShellSnapToChatWidth, String(nextEnabled));');
+        expect(getDesktopShellDimensionsSource).toContain('isShellSnapToChatWidthEnabled(shellKey)');
+        expect(getDesktopShellDimensionsSource).toContain('getChatViewportWidth(viewportSize)');
+        expect(createDesktopShellSizingSettingsGroupSource).toContain('Snap to chat width');
+        expect(createDesktopShellSizingSettingsGroupSource).toContain('setDesktopShellSnapToChatWidth(input.checked)');
+        expect(updateThemePickerUiSource).toContain('sb-desktop-shell-snap-to-chat-input');
+    });
+
+    test('opens global search as a focused readable command surface', () => {
+        const setUniversalSearchOpenStateSource = getFunctionSource('setUniversalSearchOpenState');
+        const buildUniversalSearchRowSource = getFunctionSource('buildUniversalSearchRow');
+
+        expect(tabsSource).toContain('function focusUniversalSearchInput(');
+        expect(setUniversalSearchOpenStateSource).toContain('focusUniversalSearchInput(input);');
+        expect(buildUniversalSearchRowSource).toContain('setUniversalSearchOpenState(true, { focusInput: true });');
+        expect(tabsCssSource).toMatch(/\.sb-search-results\s*\{[\s\S]*position:\s*relative;[\s\S]*isolation:\s*isolate;[\s\S]*background-color:\s*var\(--SmartThemeBlurTintColor\)/);
+        expect(tabsCssSource).toMatch(/\.sb-search-result,\s*\n\.sb-search-empty\s*\{[\s\S]*position:\s*relative;[\s\S]*isolation:\s*isolate;[\s\S]*background-color:\s*var\(--SmartThemeBlurTintColor\)/);
     });
 
     test('routes hamburger toggle intent through the lifecycle seam', () => {


### PR DESCRIPTION
## What?
Hardens the SillyBunny shell menu and search UI across mobile and desktop. This updates the mobile Quick Actions/menu icon, dedupes built-in rail quick actions, adds a persistent desktop "Snap to chat width" setting, focuses the search input when search opens, improves search surface readability, and bumps the SillyBunny frontend cache version.

## Why?
Mobile drawers could shift or extend outside the viewport after search/menu interactions, making the menu difficult to recover. Search also looked unreadable in some themes, and tapping search should immediately support typing. Desktop shell panels needed an optional mode that uses the chat column width cleanly.

## How?
Adds measured visual-viewport bounds for shell drawers, queues drawer bound re-syncs around open/close/search transitions, and clamps desktop panel resize dimensions against the viewport. The new snap-to-chat setting persists in local storage and feeds the existing shell sizing sync. Search containers now render as opaque theme-aware surfaces, and the search toggle explicitly focuses/selects the input.

## Testing?
- `bun test tests/mobile-shell-lifecycle-wiring.test.js`
- `bun test frontend-assets.test.js`
- `bun test mobile-shell-lifecycle.test.js mobile-shell-lifecycle-wiring.test.js mobile-shell-button-scale.test.js chat-render-lifecycle-mobile-viewport.test.js`
- `npm run lint`
- `npm run build:frontend`
- Manual browser probes in Edge covered mobile drawer bottom/right overflow, desktop search focus/result readability, snap-to-chat sizing, and resize clamping.

## Screenshots (optional)
Not included; this was verified with DOM geometry and computed-style browser probes across mobile and desktop viewports.

## Anything Else?
Targets `staging`.