### PR TITLE
fix: gate verbose prompt payload logging

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -5002,6 +5002,7 @@ export async function createGenerationParameters(settings, model, type, messages
     const generate_data = {
         'type': type,
         'messages': messages,
+        'log_prompts': Boolean(power_user.console_log_prompts),
         'model': model,
         'temperature': Number(settings.temp_openai),
         'frequency_penalty': Number(settings.freq_pen_openai),

--- a/scripts/check-frontend-budgets.js
+++ b/scripts/check-frontend-budgets.js
@@ -23,6 +23,7 @@ const optionalPublicAssets = new Set([
 ]);
 
 const indexHtml = fs.readFileSync(indexPath, 'utf8');
+const normalizedTextAssetExtensions = new Set(['.css', '.html', '.js', '.json', '.map', '.mjs', '.svg', '.txt']);
 
 function stripQuery(value) {
     return String(value).split(/[?#]/)[0];
@@ -50,6 +51,11 @@ function getPublicFileSize(url) {
 
         fail(`Referenced asset is missing: ${url}`);
         return 0;
+    }
+
+    if (normalizedTextAssetExtensions.has(path.extname(filePath).toLowerCase())) {
+        const source = fs.readFileSync(filePath, 'utf8').replace(/\r\n/g, '\n');
+        return Buffer.byteLength(source, 'utf8');
     }
 
     return fs.statSync(filePath).size;

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -290,7 +290,11 @@ function formatVerboseGenerationPayload(payload) {
 }
 
 function logVerboseGenerationRequest(provider, request, payload) {
-    // SillyBunny: keep full prompt payload diagnostics visible for generation routing issues.
+    if (!request.body.log_prompts) {
+        return;
+    }
+
+    // SillyBunny: keep full prompt payload diagnostics available through the existing prompt-log toggle.
     const metadata = `type=${request.body.type} source=${request.body.chat_completion_source} model=${request.body.model} stream=${request.body.stream}`;
     const payloadText = formatVerboseGenerationPayload(payload);
     console.log(`[ChatCompletions] ${provider} request payload: ${metadata}\n${payloadText}`);

--- a/tests/connection-manager-profile-save.test.js
+++ b/tests/connection-manager-profile-save.test.js
@@ -4,7 +4,8 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const connectionManagerSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'extensions', 'connection-manager', 'index.js'), 'utf8');
+const normalizeSource = source => source.replace(/\r\n/g, '\n');
+const connectionManagerSource = normalizeSource(readFileSync(path.join(repoRoot, 'public', 'scripts', 'extensions', 'connection-manager', 'index.js'), 'utf8'));
 
 function getFunctionSource(name) {
     const marker = `function ${name}(`;

--- a/tests/openai-prompt-logging-wiring.test.js
+++ b/tests/openai-prompt-logging-wiring.test.js
@@ -1,0 +1,13 @@
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const openAiSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'openai.js'), 'utf8');
+
+describe('OpenAI prompt logging wiring', () => {
+    test('passes the existing prompt-log preference to backend request metadata', () => {
+        expect(openAiSource).toContain('\'log_prompts\': Boolean(power_user.console_log_prompts),');
+    });
+});

--- a/tests/openai-responses.test.js
+++ b/tests/openai-responses.test.js
@@ -167,6 +167,61 @@ describe('OpenAI Responses integration', () => {
         });
     });
 
+    test('logs full Responses payloads only when prompt logging is enabled', async () => {
+        const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+        try {
+            const quietResponse = await fetch('http://127.0.0.1:3010/api/backends/chat-completions/generate', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    chat_completion_source: CHAT_COMPLETION_SOURCES.OPENAI_RESPONSES,
+                    reverse_proxy: 'http://127.0.0.1:3001/v1/',
+                    proxy_password: 'test-key',
+                    model: 'gpt-5.4',
+                    stream: false,
+                    temperature: 1,
+                    max_tokens: 32,
+                    top_p: 1,
+                    messages: [
+                        { role: 'user', content: 'Hidden backend prompt text.' },
+                    ],
+                }),
+            });
+
+            expect(quietResponse.status).toBe(200);
+            expect(logSpy.mock.calls.flat().join('\n')).not.toContain('Hidden backend prompt text.');
+
+            logSpy.mockClear();
+
+            const verboseResponse = await fetch('http://127.0.0.1:3010/api/backends/chat-completions/generate', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    chat_completion_source: CHAT_COMPLETION_SOURCES.OPENAI_RESPONSES,
+                    reverse_proxy: 'http://127.0.0.1:3001/v1/',
+                    proxy_password: 'test-key',
+                    model: 'gpt-5.4',
+                    stream: false,
+                    temperature: 1,
+                    max_tokens: 32,
+                    top_p: 1,
+                    log_prompts: true,
+                    messages: [
+                        { role: 'user', content: 'Visible backend prompt text.' },
+                    ],
+                }),
+            });
+
+            expect(verboseResponse.status).toBe(200);
+            const logText = logSpy.mock.calls.flat().join('\n');
+            expect(logText).toContain('[ChatCompletions] OpenAI Responses API request payload:');
+            expect(logText).toContain('Visible backend prompt text.');
+        } finally {
+            logSpy.mockRestore();
+        }
+    });
+
     test('generate resolves OpenAI Responses profile secrets by secret_id', async () => {
         const manager = new SecretManager(userDirectories);
         const profileSecretId = manager.writeSecret(SECRET_KEYS.OPENAI, 'profile-openai-key', 'Profile OpenAI');


### PR DESCRIPTION
## What?
This hardens the merged staging stack from PRs #334, #335, #336, #337, #338, #339, #341, #342, #343, #344, #345, and #346.

It gates full provider prompt payload logging behind the existing prompt logging preference, adds frontend/backend regression coverage for that behavior, makes the connection-manager static test stable across Windows line endings, and normalizes text line endings in the frontend budget checker.

## Why?
The staging stack improves reliability and diagnostics, but full prompt payloads should only be printed when prompt logging is explicitly enabled. The validation updates also keep Windows checkouts from failing on CRLF-only differences, which makes local verification match CI/source-size expectations more closely.

## How?
`createGenerationParameters` now passes `log_prompts` from `power_user.console_log_prompts` to the backend request metadata.

`logVerboseGenerationRequest` now returns unless `request.body.log_prompts` is set, preserving concise generation routing metadata while protecting full prompt text by default.

The Responses integration test verifies quiet and verbose logging paths, and a static wiring test confirms the frontend sends the preference flag. The connection-manager profile-save test normalizes source line endings before checking static wiring. The frontend budget checker measures text assets after CRLF-to-LF normalization while leaving binary assets measured by file size.

## Testing?
- `git diff --cached --check`
- `node --check src/endpoints/backends/chat-completions.js`
- `node --check public/scripts/openai.js`
- `node --check public/script.js`
- `node --check tests/openai-prompt-logging-wiring.test.js`
- `node --check scripts/check-frontend-budgets.js`
- `npm run test:unit --prefix tests -- openai-responses.test.js openai-prompt-logging-wiring.test.js connection-manager-profile-save.test.js`
- `npm run lint -- --quiet`
- `npm run check:frontend-budgets`
- `npm run build:frontend`

## Screenshots (optional)
Not included; this is logging, validation, and test hardening without a rendered UI change.

## Anything Else?
Base branch: `staging`.

This PR intentionally stays narrow: the referenced staging PRs are already present in the base branch, and this branch only adds the remaining hardening needed around their logging and validation surface.
