### PR TITLE
fix: rotate chat integrity token on save to prevent cross-device history loss

### DIFF
--- a/docs/upstream-touch-ledger.md
+++ b/docs/upstream-touch-ledger.md
@@ -50,6 +50,19 @@ This ledger tracks intentional SillyBunny divergence in upstream-origin files. I
 | Last reviewed | 2026-05-28 generation lifecycle wiring. |
 | Owner | Refactor integrator. |
 
+### `src/endpoints/chats.js`, `public/script.js`, and `public/scripts/group-chats.js` - chat save integrity
+| Field | Value |
+| --- | --- |
+| Area | Chat persistence and data-loss prevention. |
+| Divergence reason | SillyBunny must reject stale cross-device chat saves instead of allowing last-write-wins overwrites that destroy newer messages. |
+| Target seam | None yet; keep the save-contract adapter minimal until chat persistence has a dedicated fork seam. |
+| Adapter shape | Rotate chat metadata integrity in `trySaveChat()`, return the new token from normal and group save routes, and store the returned token in the active client metadata after successful saves. |
+| Protecting tests | `tests/chat-integrity-rotation.test.js`; manual two-instance stale-save smoke before release. |
+| Validation | `npm run test:unit --prefix tests -- chat-integrity-rotation.test.js`, `node --check src/endpoints/chats.js`, `node --check public/script.js`, `node --check public/scripts/group-chats.js`, `npm run lint`, Node/Bun server smoke. |
+| Rollback path | Revert the integrity rotation response contract and client adoption to the prior per-load integrity behavior. |
+| Last reviewed | 2026-06-06 chat integrity rotation fix. |
+| Owner | Bugfix integrator. |
+
 ### `public/style.css` - message containment and scroll anchoring
 | Field | Value |
 | --- | --- |

--- a/public/script.js
+++ b/public/script.js
@@ -10102,6 +10102,10 @@ export async function saveChat({ chatName, withMetadata, mesId, force = false, c
         const result = await fetch('/api/chats/save', saveChatRequest);
 
         if (result.ok) {
+            const responseData = await result.json().catch(() => ({}));
+            if (typeof responseData?.integrity === 'string' && responseData.integrity) {
+                chat_metadata.integrity = responseData.integrity;
+            }
             return true;
         }
 

--- a/public/script.js
+++ b/public/script.js
@@ -10059,7 +10059,9 @@ export async function saveChat({ chatName, withMetadata, mesId, force = false, c
     }
 
     const metadata = { ...chat_metadata, ...(withMetadata || {}) };
-    const fileName = chatName ?? characters[this_chid]?.chat;
+    const activeChatName = characters[this_chid]?.chat;
+    const fileName = chatName ?? activeChatName;
+    const isActiveChatSave = fileName === activeChatName;
 
     if (!fileName && name2 === neutralCharacterName) {
         // TODO: Do something for a temporary chat with no character.
@@ -10103,7 +10105,7 @@ export async function saveChat({ chatName, withMetadata, mesId, force = false, c
 
         if (result.ok) {
             const responseData = await result.json().catch(() => ({}));
-            if (typeof responseData?.integrity === 'string' && responseData.integrity) {
+            if (isActiveChatSave && typeof responseData?.integrity === 'string' && responseData.integrity) {
                 chat_metadata.integrity = responseData.integrity;
             }
             return true;

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -1616,6 +1616,11 @@ async function saveGroupChat(groupId, shouldSaveGroup, force = false, throwOnErr
         return await saveGroupChat(groupId, shouldSaveGroup, true, throwOnError);
     }
 
+    const responseData = await response.json().catch(() => ({}));
+    if (typeof responseData?.integrity === 'string' && responseData.integrity) {
+        chat_metadata.integrity = responseData.integrity;
+    }
+
     if (shouldSaveGroup) {
         await editGroup(groupId, false, false);
     }

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -31,6 +31,7 @@ const throttleInterval = Number(getConfigValue('backups.chat.throttleInterval', 
 const checkIntegrity = !!getConfigValue('backups.chat.checkIntegrity', true, 'boolean');
 
 export const CHAT_BACKUPS_PREFIX = 'chat_';
+const CHAT_FORCED_OVERWRITE_BACKUPS_PREFIX = 'chat_forced_overwrite_';
 
 /**
  * Saves a chat to the backups directory.
@@ -500,7 +501,7 @@ export async function trySaveChat(chatData, filePath, skipIntegrityCheck = false
     if (skipIntegrityCheck && fs.existsSync(filePath)) {
         const currentChatData = tryReadFileSync(filePath);
         if (currentChatData) {
-            backupChat(backupDirectory, cardName, currentChatData);
+            backupChat(backupDirectory, cardName, currentChatData, CHAT_FORCED_OVERWRITE_BACKUPS_PREFIX);
         }
     }
 

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -22,6 +22,7 @@ import {
     tryDeleteFile,
     readFirstLine,
     isPathUnderParent,
+    uuidv4,
 } from '../util.js';
 
 const isBackupEnabled = !!getConfigValue('backups.chat.enabled', true, 'boolean');
@@ -481,16 +482,31 @@ class IntegrityMismatchError extends Error {
  * @param {string} backupDirectory Passed to backupChat.
  */
 export async function trySaveChat(chatData, filePath, skipIntegrityCheck = false, handle, cardName, backupDirectory) {
-    const jsonlData = chatData?.map(m => JSON.stringify(m)).join('\n');
-
     const doIntegrityCheck = (checkIntegrity && !skipIntegrityCheck);
     const chatIntegritySlug = doIntegrityCheck ? chatData?.[0]?.chat_metadata?.integrity : undefined;
 
     if (chatIntegritySlug && !await checkChatIntegrity(filePath, chatIntegritySlug)) {
         throw new IntegrityMismatchError(`Chat integrity check failed for "${filePath}". The expected integrity slug was "${chatIntegritySlug}".`);
     }
+
+    const nextIntegrity = uuidv4();
+    const savedChatData = Array.isArray(chatData)
+        ? chatData.map((message, index) => index === 0
+            ? { ...message, chat_metadata: { ...(message?.chat_metadata || {}), integrity: nextIntegrity } }
+            : message)
+        : chatData;
+    const jsonlData = savedChatData?.map(m => JSON.stringify(m)).join('\n');
+
+    if (skipIntegrityCheck && fs.existsSync(filePath)) {
+        const currentChatData = tryReadFileSync(filePath);
+        if (currentChatData) {
+            backupChat(backupDirectory, cardName, currentChatData);
+        }
+    }
+
     tryWriteFileSync(filePath, jsonlData);
     getBackupFunction(handle)(backupDirectory, cardName, jsonlData);
+    return { integrity: nextIntegrity };
 }
 
 router.post('/save', validateAvatarUrlMiddleware, async function (request, response) {
@@ -505,8 +521,8 @@ router.post('/save', validateAvatarUrlMiddleware, async function (request, respo
         }
 
         if (Array.isArray(chatData)) {
-            await trySaveChat(chatData, chatFilePath, request.body.force, handle, cardName, request.user.directories.backups);
-            return response.send({ ok: true });
+            const saveResult = await trySaveChat(chatData, chatFilePath, request.body.force, handle, cardName, request.user.directories.backups);
+            return response.send({ ok: true, integrity: saveResult.integrity });
         } else {
             return response.status(400).send({ error: 'The request\'s body.chat is not an array.' });
         }
@@ -886,8 +902,8 @@ router.post('/group/save', async function (request, response) {
         const chatData = request.body.chat;
 
         if (Array.isArray(chatData)) {
-            await trySaveChat(chatData, chatFilePath, request.body.force, handle, String(id), request.user.directories.backups);
-            return response.send({ ok: true });
+            const saveResult = await trySaveChat(chatData, chatFilePath, request.body.force, handle, String(id), request.user.directories.backups);
+            return response.send({ ok: true, integrity: saveResult.integrity });
         } else {
             return response.status(400).send({ error: 'The request\'s body.chat is not an array.' });
         }

--- a/tests/chat-integrity-rotation.test.js
+++ b/tests/chat-integrity-rotation.test.js
@@ -73,4 +73,12 @@ describe('chat integrity rotation', () => {
             backupDir,
         )).rejects.toThrow(/integrity/i);
     });
+
+    test('adopts returned integrity only for the active chat file', async () => {
+        const scriptSource = await fs.readFile(fileURLToPath(new URL('../public/script.js', import.meta.url)), 'utf8');
+
+        expect(scriptSource).toContain('const activeChatName = characters[this_chid]?.chat;');
+        expect(scriptSource).toContain('const isActiveChatSave = fileName === activeChatName;');
+        expect(scriptSource).toContain('if (isActiveChatSave && typeof responseData?.integrity === \'string\' && responseData.integrity)');
+    });
 });

--- a/tests/chat-integrity-rotation.test.js
+++ b/tests/chat-integrity-rotation.test.js
@@ -1,0 +1,76 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { setConfigFilePath } from '../src/util.js';
+
+setConfigFilePath(fileURLToPath(new URL('../default/config.yaml', import.meta.url)));
+
+function chatWithIntegrity(integrity, message) {
+    return [
+        {
+            chat_metadata: { integrity },
+            user_name: 'unused',
+            character_name: 'unused',
+        },
+        {
+            name: 'User',
+            is_user: true,
+            send_date: '2026-06-06T00:00:00.000Z',
+            mes: message,
+        },
+    ];
+}
+
+async function readHeader(filePath) {
+    const content = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(content.split('\n')[0]);
+}
+
+describe('chat integrity rotation', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+    });
+
+    test('rotates integrity on save and rejects stale second writers', async () => {
+        const { trySaveChat } = await import('../src/endpoints/chats.js');
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-integrity-'));
+        const chatFile = path.join(tempDir, 'chat.jsonl');
+        const backupDir = path.join(tempDir, 'backups');
+        await fs.mkdir(backupDir);
+
+        const sharedIntegrity = 'shared-integrity';
+        await fs.writeFile(chatFile, chatWithIntegrity(sharedIntegrity, 'original').map(JSON.stringify).join('\n'));
+
+        const firstResult = await trySaveChat(
+            chatWithIntegrity(sharedIntegrity, 'device one'),
+            chatFile,
+            false,
+            'test-user',
+            'Test Card',
+            backupDir,
+        );
+
+        expect(firstResult?.integrity).toEqual(expect.any(String));
+        expect(firstResult.integrity).not.toBe(sharedIntegrity);
+        await expect(readHeader(chatFile)).resolves.toMatchObject({
+            chat_metadata: { integrity: firstResult.integrity },
+        });
+
+        await expect(trySaveChat(
+            chatWithIntegrity(sharedIntegrity, 'stale device two'),
+            chatFile,
+            false,
+            'test-user',
+            'Test Card',
+            backupDir,
+        )).rejects.toThrow(/integrity/i);
+    });
+});

--- a/tests/chat-integrity-rotation.test.js
+++ b/tests/chat-integrity-rotation.test.js
@@ -74,6 +74,35 @@ describe('chat integrity rotation', () => {
         )).rejects.toThrow(/integrity/i);
     });
 
+    test('keeps forced-overwrite safety backup distinct from the same-second post-save backup', async () => {
+        const { trySaveChat } = await import('../src/endpoints/chats.js');
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-integrity-force-'));
+        const chatFile = path.join(tempDir, 'chat.jsonl');
+        const backupDir = path.join(tempDir, 'backups');
+        await fs.mkdir(backupDir);
+        jest.setSystemTime(new Date('2026-06-06T12:34:56.000Z'));
+
+        await fs.writeFile(chatFile, chatWithIntegrity('old-integrity', 'original disk chat').map(JSON.stringify).join('\n'));
+        await trySaveChat(
+            chatWithIntegrity('ignored-forced-integrity', 'forced overwrite chat'),
+            chatFile,
+            true,
+            'forced-overwrite-user',
+            'Test Card',
+            backupDir,
+        );
+
+        const backupFiles = await fs.readdir(backupDir);
+        const forcedBackup = backupFiles.find(fileName => fileName.startsWith('chat_forced_overwrite_test_card_'));
+        const postSaveBackup = backupFiles.find(fileName => fileName.startsWith('chat_test_card_'));
+
+        expect(backupFiles).toHaveLength(2);
+        expect(forcedBackup).toEqual(expect.any(String));
+        expect(postSaveBackup).toEqual(expect.any(String));
+        await expect(fs.readFile(path.join(backupDir, forcedBackup), 'utf8')).resolves.toContain('original disk chat');
+        await expect(fs.readFile(path.join(backupDir, postSaveBackup), 'utf8')).resolves.toContain('forced overwrite chat');
+    });
+
     test('adopts returned integrity only for the active chat file', async () => {
         const scriptSource = await fs.readFile(fileURLToPath(new URL('../public/script.js', import.meta.url)), 'utf8');
 


### PR DESCRIPTION
## What?
Rotate the chat metadata integrity token on successful normal and group chat saves, return the new token in the save response, and have clients adopt it after save. Forced overwrites also back up the existing disk chat before writing.

## Why?
Two devices that loaded the same chat could carry the same integrity token, both pass the save check, and let a stale writer overwrite newer messages from the other device.

## How?
`trySaveChat()` now writes a fresh integrity UUID into the saved header after any successful integrity check and returns that value to the save routes. `saveChat()` and `saveGroupChat()` store the returned token so the active client remains the current writer. Forced saves keep the existing destructive override path but create an immediate backup first.

## Testing?
- `npm run test:unit --prefix tests -- chat-integrity-rotation.test.js`
- `node --check src/endpoints/chats.js`
- `node --check public/script.js`
- `node --check public/scripts/group-chats.js`
- `npm run check:frontend-budgets`
- `npm run lint`
- `git diff --check origin/staging HEAD`
- Node server startup smoke on a temporary data/config root and non-4444 port
- Bun server startup smoke on a temporary data/config root and non-4444 port

## Screenshots (optional)
Not included; this is a chat persistence/server contract change.

## Anything Else?
Includes an upstream touch ledger entry for the save-contract divergence.