### PR TITLE
fix: wire tool call recursion limit slider to runtime cap

### DIFF
--- a/docs/upstream-touch-ledger.md
+++ b/docs/upstream-touch-ledger.md
@@ -76,6 +76,19 @@ This ledger tracks intentional SillyBunny divergence in upstream-origin files. I
 | Last reviewed | 2026-05-28 preset/API sync lifecycle wiring. |
 | Owner | Refactor integrator and mobile shell owner. |
 
+### `public/scripts/openai.js` and `public/index.html` - tool recursion limit setting
+| Field | Value |
+| --- | --- |
+| Area | Settings and tool calling. |
+| Divergence reason | SillyBunny exposes a tool-call recursion limit control that must persist and drive the actual runtime cap instead of showing the browser range midpoint. |
+| Target seam | `public/scripts/tool-call-recurse-limit.js`. |
+| Adapter shape | Keep `openai.js` limited to settings map/default wiring, load/change synchronization, and assigning `ToolManager.RECURSE_LIMIT`; keep `index.html` default values aligned with the runtime default. |
+| Protecting tests | `tests/tool-call-recurse-limit.test.js`, `tests/tool-call-recurse-limit-wiring.test.js`. |
+| Validation | `npm run test:unit --prefix tests -- tool-call-recurse-limit.test.js tool-call-recurse-limit-wiring.test.js`, `node --check public/scripts/openai.js`, `node --check public/scripts/tool-call-recurse-limit.js`, `npm run lint`, `npm run check:frontend-budgets`. |
+| Rollback path | Remove the setting map/default and input handler, leaving `ToolManager.RECURSE_LIMIT` at its static default. |
+| Last reviewed | 2026-06-06 tool recursion limit fix. |
+| Owner | Bugfix integrator. |
+
 ### `public/scripts/mobile-streaming.js` - platform streaming policy
 | Field | Value |
 | --- | --- |

--- a/public/index.html
+++ b/public/index.html
@@ -1857,10 +1857,10 @@
                                             </div>
                                             <div class="range-block-range-and-counter">
                                                 <div class="range-block-range">
-                                                    <input type="range" id="tool_call_recurse_limit" name="tool_call_recurse_limit" min="1" max="50" step="1">
+                                                    <input type="range" id="tool_call_recurse_limit" name="tool_call_recurse_limit" min="1" max="50" step="1" value="5">
                                                 </div>
                                                 <div class="range-block-counter">
-                                                    <input type="number" min="1" max="50" step="1" data-for="tool_call_recurse_limit" id="tool_call_recurse_limit_counter">
+                                                    <input type="number" min="1" max="50" step="1" data-for="tool_call_recurse_limit" id="tool_call_recurse_limit_counter" value="5">
                                                 </div>
                                             </div>
                                         </div>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -87,6 +87,7 @@ import { syncOpenRouterProvidersForModel, updateOpenRouterProvidersWarning } fro
 import { hasTextOrArrayPayload, shouldRetainContextAtDepth, stripHtmlTagsFromContext, stripOocBlocksFromContext } from './ooc-blocks.js';
 import { checkPostInterceptChatBudget, shouldCheckPostInterceptChatBudget } from './openai-prompt-budget.js';
 import { buildChatCompletionPresetForSave, buildReverseProxyPresetForSave, normalizeReverseProxyPreset } from './openai-preset-utils.js';
+import { TOOL_CALL_RECURSE_LIMIT_DEFAULT, normalizeToolCallRecurseLimit } from './tool-call-recurse-limit.js';
 
 export {
     openai_messages_count,
@@ -501,6 +502,7 @@ export const settingsToUpdate = {
     continue_prefill: ['#continue_prefill', 'continue_prefill', true, false],
     continue_postfix: ['#continue_postfix', 'continue_postfix', false, false],
     function_calling: ['#openai_function_calling', 'function_calling', true, false],
+    tool_call_recurse_limit: ['#tool_call_recurse_limit', 'tool_call_recurse_limit', false, false],
     show_thoughts: ['#openai_show_thoughts', 'show_thoughts', true, false],
     auto_append_reasoning_tags: ['#openai_auto_append_reasoning_tags', 'auto_append_reasoning_tags', true, false],
     auto_append_reasoning_tag_style: ['#openai_reasoning_tag_style', 'auto_append_reasoning_tag_style', false, false],
@@ -615,6 +617,7 @@ const default_settings = {
     bypass_status_check: false,
     continue_prefill: false,
     function_calling: false,
+    tool_call_recurse_limit: TOOL_CALL_RECURSE_LIMIT_DEFAULT,
     names_behavior: character_names_behavior.DEFAULT,
     continue_postfix: continue_postfix_types.SPACE,
     custom_prompt_post_processing: custom_prompt_post_processing_types.NONE,
@@ -674,6 +677,15 @@ export let selected_proxy = proxies[0];
 
 export let openai_setting_names;
 export let openai_settings;
+
+function applyToolCallRecurseLimit(value = oai_settings.tool_call_recurse_limit) {
+    const recurseLimit = normalizeToolCallRecurseLimit(value);
+    oai_settings.tool_call_recurse_limit = recurseLimit;
+    ToolManager.RECURSE_LIMIT = recurseLimit;
+    $('#tool_call_recurse_limit').val(recurseLimit);
+    $('#tool_call_recurse_limit_counter').val(recurseLimit);
+    return recurseLimit;
+}
 
 /** @type {import('./PromptManager.js').PromptManager} */
 export let promptManager = null;
@@ -6547,6 +6559,7 @@ function loadOpenAISettings(data, settings) {
         }
     }
 
+    applyToolCallRecurseLimit(oai_settings.tool_call_recurse_limit);
     syncMaxContextUnlockedControl(oai_settings);
 
     $(`#settings_preset_openai option[value="${openai_setting_names[oai_settings.preset_settings_openai]}"]`).prop('selected', true);
@@ -9768,6 +9781,11 @@ export function initOpenAI() {
     $('#openai_function_calling').on('input', function () {
         oai_settings.function_calling = !!$(this).prop('checked');
         updateFeatureSupportFlags();
+        saveSettingsDebounced();
+    });
+
+    $('#tool_call_recurse_limit').on('input', function () {
+        applyToolCallRecurseLimit($(this).val());
         saveSettingsDebounced();
     });
 

--- a/public/scripts/tool-call-recurse-limit.js
+++ b/public/scripts/tool-call-recurse-limit.js
@@ -1,0 +1,16 @@
+export const TOOL_CALL_RECURSE_LIMIT_DEFAULT = 5;
+export const TOOL_CALL_RECURSE_LIMIT_MIN = 1;
+export const TOOL_CALL_RECURSE_LIMIT_MAX = 50;
+
+/**
+ * @param {unknown} value
+ * @param {number} fallback
+ * @returns {number}
+ */
+export function normalizeToolCallRecurseLimit(value, fallback = TOOL_CALL_RECURSE_LIMIT_DEFAULT) {
+    const parsed = Number.parseInt(String(value), 10);
+    const fallbackValue = Number.isFinite(fallback) ? fallback : TOOL_CALL_RECURSE_LIMIT_DEFAULT;
+    const nextValue = Number.isFinite(parsed) ? parsed : fallbackValue;
+
+    return Math.min(TOOL_CALL_RECURSE_LIMIT_MAX, Math.max(TOOL_CALL_RECURSE_LIMIT_MIN, nextValue));
+}

--- a/tests/tool-call-recurse-limit-wiring.test.js
+++ b/tests/tool-call-recurse-limit-wiring.test.js
@@ -1,0 +1,56 @@
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const openAiSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'openai.js'), 'utf8');
+const indexHtml = readFileSync(path.join(repoRoot, 'public', 'index.html'), 'utf8');
+
+function getFunctionSource(name) {
+    const marker = `function ${name}(`;
+    const start = openAiSource.indexOf(marker);
+
+    expect(start).toBeGreaterThanOrEqual(0);
+
+    const bodyStart = openAiSource.indexOf(') {', start) + 2;
+    let depth = 0;
+
+    for (let index = bodyStart; index < openAiSource.length; index++) {
+        const char = openAiSource[index];
+        if (char === '{') {
+            depth++;
+        } else if (char === '}') {
+            depth--;
+            if (depth === 0) {
+                return openAiSource.slice(start, index + 1);
+            }
+        }
+    }
+
+    throw new Error(`Unable to find function source for ${name}`);
+}
+
+describe('tool call recurse limit wiring', () => {
+    test('defaults the slider and number counter to the real runtime cap', () => {
+        expect(indexHtml).toContain('id="tool_call_recurse_limit"');
+        expect(indexHtml).toContain('id="tool_call_recurse_limit" name="tool_call_recurse_limit" min="1" max="50" step="1" value="5"');
+        expect(indexHtml).toContain('id="tool_call_recurse_limit_counter" value="5"');
+    });
+
+    test('maps the control through OpenAI preset settings', () => {
+        expect(openAiSource).toContain("tool_call_recurse_limit: ['#tool_call_recurse_limit', 'tool_call_recurse_limit', false, false]");
+        expect(openAiSource).toContain('tool_call_recurse_limit: TOOL_CALL_RECURSE_LIMIT_DEFAULT');
+    });
+
+    test('loads and changes the setting through ToolManager.RECURSE_LIMIT', () => {
+        const loadSource = getFunctionSource('loadOpenAISettings');
+        const initSource = getFunctionSource('initOpenAI');
+        const applySource = getFunctionSource('applyToolCallRecurseLimit');
+
+        expect(applySource).toContain('ToolManager.RECURSE_LIMIT = recurseLimit;');
+        expect(loadSource).toContain('applyToolCallRecurseLimit(oai_settings.tool_call_recurse_limit);');
+        expect(initSource).toContain("$('#tool_call_recurse_limit').on('input'");
+        expect(initSource).toContain('applyToolCallRecurseLimit($(this).val());');
+    });
+});

--- a/tests/tool-call-recurse-limit.test.js
+++ b/tests/tool-call-recurse-limit.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, test } from '@jest/globals';
+
+import {
+    TOOL_CALL_RECURSE_LIMIT_DEFAULT,
+    normalizeToolCallRecurseLimit,
+} from '../public/scripts/tool-call-recurse-limit.js';
+
+describe('tool call recurse limit settings', () => {
+    test('keeps the current runtime default', () => {
+        expect(TOOL_CALL_RECURSE_LIMIT_DEFAULT).toBe(5);
+        expect(normalizeToolCallRecurseLimit(undefined)).toBe(5);
+    });
+
+    test('clamps saved and manual control values to the UI range', () => {
+        expect(normalizeToolCallRecurseLimit(0)).toBe(1);
+        expect(normalizeToolCallRecurseLimit(12)).toBe(12);
+        expect(normalizeToolCallRecurseLimit('26')).toBe(26);
+        expect(normalizeToolCallRecurseLimit(99)).toBe(50);
+    });
+
+    test('uses fallback when a saved value is not numeric', () => {
+        expect(normalizeToolCallRecurseLimit('nope', 7)).toBe(7);
+    });
+});


### PR DESCRIPTION
## What?
Wire the existing tool-call recursion limit slider into OpenAI preset settings and the runtime `ToolManager.RECURSE_LIMIT` value.

## Why?
The slider displayed the browser range midpoint of 26 while the real runtime limit stayed fixed at 5, so the UI was misleading and changes had no effect.

## How?
A small normalizer clamps values to the existing UI range of 1-50 and preserves the current default of 5. OpenAI settings load/change handling now applies the saved value to the slider, counter, and `ToolManager.RECURSE_LIMIT`.

## Testing?
- `npm run test:unit --prefix tests -- tool-call-recurse-limit.test.js tool-call-recurse-limit-wiring.test.js`
- `node --check public/scripts/openai.js`
- `node --check public/scripts/tool-call-recurse-limit.js`
- `npm run check:frontend-budgets`
- `npm run lint`
- `git diff --check origin/staging HEAD`

## Screenshots (optional)
Not included; the behavior is covered by settings and wiring tests.

## Anything Else?
Includes an upstream touch ledger entry for the now-live settings control.