### PR TITLE
fix: prevent stale character chat cloning

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -38,6 +38,7 @@ import {
     getStatusTextgen,
 } from './scripts/textgen-settings.js';
 import { shouldRestoreTextGenStatusOnStartup } from './scripts/textgen-startup-status.js';
+import { normalizeCharacterChatName, resolveCharacterChatNameForLoad } from './scripts/character-chat-resolver.js';
 
 import {
     world_info,
@@ -1735,20 +1736,21 @@ async function resolveCharacterChatForLoad(characterId, { allowCreate = false, a
         return { chatName: '', created: false };
     }
 
-    const persistedChat = String(character.chat || '').trim();
+    const persistedChat = normalizeCharacterChatName(character.chat);
     if (persistedChat && allowMissingPersisted) {
         character.chat = persistedChat;
         return { chatName: persistedChat, created: true };
     }
 
-    if (persistedChat) {
-        character.chat = persistedChat;
-        return { chatName: persistedChat, created: false };
-    }
-
     const existingChats = await getExistingCharacterChats(characterId);
-    const latestChat = existingChats[0]?.file_name?.replace('.jsonl', '') || '';
-    const nextChatName = latestChat || (allowCreate ? `${character.name} - ${humanizedDateTime()}` : '');
+    // SillyBunny: avoid recreating stale character.chat filenames as new files.
+    const resolvedChat = resolveCharacterChatNameForLoad({
+        persistedChat,
+        existingChats,
+        allowCreate,
+        newChatName: allowCreate ? `${character.name} - ${humanizedDateTime()}` : '',
+    });
+    const nextChatName = resolvedChat.chatName;
 
     if (nextChatName && nextChatName !== persistedChat) {
         await updateRemoteChatName(characterId, nextChatName);
@@ -1758,7 +1760,7 @@ async function resolveCharacterChatForLoad(characterId, { allowCreate = false, a
 
     return {
         chatName: nextChatName,
-        created: Boolean(!latestChat && allowCreate && nextChatName),
+        created: resolvedChat.created,
     };
 }
 

--- a/public/scripts/character-chat-resolver.js
+++ b/public/scripts/character-chat-resolver.js
@@ -1,0 +1,27 @@
+export function normalizeCharacterChatName(chatName) {
+    return String(chatName || '').trim().replace(/\.jsonl$/i, '');
+}
+
+export function resolveCharacterChatNameForLoad({ persistedChat, existingChats = [], allowCreate = false, allowMissingPersisted = false, newChatName = '' } = {}) {
+    const normalizedPersistedChat = normalizeCharacterChatName(persistedChat);
+
+    if (normalizedPersistedChat && allowMissingPersisted) {
+        return { chatName: normalizedPersistedChat, created: true };
+    }
+
+    const existingChatNames = existingChats
+        .map(chatInfo => normalizeCharacterChatName(chatInfo?.file_name))
+        .filter(Boolean);
+
+    if (normalizedPersistedChat && existingChatNames.includes(normalizedPersistedChat)) {
+        return { chatName: normalizedPersistedChat, created: false };
+    }
+
+    const latestChat = existingChatNames[0] || '';
+    const nextChatName = latestChat || (allowCreate ? normalizeCharacterChatName(newChatName) : '');
+
+    return {
+        chatName: nextChatName,
+        created: Boolean(!latestChat && allowCreate && nextChatName),
+    };
+}

--- a/tests/character-chat-resolver.test.js
+++ b/tests/character-chat-resolver.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, test } from '@jest/globals';
+import { normalizeCharacterChatName, resolveCharacterChatNameForLoad } from '../public/scripts/character-chat-resolver.js';
+
+describe('normalizeCharacterChatName', () => {
+    test('trims names and strips jsonl extensions', () => {
+        expect(normalizeCharacterChatName(' Chat One.jsonl ')).toBe('Chat One');
+    });
+});
+
+describe('resolveCharacterChatNameForLoad', () => {
+    test('keeps persisted chat when it exists', () => {
+        expect(resolveCharacterChatNameForLoad({
+            persistedChat: 'Existing Chat',
+            existingChats: [
+                { file_name: 'Existing Chat.jsonl' },
+                { file_name: 'Older Chat.jsonl' },
+            ],
+            allowCreate: true,
+            newChatName: 'New Chat',
+        })).toEqual({ chatName: 'Existing Chat', created: false });
+    });
+
+    test('falls back to latest existing chat when persisted chat is stale', () => {
+        expect(resolveCharacterChatNameForLoad({
+            persistedChat: 'Missing Chat',
+            existingChats: [
+                { file_name: 'Latest Real Chat.jsonl' },
+                { file_name: 'Older Real Chat.jsonl' },
+            ],
+            allowCreate: true,
+            newChatName: 'New Chat',
+        })).toEqual({ chatName: 'Latest Real Chat', created: false });
+    });
+
+    test('creates a new chat only when no real chat exists', () => {
+        expect(resolveCharacterChatNameForLoad({
+            persistedChat: 'Missing Chat',
+            existingChats: [],
+            allowCreate: true,
+            newChatName: 'Fresh Chat',
+        })).toEqual({ chatName: 'Fresh Chat', created: true });
+    });
+
+    test('allows missing persisted chat for intentional new chat creation', () => {
+        expect(resolveCharacterChatNameForLoad({
+            persistedChat: 'Intentional New Chat',
+            existingChats: [],
+            allowCreate: true,
+            allowMissingPersisted: true,
+            newChatName: 'Fallback Chat',
+        })).toEqual({ chatName: 'Intentional New Chat', created: true });
+    });
+});


### PR DESCRIPTION
## Summary
- verify persisted character chat names exist before loading them
- fall back to the latest real chat instead of recreating stale missing files
- preserve intentional new-chat creation via allowMissingPersisted

Closes #340

## Tests
- node --experimental-vm-modules /home/platinum/SillyBunny/tests/node_modules/jest/bin/jest.js --config /home/platinum/SillyBunny-fix-chat-cloning/tests/jest.config.json /home/platinum/SillyBunny-fix-chat-cloning/tests/character-chat-resolver.test.js
- node /home/platinum/SillyBunny/node_modules/eslint/bin/eslint.js --resolve-plugins-relative-to /home/platinum/SillyBunny public/script.js public/scripts/character-chat-resolver.js
- node /home/platinum/SillyBunny/tests/node_modules/eslint/bin/eslint.js --resolve-plugins-relative-to /home/platinum/SillyBunny/tests character-chat-resolver.test.js
- node /home/platinum/SillyBunny/node_modules/eslint/bin/eslint.js --resolve-plugins-relative-to /home/platinum/SillyBunny "src/**/*.js" "public/**/*.js" "scripts/**/*.js" ./*.js