### PR TITLE
fix: stabilize mobile viewport on search close and auto-focus search input

### DIFF
--- a/docs/upstream-touch-ledger.md
+++ b/docs/upstream-touch-ledger.md
@@ -67,13 +67,26 @@ This ledger tracks intentional SillyBunny divergence in upstream-origin files. I
 | Field | Value |
 | --- | --- |
 | Area | Mobile shell, chat navigation, and preset/API sync. |
-| Divergence reason | SillyBunny shell owns top/bottom navigation, chat controls, drawers, mobile actions, and mirrored connection-profile controls that interact with chat and API state. |
+| Divergence reason | SillyBunny shell owns top/bottom navigation, chat controls, drawers, mobile actions, search shortcut focus, viewport-reset dispatches, and mirrored connection-profile controls that interact with chat and API state. |
 | Target seam | `public/scripts/chat-render-lifecycle/` for chat scroll requests; `public/scripts/mobile-shell-lifecycle/` for drawer/nav/viewport behavior; `public/scripts/preset-api-sync-lifecycle/` for active API and connection-profile mirror decisions. |
-| Adapter shape | Shell code keeps DOM wiring and requests lifecycle decisions for nav drag, page scroll, overlay open/close, auto-close, modal inert policy, active API connect-button lookup, and connection-profile mirror state. |
+| Adapter shape | Shell code keeps DOM wiring and requests lifecycle decisions for nav drag, page scroll, overlay open/close, auto-close, modal inert policy, search shortcut pre-focus, viewport reset timing, active API connect-button lookup, and connection-profile mirror state. |
 | Protecting tests | `tests/mobile-shell-lifecycle.test.js`, `tests/mobile-shell-lifecycle-wiring.test.js`, `tests/preset-api-sync-lifecycle.test.js`, `tests/preset-api-sync-lifecycle-wiring.test.js`, future shell smoke checks for drawer/tab/preset/chat-scroll behavior. |
-| Validation | `npm run test:unit --prefix tests -- mobile-shell-lifecycle.test.js mobile-shell-lifecycle-wiring.test.js`, `npm run lint --prefix tests -- mobile-shell-lifecycle.test.js mobile-shell-lifecycle-wiring.test.js`, `npm run test:unit --prefix tests -- preset-api-sync-lifecycle.test.js preset-api-sync-lifecycle-wiring.test.js`, `npm run lint --prefix tests -- preset-api-sync-lifecycle.test.js preset-api-sync-lifecycle-wiring.test.js`, `npm run lint`, `npm run check:frontend-budgets`. |
+| Validation | `npm run test:unit --prefix tests -- mobile-shell-lifecycle.test.js mobile-shell-lifecycle-wiring.test.js`, `npm run lint --prefix tests -- mobile-shell-lifecycle.test.js mobile-shell-lifecycle-wiring.test.js`, `npm run test:unit --prefix tests -- preset-api-sync-lifecycle.test.js preset-api-sync-lifecycle-wiring.test.js`, `npm run lint --prefix tests -- preset-api-sync-lifecycle.test.js preset-api-sync-lifecycle-wiring.test.js`, `node --check public/scripts/sillybunny-tabs.js`, `npm run lint`, `npm run check:frontend-budgets`. |
 | Rollback path | Keep shell calls narrow so a bad adapter route can be reverted without removing shell UI. |
-| Last reviewed | 2026-05-28 preset/API sync lifecycle wiring. |
+| Last reviewed | 2026-06-06 Bug 2 mobile search viewport reset and focus. |
+| Owner | Refactor integrator and mobile shell owner. |
+
+### `public/scripts/browser-fixes.js` - mobile viewport reset guard
+| Field | Value |
+| --- | --- |
+| Area | Mobile shell. |
+| Divergence reason | SillyBunny must restore scroll and avoid re-pinning the root while mobile keyboard close/reset events are still settling. |
+| Target seam | No separate seam yet; this file owns browser-specific viewport patches. |
+| Adapter shape | Keep reset scheduling, transient fixed-position cleanup, scroll restoration, and reapply suppression in the mobile browser fix helper. |
+| Protecting tests | `tests/mobile-shell-lifecycle-wiring.test.js`. |
+| Validation | `npm run test:unit --prefix tests -- mobile-shell-lifecycle-wiring.test.js`, `node --check public/scripts/browser-fixes.js`, `node --check public/scripts/sillybunny-tabs.js`, mobile smoke for search close/focus. |
+| Rollback path | Restore the prior reset timeout and remove scroll restoration/reapply suppression if mobile viewport behavior regresses. |
+| Last reviewed | 2026-06-06 Bug 2 mobile search viewport reset. |
 | Owner | Refactor integrator and mobile shell owner. |
 
 ### `public/scripts/mobile-streaming.js` - platform streaming policy

--- a/public/scripts/browser-fixes.js
+++ b/public/scripts/browser-fixes.js
@@ -116,6 +116,7 @@ function applyBrowserFixes() {
     if (isMobile()) {
         const viewport = window.visualViewport;
         const isIOSWebKit = /iPad|iPhone|iPod/.test(navigator.platform) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+        const viewportResetSettleMs = 360;
         let viewportFixScheduled = false;
         let viewportResetScheduled = false;
         let lastViewportHeight = Math.round(viewport?.height || window.innerHeight || 0);
@@ -126,7 +127,7 @@ function applyBrowserFixes() {
             lastViewportHeight = Math.round(viewport?.height || window.innerHeight || 0);
         };
 
-        const resetTransientViewportPosition = () => {
+        const resetTransientViewportPosition = ({ restoreScroll = false } = {}) => {
             document.documentElement.style.position = '';
             document.documentElement.style.top = '';
             document.documentElement.style.left = '';
@@ -138,6 +139,10 @@ function applyBrowserFixes() {
             document.body.style.right = '';
             document.body.style.bottom = '';
             document.body.style.transform = '';
+
+            if (restoreScroll && (document.scrollingElement?.scrollTop || 0) > 0) {
+                window.scrollTo(0, 0);
+            }
         };
 
         const scheduleViewportReset = () => {
@@ -148,19 +153,23 @@ function applyBrowserFixes() {
             viewportResetScheduled = true;
 
             requestAnimationFrame(() => {
-                resetTransientViewportPosition();
+                resetTransientViewportPosition({ restoreScroll: true });
                 updateViewportBaseline();
 
                 window.setTimeout(() => {
-                    resetTransientViewportPosition();
+                    resetTransientViewportPosition({ restoreScroll: true });
                     updateViewportBaseline();
                     viewportResetScheduled = false;
-                }, 80);
+                }, viewportResetSettleMs);
             });
         };
 
         const applyPositionFix = ({ force = false } = {}) => {
             updateViewportBaseline();
+
+            if (!force && viewportResetScheduled) {
+                return;
+            }
 
             // SillyBunny: do not force the viewport fix while the mobile shell is
             // actively editing an input; that can disrupt IME composition and text fixes.

--- a/public/scripts/browser-fixes.js
+++ b/public/scripts/browser-fixes.js
@@ -145,7 +145,7 @@ function applyBrowserFixes() {
             }
         };
 
-        const scheduleViewportReset = () => {
+        const scheduleViewportReset = ({ restoreScroll = false } = {}) => {
             if (viewportResetScheduled) {
                 return;
             }
@@ -153,15 +153,19 @@ function applyBrowserFixes() {
             viewportResetScheduled = true;
 
             requestAnimationFrame(() => {
-                resetTransientViewportPosition({ restoreScroll: true });
+                resetTransientViewportPosition({ restoreScroll });
                 updateViewportBaseline();
 
                 window.setTimeout(() => {
-                    resetTransientViewportPosition({ restoreScroll: true });
+                    resetTransientViewportPosition({ restoreScroll });
                     updateViewportBaseline();
                     viewportResetScheduled = false;
                 }, viewportResetSettleMs);
             });
+        };
+
+        const handleMobileViewportReset = (event) => {
+            scheduleViewportReset({ restoreScroll: Boolean(event?.detail?.restoreScroll) });
         };
 
         const applyPositionFix = ({ force = false } = {}) => {
@@ -253,7 +257,7 @@ function applyBrowserFixes() {
                 scheduleViewportReset();
             }
         }, true);
-        window.addEventListener('sb-mobile-viewport-reset', scheduleViewportReset);
+        window.addEventListener('sb-mobile-viewport-reset', handleMobileViewportReset);
     }
 
     addMacOSPatch();

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -125,6 +125,7 @@ let sbStorageFlushTimer = 0;
 let sbStorageFlushEventsBound = false;
 let sbMessageActionEventsBound = false;
 let sbPendingBottomChatScrollCancel = null;
+let sbSearchShortcutPreFocusAt = 0;
 const sbStorageCache = new Map();
 const sbStoragePendingWrites = new Map();
 const SB_EXTENSION_ALIASES = {
@@ -173,6 +174,12 @@ function activateShortcutTarget(target) {
         const searchState = getUniversalSearchState();
 
         if (searchState.expanded) {
+            if (performance.now() - sbSearchShortcutPreFocusAt < SB_MOBILE_ACTION_DEBOUNCE_MS * 2) {
+                sbSearchShortcutPreFocusAt = 0;
+                focusUniversalSearchInput(searchState.input);
+                return;
+            }
+
             setUniversalSearchOpenState(false);
 
             if (searchState.input instanceof HTMLInputElement && document.activeElement === searchState.input) {
@@ -593,7 +600,7 @@ const SB_MOBILE_QUICK_ACTION_LIMIT = 12;
 const SB_MOBILE_QUICK_ACTION_LABEL_MAX_LENGTH = 36;
 const SB_MOBILE_QUICK_ACTION_ICON_FALLBACK = 'fa-bolt';
 const SB_MOBILE_NAV_CLOSED_ICON = 'fa-compass';
-const SB_MOBILE_VIEWPORT_RESET_FOLLOWUP_MS = 180;
+const SB_MOBILE_VIEWPORT_RESET_FOLLOWUP_MS = 350;
 const SB_FONT_AWESOME_STYLE_CLASSES = Object.freeze(new Set(['fa-solid', 'fa-regular', 'fa-brands']));
 const SB_MOBILE_NAV_LAYOUTS = Object.freeze(['horizontal', 'vertical']);
 const SB_MOBILE_DEFAULT_QUICK_ACTIONS = Object.freeze([
@@ -3977,6 +3984,30 @@ function createProxyButton({ id, icon, label, title, className = '' }, onClick) 
     button.addEventListener('click', debounceAction(onClick));
 
     return button;
+}
+
+function bindSearchShortcutPreFocus(button, targetGetter) {
+    if (!(button instanceof HTMLElement) || typeof targetGetter !== 'function') {
+        return;
+    }
+
+    const openAndFocusSearch = () => {
+        if (!isSearchShortcutTarget(targetGetter())) {
+            return;
+        }
+
+        const searchState = getUniversalSearchState();
+        if (searchState.expanded) {
+            return;
+        }
+
+        closeAllDropdowns({ except: 'search' });
+        setUniversalSearchOpenState(true, { focusInput: true });
+        sbSearchShortcutPreFocusAt = performance.now();
+    };
+
+    button.addEventListener('pointerdown', openAndFocusSearch, { passive: true });
+    button.addEventListener('touchstart', openAndFocusSearch, { passive: true });
 }
 
 function createTopBarIconButton({ id = '', icon, title, className = '', label = '' }, onClick) {
@@ -7958,6 +7989,7 @@ function buildTopBar() {
         },
         () => activateShortcutTarget(getShortcutTarget('left')),
     );
+    bindSearchShortcutPreFocus(leftShortcut, () => getShortcutTarget('left'));
 
     const rightShortcutConfig = getShortcutConfig(getShortcutTarget('right'));
     const rightShortcut = createProxyButton(
@@ -7970,6 +8002,7 @@ function buildTopBar() {
         },
         () => activateShortcutTarget(getShortcutTarget('right')),
     );
+    bindSearchShortcutPreFocus(rightShortcut, () => getShortcutTarget('right'));
 
     centerGroup.innerHTML = `
         <div id="sb-topbar-title" class="sb-brand-title">${SB_IDLE_BRAND_LABEL}</div>

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -2045,12 +2045,14 @@ function focusUniversalSearchInput(input) {
     window.requestAnimationFrame(applyFocus);
 }
 
-function requestMobileViewportReset() {
+function requestMobileViewportReset({ restoreScroll = false } = {}) {
     if (!isMobileViewport() || typeof window === 'undefined' || typeof window.dispatchEvent !== 'function') {
         return;
     }
 
-    const dispatchReset = () => window.dispatchEvent(new Event('sb-mobile-viewport-reset'));
+    const dispatchReset = () => window.dispatchEvent(new CustomEvent('sb-mobile-viewport-reset', {
+        detail: { restoreScroll: Boolean(restoreScroll) },
+    }));
 
     if (typeof window.requestAnimationFrame === 'function') {
         window.requestAnimationFrame(dispatchReset);
@@ -2082,7 +2084,7 @@ function setUniversalSearchOpenState(isOpen, { focusInput = false } = {}) {
     if (!nextOpenState) {
         searchState.results?.classList.remove('is-visible');
         if (wasOpen) {
-            requestMobileViewportReset();
+            requestMobileViewportReset({ restoreScroll: true });
         }
     } else {
         renderUniversalSearchResults(input?.value ?? '');

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -5,6 +5,7 @@ import path from 'node:path';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const tabsSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'sillybunny-tabs.js'), 'utf8');
+const browserFixesSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'browser-fixes.js'), 'utf8');
 const tabsCssSource = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-tabs.css'), 'utf8');
 const mobileShellCssSource = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-mobile-shell.css'), 'utf8');
 
@@ -121,10 +122,20 @@ describe('mobile shell lifecycle wiring', () => {
         const setMobileNavOpenStateSource = getFunctionSource('setMobileNavOpenState');
 
         expect(tabsSource).toContain('function requestMobileViewportReset(');
+        expect(tabsSource).toContain('const SB_MOBILE_VIEWPORT_RESET_FOLLOWUP_MS = 350;');
         expect(searchOpenStateSource).toContain('requestMobileViewportReset();');
         expect(closeShellSource).toContain('requestMobileViewportReset();');
         expect(closeCharacterPanelSource).toContain('requestMobileViewportReset();');
         expect(setMobileNavOpenStateSource).toContain('requestMobileViewportReset();');
+    });
+
+    test('settles mobile viewport reset without reapplying the fixed-position workaround', () => {
+        expect(browserFixesSource).toContain('const viewportResetSettleMs = 360;');
+        expect(browserFixesSource).toContain('const resetTransientViewportPosition = ({ restoreScroll = false } = {}) => {');
+        expect(browserFixesSource).toContain('window.scrollTo(0, 0);');
+        expect(browserFixesSource).toContain('resetTransientViewportPosition({ restoreScroll: true });');
+        expect(browserFixesSource).toContain('if (!force && viewportResetScheduled) {');
+        expect(browserFixesSource).toContain('}, viewportResetSettleMs);');
     });
 
     test('dedupes rail quick actions against all built-in rail actions', () => {
@@ -194,6 +205,10 @@ describe('mobile shell lifecycle wiring', () => {
         const buildUniversalSearchRowSource = getFunctionSource('buildUniversalSearchRow');
 
         expect(tabsSource).toContain('function focusUniversalSearchInput(');
+        expect(tabsSource).toContain('function bindSearchShortcutPreFocus(');
+        expect(tabsSource).toContain('sbSearchShortcutPreFocusAt = performance.now();');
+        expect(tabsSource).toContain('bindSearchShortcutPreFocus(leftShortcut, () => getShortcutTarget(\'left\'));');
+        expect(tabsSource).toContain('bindSearchShortcutPreFocus(rightShortcut, () => getShortcutTarget(\'right\'));');
         expect(setUniversalSearchOpenStateSource).toContain('focusUniversalSearchInput(input);');
         expect(buildUniversalSearchRowSource).toContain('setUniversalSearchOpenState(true, { focusInput: true });');
         expect(tabsCssSource).toMatch(/\.sb-search-results\s*\{[\s\S]*position:\s*relative;[\s\S]*isolation:\s*isolate;[\s\S]*background-color:\s*var\(--SmartThemeBlurTintColor\)/);

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -122,8 +122,9 @@ describe('mobile shell lifecycle wiring', () => {
         const setMobileNavOpenStateSource = getFunctionSource('setMobileNavOpenState');
 
         expect(tabsSource).toContain('function requestMobileViewportReset(');
+        expect(tabsSource).toContain('detail: { restoreScroll: Boolean(restoreScroll) },');
         expect(tabsSource).toContain('const SB_MOBILE_VIEWPORT_RESET_FOLLOWUP_MS = 350;');
-        expect(searchOpenStateSource).toContain('requestMobileViewportReset();');
+        expect(searchOpenStateSource).toContain('requestMobileViewportReset({ restoreScroll: true });');
         expect(closeShellSource).toContain('requestMobileViewportReset();');
         expect(closeCharacterPanelSource).toContain('requestMobileViewportReset();');
         expect(setMobileNavOpenStateSource).toContain('requestMobileViewportReset();');
@@ -132,8 +133,10 @@ describe('mobile shell lifecycle wiring', () => {
     test('settles mobile viewport reset without reapplying the fixed-position workaround', () => {
         expect(browserFixesSource).toContain('const viewportResetSettleMs = 360;');
         expect(browserFixesSource).toContain('const resetTransientViewportPosition = ({ restoreScroll = false } = {}) => {');
+        expect(browserFixesSource).toContain('const scheduleViewportReset = ({ restoreScroll = false } = {}) => {');
+        expect(browserFixesSource).toContain('scheduleViewportReset({ restoreScroll: Boolean(event?.detail?.restoreScroll) });');
         expect(browserFixesSource).toContain('window.scrollTo(0, 0);');
-        expect(browserFixesSource).toContain('resetTransientViewportPosition({ restoreScroll: true });');
+        expect(browserFixesSource).toContain('resetTransientViewportPosition({ restoreScroll });');
         expect(browserFixesSource).toContain('if (!force && viewportResetScheduled) {');
         expect(browserFixesSource).toContain('}, viewportResetSettleMs);');
     });


### PR DESCRIPTION
## What?
Stabilize mobile viewport reset timing around search/panel close and pre-focus the universal search input from mobile top-bar search shortcuts.

## Why?
Mobile search close could leave the viewport scrolled or pinned during keyboard settle, and tapping the search shortcut could open then immediately close instead of focusing the input.

## How?
The browser fix reset path now restores scroll during scheduled resets, suppresses position reapply while reset is pending, and uses a longer settle window. Search shortcut pointer/touch pre-focus opens search before the click handler, then the click path recognizes that fresh pre-focus and keeps search open.

## Testing?
- `npm run test:unit --prefix tests -- mobile-shell-lifecycle-wiring.test.js`
- `node --check public/scripts/browser-fixes.js`
- `node --check public/scripts/sillybunny-tabs.js`
- `npm run check:frontend-budgets`
- `npm run build:frontend`
- `npm run lint`
- `git diff --check origin/staging HEAD`

## Screenshots (optional)
Not included; the change is timing/focus behavior covered by wiring, syntax, budget, and build checks.

## Anything Else?
Includes upstream touch ledger updates for mobile shell search focus and viewport reset behavior.