### PR TITLE
fix: paint message-block transparency in core without Moonlit Echoes

### DIFF
--- a/docs/upstream-touch-ledger.md
+++ b/docs/upstream-touch-ledger.md
@@ -145,13 +145,26 @@ This ledger tracks intentional SillyBunny divergence in upstream-origin files. I
 | Field | Value |
 | --- | --- |
 | Area | Settings and frontend boot. |
-| Divergence reason | SillyBunny keeps `script.js` loaded through its canonical URL and keeps OOC/HTML retention settings copy synchronized with active-turn depth behavior. |
-| Target seam | `public/scripts/ooc-blocks.js` for retention behavior; no separate seam for the HTML boot URL. |
+| Divergence reason | SillyBunny keeps `script.js` loaded through its canonical URL, keeps OOC/HTML retention settings copy synchronized with active-turn depth behavior, and exposes core background transparency sliders without requiring Moonlit Echoes. |
+| Target seam | `public/scripts/ooc-blocks.js` for retention behavior; `public/css/sillybunny-chat-styles.css` and `public/scripts/power-user.js` for core transparency behavior. |
 | Adapter shape | Keep HTML changes limited to static boot references and settings labels/tooltips. |
-| Protecting tests | `tests/frontend-assets.test.js`, `tests/ooc-blocks.test.js`. |
-| Validation | `npm run test:unit --prefix tests -- frontend-assets.test.js ooc-blocks.test.js`, `npm run build:frontend`, browser smoke check. |
-| Rollback path | Restore versioned `script.js` references and previous settings copy if cache behavior or settings semantics regress. |
-| Last reviewed | 2026-06-02 frontend asset and OOC settings update. |
+| Protecting tests | `tests/frontend-assets.test.js`, `tests/ooc-blocks.test.js`, `tests/core-message-transparency.test.js`. |
+| Validation | `npm run test:unit --prefix tests -- frontend-assets.test.js ooc-blocks.test.js`, `npm run test:unit --prefix tests -- core-message-transparency.test.js`, `npm run build:frontend`, browser smoke check. |
+| Rollback path | Restore versioned `script.js` references, previous settings copy, and remove core transparency slider markup if cache behavior or settings semantics regress. Chat transparency CSS loading rolls back through `public/scripts/power-user.js`. |
+| Last reviewed | 2026-06-06 Bug 1 transparency migration. |
+| Owner | Refactor integrator. |
+
+### `public/css/backgrounds.css` - background image transparency
+| Field | Value |
+| --- | --- |
+| Area | Settings and frontend boot. |
+| Divergence reason | SillyBunny background-image opacity and blur must work without the Moonlit Echoes extension enabled. |
+| Target seam | `public/scripts/power-user.js` owns the persisted theme effect values; CSS remains declarative. |
+| Adapter shape | Consume `--customCSS-bg-opacity` and `--customCSS-bg-blur` on the background image elements. |
+| Protecting tests | `tests/core-message-transparency.test.js`. |
+| Validation | `npm run test:unit --prefix tests -- core-message-transparency.test.js`, `node --check public/scripts/power-user.js`, `npm run check:frontend-budgets`. |
+| Rollback path | Remove the two CSS variable consumers and leave existing background image selection untouched. |
+| Last reviewed | 2026-06-06 Bug 1 transparency migration. |
 | Owner | Refactor integrator. |
 
 ### `public/scripts/sillybunny-tabs.js` - menu layout and character drawer

--- a/public/css/backgrounds.css
+++ b/public/css/backgrounds.css
@@ -6,8 +6,15 @@
     position: absolute;
     width: 100%;
     height: 100%;
-    transition: background-image var(--sb-transition-slow);
+    opacity: var(--customCSS-bg-opacity, 1);
+    filter: blur(calc(var(--customCSS-bg-blur, 0) * 1px));
+    transition: background-image var(--sb-transition-slow), opacity var(--sb-transition-slow), filter var(--sb-transition-slow);
     z-index: -1;
+}
+
+#bg_custom {
+    opacity: var(--customCSS-bg-opacity, 1);
+    filter: blur(calc(var(--customCSS-bg-blur, 0) * 1px));
 }
 
 /* Fitting options */

--- a/public/css/sillybunny-chat-styles.css
+++ b/public/css/sillybunny-chat-styles.css
@@ -45,6 +45,37 @@
     --moonlit-sb-swipe-inline-offset: 24px;
     --moonlit-sb-user-message-bg: color-mix(in srgb, var(--SmartThemeUserMesBlurTintColor) var(--sb-shell-surface-opacity-percent, 100%), transparent);
     --moonlit-sb-bot-message-bg: color-mix(in srgb, var(--SmartThemeBotMesBlurTintColor) var(--sb-shell-surface-opacity-percent, 100%), transparent);
+    --customCSS-bg-opacity: 1;
+    --customCSS-bg-blur: 0;
+    --sheldBackgroundColor: transparent;
+    --sheldBlurStrength: 0;
+    --mobileSheldBlurStrength: 0;
+}
+
+#sheld::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: var(--sheldBackgroundColor, transparent);
+    backdrop-filter: blur(calc(var(--sheldBlurStrength, 0) * 1px));
+    -webkit-backdrop-filter: blur(calc(var(--sheldBlurStrength, 0) * 1px));
+    z-index: -1 !important;
+    pointer-events: none;
+}
+
+body:not(.bubblechat):not(.echostyle):not(.whisperstyle):not(.hushstyle):not(.ripplestyle):not(.tidestyle) #chat .mes:not(.smallSysMes) .mes_block {
+    background-color: var(--SmartThemeBotMesBlurTintColor);
+}
+
+body:not(.bubblechat):not(.echostyle):not(.whisperstyle):not(.hushstyle):not(.ripplestyle):not(.tidestyle) #chat .mes[is_user="true"]:not(.smallSysMes) .mes_block {
+    background-color: var(--SmartThemeUserMesBlurTintColor);
+}
+
+@media screen and (max-width: 1000px) {
+    #sheld::before {
+        backdrop-filter: blur(calc(var(--mobileSheldBlurStrength, 0) * 1px));
+        -webkit-backdrop-filter: blur(calc(var(--mobileSheldBlurStrength, 0) * 1px));
+    }
 }
 body.hideChatAvatars.echostyle #chat,
 body.hideChatAvatars.whisperstyle #chat,

--- a/public/css/sillybunny-chat-styles.css
+++ b/public/css/sillybunny-chat-styles.css
@@ -49,7 +49,7 @@
     --customCSS-bg-blur: 0;
     --sheldBackgroundColor: transparent;
     --sheldBlurStrength: 0;
-    --mobileSheldBlurStrength: 0;
+    --mobileSheldBlurStrength: var(--sheldBlurStrength, 0);
 }
 
 #sheld::before {

--- a/public/index.html
+++ b/public/index.html
@@ -5223,6 +5223,33 @@
                                             <input class="neo-range-slider" type="range" id="shadow_width" name="shadow_width" min="0" max="5" step="1">
                                             <input class="neo-range-input" type="number" min="0" max="5" step="1" data-for="shadow_width" id="shadow_width_counter">
                                         </div>
+
+                                        <div id="background-blur-block" class="alignitemscenter flex-container flexFlowColumn flexBasis48p flexGrow flexShrink gap0">
+                                            <small>
+                                                <span>Background Blur</span>
+                                                <div class="fa-solid fa-circle-info opacity50p" title="Blur strength for the page background image."></div>
+                                            </small>
+                                            <input class="neo-range-slider" type="range" id="background_blur" name="background_blur" min="0" max="10" step="1">
+                                            <input class="neo-range-input" type="number" min="0" max="10" step="1" data-for="background_blur" id="background_blur_counter">
+                                        </div>
+
+                                        <div id="background-opacity-block" class="alignitemscenter flex-container flexFlowColumn flexBasis48p flexGrow flexShrink gap0">
+                                            <small>
+                                                <span>Background Opacity</span>
+                                                <div class="fa-solid fa-circle-info opacity50p" title="Opacity for the page background image."></div>
+                                            </small>
+                                            <input class="neo-range-slider" type="range" id="background_opacity" name="background_opacity" min="0" max="1" step="0.05">
+                                            <input class="neo-range-input" type="number" min="0" max="1" step="0.05" data-for="background_opacity" id="background_opacity_counter">
+                                        </div>
+
+                                        <div id="sheld-blur-strength-block" class="alignitemscenter flex-container flexFlowColumn flexBasis48p flexGrow flexShrink gap0">
+                                            <small>
+                                                <span>Chat Field Blur</span>
+                                                <div class="fa-solid fa-circle-info opacity50p" title="Blur strength behind the chat field."></div>
+                                            </small>
+                                            <input class="neo-range-slider" type="range" id="sheld_blur_strength" name="sheld_blur_strength" min="0" max="10" step="1">
+                                            <input class="neo-range-input" type="number" min="0" max="10" step="1" data-for="sheld_blur_strength" id="sheld_blur_strength_counter">
+                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -5229,8 +5229,8 @@
                                                 <span>Background Blur</span>
                                                 <div class="fa-solid fa-circle-info opacity50p" title="Blur strength for the page background image."></div>
                                             </small>
-                                            <input class="neo-range-slider" type="range" id="background_blur" name="background_blur" min="0" max="10" step="1">
-                                            <input class="neo-range-input" type="number" min="0" max="10" step="1" data-for="background_blur" id="background_blur_counter">
+                                            <input class="neo-range-slider" type="range" id="background_blur" name="background_blur" min="0" max="10" step="1" aria-label="Background blur">
+                                            <input class="neo-range-input" type="number" min="0" max="10" step="1" data-for="background_blur" id="background_blur_counter" aria-label="Background blur value">
                                         </div>
 
                                         <div id="background-opacity-block" class="alignitemscenter flex-container flexFlowColumn flexBasis48p flexGrow flexShrink gap0">
@@ -5238,8 +5238,8 @@
                                                 <span>Background Opacity</span>
                                                 <div class="fa-solid fa-circle-info opacity50p" title="Opacity for the page background image."></div>
                                             </small>
-                                            <input class="neo-range-slider" type="range" id="background_opacity" name="background_opacity" min="0" max="1" step="0.05">
-                                            <input class="neo-range-input" type="number" min="0" max="1" step="0.05" data-for="background_opacity" id="background_opacity_counter">
+                                            <input class="neo-range-slider" type="range" id="background_opacity" name="background_opacity" min="0" max="1" step="0.05" aria-label="Background opacity">
+                                            <input class="neo-range-input" type="number" min="0" max="1" step="0.05" data-for="background_opacity" id="background_opacity_counter" aria-label="Background opacity value">
                                         </div>
 
                                         <div id="sheld-blur-strength-block" class="alignitemscenter flex-container flexFlowColumn flexBasis48p flexGrow flexShrink gap0">
@@ -5247,8 +5247,8 @@
                                                 <span>Chat Field Blur</span>
                                                 <div class="fa-solid fa-circle-info opacity50p" title="Blur strength behind the chat field."></div>
                                             </small>
-                                            <input class="neo-range-slider" type="range" id="sheld_blur_strength" name="sheld_blur_strength" min="0" max="10" step="1">
-                                            <input class="neo-range-input" type="number" min="0" max="10" step="1" data-for="sheld_blur_strength" id="sheld_blur_strength_counter">
+                                            <input class="neo-range-slider" type="range" id="sheld_blur_strength" name="sheld_blur_strength" min="0" max="10" step="1" aria-label="Chat field blur">
+                                            <input class="neo-range-input" type="number" min="0" max="10" step="1" data-for="sheld_blur_strength" id="sheld_blur_strength_counter" aria-label="Chat field blur value">
                                         </div>
                                     </div>
                                 </div>

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -174,8 +174,7 @@ const THEME_COLOR_PROPERTIES = Object.freeze([
 const THEME_EFFECT_PROPERTIES = Object.freeze([
     { key: 'customCSS-bg-blur', selector: '#background_blur', counterSelector: '#background_blur_counter', cssVar: '--customCSS-bg-blur', defaultValue: 0, min: 0, max: 10 },
     { key: 'customCSS-bg-opacity', selector: '#background_opacity', counterSelector: '#background_opacity_counter', cssVar: '--customCSS-bg-opacity', defaultValue: 1, min: 0, max: 1 },
-    { key: 'sheldBlurStrength', selector: '#sheld_blur_strength', counterSelector: '#sheld_blur_strength_counter', cssVar: '--sheldBlurStrength', defaultValue: 0, min: 0, max: 10 },
-    { key: 'mobileSheldBlurStrength', cssVar: '--mobileSheldBlurStrength', defaultValue: 0, min: 0, max: 10 },
+    { key: 'sheldBlurStrength', selector: '#sheld_blur_strength', counterSelector: '#sheld_blur_strength_counter', cssVar: '--sheldBlurStrength', linkedCssVars: ['--mobileSheldBlurStrength'], defaultValue: 0, min: 0, max: 10 },
     { key: 'sheldBackgroundColor', cssVar: '--sheldBackgroundColor', defaultValue: 'transparent' },
 ]);
 
@@ -1590,6 +1589,9 @@ function applyThemeEffects() {
         const value = normalizeThemeEffectValue(property);
         power_user[property.key] = value;
         document.documentElement.style.setProperty(property.cssVar, String(value));
+        for (const cssVar of property.linkedCssVars || []) {
+            document.documentElement.style.setProperty(cssVar, String(value));
+        }
 
         if (property.selector) {
             $(property.selector).val(value);

--- a/public/scripts/power-user.js
+++ b/public/scripts/power-user.js
@@ -171,6 +171,14 @@ const THEME_COLOR_PROPERTIES = Object.freeze([
     { key: 'border_color', selector: '#border-color-picker', type: 'border' },
 ]);
 
+const THEME_EFFECT_PROPERTIES = Object.freeze([
+    { key: 'customCSS-bg-blur', selector: '#background_blur', counterSelector: '#background_blur_counter', cssVar: '--customCSS-bg-blur', defaultValue: 0, min: 0, max: 10 },
+    { key: 'customCSS-bg-opacity', selector: '#background_opacity', counterSelector: '#background_opacity_counter', cssVar: '--customCSS-bg-opacity', defaultValue: 1, min: 0, max: 1 },
+    { key: 'sheldBlurStrength', selector: '#sheld_blur_strength', counterSelector: '#sheld_blur_strength_counter', cssVar: '--sheldBlurStrength', defaultValue: 0, min: 0, max: 10 },
+    { key: 'mobileSheldBlurStrength', cssVar: '--mobileSheldBlurStrength', defaultValue: 0, min: 0, max: 10 },
+    { key: 'sheldBackgroundColor', cssVar: '--sheldBackgroundColor', defaultValue: 'transparent' },
+]);
+
 const avatar_styles = {
     ROUND: 0,
     RECTANGULAR: 1,
@@ -202,15 +210,8 @@ const CHAT_STYLE_BODY_CLASSES = Object.freeze({
 });
 
 const LEGACY_CHAT_STYLE_BODY_CLASSES = Object.freeze([]);
-const NATIVE_CHAT_STYLE_VALUES = new Set([
-    chat_styles.ECHO,
-    chat_styles.WHISPER,
-    chat_styles.HUSH,
-    chat_styles.RIPPLE,
-    chat_styles.TIDE,
-]);
 const NATIVE_CHAT_STYLE_STYLESHEET_ID = 'sillybunny-native-chat-styles';
-const NATIVE_CHAT_STYLE_STYLESHEET_HREF = 'css/sillybunny-chat-styles.css?v=20260513b';
+const NATIVE_CHAT_STYLE_STYLESHEET_HREF = 'css/sillybunny-chat-styles.css?v=20260606a';
 
 function ensureNativeChatStyleStylesheet() {
     if (document.getElementById(NATIVE_CHAT_STYLE_STYLESHEET_ID)) {
@@ -296,6 +297,11 @@ export const power_user = {
     font_scale: 1,
     blur_strength: 10,
     shadow_width: 2,
+    'customCSS-bg-blur': 0,
+    'customCSS-bg-opacity': 1,
+    sheldBlurStrength: 0,
+    mobileSheldBlurStrength: 0,
+    sheldBackgroundColor: 'transparent',
 
     main_text_color: `${getComputedStyle(document.documentElement).getPropertyValue('--SmartThemeBodyColor').trim()}`,
     italics_text_color: `${getComputedStyle(document.documentElement).getPropertyValue('--SmartThemeEmColor').trim()}`,
@@ -1254,9 +1260,7 @@ function applyChatDisplay() {
     const nextClass = CHAT_STYLE_BODY_CLASSES[power_user.chat_display] ?? CHAT_STYLE_BODY_CLASSES[chat_styles.DEFAULT];
     const allClasses = [...Object.values(CHAT_STYLE_BODY_CLASSES), ...LEGACY_CHAT_STYLE_BODY_CLASSES].join(' ');
 
-    if (NATIVE_CHAT_STYLE_VALUES.has(power_user.chat_display)) {
-        ensureNativeChatStyleStylesheet();
-    }
+    ensureNativeChatStyleStylesheet();
 
     console.debug(`applying ${nextClass}`);
     $('body').removeClass(allClasses);
@@ -1566,6 +1570,37 @@ function applyShadowWidth() {
     $('#shadow_width').val(power_user.shadow_width);
 }
 
+function normalizeThemeEffectValue(property) {
+    const value = power_user[property.key] ?? property.defaultValue;
+
+    if (typeof property.min === 'number' && typeof property.max === 'number') {
+        const numericValue = Number(value);
+        if (!Number.isFinite(numericValue)) {
+            return property.defaultValue;
+        }
+        return Math.min(property.max, Math.max(property.min, numericValue));
+    }
+
+    const stringValue = String(value ?? '').trim();
+    return stringValue || property.defaultValue;
+}
+
+function applyThemeEffects() {
+    for (const property of THEME_EFFECT_PROPERTIES) {
+        const value = normalizeThemeEffectValue(property);
+        power_user[property.key] = value;
+        document.documentElement.style.setProperty(property.cssVar, String(value));
+
+        if (property.selector) {
+            $(property.selector).val(value);
+        }
+
+        if (property.counterSelector) {
+            $(property.counterSelector).val(value);
+        }
+    }
+}
+
 function applyFontScale(type) {
     //this is to allow forced setting on page load, theme swap, etc
     if (type === 'forced') {
@@ -1624,6 +1659,13 @@ function applyTheme(name) {
         }
     }
 
+    for (const { key } of THEME_EFFECT_PROPERTIES) {
+        if (theme[key] !== undefined) {
+            power_user[key] = theme[key];
+        }
+    }
+    applyThemeEffects();
+
     console.log('theme applied: ' + name);
 }
 
@@ -1666,6 +1708,7 @@ export function applyPowerUserSettings() {
     applyChatWidth('forced');
     applyAvatarStyle();
     applyBlurStrength();
+    applyThemeEffects();
     applyLandingContrastPalette();
     applyShadowWidth();
     applyCustomCSS();
@@ -1980,6 +2023,7 @@ export async function loadPowerUserSettings(settings, data) {
 
     $('#shadow_width').val(power_user.shadow_width);
     $('#shadow_width_counter').val(power_user.shadow_width);
+    applyThemeEffects();
 
     syncThemeColorPickersFromState();
     $('#reduced_motion').prop('checked', power_user.reduced_motion);
@@ -2887,6 +2931,10 @@ export function getThemeObject(name) {
     const theme = { name };
 
     for (const { key } of THEME_COLOR_PROPERTIES) {
+        theme[key] = power_user[key];
+    }
+
+    for (const { key } of THEME_EFFECT_PROPERTIES) {
         theme[key] = power_user[key];
     }
 
@@ -3835,6 +3883,14 @@ jQuery(async () => {
         applyShadowWidth();
         saveSettingsDebounced();
     });
+
+    for (const property of THEME_EFFECT_PROPERTIES.filter(property => property.selector)) {
+        $(property.selector).on('input', function () {
+            power_user[property.key] = Number($(this).val());
+            applyThemeEffects();
+            saveSettingsDebounced();
+        });
+    }
 
     $('#main-text-color-picker').on('change', (/** @type {ColorPickerEvent} */ evt) => {
         power_user.main_text_color = evt.detail.rgba;

--- a/public/style.css
+++ b/public/style.css
@@ -13,7 +13,7 @@
 @import url(css/welcome.css?v=20260603e);
 @import url(css/data-maid.css);
 @import url(css/secrets.css);
-@import url(css/backgrounds.css?v=20260425a);
+@import url(css/backgrounds.css?v=20260606a);
 @import url(css/chat-backups.css);
 @import url(css/spacing-system.css);
 @import url(css/streaming-display.css);

--- a/tests/core-message-transparency.test.js
+++ b/tests/core-message-transparency.test.js
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const readSource = (...parts) => readFileSync(path.join(repoRoot, ...parts), 'utf8').replace(/\r\n/g, '\n');
+
+describe('core message transparency wiring', () => {
+    const chatStylesSource = readSource('public', 'css', 'sillybunny-chat-styles.css');
+    const backgroundsSource = readSource('public', 'css', 'backgrounds.css');
+    const powerUserSource = readSource('public', 'scripts', 'power-user.js');
+    const indexSource = readSource('public', 'index.html');
+
+    test('loads the native chat stylesheet during chat-display setup so default chat styles get core transparency', () => {
+        expect(indexSource).not.toContain('id="sillybunny-native-chat-styles"');
+        expect(powerUserSource).toContain("const NATIVE_CHAT_STYLE_STYLESHEET_HREF = 'css/sillybunny-chat-styles.css?v=20260606a';");
+        expect(powerUserSource).toContain('ensureNativeChatStyleStylesheet();');
+    });
+
+    test('paints default and document message blocks without double-painting bubble or native styles', () => {
+        expect(chatStylesSource).toContain('body:not(.bubblechat):not(.echostyle):not(.whisperstyle):not(.hushstyle):not(.ripplestyle):not(.tidestyle) #chat .mes:not(.smallSysMes) .mes_block');
+        expect(chatStylesSource).toContain('background-color: var(--SmartThemeBotMesBlurTintColor);');
+        expect(chatStylesSource).toContain('body:not(.bubblechat):not(.echostyle):not(.whisperstyle):not(.hushstyle):not(.ripplestyle):not(.tidestyle) #chat .mes[is_user="true"]:not(.smallSysMes) .mes_block');
+        expect(chatStylesSource).toContain('background-color: var(--SmartThemeUserMesBlurTintColor);');
+    });
+
+    test('migrates background and sheld transparency variables with no-op defaults', () => {
+        expect(chatStylesSource).toContain('--customCSS-bg-opacity: 1;');
+        expect(chatStylesSource).toContain('--customCSS-bg-blur: 0;');
+        expect(chatStylesSource).toContain('--sheldBackgroundColor: transparent;');
+        expect(chatStylesSource).toContain('--sheldBlurStrength: 0;');
+        expect(chatStylesSource).toContain('--mobileSheldBlurStrength: 0;');
+        expect(chatStylesSource).toContain('#sheld::before');
+        expect(chatStylesSource).toContain('backdrop-filter: blur(calc(var(--sheldBlurStrength, 0) * 1px));');
+        expect(backgroundsSource).toContain('opacity: var(--customCSS-bg-opacity, 1);');
+        expect(backgroundsSource).toContain('filter: blur(calc(var(--customCSS-bg-blur, 0) * 1px));');
+    });
+
+    test('persists and applies the three core visual sliders', () => {
+        expect(indexSource).toContain('id="background_blur"');
+        expect(indexSource).toContain('id="background_opacity"');
+        expect(indexSource).toContain('id="sheld_blur_strength"');
+        expect(powerUserSource).toContain('const THEME_EFFECT_PROPERTIES = Object.freeze([');
+        expect(powerUserSource).toContain("{ key: 'customCSS-bg-blur', selector: '#background_blur'");
+        expect(powerUserSource).toContain("{ key: 'customCSS-bg-opacity', selector: '#background_opacity'");
+        expect(powerUserSource).toContain("{ key: 'sheldBlurStrength', selector: '#sheld_blur_strength'");
+        expect(powerUserSource).toContain('function applyThemeEffects()');
+        expect(powerUserSource).toContain('theme[key] = power_user[key];');
+        expect(powerUserSource).toContain('applyThemeEffects();');
+    });
+});

--- a/tests/core-message-transparency.test.js
+++ b/tests/core-message-transparency.test.js
@@ -8,6 +8,7 @@ const readSource = (...parts) => readFileSync(path.join(repoRoot, ...parts), 'ut
 describe('core message transparency wiring', () => {
     const chatStylesSource = readSource('public', 'css', 'sillybunny-chat-styles.css');
     const backgroundsSource = readSource('public', 'css', 'backgrounds.css');
+    const styleSource = readSource('public', 'style.css');
     const powerUserSource = readSource('public', 'scripts', 'power-user.js');
     const indexSource = readSource('public', 'index.html');
 
@@ -34,12 +35,19 @@ describe('core message transparency wiring', () => {
         expect(chatStylesSource).toContain('backdrop-filter: blur(calc(var(--sheldBlurStrength, 0) * 1px));');
         expect(backgroundsSource).toContain('opacity: var(--customCSS-bg-opacity, 1);');
         expect(backgroundsSource).toContain('filter: blur(calc(var(--customCSS-bg-blur, 0) * 1px));');
+        expect(styleSource).toContain('@import url(css/backgrounds.css?v=20260606a);');
     });
 
     test('persists and applies the three core visual sliders', () => {
         expect(indexSource).toContain('id="background_blur"');
+        expect(indexSource).toContain('aria-label="Background blur"');
+        expect(indexSource).toContain('aria-label="Background blur value"');
         expect(indexSource).toContain('id="background_opacity"');
+        expect(indexSource).toContain('aria-label="Background opacity"');
+        expect(indexSource).toContain('aria-label="Background opacity value"');
         expect(indexSource).toContain('id="sheld_blur_strength"');
+        expect(indexSource).toContain('aria-label="Chat field blur"');
+        expect(indexSource).toContain('aria-label="Chat field blur value"');
         expect(powerUserSource).toContain('const THEME_EFFECT_PROPERTIES = Object.freeze([');
         expect(powerUserSource).toContain("{ key: 'customCSS-bg-blur', selector: '#background_blur'");
         expect(powerUserSource).toContain("{ key: 'customCSS-bg-opacity', selector: '#background_opacity'");

--- a/tests/core-message-transparency.test.js
+++ b/tests/core-message-transparency.test.js
@@ -30,7 +30,7 @@ describe('core message transparency wiring', () => {
         expect(chatStylesSource).toContain('--customCSS-bg-blur: 0;');
         expect(chatStylesSource).toContain('--sheldBackgroundColor: transparent;');
         expect(chatStylesSource).toContain('--sheldBlurStrength: 0;');
-        expect(chatStylesSource).toContain('--mobileSheldBlurStrength: 0;');
+        expect(chatStylesSource).toContain('--mobileSheldBlurStrength: var(--sheldBlurStrength, 0);');
         expect(chatStylesSource).toContain('#sheld::before');
         expect(chatStylesSource).toContain('backdrop-filter: blur(calc(var(--sheldBlurStrength, 0) * 1px));');
         expect(backgroundsSource).toContain('opacity: var(--customCSS-bg-opacity, 1);');
@@ -52,7 +52,10 @@ describe('core message transparency wiring', () => {
         expect(powerUserSource).toContain("{ key: 'customCSS-bg-blur', selector: '#background_blur'");
         expect(powerUserSource).toContain("{ key: 'customCSS-bg-opacity', selector: '#background_opacity'");
         expect(powerUserSource).toContain("{ key: 'sheldBlurStrength', selector: '#sheld_blur_strength'");
+        expect(powerUserSource).toContain("linkedCssVars: ['--mobileSheldBlurStrength']");
+        expect(powerUserSource).not.toContain("key: 'mobileSheldBlurStrength'");
         expect(powerUserSource).toContain('function applyThemeEffects()');
+        expect(powerUserSource).toContain('for (const cssVar of property.linkedCssVars || [])');
         expect(powerUserSource).toContain('theme[key] = power_user[key];');
         expect(powerUserSource).toContain('applyThemeEffects();');
     });


### PR DESCRIPTION
## What?
Move core message-block tinting plus background opacity/blur and chat-field blur variables into the core SillyBunny UI path without requiring Moonlit Echoes.

## Why?
Default/document chat styles lost the expected transparency behavior when the extension was disabled, and the related background controls were extension-only.

## How?
Core chat styles now define no-op defaults for the migrated CSS variables, paint default message blocks with the smart theme tint colors while excluding bubble/native styles, and apply background/sheld blur variables in CSS. Power-user theme handling persists and applies the three visual sliders, and the native chat stylesheet is loaded through `applyChatDisplay()` instead of being added as a blocking stylesheet.

## Testing?
- `npm run test:unit --prefix tests -- core-message-transparency.test.js`
- `node --check public/scripts/power-user.js`
- `npm run check:frontend-budgets`
- `npm run build:frontend`
- `npm run lint`
- `git diff --check origin/staging HEAD`

## Screenshots (optional)
Not included; this PR changes theme/CSS wiring and is covered by selector, budget, and frontend build checks.

## Anything Else?
Includes upstream touch ledger updates for the core transparency and background CSS changes.