### PR TITLE
fix: stabilize connection profile saves

### DIFF
--- a/public/scripts/extensions/connection-manager/index.js
+++ b/public/scripts/extensions/connection-manager/index.js
@@ -1,6 +1,6 @@
 import { DOMPurify, Fuse } from '../../../lib.js';
 
-import { activateSendButtons, deactivateSendButtons, event_types, eventSource, main_api, online_status, saveSettings } from '../../../script.js';
+import { activateSendButtons, deactivateSendButtons, event_types, eventSource, main_api, online_status, saveSettings, saveSettingsDebounced } from '../../../script.js';
 import { extension_settings, getContext, renderExtensionTemplateAsync } from '../../extensions.js';
 import { callGenericPopup, Popup, POPUP_RESULT, POPUP_TYPE } from '../../popup.js';
 import { SlashCommand } from '../../slash-commands/SlashCommand.js';
@@ -12,7 +12,7 @@ import { enumTypes, SlashCommandEnumValue } from '../../slash-commands/SlashComm
 import { SlashCommandClosure } from '../../slash-commands/SlashCommandClosure.js';
 import { SlashCommandParser } from '../../slash-commands/SlashCommandParser.js';
 import { SlashCommandScope } from '../../slash-commands/SlashCommandScope.js';
-import { collapseSpaces, getUniqueName, isFalseBoolean, isTrueBoolean, uuidv4, waitUntilCondition } from '../../utils.js';
+import { cancelDebounce, collapseSpaces, getUniqueName, isFalseBoolean, isTrueBoolean, uuidv4, waitUntilCondition } from '../../utils.js';
 import { t } from '../../i18n.js';
 import { getSecretLabelById } from '../../secrets.js';
 import { performFuzzySearch } from '/scripts/power-user.js';
@@ -41,6 +41,11 @@ const ALLOW_EMPTY = [
     'custom-reasoning-param-name',
     'custom-reasoning-enabled-value',
     'custom-reasoning-disabled-value',
+];
+
+const CLEAR_ON_EMPTY_RESULT = [
+    'api-url',
+    'secret-id',
 ];
 
 const CC_COMMANDS = [
@@ -607,6 +612,10 @@ async function readProfileFromCommands(mode, profile, cleanUp = false) {
                 profile[command] = result;
                 continue;
             }
+
+            if (cleanUp && CLEAR_ON_EMPTY_RESULT.includes(command)) {
+                delete profile[command];
+            }
         } catch (error) {
             console.error(`Failed to execute command: ${command}`, error);
         }
@@ -949,7 +958,15 @@ async function applyConnectionProfile(profile) {
             }
             try {
                 const args = getNamedArguments(allowEmpty ? { force: 'true' } : {});
-                await SlashCommandParser.commands[command].callback(args, argument);
+                const commandPromise = SlashCommandParser.commands[command].callback(args, argument);
+                // SillyBunny: profile application triggers UI handlers that queue partial settings saves.
+                // Keep persistence centralized in the explicit save after the full profile is applied.
+                cancelDebounce(saveSettingsDebounced);
+                try {
+                    await commandPromise;
+                } finally {
+                    cancelDebounce(saveSettingsDebounced);
+                }
             } catch (error) {
                 if (spinner.isAborted()) {
                     throw new Error(PROFILE_APPLICATION_ABORTED);

--- a/tests/connection-manager-profile-save.test.js
+++ b/tests/connection-manager-profile-save.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const connectionManagerSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'extensions', 'connection-manager', 'index.js'), 'utf8');
+
+function getFunctionSource(name) {
+    const marker = `function ${name}(`;
+    const start = connectionManagerSource.indexOf(marker);
+
+    expect(start).toBeGreaterThanOrEqual(0);
+
+    const bodyStart = connectionManagerSource.indexOf('{', start);
+    let depth = 0;
+
+    for (let index = bodyStart; index < connectionManagerSource.length; index++) {
+        const char = connectionManagerSource[index];
+        if (char === '{') {
+            depth++;
+        } else if (char === '}') {
+            depth--;
+            if (depth === 0) {
+                return connectionManagerSource.slice(start, index + 1);
+            }
+        }
+    }
+
+    throw new Error(`Unable to find function source for ${name}`);
+}
+
+describe('connection manager profile save wiring', () => {
+    test('cancels debounced settings saves while applying profile commands', () => {
+        const applySource = getFunctionSource('applyConnectionProfile');
+
+        expect(connectionManagerSource).toContain('saveSettingsDebounced } from \'../../../script.js\';');
+        expect(connectionManagerSource).toContain('cancelDebounce, collapseSpaces');
+        expect(applySource).toContain('const commandPromise = SlashCommandParser.commands[command].callback(args, argument);');
+        expect(applySource).toContain('cancelDebounce(saveSettingsDebounced);');
+        expect(applySource).toContain('finally {\n                    cancelDebounce(saveSettingsDebounced);\n                }');
+    });
+
+    test('clears stale endpoint and secret fields when updating to providers without values', () => {
+        const readSource = getFunctionSource('readProfileFromCommands');
+
+        expect(connectionManagerSource).toContain('const CLEAR_ON_EMPTY_RESULT = [\n    \'api-url\',\n    \'secret-id\',\n];');
+        expect(readSource).toContain('if (cleanUp && CLEAR_ON_EMPTY_RESULT.includes(command)) {');
+        expect(readSource).toContain('delete profile[command];');
+    });
+});


### PR DESCRIPTION
## Summary
- cancel pending debounced settings saves while connection profile slash commands apply, so partial provider/key/post-processing state is not persisted mid-switch
- clear stale endpoint and secret fields when updating a profile to a provider that does not return those values
- add a focused regression test for the connection manager save wiring

## Tests
- bun test tests/connection-manager-profile-save.test.js
- npm run test:unit --prefix tests -- connection-manager-profile-save.test.js
- ./node_modules/.bin/eslint public/scripts/extensions/connection-manager/index.js
- ./node_modules/.bin/eslint connection-manager-profile-save.test.js (from tests/)
