### PR TITLE
fix: isolate mobile alternate greeting controls

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -897,6 +897,16 @@
     #right-nav-panel .delete_alternate_greeting {
         padding-inline: 8px !important;
     }
+
+    #right-nav-panel .alternate_greeting_actions {
+        gap: 4px !important;
+    }
+
+    #right-nav-panel .alternate_greeting_actions :is(.menu_button, .right_menu_button) {
+        min-width: 40px !important;
+        min-height: 40px !important;
+        touch-action: manipulation;
+    }
 }
 
 @media screen and (max-width: 768px) {

--- a/public/index.html
+++ b/public/index.html
@@ -8247,28 +8247,27 @@
         </div>
         <div id="alternate_greeting_form_template" class="template_element">
             <div class="alternate_greeting">
-                <details open>
-                    <summary>
-                        <div class="title_restorable gap5px">
-                            <div class="flex-container alignItemsCenter">
-                                <strong><span data-i18n="Alternate Greeting #">Alternate Greeting #</span><span class="greeting_index"></span></strong>
-                                <i class="editor_maximize fa-solid fa-maximize right_menu_button" title="Expand the editor" data-i18n="[title]Expand the editor"></i>
-                            </div>
-                            <span class="expander"></span>
-                            <div class="menu_button menu_button_icon move_up_alternate_greeting" title="Move up" data-i18n="[title]Move up">
-                                <i class="fa-solid fa-chevron-up"></i>
-                            </div>
-                            <div class="menu_button menu_button_icon move_down_alternate_greeting" title="Move down" data-i18n="[title]Move down">
-                                <i class="fa-solid fa-chevron-down"></i>
-                            </div>
-                            <div class="menu_button menu_button_icon delete_alternate_greeting">
-                                <i class="fa-solid fa-trash-alt"></i>
-                                <span data-i18n="Delete">Delete</span>
-                            </div>
+                <div class="alternate_greeting_header title_restorable gap5px">
+                    <details open>
+                        <summary>
+                            <strong><span data-i18n="Alternate Greeting #">Alternate Greeting #</span><span class="greeting_index"></span></strong>
+                        </summary>
+                        <textarea data-macros name="alternate_greetings" data-i18n="[placeholder](This will be the first message from the character that starts every chat)" placeholder="(This will be the first message from the character that starts every chat)" class="text_pole textarea_compact alternate_greeting_text mdHotkeys" value="" autocomplete="off" rows="12"></textarea>
+                    </details>
+                    <div class="alternate_greeting_actions flex-container alignItemsCenter gap5px">
+                        <i class="editor_maximize fa-solid fa-maximize right_menu_button" title="Expand the editor" data-i18n="[title]Expand the editor"></i>
+                        <div class="menu_button menu_button_icon move_up_alternate_greeting" title="Move up" data-i18n="[title]Move up">
+                            <i class="fa-solid fa-chevron-up"></i>
                         </div>
-                    </summary>
-                    <textarea data-macros name="alternate_greetings" data-i18n="[placeholder](This will be the first message from the character that starts every chat)" placeholder="(This will be the first message from the character that starts every chat)" class="text_pole textarea_compact alternate_greeting_text mdHotkeys" value="" autocomplete="off" rows="12"></textarea>
-                </details>
+                        <div class="menu_button menu_button_icon move_down_alternate_greeting" title="Move down" data-i18n="[title]Move down">
+                            <i class="fa-solid fa-chevron-down"></i>
+                        </div>
+                        <div class="menu_button menu_button_icon delete_alternate_greeting">
+                            <i class="fa-solid fa-trash-alt"></i>
+                            <span data-i18n="Delete">Delete</span>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
 

--- a/public/script.js
+++ b/public/script.js
@@ -12969,7 +12969,7 @@ function syncAlternateGreetingsEditor() {
 
         greetingBlock.find('.delete_alternate_greeting').on('click', async function (event) {
             event.preventDefault();
-            event.stopPropagation();
+            event.stopImmediatePropagation();
 
             const confirm = await callGenericPopup(t`Are you sure you want to delete this alternate greeting?`, POPUP_TYPE.CONFIRM);
             if (!confirm) {
@@ -12986,7 +12986,7 @@ function syncAlternateGreetingsEditor() {
 
         greetingBlock.find('.move_up_alternate_greeting').on('click', function (event) {
             event.preventDefault();
-            event.stopPropagation();
+            event.stopImmediatePropagation();
 
             if (index <= 0) {
                 return;
@@ -13004,7 +13004,7 @@ function syncAlternateGreetingsEditor() {
 
         greetingBlock.find('.move_down_alternate_greeting').on('click', function (event) {
             event.preventDefault();
-            event.stopPropagation();
+            event.stopImmediatePropagation();
 
             if (index >= greetings.length - 1) {
                 return;

--- a/public/style.css
+++ b/public/style.css
@@ -3772,6 +3772,28 @@ grammarly-extension {
     padding-left: 5px;
 }
 
+.alternate_greeting_header {
+    align-items: flex-start;
+    width: 100%;
+}
+
+.alternate_greeting_header details {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.alternate_greeting_actions {
+    flex: 0 0 auto;
+    flex-wrap: nowrap;
+}
+
+.alternate_greeting_actions :is(.menu_button, .right_menu_button) {
+    justify-content: center;
+    min-width: 32px;
+    min-height: 32px;
+    touch-action: manipulation;
+}
+
 .alternate_greeting textarea {
     field-sizing: content;
     max-height: 50dvh;


### PR DESCRIPTION
## Summary
- move alternate greeting action controls out of the native details summary hit area
- add isolated touch targets for mobile alternate greeting controls
- prevent parent/delegated click handling from running after alternate greeting actions

## Testing
- ./node_modules/.bin/eslint public/script.js
- bun run check:frontend-budgets
- mobile Firefox BiDi smoke: create flow added three alternate greetings, moved second up and first down; first message stayed unchanged; controls are outside summary with 40px touch targets