### PR TITLE
fix: show stop button during in-chat agent generation

### DIFF
--- a/docs/upstream-touch-ledger.md
+++ b/docs/upstream-touch-ledger.md
@@ -41,13 +41,13 @@ This ledger tracks intentional SillyBunny divergence in upstream-origin files. I
 | Field | Value |
 | --- | --- |
 | Area | Generation lifecycle. |
-| Divergence reason | SillyBunny generation flow needs explicit UI lock, stop, and unblock decisions while preserving provider calls, prompt assembly, token accounting, and persistence in the existing generation path. |
+| Divergence reason | SillyBunny generation flow needs explicit UI lock, stop, agent-generation, and unblock decisions while preserving provider calls, prompt assembly, token accounting, and persistence in the existing generation path. |
 | Target seam | `public/scripts/generation-lifecycle/`. |
 | Adapter shape | Keep exported generation functions in `public/script.js`; delegate send-button lock state, stop-generation request state, and unblock cleanup decisions to the lifecycle module. |
-| Protecting tests | `tests/generation-lifecycle.test.js`, `tests/generation-lifecycle-wiring.test.js`, existing export-surface coverage. |
-| Validation | `npm run test:unit --prefix tests -- generation-lifecycle.test.js generation-lifecycle-wiring.test.js`, `npm run lint --prefix tests -- generation-lifecycle.test.js generation-lifecycle-wiring.test.js`, `npm run lint`, `npm run check:frontend-budgets`. |
+| Protecting tests | `tests/generation-lifecycle.test.js`, `tests/generation-lifecycle-wiring.test.js`, `tests/in-chat-agents-generation-ui-wiring.test.js`, existing export-surface coverage. |
+| Validation | `npm run test:unit --prefix tests -- generation-lifecycle.test.js generation-lifecycle-wiring.test.js in-chat-agents-generation-ui-wiring.test.js`, `npm run lint --prefix tests -- generation-lifecycle.test.js generation-lifecycle-wiring.test.js in-chat-agents-generation-ui-wiring.test.js`, `npm run lint`, `npm run check:frontend-budgets`. |
 | Rollback path | Revert lifecycle calls in `public/script.js` while keeping existing provider and prompt paths intact. |
-| Last reviewed | 2026-05-28 generation lifecycle wiring. |
+| Last reviewed | 2026-06-06 in-chat agent stop-button wiring. |
 | Owner | Refactor integrator. |
 
 ### `public/style.css` - message containment and scroll anchoring

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -2,8 +2,9 @@ import { DiffMatchPatch } from '../../../lib.js';
 import { extension_settings, renderExtensionTemplateAsync, getContext } from '../../extensions.js';
 import { Popup, POPUP_TYPE, POPUP_RESULT } from '../../popup.js';
 import { download, escapeHtml, escapeRegex, getSortableDelay, uuidv4 } from '../../utils.js';
-import { CLIENT_VERSION, chat, getRequestHeaders, generateQuietPrompt, normalizeContentText, saveSettingsDebounced, substituteParams } from '../../../script.js';
+import { activateSendButtons, CLIENT_VERSION, chat, deactivateSendButtons, getRequestHeaders, generateQuietPrompt, is_send_press, normalizeContentText, saveSettingsDebounced, substituteParams } from '../../../script.js';
 import { eventSource, event_types } from '../../events.js';
+import { is_group_generating } from '../../group-chats.js';
 import {
     areAgentsGloballyEnabled,
     getAgents,
@@ -189,6 +190,22 @@ function getLastAssistantMessageIndex() {
 
 function updateCancelGenerationButton() {
     $('#ica--cancelGeneration').toggle(isAgentGenerationActive());
+}
+
+function updateAgentGenerationSendControls(active = isAgentGenerationActive()) {
+    if (active) {
+        deactivateSendButtons();
+        return;
+    }
+
+    if (!is_send_press && !is_group_generating) {
+        activateSendButtons();
+    }
+}
+
+function refreshGenerationUi(active = isAgentGenerationActive()) {
+    updateCancelGenerationButton();
+    updateAgentGenerationSendControls(active);
 }
 
 function updateGlobalAgentToggle() {
@@ -4218,8 +4235,15 @@ async function refinePromptWithAI(currentPrompt, category, phase, connectionProf
         eventSource.on(eventName, refreshProfileUi);
     }
 
-    const refreshGenerationUi = () => updateCancelGenerationButton();
     onAgentGenerationStateChanged(refreshGenerationUi);
+    $(document).on('click', '#mes_stop', () => {
+        if (!isAgentGenerationActive()) {
+            return;
+        }
+
+        cancelAgentGeneration();
+        refreshGenerationUi();
+    });
     for (const eventName of [
         event_types.GENERATION_STARTED,
         event_types.GENERATION_ENDED,

--- a/tests/in-chat-agents-generation-ui-wiring.test.js
+++ b/tests/in-chat-agents-generation-ui-wiring.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const indexSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'extensions', 'in-chat-agents', 'index.js'), 'utf8');
+
+function getFunctionSource(name) {
+    const marker = `function ${name}(`;
+    const start = indexSource.indexOf(marker);
+
+    expect(start).toBeGreaterThanOrEqual(0);
+
+    const bodyStart = indexSource.indexOf(') {', start) + 2;
+    let depth = 0;
+
+    for (let index = bodyStart; index < indexSource.length; index++) {
+        const char = indexSource[index];
+        if (char === '{') {
+            depth++;
+        } else if (char === '}') {
+            depth--;
+            if (depth === 0) {
+                return indexSource.slice(start, index + 1);
+            }
+        }
+    }
+
+    throw new Error(`Unable to find function source for ${name}`);
+}
+
+describe('in-chat agents generation UI wiring', () => {
+    test('uses the shared send-button lifecycle for agent activity', () => {
+        const updateSource = getFunctionSource('updateAgentGenerationSendControls');
+
+        expect(indexSource).toContain('activateSendButtons');
+        expect(indexSource).toContain('deactivateSendButtons');
+        expect(updateSource).toContain('deactivateSendButtons();');
+        expect(updateSource).toContain('if (!is_send_press && !is_group_generating)');
+        expect(updateSource).toContain('activateSendButtons();');
+    });
+
+    test('subscribes agent state changes and routes send-bar stop clicks to agent cancel', () => {
+        expect(indexSource).toContain('onAgentGenerationStateChanged(refreshGenerationUi);');
+        expect(indexSource).toContain("$(document).on('click', '#mes_stop'");
+        expect(indexSource).toContain('cancelAgentGeneration();');
+    });
+});

--- a/tests/in-chat-agents-pre-intercept-summary.test.js
+++ b/tests/in-chat-agents-pre-intercept-summary.test.js
@@ -49,12 +49,19 @@ beforeAll(async () => {
 
     await jest.unstable_mockModule('../public/script.js', () => ({
         CLIENT_VERSION: 'test',
+        activateSendButtons: jest.fn(),
         chat: [],
+        deactivateSendButtons: jest.fn(),
         getRequestHeaders: jest.fn(() => ({})),
         generateQuietPrompt: jest.fn(),
+        is_send_press: false,
         normalizeContentText: jest.fn(value => String(value ?? '')),
         saveSettingsDebounced: jest.fn(),
         substituteParams: jest.fn(value => String(value ?? '')),
+    }));
+
+    await jest.unstable_mockModule('../public/scripts/group-chats.js', () => ({
+        is_group_generating: false,
     }));
 
     await jest.unstable_mockModule('../public/scripts/events.js', () => ({


### PR DESCRIPTION
## What?
Show the shared send-bar stop state while in-chat agent generation is active and route `#mes_stop` clicks to the agent cancellation path.

## Why?
Agent generation could continue while the normal send controls looked idle, so the stop affordance did not honestly represent active generation work.

## How?
Agent generation state now refreshes both the extension cancel button and shared send controls. The unlock path is guarded so normal or group generation keeps the stop state active, and the send-bar stop handler cancels an active agent run.

## Testing?
- `npm run test:unit --prefix tests -- generation-lifecycle.test.js generation-lifecycle-wiring.test.js in-chat-agents-generation-ui-wiring.test.js in-chat-agents-pre-intercept-summary.test.js`
- `node --check public/scripts/extensions/in-chat-agents/index.js`
- `npm run check:frontend-budgets`
- `npm run lint`
- `git diff --check origin/staging HEAD`

## Screenshots (optional)
Not included; the shared send-control behavior is covered by wiring tests.

## Anything Else?
Updates the generation lifecycle ledger entry to note agent-generation stop-button wiring.