### PR TITLE
fix: handle Windows EPERM errors on atomic file writes

### DIFF
--- a/src/endpoints/groups.js
+++ b/src/endpoints/groups.js
@@ -4,9 +4,9 @@ import path from 'node:path';
 
 import express from 'express';
 import sanitize from 'sanitize-filename';
-import { sync as writeFileAtomicSync, default as writeFileAtomic } from 'write-file-atomic';
+import { default as writeFileAtomic } from 'write-file-atomic';
 
-import { color, tryParse } from '../util.js';
+import { color, tryParse, tryWriteFileSync } from '../util.js';
 import { getFileNameValidationFunction } from '../middleware/validateFileName.js';
 
 export const router = express.Router();
@@ -211,7 +211,7 @@ router.post('/create', (request, response) => {
         fs.mkdirSync(request.user.directories.groups);
     }
 
-    writeFileAtomicSync(pathToFile, fileData);
+    tryWriteFileSync(pathToFile, fileData);
     return response.send(groupMetadata);
 });
 
@@ -224,7 +224,7 @@ router.post('/edit', getFileNameValidationFunction('id'), (request, response) =>
     const pathToFile = path.join(request.user.directories.groups, sanitize(`${id}.json`));
     const fileData = JSON.stringify(request.body, null, 4);
 
-    writeFileAtomicSync(pathToFile, fileData);
+    tryWriteFileSync(pathToFile, fileData);
     return response.send({ ok: true });
 });
 

--- a/src/endpoints/in-chat-agents.js
+++ b/src/endpoints/in-chat-agents.js
@@ -3,9 +3,8 @@ import path from 'node:path';
 
 import express from 'express';
 import sanitize from 'sanitize-filename';
-import { sync as writeFileAtomicSync } from 'write-file-atomic';
 
-import { ensureDirectory } from '../util.js';
+import { ensureDirectory, tryWriteFileSync } from '../util.js';
 
 export const router = express.Router();
 
@@ -89,7 +88,7 @@ router.post('/save', (request, response) => {
 
     ensureDirectory(request.user.directories.inChatAgents);
     const filename = getStorageFilename(request.user.directories.inChatAgents, String(request.body.id));
-    writeFileAtomicSync(filename, JSON.stringify(request.body, null, 4), 'utf8');
+    tryWriteFileSync(filename, JSON.stringify(request.body, null, 4));
 
     return response.sendStatus(200);
 });
@@ -129,7 +128,7 @@ router.post('/groups/save', (request, response) => {
 
     ensureDirectory(request.user.directories.inChatAgentGroups);
     const filename = getStorageFilename(request.user.directories.inChatAgentGroups, group.id);
-    writeFileAtomicSync(filename, JSON.stringify(group, null, 4), 'utf8');
+    tryWriteFileSync(filename, JSON.stringify(group, null, 4));
 
     return response.sendStatus(200);
 });

--- a/src/endpoints/moving-ui.js
+++ b/src/endpoints/moving-ui.js
@@ -1,7 +1,8 @@
 import path from 'node:path';
 import express from 'express';
 import sanitize from 'sanitize-filename';
-import { sync as writeFileAtomicSync } from 'write-file-atomic';
+
+import { tryWriteFileSync } from '../util.js';
 
 export const router = express.Router();
 
@@ -11,7 +12,7 @@ router.post('/save', (request, response) => {
     }
 
     const filename = path.join(request.user.directories.movingUI, sanitize(`${request.body.name}.json`));
-    writeFileAtomicSync(filename, JSON.stringify(request.body, null, 4), 'utf8');
+    tryWriteFileSync(filename, JSON.stringify(request.body, null, 4));
 
     return response.sendStatus(200);
 });

--- a/src/endpoints/presets.js
+++ b/src/endpoints/presets.js
@@ -3,8 +3,8 @@ import path from 'node:path';
 
 import express from 'express';
 import sanitize from 'sanitize-filename';
-import { sync as writeFileAtomicSync } from 'write-file-atomic';
 
+import { tryWriteFileSync } from '../util.js';
 import {
     clearDefaultPresetDeletion,
     findDefaultPreset,
@@ -97,7 +97,7 @@ router.post('/save', function (request, response) {
         clearDefaultPresetDeletion(request.user.directories, defaultPreset);
     }
 
-    writeFileAtomicSync(fullpath, JSON.stringify(request.body.preset, null, 4), 'utf-8');
+    tryWriteFileSync(fullpath, JSON.stringify(request.body.preset, null, 4));
     return response.send({ name });
 });
 

--- a/src/endpoints/quick-replies.js
+++ b/src/endpoints/quick-replies.js
@@ -3,7 +3,8 @@ import path from 'node:path';
 
 import express from 'express';
 import sanitize from 'sanitize-filename';
-import { sync as writeFileAtomicSync } from 'write-file-atomic';
+
+import { tryWriteFileSync } from '../util.js';
 
 export const router = express.Router();
 
@@ -13,7 +14,7 @@ router.post('/save', (request, response) => {
     }
 
     const filename = path.join(request.user.directories.quickreplies, sanitize(`${request.body.name}.json`));
-    writeFileAtomicSync(filename, JSON.stringify(request.body, null, 4), 'utf8');
+    tryWriteFileSync(filename, JSON.stringify(request.body, null, 4));
 
     return response.sendStatus(200);
 });

--- a/src/endpoints/secrets.js
+++ b/src/endpoints/secrets.js
@@ -2,8 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import express from 'express';
-import { sync as writeFileAtomicSync } from 'write-file-atomic';
-import { color, getConfigValue, uuidv4 } from '../util.js';
+import { color, getConfigValue, uuidv4, tryWriteFileSync } from '../util.js';
 import { encrypt, decrypt, isEncrypted, getEncryptionPassphrase } from '../encryption.js';
 
 export const SECRETS_FILE = 'secrets.json';
@@ -127,7 +126,7 @@ export class SecretManager {
      */
     _ensureSecretsFile() {
         if (!fs.existsSync(this.filePath)) {
-            writeFileAtomicSync(this.filePath, JSON.stringify(this.defaultSecrets), 'utf-8');
+            tryWriteFileSync(this.filePath, JSON.stringify(this.defaultSecrets));
         }
     }
 
@@ -169,13 +168,13 @@ export class SecretManager {
 
         if (passphrase) {
             const encrypted = encrypt(jsonString, passphrase);
-            writeFileAtomicSync(this.filePath, encrypted);
+            tryWriteFileSync(this.filePath, encrypted);
             if (this._needsEncryptionMigration) {
                 console.info(`Secrets file at ${this.filePath} has been encrypted.`);
                 this._needsEncryptionMigration = false;
             }
         } else {
-            writeFileAtomicSync(this.filePath, jsonString, 'utf-8');
+            tryWriteFileSync(this.filePath, jsonString);
         }
     }
 

--- a/src/endpoints/server-admin.js
+++ b/src/endpoints/server-admin.js
@@ -5,7 +5,6 @@ import { spawn } from 'node:child_process';
 
 import express from 'express';
 import yaml from 'yaml';
-import { sync as writeFileAtomicSync } from 'write-file-atomic';
 import { sync as commandExistsSync } from 'command-exists';
 import simpleGit from 'simple-git';
 
@@ -22,7 +21,7 @@ import {
 import { getServerLogSnapshot } from '../server-log-buffer.js';
 import { serverDirectory } from '../server-directory.js';
 import { requireAdminMiddleware } from '../users.js';
-import { getConfigValue, getVersion, isPathUnderParent } from '../util.js';
+import { getConfigValue, getVersion, isPathUnderParent, tryWriteFileSync } from '../util.js';
 import { getThumbnailDimensions, setThumbnailDimensions } from './image-metadata.js';
 import { getThumbnailRuntimeSettings, setThumbnailRuntimeSettings } from './thumbnails.js';
 
@@ -155,7 +154,7 @@ function ensureExpectedConfigMtime(stat, expectedLastModifiedMs) {
 function writeConfigDocument(configPath, document) {
     const nextContent = document.toString();
     const serializedContent = nextContent.endsWith('\n') ? nextContent : `${nextContent}\n`;
-    writeFileAtomicSync(configPath, serializedContent, 'utf8');
+    tryWriteFileSync(configPath, serializedContent);
     return fs.statSync(configPath);
 }
 
@@ -570,7 +569,7 @@ router.post('/config/save', requireAdminMiddleware, async (request, response) =>
         }
 
         const nextContent = content.endsWith('\n') ? content : `${content}\n`;
-        writeFileAtomicSync(configPath, nextContent, 'utf8');
+        tryWriteFileSync(configPath, nextContent);
         const nextStat = fs.statSync(configPath);
 
         if (restart) {

--- a/src/endpoints/settings.js
+++ b/src/endpoints/settings.js
@@ -3,11 +3,10 @@ import path from 'node:path';
 
 import express from 'express';
 import _ from 'lodash';
-import { sync as writeFileAtomicSync } from 'write-file-atomic';
 import bytes from 'bytes';
 
 import { SETTINGS_FILE } from '../constants.js';
-import { getConfigValue, generateTimestamp, removeOldBackups } from '../util.js';
+import { getConfigValue, generateTimestamp, removeOldBackups, tryWriteFileSync } from '../util.js';
 import { getAllUserHandles, getUserDirectories } from '../users.js';
 import { getFileNameValidationFunction } from '../middleware/validateFileName.js';
 
@@ -217,7 +216,7 @@ export const router = express.Router();
 router.post('/save', function (request, response) {
     try {
         const pathToSettings = path.join(request.user.directories.root, SETTINGS_FILE);
-        writeFileAtomicSync(pathToSettings, JSON.stringify(request.body, null, 4), 'utf8');
+        tryWriteFileSync(pathToSettings, JSON.stringify(request.body, null, 4));
         triggerAutoSave(request.user.profile.handle);
         response.send({ result: 'ok' });
     } catch (err) {

--- a/src/endpoints/themes.js
+++ b/src/endpoints/themes.js
@@ -3,7 +3,8 @@ import fs from 'node:fs';
 
 import express from 'express';
 import sanitize from 'sanitize-filename';
-import { sync as writeFileAtomicSync } from 'write-file-atomic';
+
+import { tryWriteFileSync } from '../util.js';
 
 export const router = express.Router();
 
@@ -13,7 +14,7 @@ router.post('/save', (request, response) => {
     }
 
     const filename = path.join(request.user.directories.themes, sanitize(`${request.body.name}.json`));
-    writeFileAtomicSync(filename, JSON.stringify(request.body, null, 4), 'utf8');
+    tryWriteFileSync(filename, JSON.stringify(request.body, null, 4));
 
     return response.sendStatus(200);
 });

--- a/src/endpoints/worldinfo.js
+++ b/src/endpoints/worldinfo.js
@@ -4,8 +4,7 @@ import path from 'node:path';
 import express from 'express';
 import sanitize from 'sanitize-filename';
 import _ from 'lodash';
-import { sync as writeFileAtomicSync } from 'write-file-atomic';
-import { tryParse } from '../util.js';
+import { tryParse, tryWriteFileSync } from '../util.js';
 
 /**
  * Reads a World Info file and returns its contents
@@ -127,7 +126,7 @@ router.post('/import', (request, response) => {
         return response.status(400).send('World file must have a name');
     }
 
-    writeFileAtomicSync(pathToNewFile, fileContents);
+    tryWriteFileSync(pathToNewFile, fileContents);
     return response.send({ name: worldName });
 });
 
@@ -151,7 +150,7 @@ router.post('/edit', (request, response) => {
     const filename = sanitize(`${request.body.name}.json`);
     const pathToFile = path.join(request.user.directories.worlds, filename);
 
-    writeFileAtomicSync(pathToFile, JSON.stringify(request.body.data, null, 4));
+    tryWriteFileSync(pathToFile, JSON.stringify(request.body.data, null, 4));
 
     return response.send({ ok: true });
 });

--- a/tests/secrets.test.js
+++ b/tests/secrets.test.js
@@ -15,6 +15,7 @@ async function importSecrets() {
             red: value => value,
         },
         getConfigValue: jest.fn(() => false),
+        tryWriteFileSync: jest.fn((filePath, data) => fs.writeFileSync(filePath, data)),
         uuidv4: jest.fn(() => `secret-id-${++idCounter}`),
     }));
 


### PR DESCRIPTION
## Summary

Replaces direct `writeFileAtomicSync` calls with the existing `tryWriteFileSync` helper (from `src/util.js`) across 10 endpoint files.

## Problem

On Windows, `write-file-atomic` calls `fs.renameSync()` which fails with `EPERM` when the target file is locked by antivirus software, Windows Search indexing, or other processes. The error spams the console and prevents saving data. This was reported in #333 for `settings.js` but affects all endpoint files using `writeFileAtomicSync`.

## Solution

`tryWriteFileSync` (already defined in `src/util.js:2075`) wraps atomic writes with:
1. **Retries** with exponential backoff (50ms, 125ms, 250ms delays) to handle transient file locks
2. **Fallback** to `fs.writeFileSync` if all retries fail on Windows `EACCES`, `EBUSY`, or `EPERM` errors

This PR applies that pattern consistently across all sync write endpoints that previously called `writeFileAtomicSync` directly.

## Files Changed

| File | Endpoints Affected |
|------|-------------------|
| `src/endpoints/settings.js` | `POST /save` |
| `src/endpoints/presets.js` | `POST /save` |
| `src/endpoints/quick-replies.js` | `POST /save` |
| `src/endpoints/themes.js` | `POST /save` |
| `src/endpoints/moving-ui.js` | `POST /save` |
| `src/endpoints/worldinfo.js` | `POST /create`, `POST /edit` |
| `src/endpoints/in-chat-agents.js` | `POST /save`, `POST /groups/save` |
| `src/endpoints/server-admin.js` | Config write functions |
| `src/endpoints/secrets.js` | Secrets file writes (3 sites) |
| `src/endpoints/groups.js` | `POST /create`, `POST /edit` |

Async `writeFileAtomic` calls in migration code (`groups.js`) were intentionally left untouched.

## Testing

- No API changes — drop-in replacement for existing sync write calls
- `tryWriteFileSync` is already battle-tested in `chats.js` (2 call sites)

Closes #333