### PR TITLE
fix: prevent chat cloning races

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -39,6 +39,7 @@ import {
 } from './scripts/textgen-settings.js';
 import { shouldRestoreTextGenStatusOnStartup } from './scripts/textgen-startup-status.js';
 import { normalizeCharacterChatName, resolveCharacterChatNameForLoad } from './scripts/character-chat-resolver.js';
+import { getDebouncedChatSaveAbortReason } from './scripts/chat-save-guard.js';
 
 import {
     world_info,
@@ -9924,19 +9925,25 @@ async function renamePastChats(oldAvatar, newAvatar, newName) {
 export function saveChatDebounced() {
     const chid = this_chid;
     const selectedGroup = selected_group;
+    const chatId = getCurrentChatId();
 
     cancelDebouncedChatSave();
 
     chatSaveTimeout = setTimeout(async () => {
         chatSaveTimeout = null;
 
-        if (selectedGroup !== selected_group) {
-            console.warn('Chat save timeout triggered, but group changed. Aborting.');
-            return;
-        }
+        // SillyBunny: keep debounced saves bound to the file they were scheduled for.
+        const abortReason = getDebouncedChatSaveAbortReason({
+            scheduledGroupId: selectedGroup,
+            currentGroupId: selected_group,
+            scheduledCharacterId: chid,
+            currentCharacterId: this_chid,
+            scheduledChatId: chatId,
+            currentChatId: getCurrentChatId(),
+        });
 
-        if (chid !== this_chid) {
-            console.warn('Chat save timeout triggered, but chid changed. Aborting.');
+        if (abortReason) {
+            console.warn(`Chat save timeout triggered, but ${abortReason} changed. Aborting.`);
             return;
         }
 
@@ -14956,6 +14963,14 @@ export async function renameGroupOrCharacterChat({ characterId, groupId, oldFile
     }) : null;
 
     try {
+        const currentChatBaseName = getChatBaseName(currentChatId);
+        if (currentChatBaseName && currentChatBaseName === getChatBaseName(oldFileName)) {
+            const didFlush = await flushPendingChatSaves();
+            if (!didFlush) {
+                throw new Error('Could not save the current chat before renaming.');
+            }
+        }
+
         const response = await fetch('/api/chats/rename', {
             method: 'POST',
             body: JSON.stringify(body),

--- a/public/scripts/chat-save-guard.js
+++ b/public/scripts/chat-save-guard.js
@@ -1,0 +1,22 @@
+export function getDebouncedChatSaveAbortReason({
+    scheduledGroupId,
+    currentGroupId,
+    scheduledCharacterId,
+    currentCharacterId,
+    scheduledChatId,
+    currentChatId,
+} = {}) {
+    if (scheduledGroupId !== currentGroupId) {
+        return 'group';
+    }
+
+    if (scheduledCharacterId !== currentCharacterId) {
+        return 'character';
+    }
+
+    if (scheduledChatId !== currentChatId) {
+        return 'chat';
+    }
+
+    return '';
+}

--- a/src/chat-rename.js
+++ b/src/chat-rename.js
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import process from 'node:process';
+
+export function shouldFallbackChatRename(error, platform = process.platform) {
+    return error?.code === 'EXDEV' || (platform === 'win32' && error?.code === 'EPERM');
+}
+
+export function renameChatFile(sourcePath, destinationPath, { fsModule = fs, platform = process.platform } = {}) {
+    try {
+        fsModule.renameSync(sourcePath, destinationPath);
+        return { method: 'atomic' };
+    } catch (error) {
+        if (!shouldFallbackChatRename(error, platform)) {
+            throw error;
+        }
+
+        fsModule.copyFileSync(sourcePath, destinationPath);
+
+        try {
+            fsModule.unlinkSync(sourcePath);
+        } catch (unlinkError) {
+            try {
+                fsModule.unlinkSync(destinationPath);
+            } catch (cleanupError) {
+                console.warn('Failed to clean up copied chat file after rename fallback failed.', cleanupError);
+            }
+            throw unlinkError;
+        }
+
+        return { method: 'fallback', fallbackCode: error?.code };
+    }
+}

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -9,6 +9,7 @@ import { sync as writeFileAtomicSync } from 'write-file-atomic';
 import _ from 'lodash';
 
 import validateAvatarUrlMiddleware from '../middleware/validateFileName.js';
+import { renameChatFile } from '../chat-rename.js';
 import {
     getConfigValue,
     humanizedDateTime,
@@ -591,9 +592,9 @@ router.post('/rename', validateAvatarUrlMiddleware, async function (request, res
             return response.status(400).send({ error: true });
         }
 
-        fs.copyFileSync(pathToOriginalFile, pathToRenamedFile);
-        fs.unlinkSync(pathToOriginalFile);
-        console.info('Successfully renamed chat file.');
+        // SillyBunny: atomic renames prevent interrupted chat renames from leaving cloned files behind.
+        const renameResult = renameChatFile(pathToOriginalFile, pathToRenamedFile);
+        console.info(`Successfully renamed chat file (${renameResult.method}).`);
         return response.send({ ok: true, sanitizedFileName });
     } catch (error) {
         console.error('Error renaming chat file:', error);

--- a/tests/chat-rename.test.js
+++ b/tests/chat-rename.test.js
@@ -1,0 +1,83 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import { renameChatFile, shouldFallbackChatRename } from '../src/chat-rename.js';
+
+describe('shouldFallbackChatRename', () => {
+    test('allows cross-device rename fallback on all platforms', () => {
+        expect(shouldFallbackChatRename({ code: 'EXDEV' }, 'linux')).toBe(true);
+    });
+
+    test('allows Windows EPERM fallback only on Windows', () => {
+        expect(shouldFallbackChatRename({ code: 'EPERM' }, 'win32')).toBe(true);
+        expect(shouldFallbackChatRename({ code: 'EPERM' }, 'linux')).toBe(false);
+    });
+});
+
+describe('renameChatFile', () => {
+    test('uses atomic rename when available', () => {
+        const fsModule = {
+            renameSync: jest.fn(),
+            copyFileSync: jest.fn(),
+            unlinkSync: jest.fn(),
+        };
+
+        expect(renameChatFile('/old.jsonl', '/new.jsonl', { fsModule, platform: 'linux' })).toEqual({ method: 'atomic' });
+        expect(fsModule.renameSync).toHaveBeenCalledWith('/old.jsonl', '/new.jsonl');
+        expect(fsModule.copyFileSync).not.toHaveBeenCalled();
+        expect(fsModule.unlinkSync).not.toHaveBeenCalled();
+    });
+
+    test('falls back to copy and unlink for cross-device renames', () => {
+        const error = Object.assign(new Error('cross-device rename'), { code: 'EXDEV' });
+        const fsModule = {
+            renameSync: jest.fn(() => { throw error; }),
+            copyFileSync: jest.fn(),
+            unlinkSync: jest.fn(),
+        };
+
+        expect(renameChatFile('/old.jsonl', '/new.jsonl', { fsModule, platform: 'linux' })).toEqual({ method: 'fallback', fallbackCode: 'EXDEV' });
+        expect(fsModule.copyFileSync).toHaveBeenCalledWith('/old.jsonl', '/new.jsonl');
+        expect(fsModule.unlinkSync).toHaveBeenCalledWith('/old.jsonl');
+    });
+
+    test('falls back to copy and unlink for Windows EPERM renames', () => {
+        const error = Object.assign(new Error('locked rename'), { code: 'EPERM' });
+        const fsModule = {
+            renameSync: jest.fn(() => { throw error; }),
+            copyFileSync: jest.fn(),
+            unlinkSync: jest.fn(),
+        };
+
+        expect(renameChatFile('/old.jsonl', '/new.jsonl', { fsModule, platform: 'win32' })).toEqual({ method: 'fallback', fallbackCode: 'EPERM' });
+        expect(fsModule.copyFileSync).toHaveBeenCalledWith('/old.jsonl', '/new.jsonl');
+        expect(fsModule.unlinkSync).toHaveBeenCalledWith('/old.jsonl');
+    });
+
+    test('throws unexpected rename failures without copying', () => {
+        const error = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+        const fsModule = {
+            renameSync: jest.fn(() => { throw error; }),
+            copyFileSync: jest.fn(),
+            unlinkSync: jest.fn(),
+        };
+
+        expect(() => renameChatFile('/old.jsonl', '/new.jsonl', { fsModule, platform: 'linux' })).toThrow(error);
+        expect(fsModule.copyFileSync).not.toHaveBeenCalled();
+        expect(fsModule.unlinkSync).not.toHaveBeenCalled();
+    });
+
+    test('removes the copied destination if fallback cannot delete the original', () => {
+        const renameError = Object.assign(new Error('cross-device rename'), { code: 'EXDEV' });
+        const unlinkError = new Error('cannot delete original');
+        const fsModule = {
+            renameSync: jest.fn(() => { throw renameError; }),
+            copyFileSync: jest.fn(),
+            unlinkSync: jest.fn()
+                .mockImplementationOnce(() => { throw unlinkError; })
+                .mockImplementationOnce(() => {}),
+        };
+
+        expect(() => renameChatFile('/old.jsonl', '/new.jsonl', { fsModule, platform: 'linux' })).toThrow(unlinkError);
+        expect(fsModule.unlinkSync).toHaveBeenNthCalledWith(1, '/old.jsonl');
+        expect(fsModule.unlinkSync).toHaveBeenNthCalledWith(2, '/new.jsonl');
+    });
+});

--- a/tests/chat-save-guard.test.js
+++ b/tests/chat-save-guard.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, test } from '@jest/globals';
+import { getDebouncedChatSaveAbortReason } from '../public/scripts/chat-save-guard.js';
+
+describe('getDebouncedChatSaveAbortReason', () => {
+    test('allows saves when the scheduled target still matches', () => {
+        expect(getDebouncedChatSaveAbortReason({
+            scheduledGroupId: null,
+            currentGroupId: null,
+            scheduledCharacterId: 1,
+            currentCharacterId: 1,
+            scheduledChatId: 'Chat A',
+            currentChatId: 'Chat A',
+        })).toBe('');
+    });
+
+    test('aborts when the selected group changes', () => {
+        expect(getDebouncedChatSaveAbortReason({
+            scheduledGroupId: 'group-a',
+            currentGroupId: 'group-b',
+            scheduledCharacterId: undefined,
+            currentCharacterId: undefined,
+            scheduledChatId: 'Chat A',
+            currentChatId: 'Chat A',
+        })).toBe('group');
+    });
+
+    test('aborts when the selected character changes', () => {
+        expect(getDebouncedChatSaveAbortReason({
+            scheduledGroupId: null,
+            currentGroupId: null,
+            scheduledCharacterId: 1,
+            currentCharacterId: 2,
+            scheduledChatId: 'Chat A',
+            currentChatId: 'Chat A',
+        })).toBe('character');
+    });
+
+    test('aborts when the active chat file changes for the same character', () => {
+        expect(getDebouncedChatSaveAbortReason({
+            scheduledGroupId: null,
+            currentGroupId: null,
+            scheduledCharacterId: 1,
+            currentCharacterId: 1,
+            scheduledChatId: 'Chat A',
+            currentChatId: 'Chat B',
+        })).toBe('chat');
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #340.

This closes two chat-cloning race windows that can leave multiple physical chat files visible in Recent Chats:

- Use an atomic server-side chat rename instead of copy-then-delete, with EXDEV and Windows EPERM fallback behavior.
- Bind debounced chat saves to the chat file they were scheduled for, so a delayed save cannot write old chat state into a newly selected chat file for the same character or group.
- Flush pending saves before renaming the currently open chat.

## Testing

- `npm run lint`
- `npm run test:unit --prefix tests`
- `npm run check:frontend-budgets`
- `npm run build:frontend`
- `bun install --frozen-lockfile && bun src/server-init.js`
