### PR TITLE
feat: add INFO-level dispatch logging for prompt routing

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -7600,7 +7600,7 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
             console.log(typeof generate_data.prompt === 'string' ? generate_data.prompt : JSON.stringify(generate_data.prompt));
         }
 
-        console.debug('rungenerate calling API');
+        console.log(`[rungenerate] calling API: main_api=${main_api}${main_api === 'openai' ? ` source=${oai_settings.chat_completion_source} model=${getChatCompletionModel(oai_settings)}` : ''}`);
 
         showStopButton();
 

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -5319,6 +5319,8 @@ async function sendOpenAIRequest(type, messages, signal, { jsonSchema = null, ca
     const { generate_data, stream, canMultiSwipe } = await createGenerationParameters(oai_settings, model, type, messages, { jsonSchema, cacheScope });
     await eventSource.emit(event_types.CHAT_COMPLETION_SETTINGS_READY, generate_data);
 
+    console.log(`[OpenAI frontend] sendOpenAIRequest: type=${type} source=${generate_data.chat_completion_source} model=${generate_data.model} stream=${generate_data.stream}`);
+
     const generate_url = '/api/backends/chat-completions/generate';
     const response = await fetch(generate_url, {
         method: 'POST',

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -2744,6 +2744,8 @@ router.post('/generate', async function (request, response) {
     try {
         if (!request.body) return response.status(400).send({ error: true });
 
+        console.log(`[ChatCompletions] generate: type=${request.body.type} source=${request.body.chat_completion_source} model=${request.body.model} stream=${request.body.stream}`);
+
         const postProcessingType = request.body.custom_prompt_post_processing;
         if (Array.isArray(request.body.messages) && postProcessingType) {
             console.debug('Applying custom prompt post-processing of type', postProcessingType);


### PR DESCRIPTION
## Summary
- Add INFO-level rungenerate logging with main_api plus OpenAI source/model details
- Add INFO-level OpenAI frontend dispatch logging with type/source/model/stream
- Add INFO-level backend Chat Completions dispatch logging with type/source/model/stream

## Testing
- bun run lint