### PR TITLE
fix: hide disabled edit move arrows

### DIFF
--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -1653,6 +1653,10 @@ body.bubblechat #chat .mes[is_user='true']:has(.reasoning_edit_textarea)::before
     box-shadow: none;
 }
 
+#chat .mes_edit_buttons :is(.mes_edit_up, .mes_edit_down).menu_button:is(.disabled, .is-disabled, [disabled]) {
+    display: none;
+}
+
 #chat .mes .swipeRightBlock {
     inline-size: 44px;
     align-items: center;


### PR DESCRIPTION
## Summary
- hide disabled message edit move arrows in the SillyBunny theme so the edit toolbar no longer shows an empty pill where a move action is unavailable
- keep active edit controls and upstream edit logic unchanged

## Testing
- git diff --check
- Firefox fixture at 1280x800 confirmed the disabled down arrow is absent while up/cancel remain visible
- Firefox fixture at 390x844 confirmed the same mobile behavior