### PR TITLE
fix: budget mutated chat prompts as full payloads

### DIFF
--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -4218,12 +4218,13 @@ async function onChatCompletionPromptReady(eventData) {
     const result = await runPreGenerationInterceptorsOnChat(originalChat, currentMainGenerationType);
     const nextChat = result.chat;
     pendingPreGenerationInterceptRuns.push(...result.runs);
-    if (nextChat === originalChat) {
+    if (nextChat === originalChat || !result.runs.some(run => run.changed)) {
         return;
     }
 
     originalChat.splice(0, originalChat.length, ...nextChat);
     eventData.chat = originalChat;
+    eventData.chatChanged = true;
 }
 
 async function onGenerationOutputBufferingDecision(eventData) {

--- a/public/scripts/extensions/prompt-inspector/index.js
+++ b/public/scripts/extensions/prompt-inspector/index.js
@@ -91,6 +91,7 @@ eventSource.on(event_types.CHAT_COMPLETION_PROMPT_READY, async (data) => {
         // Chat is passed by reference, so we can modify it directly
         if (Array.isArray(chat) && Array.isArray(data.chat)) {
             data.chat.splice(0, data.chat.length, ...chat);
+            data.chatChanged = true;
         }
 
         console.debug('Prompt Inspector: Prompt updated');

--- a/public/scripts/extensions/quick-image-gen/index.js
+++ b/public/scripts/extensions/quick-image-gen/index.js
@@ -14393,6 +14393,7 @@ function onChatCompletionPromptReady(eventData) {
         }
 
         const injectMsg = { role: "system", content: promptText };
+        let injected = false;
 
         if (position === "afterScenario") {
             // Insert after the first system message (scenario)
@@ -14402,11 +14403,13 @@ function onChatCompletionPromptReady(eventData) {
             } else {
                 prompts.push(injectMsg);
             }
+            injected = true;
         } else if (position === "inUser") {
             // Insert as system message before the last user message
             for (let i = prompts.length - 1; i >= 0; i--) {
                 if (prompts[i].role === "user") {
                     prompts.splice(i, 0, injectMsg);
+                    injected = true;
                     break;
                 }
             }
@@ -14414,9 +14417,15 @@ function onChatCompletionPromptReady(eventData) {
             // Insert at specific depth from the end
             const insertIdx = Math.max(0, prompts.length - depth);
             prompts.splice(insertIdx, 0, injectMsg);
+            injected = true;
         }
 
-        log(`Inject: Injected prompt at position '${position}'${position === "atDepth" ? ` depth ${depth}` : ""}`);
+        if (injected) {
+            if (eventData && !Array.isArray(eventData)) {
+                eventData.chatChanged = true;
+            }
+            log(`Inject: Injected prompt at position '${position}'${position === "atDepth" ? ` depth ${depth}` : ""}`);
+        }
     } catch (e) {
         log(`Inject: Error injecting prompt: ${e.message}`);
     }

--- a/public/scripts/openai-prompt-budget.js
+++ b/public/scripts/openai-prompt-budget.js
@@ -1,4 +1,14 @@
 /**
+ * Determines whether a prompt-ready chat payload needs a post-mutation budget recount.
+ *
+ * @param {object} eventData CHAT_COMPLETION_PROMPT_READY event payload.
+ * @returns {boolean}
+ */
+export function shouldCheckPostInterceptChatBudget(eventData) {
+    return eventData?.chatChanged === true;
+}
+
+/**
  * Recounts a finalized chat-completion payload against the prompt budget.
  *
  * @param {object[]} chat Final chat-completion messages.

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -70,7 +70,7 @@ import {
     textValueMatcher,
     uuidv4,
 } from './utils.js';
-import { countTokensOpenAIAsync, getTokenizerModel } from './tokenizers.js';
+import { countChatCompletionPayloadTokensOpenAIAsync, countTokensOpenAIAsync, getTokenizerModel } from './tokenizers.js';
 import { isMobile } from './RossAscends-mods.js';
 import { saveLogprobsForActiveMessage } from './logprobs.js';
 import { SlashCommandParser } from './slash-commands/SlashCommandParser.js';
@@ -85,7 +85,7 @@ import { accountStorage } from './util/AccountStorage.js';
 import { COMETAPI_IGNORE_PATTERNS, IGNORE_SYMBOL, MEDIA_DISPLAY, MEDIA_TYPE } from './constants.js';
 import { syncOpenRouterProvidersForModel, updateOpenRouterProvidersWarning } from './textgen-models.js';
 import { hasTextOrArrayPayload, shouldRetainContextAtDepth, stripHtmlTagsFromContext, stripOocBlocksFromContext } from './ooc-blocks.js';
-import { checkPostInterceptChatBudget } from './openai-prompt-budget.js';
+import { checkPostInterceptChatBudget, shouldCheckPostInterceptChatBudget } from './openai-prompt-budget.js';
 import { buildChatCompletionPresetForSave, buildReverseProxyPresetForSave, normalizeReverseProxyPreset } from './openai-preset-utils.js';
 
 export {
@@ -1785,7 +1785,9 @@ export async function prepareOpenAIMessages({
 
     let chat = chatCompletion.getChat();
 
-    const eventData = { chat, dryRun };
+    // SillyBunny: only prompt-ready listeners that mutate the finalized chat should
+    // trigger the post-mutation budget recount.
+    const eventData = { chat, dryRun, chatChanged: false };
     await eventSource.emit(event_types.CHAT_COMPLETION_PROMPT_READY, eventData);
     if (!Array.isArray(eventData.chat)) {
         chatCompletion.log('Pre-generation intercepts produced an invalid chat payload.');
@@ -1794,8 +1796,8 @@ export async function prepareOpenAIMessages({
 
     chat = eventData.chat;
 
-    if (!dryRun) {
-        const { promptTokens, promptTokenBudget, exceeded } = await checkPostInterceptChatBudget(chat, userSettings, countTokensOpenAIAsync);
+    if (!dryRun && shouldCheckPostInterceptChatBudget(eventData)) {
+        const { promptTokens, promptTokenBudget, exceeded } = await checkPostInterceptChatBudget(chat, userSettings, countChatCompletionPayloadTokensOpenAIAsync);
         if (exceeded) {
             toastr.error(t`Pre-generation intercepts exceed the context size.`);
             chatCompletion.log(`Pre-generation intercepts exceed the context size. Tokens: ${promptTokens}. Budget: ${promptTokenBudget}.`);

--- a/public/scripts/tokenizers.js
+++ b/public/scripts/tokenizers.js
@@ -887,6 +887,28 @@ export async function countTokensOpenAIAsync(messages, full = false) {
 }
 
 /**
+ * Returns the token count for a finalized chat completion payload using the OpenAI tokenizer.
+ * @param {object[]} messages Final chat-completion messages.
+ * @returns {Promise<number>} Token count.
+ */
+export async function countChatCompletionPayloadTokensOpenAIAsync(messages) {
+    const tokenizerEndpoint = `/api/tokenizers/openai/count?model=${getTokenizerModel()}`;
+
+    // SillyBunny: count post-intercept payloads in one request so backend-specific
+    // per-payload padding is applied once instead of once per message.
+    const data = await jQuery.ajax({
+        async: true,
+        type: 'POST', //
+        url: tokenizerEndpoint,
+        data: JSON.stringify(messages),
+        dataType: 'json',
+        contentType: 'application/json',
+    });
+
+    return Number(data.token_count);
+}
+
+/**
  * Gets the token cache object for the current chat.
  * @returns {Object} Token cache object for the current chat.
  */
@@ -1228,4 +1250,3 @@ export async function initTokenizers() {
     await loadTokenCache();
     registerDebugFunction('resetTokenCache', 'Reset token cache', 'Purges the calculated token counts. Use this if you want to force a full re-tokenization of all chats or suspect the token counts are wrong.', resetTokenCache);
 }
-

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -885,6 +885,7 @@ describe('in-chat agent post-processing runner', () => {
             { role: 'system', content: 'rewritten system prompt' },
             { role: 'user', content: 'rewritten user prompt' },
         ]);
+        expect(eventData.chatChanged).toBe(true);
     });
 
     test('leaves chat completion prompts unchanged when intercept output has invalid messages', async () => {
@@ -913,6 +914,7 @@ describe('in-chat agent post-processing runner', () => {
 
                 expect(eventData.chat).toBe(originalChat);
                 expect(eventData.chat).toEqual([originalMessage]);
+                expect(eventData.chatChanged).toBeUndefined();
                 expect(warnSpy).toHaveBeenCalledWith(
                     expect.stringContaining('Leaving chat context unchanged'),
                     expect.any(Error),
@@ -967,6 +969,7 @@ describe('in-chat agent post-processing runner', () => {
             { role: 'user', content: '<patch>\npatch note\n</patch>' },
             originalMessage,
         ]);
+        expect(eventData.chatChanged).toBe(true);
 
         chat.push({
             name: 'Assistant',

--- a/tests/openai-prompt-budget.test.js
+++ b/tests/openai-prompt-budget.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, jest, test } from '@jest/globals';
-import { checkPostInterceptChatBudget } from '../public/scripts/openai-prompt-budget.js';
+import { checkPostInterceptChatBudget, shouldCheckPostInterceptChatBudget } from '../public/scripts/openai-prompt-budget.js';
 
 describe('OpenAI post-intercept prompt budget', () => {
     test('recounts chat payloads after pre-generation intercepts', async () => {
@@ -33,5 +33,12 @@ describe('OpenAI post-intercept prompt budget', () => {
             openai_max_context: 150,
             openai_max_tokens: 40,
         }, async () => 0)).rejects.toThrow('Post-intercept chat payload must be an array.');
+    });
+
+    test('checks budget only when the prompt-ready chat changed', () => {
+        expect(shouldCheckPostInterceptChatBudget({ chatChanged: true })).toBe(true);
+        expect(shouldCheckPostInterceptChatBudget({ chatChanged: false })).toBe(false);
+        expect(shouldCheckPostInterceptChatBudget({})).toBe(false);
+        expect(shouldCheckPostInterceptChatBudget(null)).toBe(false);
     });
 });


### PR DESCRIPTION
Summary:
- Skip the post-prompt-ready budget recount unless a listener actually changed the finalized chat payload.
- Mark known chat prompt mutators when they change the prompt.
- Count changed chat-completion payloads in one tokenizer request so backend per-payload padding is applied once across providers.

Tests:
- `npm run test:unit -- in-chat-agents-runner.test.js openai-prompt-budget.test.js`
- `npx eslint public/scripts/openai.js public/scripts/tokenizers.js public/scripts/openai-prompt-budget.js public/scripts/extensions/in-chat-agents/agent-runner.js public/scripts/extensions/prompt-inspector/index.js tests/openai-prompt-budget.test.js tests/in-chat-agents-runner.test.js`

Note:
- `public/scripts/extensions/quick-image-gen/index.js` is ignored by the repo ESLint config; running ESLint with it included reports only the ignore warning.