### PR TITLE
fix: align docker compose build context

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -95,7 +95,7 @@ Then, run the appropriate launcher for your OS, which auto-installs all dependen
 | macOS (Terminal) | `./Start.command` |
 | macOS (Finder) | Double-click `Start.command` (right-click > Open if Gatekeeper warns) |
 | Linux / WSL | `./start.sh` |
-| Docker | `docker compose -f docker/docker-compose.yml up --build`
+| Docker | `docker compose --project-directory . -f docker/docker-compose.yml up --build`
 | Android (Termux) | `bash start.sh` |
 
 If you already manage your own Bun install, run via `bun run start`. Other launch variants:

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Then, run the appropriate launcher for your OS, which auto-installs all dependen
 | macOS (Terminal) | `./Start.command` |
 | macOS (Finder) | Double-click `Start.command` (right-click > Open if Gatekeeper warns) |
 | Linux / WSL | `./start.sh` |
-| Docker | `docker compose -f docker/docker-compose.yml up --build`
+| Docker | `docker compose --project-directory . -f docker/docker-compose.yml up --build`
 | Android (Termux) | `bash start.sh` |
 
 If you already manage your own Bun install, run via `bun run start`. Other launch variants:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   sillybunny:
-    build: ..
+    build:
+      # Repo root; Coolify and the documented local command set this as project directory.
+      context: .
+      dockerfile: Dockerfile
     container_name: sillybunny
     hostname: sillybunny
     image: sillybunny:latest
@@ -14,10 +17,10 @@ services:
     ports:
       - "4444:4444"
     volumes:
-      - "./config:/home/bun/app/config"
-      - "./data:/home/bun/app/data"
-      - "./plugins:/home/bun/app/plugins"
-      - "./extensions:/home/bun/app/public/scripts/extensions/third-party"
+      - "./docker/config:/home/bun/app/config"
+      - "./docker/data:/home/bun/app/data"
+      - "./docker/plugins:/home/bun/app/plugins"
+      - "./docker/extensions:/home/bun/app/public/scripts/extensions/third-party"
     healthcheck:
       test: ["CMD", "bun", "src/healthcheck.js"]
       interval: 30s


### PR DESCRIPTION
## What?
Update the Docker Compose build configuration so `docker/docker-compose.yml` resolves the SillyBunny build context from the repository root. The Docker launch command in both README copies now includes `--project-directory .` to match that path model.

## Why?
Coolify deploys the compose file with `--project-directory` set to the repository root. The previous `build: ..` resolved one directory above the checkout in that invocation, so Docker could not find the root `Dockerfile` and the deployment failed before building.

## How?
The compose service now uses an explicit build object with `context: .` and `dockerfile: Dockerfile`. Bind mounts now point at `./docker/config`, `./docker/data`, `./docker/plugins`, and `./docker/extensions` so runtime Docker data still lives under the Docker folder when the project directory is the repository root.

## Testing?
- `git diff --check`
- Verified the Coolify-style path model resolves to the repository root and root `Dockerfile`.
- Docker build was not run because Docker CLI is unavailable in this environment.

## Screenshots (optional)
Not applicable; deployment configuration change only.

## Anything Else?
This is targeted at `main`, where the Coolify deployment failure occurred.