### PR TITLE
fix: refresh character editor reopen data

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -667,7 +667,38 @@ export const DEFAULT_SAVE_EDIT_TIMEOUT = debounce_timeout.relaxed;
 export const DEFAULT_PRINT_TIMEOUT = debounce_timeout.quick;
 
 export const saveSettingsDebounced = debounce((loopCounter = 0) => saveSettings(loopCounter), DEFAULT_SAVE_EDIT_TIMEOUT);
-export const saveCharacterDebounced = debounce(() => $('#create_button').trigger('click'), DEFAULT_SAVE_EDIT_TIMEOUT);
+/** @type {ReturnType<typeof setTimeout> | null} */
+let pendingCharacterSaveTimer = null;
+let characterSavePromise = Promise.resolve();
+
+// SillyBunny: the custom editor shell needs to wait for autosaves before reopening stale form data.
+function queueCharacterSave() {
+    characterSavePromise = characterSavePromise
+        .catch(error => console.warn('Previous character save failed before queued save.', error))
+        .then(() => createOrEditCharacter())
+        .catch(error => console.error('Error while saving character.', error));
+
+    return characterSavePromise;
+}
+
+export function saveCharacterDebounced() {
+    clearTimeout(pendingCharacterSaveTimer);
+    pendingCharacterSaveTimer = setTimeout(() => {
+        pendingCharacterSaveTimer = null;
+        void queueCharacterSave();
+    }, DEFAULT_SAVE_EDIT_TIMEOUT);
+}
+
+export async function flushCharacterSaveDebounced() {
+    if (pendingCharacterSaveTimer) {
+        clearTimeout(pendingCharacterSaveTimer);
+        pendingCharacterSaveTimer = null;
+        await queueCharacterSave();
+        return;
+    }
+
+    await characterSavePromise;
+}
 
 /**
  * Prints the character list in a debounced fashion without blocking, with a delay of 100 milliseconds.

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -5,6 +5,7 @@ import {
 } from './mobile-shell-lifecycle/index.js';
 import { createPresetApiSyncLifecycle } from './preset-api-sync-lifecycle/index.js';
 import { flashHighlight, showFontAwesomePicker } from './utils.js';
+import { flushCharacterSaveDebounced, getOneCharacter } from '../script.js';
 
 const sbMobileShellLifecycle = createMobileShellLifecycle();
 const sbPresetApiSyncLifecycle = createPresetApiSyncLifecycle();
@@ -7191,7 +7192,7 @@ function openCharacterPanelTab(tabId) {
             void showCharacterListView('groups');
         } else if (normalizedTabId === 'editor') {
             setCharacterPanelMenuType(panel, 'character_edit');
-            openCharacterEditorTab();
+            void openCharacterEditorTab();
         } else if (normalizedTabId === 'world-info') {
             setCharacterPanelMenuType(panel, 'world-info');
             openCharacterWorldInfoTab();
@@ -7218,20 +7219,20 @@ function restoreLastCharacterPanelView() {
     } else if (lastTab === 'groups') {
         void showCharacterListView('groups');
     } else if (lastTab === 'editor') {
-        openCharacterEditorTab();
+        void openCharacterEditorTab();
     } else {
         void showCharacterListView('characters');
     }
 }
 
-function openCharacterEditorTab() {
+async function openCharacterEditorTab() {
     sbState.characterDrawer.lastTab = 'editor';
     setCharacterEditorEmptyState(false);
     setCharacterPersonaPanelVisible(false);
     setCharacterImportPanelVisible(false);
     setCharacterWorldInfoPanelVisible(false);
 
-    if (showActiveCharacterEditor()) {
+    if (await showActiveCharacterEditor()) {
         syncCharacterShellTabs('editor');
         return true;
     }
@@ -7323,7 +7324,27 @@ function syncCharacterHeaderCopy(activeTab = 'characters') {
     }
 }
 
-function showActiveCharacterEditor() {
+async function refreshActiveCharacterBeforeEditorOpen() {
+    const context = getSillyTavernContext();
+    const characterId = context?.characterId;
+    const avatar = context?.groupId ? null : context?.characters?.[characterId]?.avatar;
+
+    if (!avatar) {
+        return;
+    }
+
+    try {
+        await flushCharacterSaveDebounced();
+        const refreshedContext = getSillyTavernContext();
+        const refreshedCharacterId = refreshedContext?.characterId;
+        const refreshedAvatar = refreshedContext?.groupId ? null : refreshedContext?.characters?.[refreshedCharacterId]?.avatar;
+        await getOneCharacter(refreshedAvatar || avatar);
+    } catch (error) {
+        console.warn('Failed to refresh character before opening editor.', error);
+    }
+}
+
+async function showActiveCharacterEditor() {
     if (!hasActiveCharacterChat()) {
         return false;
     }
@@ -7333,6 +7354,7 @@ function showActiveCharacterEditor() {
         return false;
     }
 
+    await refreshActiveCharacterBeforeEditorOpen();
     selectedCharacterButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     setCharacterEditorEmptyState(false);
     setCharacterPersonaPanelVisible(false);
@@ -13536,7 +13558,7 @@ function injectCharacterDrawerControls() {
     const editorTab = document.getElementById('sb_character_tab_editor');
     if (editorTab instanceof HTMLButtonElement && editorTab.dataset.sbBound !== 'true') {
         editorTab.dataset.sbBound = 'true';
-        editorTab.addEventListener('click', () => openCharacterEditorTab());
+        editorTab.addEventListener('click', () => { void openCharacterEditorTab(); });
     }
 
     const personaTab = document.getElementById('sb_character_tab_persona');

--- a/tests/__snapshots__/script-export-surface.test.js.snap
+++ b/tests/__snapshots__/script-export-surface.test.js.snap
@@ -81,6 +81,7 @@ exports[`public/script.js named export surface matches the parser-derived export
   "extractMessageFromData",
   "findItemizedPromptSet",
   "firstRun",
+  "flushCharacterSaveDebounced",
   "flushPendingChatSaves",
   "formatCharacterAvatar",
   "generateQuietPrompt",


### PR DESCRIPTION
## Summary
- make character autosaves flushable so editor reopen can wait for pending saves
- refresh the active character from the server before repopulating the SillyBunny editor tab
- keep group/editor tab callers fire-and-forget while awaiting the refresh internally

## Tests
- bun run lint
- npm run build:frontend

Addresses the stale character editor reopen behavior reported in #333.