### PR TITLE
fix: preserve pending swipe saves before chat switches

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1259,6 +1259,10 @@ export async function selectCharacterById(id, { switchMenu = true } = {}) {
             return false;
         }
 
+        if (!await flushPendingChatSavesForNavigation()) {
+            return false;
+        }
+
         setCharacterId(undefined);
         setCharacterName('');
         resetSelectedGroup();
@@ -1865,6 +1869,10 @@ export async function deleteCharacterChatByName(characterId, fileName) {
 }
 
 export async function replaceCurrentChat() {
+    if (!await flushPendingChatSavesForNavigation()) {
+        return;
+    }
+
     await clearChat({ clearData: true });
 
     const chatsResponse = await fetch('/api/characters/chats', {
@@ -9962,6 +9970,19 @@ function hasPendingChatSave() {
     return chatSaveTimeout !== null || chatSavePromise !== null;
 }
 
+export async function flushPendingChatSavesForNavigation() {
+    if (!hasPendingChatSave()) {
+        return true;
+    }
+
+    // SillyBunny: preserve swipe/message edits before navigation clears the active chat.
+    const didFlush = await flushPendingChatSaves();
+    if (!didFlush) {
+        toastr.error(t`Could not save the current chat before switching chats. Try again in a moment.`, t`Chat save failed`);
+    }
+    return didFlush;
+}
+
 /**
  * Flushes any pending chat save, waits for in-flight saves, and saves the current chat immediately.
  * @returns {Promise<boolean>} Whether the chat save completed successfully.
@@ -10508,6 +10529,10 @@ function getFirstMessage() {
 }
 
 export async function openCharacterChat(file_name) {
+    if (!await flushPendingChatSavesForNavigation()) {
+        return;
+    }
+
     await waitUntilCondition(() => !isChatSaving, debounce_timeout.extended, 10);
     await clearChat({ clearData: true });
     characters[this_chid].chat = file_name;
@@ -14901,6 +14926,10 @@ export async function doNewChat({ deleteCurrentChat = false } = {}) {
         return;
     }
 
+    if (!await flushPendingChatSavesForNavigation()) {
+        return;
+    }
+
     //Fix it; New chat doesn't create while open create character menu
     await waitUntilCondition(() => !isChatSaving, debounce_timeout.extended, 10);
     await clearChat({ clearData: true });
@@ -15035,6 +15064,10 @@ export async function renameChat(oldFileName, newName) {
  */
 export async function closeCurrentChat() {
     if (is_send_press == false) {
+        if (!await flushPendingChatSavesForNavigation()) {
+            return false;
+        }
+
         await waitUntilCondition(() => !isChatSaving, debounce_timeout.extended, 10);
         await clearChat({ clearData: true });
         resetSelectedGroup();

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -58,6 +58,7 @@ import {
     sendMessageAsUser,
     getBiasStrings,
     saveChatConditional,
+    flushPendingChatSavesForNavigation,
     deactivateSendButtons,
     activateSendButtons,
     eventSource,
@@ -3352,6 +3353,10 @@ export async function openGroupById(groupId, { switchMenu = true } = {}) {
         return true;
     }
 
+    if (!await flushPendingChatSavesForNavigation()) {
+        return false;
+    }
+
     groupChatQueueOrder = new Map();
     setCharacterId(undefined);
     setCharacterName('');
@@ -3543,6 +3548,10 @@ export async function createNewGroupChat(groupId) {
         return;
     }
 
+    if (!await flushPendingChatSavesForNavigation()) {
+        return;
+    }
+
     await clearChat({ clearData: true });
     const newChatName = humanizedDateTime();
     group.chats.push(newChatName);
@@ -3597,6 +3606,10 @@ export async function openGroupChat(groupId, chatId) {
     const group = groups.find(x => x.id === groupId);
 
     if (!group || !group.chats.includes(chatId)) {
+        return;
+    }
+
+    if (!await flushPendingChatSavesForNavigation()) {
         return;
     }
 

--- a/tests/__snapshots__/script-export-surface.test.js.snap
+++ b/tests/__snapshots__/script-export-surface.test.js.snap
@@ -83,6 +83,7 @@ exports[`public/script.js named export surface matches the parser-derived export
   "firstRun",
   "flushCharacterSaveDebounced",
   "flushPendingChatSaves",
+  "flushPendingChatSavesForNavigation",
   "formatCharacterAvatar",
   "generateQuietPrompt",
   "generateRaw",


### PR DESCRIPTION
## Summary

Fixes the remaining intermittent swipe-save issue reported after #349 by flushing pending chat saves before navigation clears the active chat state.

## Changes

- Adds `flushPendingChatSavesForNavigation()` so pending swipe/message edits are saved before chat switches clear the current chat.
- Uses the guard before character chat switches, replacement, new-chat creation, close-current-chat, and group chat navigation.
- Updates the public script export snapshot for the new helper used by group chat navigation.

## Testing

- `npm run lint`
- `npm run test:unit --prefix tests`
- `npm run check:frontend-budgets`
- `npm run build:frontend`
- `bun install --frozen-lockfile && bun src/server-init.js`
