### PR TITLE
feat: add explicit runtime launchers

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -90,16 +90,16 @@ git clone https://github.com/platberlitz/SillyBunny.git
 cd SillyBunny
 ```
 
-Then, run the appropriate launcher for your OS, which auto-installs all dependencies, checks for updates, and starts a server instance. You can also open `http://127.0.0.1:4444` manually in your browser.
+Then, run the appropriate launcher for your OS, which auto-installs all dependencies, checks for updates, and starts a server instance. You can also open `http://127.0.0.1:4444` manually in your browser. The default launchers choose the recommended runtime automatically; use a runtime-specific launcher if you want to force Node.js or Bun.
 
-| Platform | Command |
-|----------|---------|
-| Windows | `.\Start.bat` |
-| macOS (Terminal) | `./Start.command` |
-| macOS (Finder) | Double-click `Start.command` (right-click > Open if Gatekeeper warns) |
-| Linux / WSL | `./start.sh` |
-| Docker | `docker compose --project-directory . -f docker/docker-compose.yml up --build`
-| Android (Termux) | `bash start.sh` |
+| Platform | Default / auto | Force Node.js | Force Bun |
+|----------|----------------|---------------|-----------|
+| Windows | `.\Start.bat` | `.\Start-Node.bat` | `.\Start-Bun.bat` |
+| macOS (Terminal) | `./Start.command` | `./Start-Node.command` | `./Start-Bun.command` |
+| macOS (Finder) | Double-click `Start.command` | Double-click `Start-Node.command` | Double-click `Start-Bun.command` |
+| Linux / WSL | `./start.sh` | `./start-node.sh` | `./start-bun.sh` |
+| Android (Termux) | `bash start.sh` | `bash start-termux-node.sh` | `bash start-termux-bun.sh` |
+| Docker | `docker compose --project-directory . -f docker/docker-compose.yml up --build` | N/A | N/A |
 
 If you already manage your own Bun install, run via `bun run start`. Other launch variants:
 
@@ -112,9 +112,10 @@ bun run start:no-csrf  # disable CSRF (local dev)
 ### macOS notes
 
 - If the launcher window closes too fast, run `./Start.command` from Terminal to keep output visible
+- Finder launch: double-click a `Start*.command` file (right-click > Open if Gatekeeper warns)
 - If Git is missing, the launcher triggers `xcode-select --install` automatically
 - Quarantine metadata from ZIP downloads: `xattr -dr com.apple.quarantine /path/to/SillyBunny`
-- Stripped permissions from unzip: `chmod +x Start.command start.sh scripts/*.sh`
+- Stripped permissions from unzip: `chmod +x Start*.command start*.sh scripts/*.sh`
 
 ### Termux (Android) notes
 
@@ -123,11 +124,12 @@ pkg update && pkg upgrade -y
 pkg install -y git curl unzip
 git clone https://github.com/platberlitz/SillyBunny.git
 cd SillyBunny
-bash start.sh
+bash start-termux-node.sh
 ```
 
-- The launcher defaults to Node.js + npm on native Termux and ARM devices when Node.js is available
-- To force Bun anyway: `SILLYBUNNY_USE_BUN=1 bash start.sh`
+- `bash start.sh` also defaults to Node.js + npm on native Termux and ARM devices when Node.js is available
+- To force Node.js explicitly: `bash start-termux-node.sh`
+- To force Bun explicitly: `bash start-termux-bun.sh`
 - For shared storage access: `termux-setup-storage` once before starting
   
 ### How to Update
@@ -171,7 +173,7 @@ The original SillyTavern layout is replaced with a custom, easy-to-navigate grap
 
 ### Bun-first runtime
 
-We primarily use Bun as a runtime, instead of node.js. This results in consistently faster startups, overall performance, and automatic launcher bootstraping. Node.js is still fully functional as a legacy fallback system.
+We primarily use Bun as a runtime, instead of node.js. This results in consistently faster startups, overall performance, and automatic launcher bootstrapping. Node.js is still fully functional as a legacy fallback system.
 
 ### In-Chat Agentic Support
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ When a new, stable upstream SillyTavern version releases:
 2. An IDE or editor of your choice. Visual Studio Code is a safe default.
 3. You can also use GitHub Codespaces which sets up everything for you.
 
-Native Termux contributors should use the launcher default of Node.js + npm unless specifically testing Bun behavior; Bun can still be forced with `SILLYBUNNY_TERMUX_RUNTIME=bun bash start.sh`.
+Native Termux contributors should use `bash start-termux-node.sh` for Node.js + npm unless specifically testing Bun behavior; use `bash start-termux-bun.sh` when checking Bun-specific behavior.
 
 ## Getting the code ready
 

--- a/README.md
+++ b/README.md
@@ -88,16 +88,16 @@ git clone https://github.com/platberlitz/SillyBunny.git
 cd SillyBunny
 ```
 
-Then, run the appropriate launcher for your OS, which auto-installs all dependencies, checks for updates, and starts a server instance. You can also open `http://127.0.0.1:4444` manually in your browser.
+Then, run the appropriate launcher for your OS, which auto-installs all dependencies, checks for updates, and starts a server instance. You can also open `http://127.0.0.1:4444` manually in your browser. The default launchers choose the recommended runtime automatically; use a runtime-specific launcher if you want to force Node.js or Bun.
 
-| Platform | Command |
-|----------|---------|
-| Windows | `.\Start.bat` |
-| macOS (Terminal) | `./Start.command` |
-| macOS (Finder) | Double-click `Start.command` (right-click > Open if Gatekeeper warns) |
-| Linux / WSL | `./start.sh` |
-| Docker | `docker compose --project-directory . -f docker/docker-compose.yml up --build`
-| Android (Termux) | `bash start.sh` |
+| Platform | Default / auto | Force Node.js | Force Bun |
+|----------|----------------|---------------|-----------|
+| Windows | `.\Start.bat` | `.\Start-Node.bat` | `.\Start-Bun.bat` |
+| macOS (Terminal) | `./Start.command` | `./Start-Node.command` | `./Start-Bun.command` |
+| macOS (Finder) | Double-click `Start.command` | Double-click `Start-Node.command` | Double-click `Start-Bun.command` |
+| Linux / WSL | `./start.sh` | `./start-node.sh` | `./start-bun.sh` |
+| Android (Termux) | `bash start.sh` | `bash start-termux-node.sh` | `bash start-termux-bun.sh` |
+| Docker | `docker compose --project-directory . -f docker/docker-compose.yml up --build` | N/A | N/A |
 
 If you already manage your own Bun install, run via `bun run start`. Other launch variants:
 
@@ -110,9 +110,10 @@ bun run start:no-csrf  # disable CSRF (local dev)
 ### macOS notes
 
 - If the launcher window closes too fast, run `./Start.command` from Terminal to keep output visible
+- Finder launch: double-click a `Start*.command` file (right-click > Open if Gatekeeper warns)
 - If Git is missing, the launcher triggers `xcode-select --install` automatically
 - Quarantine metadata from ZIP downloads: `xattr -dr com.apple.quarantine /path/to/SillyBunny`
-- Stripped permissions from unzip: `chmod +x Start.command start.sh scripts/*.sh`
+- Stripped permissions from unzip: `chmod +x Start*.command start*.sh scripts/*.sh`
 
 ### Termux (Android) notes
 
@@ -121,11 +122,12 @@ pkg update && pkg upgrade -y
 pkg install -y git curl unzip
 git clone https://github.com/platberlitz/SillyBunny.git
 cd SillyBunny
-bash start.sh
+bash start-termux-node.sh
 ```
 
-- The launcher defaults to Node.js + npm on native Termux and ARM devices when Node.js is available
-- To force Bun anyway: `SILLYBUNNY_USE_BUN=1 bash start.sh`
+- `bash start.sh` also defaults to Node.js + npm on native Termux and ARM devices when Node.js is available
+- To force Node.js explicitly: `bash start-termux-node.sh`
+- To force Bun explicitly: `bash start-termux-bun.sh`
 - For shared storage access: `termux-setup-storage` once before starting
   
 ### How to Update
@@ -169,7 +171,7 @@ The original SillyTavern layout is replaced with a custom, easy-to-navigate grap
 
 ### Bun-first runtime
 
-We primarily use Bun as a runtime, instead of node.js. This results in consistently faster startups, overall performance, and automatic launcher bootstraping. Node.js is still fully functional as a legacy fallback system.
+We primarily use Bun as a runtime, instead of node.js. This results in consistently faster startups, overall performance, and automatic launcher bootstrapping. Node.js is still fully functional as a legacy fallback system.
 
 ### In-Chat Agentic Support
 

--- a/Start-Bun.bat
+++ b/Start-Bun.bat
@@ -1,0 +1,8 @@
+@echo off
+REM Force SillyBunny to use Bun instead of Node.js.
+setlocal
+set "SILLYBUNNY_USE_NODE="
+set "SILLYBUNNY_USE_BUN=1"
+call "%~dp0Start.bat" %*
+set "_exit=%errorlevel%"
+endlocal & exit /b %_exit%

--- a/Start-Bun.command
+++ b/Start-Bun.command
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+chmod +x "$SCRIPT_DIR/start.sh" >/dev/null 2>&1 || true
+chmod +x "$SCRIPT_DIR/start-bun.sh" >/dev/null 2>&1 || true
+chmod +x "$SCRIPT_DIR/scripts/install-prerequisites.sh" >/dev/null 2>&1 || true
+chmod +x "$SCRIPT_DIR/scripts/self-update.sh" >/dev/null 2>&1 || true
+
+if ! "$SCRIPT_DIR/start-bun.sh" "$@"; then
+    echo
+    read -r -p "Startup failed. Press Enter to close this window..."
+    exit 1
+fi

--- a/Start-Node.command
+++ b/Start-Node.command
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+chmod +x "$SCRIPT_DIR/start.sh" >/dev/null 2>&1 || true
+chmod +x "$SCRIPT_DIR/start-node.sh" >/dev/null 2>&1 || true
+chmod +x "$SCRIPT_DIR/scripts/install-prerequisites.sh" >/dev/null 2>&1 || true
+chmod +x "$SCRIPT_DIR/scripts/self-update.sh" >/dev/null 2>&1 || true
+
+if ! "$SCRIPT_DIR/start-node.sh" "$@"; then
+    echo
+    read -r -p "Startup failed. Press Enter to close this window..."
+    exit 1
+fi

--- a/Start.bat
+++ b/Start.bat
@@ -107,7 +107,7 @@ if /I "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
     if !errorlevel! equ 0 (
         echo.
         echo [SillyBunny] ARM64 detected. Bun may use excessive CPU on this platform.
-        echo [SillyBunny] Switching to Node.js automatically. Use Start.bat with SILLYBUNNY_USE_BUN=1 to override.
+        echo [SillyBunny] Switching to Node.js automatically. Use Start-Bun.bat or Start.bat with SILLYBUNNY_USE_BUN=1 to override.
         echo.
         if /I not "!SILLYBUNNY_USE_BUN!"=="1" set "_server_runtime=node"
     )

--- a/start-bun.sh
+++ b/start-bun.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Force SillyBunny to use Bun instead of Node.js.
+# Use this when you specifically want Bun behavior on a platform that may prefer Node.js.
+unset SILLYBUNNY_USE_NODE
+export SILLYBUNNY_USE_BUN=1
+export SILLYBUNNY_TERMUX_RUNTIME=bun
+exec "$(dirname "${BASH_SOURCE[0]}")/start.sh" "$@"

--- a/start-node.sh
+++ b/start-node.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # Force SillyBunny to use Node.js instead of Bun.
 # Use this if Bun causes high CPU usage on your platform.
+unset SILLYBUNNY_USE_BUN
 export SILLYBUNNY_USE_NODE=1
+export SILLYBUNNY_TERMUX_RUNTIME=node
 exec "$(dirname "${BASH_SOURCE[0]}")/start.sh" "$@"

--- a/start-termux-bun.sh
+++ b/start-termux-bun.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Termux-friendly launcher that explicitly uses Bun.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "$SCRIPT_DIR/start-bun.sh" "$@"

--- a/start-termux-node.sh
+++ b/start-termux-node.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Termux-friendly launcher that explicitly uses Node.js + npm.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "$SCRIPT_DIR/start-node.sh" "$@"


### PR DESCRIPTION
## Summary
- add explicit Bun, macOS, Linux/WSL, and Termux launcher wrappers
- tighten the existing Node shell launcher so it clears Bun overrides
- document default, forced Node.js, and forced Bun launch commands across platforms
- sync the mirrored GitHub README

## Tests
- bash -n start.sh start-node.sh start-bun.sh start-termux-node.sh start-termux-bun.sh Start.command Start-Node.command Start-Bun.command scripts/install-prerequisites.sh scripts/sync-readme-mirror.sh
- bash scripts/sync-readme-mirror.sh --check
- git diff --check
- git diff --check --cached