### PR TITLE
fix: handle Windows EPERM character card saves

### DIFF
--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -5,7 +5,6 @@ import { Buffer } from 'node:buffer';
 
 import express from 'express';
 import sanitize from 'sanitize-filename';
-import { sync as writeFileAtomicSync } from 'write-file-atomic';
 import yaml from 'yaml';
 import _ from 'lodash';
 import mime from 'mime-types';
@@ -15,7 +14,7 @@ import storage from 'node-persist';
 
 import { AVATAR_WIDTH, AVATAR_HEIGHT, DEFAULT_AVATAR_PATH } from '../constants.js';
 import { default as validateAvatarUrlMiddleware, getFileNameValidationFunction } from '../middleware/validateFileName.js';
-import { deepMerge, humanizedDateTime, tryParse, MemoryLimitedMap, getConfigValue, mutateJsonString, clientRelativePath, getUniqueName, sanitizeSafeCharacterReplacements } from '../util.js';
+import { deepMerge, humanizedDateTime, tryParse, MemoryLimitedMap, getConfigValue, mutateJsonString, clientRelativePath, getUniqueName, sanitizeSafeCharacterReplacements, tryWriteFileSync } from '../util.js';
 import { TavernCardValidator } from '../validator/TavernCardValidator.js';
 import { parse, read, write } from '../character-card-parser.js';
 import { readWorldInfoFile } from './worldinfo.js';
@@ -259,7 +258,7 @@ async function writeCharacterData(inputFile, data, outputFile, request, crop = u
         const outputImage = write(inputImage, data);
         const outputImagePath = path.join(request.user.directories.characters, `${outputFile}.png`);
 
-        writeFileAtomicSync(outputImagePath, outputImage);
+        tryWriteFileSync(outputImagePath, outputImage);
         return true;
     } catch (err) {
         console.error(err);
@@ -881,7 +880,7 @@ async function importFromByaf(uploadPath, { request }, preservedFileName) {
             const filePath = path.join(request.user.directories.chats, path.basename(fileName), chatName);
             const dir = path.dirname(filePath);
             if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-            writeFileAtomicSync(filePath, ByafParser.getChatFromScenario(scenario, request.body.user_name, card.name, byafData.chatBackgrounds), 'utf8');
+            tryWriteFileSync(filePath, ByafParser.getChatFromScenario(scenario, request.body.user_name, card.name, byafData.chatBackgrounds));
             console.log(`Created ${chatName} chat from BYAF import`);
             return chatName;
         };
@@ -895,7 +894,7 @@ async function importFromByaf(uploadPath, { request }, preservedFileName) {
             const file = getUniqueName(baseName, (name) => fs.existsSync(path.join(filePath, `${name}${extension}`)));
             if (Buffer.isBuffer(bg.data)) {
                 const newFile = `${file}${extension}`;
-                writeFileAtomicSync(path.join(filePath, newFile), bg.data);
+                tryWriteFileSync(path.join(filePath, newFile), bg.data);
                 bg.name = clientRelativePath(request.user.directories.root, path.join(filePath, newFile)); // Update background name to the new file
                 console.log(`Created ${newFile} background from BYAF import`);
             }
@@ -924,7 +923,7 @@ async function importFromByaf(uploadPath, { request }, preservedFileName) {
             const extension = path.extname(icon.filename) || '.png';
             const file = getUniqueName(`${sanitize(icon.label, { replacement: sanitizeSafeCharacterReplacements }) || 'alt'}`, (name) => fs.existsSync(path.join(altImagesFolder, `${name}${extension}`)));
             if (Buffer.isBuffer(icon.image)) {
-                writeFileAtomicSync(path.join(altImagesFolder, `${file}${extension}`), icon.image);
+                tryWriteFileSync(path.join(altImagesFolder, `${file}${extension}`), icon.image);
                 console.log(`Created ${file}${extension} alternate icon from BYAF import`);
             }
         }

--- a/src/util.js
+++ b/src/util.js
@@ -2070,9 +2070,10 @@ export function flattenSchema(schema, api) {
 /**
  * Writes to a file, creating it's parent directories if needed.
  * @param {string} filePath
- * @param {string} data
+ * @param {string|Buffer} data
+ * @param {import('node:fs').WriteFileOptions} [options]
  */
-export function tryWriteFileSync(filePath, data) {
+export function tryWriteFileSync(filePath, data, options = typeof data === 'string' ? 'utf8' : undefined) {
     const isRetryableWindowsWriteError = (error) => process.platform === 'win32' && ['EACCES', 'EBUSY', 'EPERM'].includes(error?.code);
     const sleepSync = (delayMs) => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
     const directory = path.dirname(filePath);
@@ -2086,7 +2087,7 @@ export function tryWriteFileSync(filePath, data) {
 
     for (let attempt = 0; attempt <= retryDelaysMs.length; attempt++) {
         try {
-            writeFileAtomicSync(filePath, data, 'utf8');
+            writeFileAtomicSync(filePath, data, options);
             return;
         } catch (error) {
             if (!isRetryableWindowsWriteError(error)) {
@@ -2103,7 +2104,7 @@ export function tryWriteFileSync(filePath, data) {
     if (lastError) {
         console.debug(`Atomic write failed for ${filePath}. Falling back to a direct write.`, lastError?.code);
     }
-    fs.writeFileSync(filePath, data, 'utf8');
+    fs.writeFileSync(filePath, data, options);
 }
 
 /**


### PR DESCRIPTION
## Summary
- extend tryWriteFileSync so it preserves UTF-8 behavior for string writes while supporting Buffer writes without forcing an encoding
- route character card PNG saves through the Windows retry/fallback helper
- use the same helper for BYAF character import chat/background/alternate-icon writes in characters.js

## Context
Follow-up to #336 for the character-card rename failure reported in https://github.com/platberlitz/SillyBunny/issues/333#issuecomment-4618885486.

Fixes #333.

## Verification
- `/home/platinum/SillyBunny/node_modules/.bin/eslint --resolve-plugins-relative-to /home/platinum/SillyBunny src/util.js src/endpoints/characters.js`
- `node --check src/util.js`
- `node --check src/endpoints/characters.js`

Note: the package does not define a Jest test script, and the checked-out dependency set does not include a Jest binary.