### PR TITLE
fix: keep impersonate first-person on chat-completion backends

### DIFF
--- a/docs/upstream-touch-ledger.md
+++ b/docs/upstream-touch-ledger.md
@@ -180,6 +180,19 @@ This ledger tracks intentional SillyBunny divergence in upstream-origin files. I
 | Last reviewed | 2026-06-02 PR #315 mobile dropdown fix. |
 | Owner | Refactor integrator and settings owner. |
 
+### `public/scripts/openai.js` - impersonate first-person defaults
+| Field | Value |
+| --- | --- |
+| Area | Generation lifecycle and settings. |
+| Divergence reason | SillyBunny impersonate generations on chat-completion backends need a first-person user-voice control prompt even when the editable impersonation fields are empty. |
+| Target seam | Core chat-completion prompt preparation in `public/scripts/openai.js`; Guided Generations adds its own fork-side system frame. |
+| Adapter shape | Keep fallback selection in tiny helpers, use the default impersonation prompt for empty system directives, use a default Claude user-speaker prefill, and respect prompt-manager disabling when adding the impersonate control prompt. |
+| Protecting tests | `tests/openai-impersonate-defaults.test.js`, `tests/guided-generations-steering.test.js`. |
+| Validation | `npm run test:unit --prefix tests -- openai-impersonate-defaults.test.js guided-generations-steering.test.js`, `node --check public/scripts/openai.js`, live chat-completion impersonate smoke when API access is available. |
+| Rollback path | Restore empty-string behavior for impersonation prompt/prefill and remove the prompt-manager guard if provider behavior regresses. |
+| Last reviewed | 2026-06-06 Bug 6 impersonate first-person defaults. |
+| Owner | Refactor integrator and settings owner. |
+
 ### `public/css/sillybunny-tabs.css`, `public/css/sillybunny-mobile-shell.css`, `public/css/select2-overrides.css`, `public/css/welcome.css`, `public/style.css`, `public/script.js`, `public/sw.js`, and `public/index.html` - menu polish assets
 | Field | Value |
 | --- | --- |

--- a/public/scripts/extensions/guided-generations/index.js
+++ b/public/scripts/extensions/guided-generations/index.js
@@ -27,7 +27,7 @@ const defaultSettings = {
     promptGuidedResponse: '[Take the following into special consideration for your next message: {{input}}]',
     promptGuidedSwipe: '[Take the following into special consideration for your next message: {{input}}]',
     promptGuidedCorrection: '[Apply the following correction to your previous message: {{input}}]',
-    promptImpersonate1st: 'Write in first Person perspective from {{user}}. {{input}}',
+    promptImpersonate1st: 'Write the next message in first person as {{user}}, not {{char}}. Keep the response in {{user}}\'s own words and actions. {{input}}',
     helperPrefillMessages: '',
     depthPromptGuidedResponse: 0,
     depthPromptGuidedSwipe: 0,

--- a/public/scripts/extensions/guided-generations/scripts/guidedImpersonate.js
+++ b/public/scripts/extensions/guided-generations/scripts/guidedImpersonate.js
@@ -20,6 +20,10 @@ function escapeSlashCommandDelimiters(value) {
     return String(value ?? '').replace(/\|/g, '\\|');
 }
 
+function getImpersonateSystemFrame() {
+    return 'Guided Impersonate: write only as {{user}} in first person. Do not answer as {{char}}, narrator, or system. Treat helper prefill text as context, not as a speaker override.';
+}
+
 async function guidedImpersonate() {
     const textarea = document.getElementById('send_textarea');
     if (!(textarea instanceof HTMLTextAreaElement)) {
@@ -50,7 +54,10 @@ async function guidedImpersonate() {
         .map(value => String(value ?? '').trim())
         .filter(Boolean)
         .join('\n\n');
-    const fullScript = `// Impersonate guide|\n/impersonate await=true ${escapeSlashCommandDelimiters(impersonatePrompt)} |`;
+    const fullScript = `// Impersonate guide|
+/inject id=gg-impersonate-voice position=chat ephemeral=true scan=true depth=0 role=system ${escapeSlashCommandDelimiters(getImpersonateSystemFrame())} |
+/impersonate await=true ${escapeSlashCommandDelimiters(impersonatePrompt)} |
+/flushinject gg-impersonate-voice |`;
 
     try {
         await switching.switch();

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -108,6 +108,7 @@ const default_main_prompt = 'Write {{char}}\'s next reply in a fictional chat be
 const default_nsfw_prompt = '';
 const default_jailbreak_prompt = '';
 const default_impersonation_prompt = '[Write your next reply from the point of view of {{user}}, using the chat history so far as a guideline for the writing style of {{user}}. Don\'t write as {{char}} or system. Don\'t describe actions of {{char}}.]';
+const default_assistant_impersonation = '{{user}}:';
 const default_enhance_definitions_prompt = 'If you have more knowledge of {{char}}, add to the character\'s lore and personality to enhance them but keep the Character Sheet\'s definitions absolute.';
 const default_wi_format = '{0}';
 const default_new_chat_prompt = '[Start a new Chat]';
@@ -604,7 +605,7 @@ const default_settings = {
     show_external_models: false,
     proxy_password: '',
     assistant_prefill: '',
-    assistant_impersonation: '',
+    assistant_impersonation: default_assistant_impersonation,
     use_sysprompt: false,
     vertexai_auth_mode: 'express',
     vertexai_region: 'us-central1',
@@ -888,6 +889,16 @@ function setupChatCompletionPromptManager(openAiSettings) {
     promptManager.render(false);
 
     return promptManager;
+}
+
+function getEffectiveImpersonationPrompt() {
+    const prompt = String(oai_settings.impersonation_prompt ?? '').trim() || default_impersonation_prompt;
+    return substituteParams(prompt);
+}
+
+function getEffectiveAssistantImpersonationPrefill(settings) {
+    const prefill = String(settings?.assistant_impersonation ?? '').trim() || default_assistant_impersonation;
+    return substituteParams(prefill);
 }
 
 /**
@@ -1392,7 +1403,9 @@ async function populateChatCompletion(prompts, chatCompletion, { bias, quietProm
     const controlPrompts = new MessageCollection('controlPrompts');
 
     const impersonateMessage = await Message.fromPromptAsync(prompts.get('impersonate')) ?? null;
-    if (type === 'impersonate') controlPrompts.add(impersonateMessage);
+    if (type === 'impersonate' && !promptManager.isPromptDisabledForActiveCharacter('impersonate')) {
+        controlPrompts.add(impersonateMessage);
+    }
 
     // Add quiet prompt to control prompts
     // This should always be last, even in control prompts. Add all further control prompts BEFORE this prompt
@@ -1538,7 +1551,7 @@ async function preparePromptsForChatCompletion({ scenario, charPersonality, name
     const scenarioText = scenario && oai_settings.scenario_format ? substituteParams(oai_settings.scenario_format) : (scenario || '');
     const charPersonalityText = charPersonality && oai_settings.personality_format ? substituteParams(oai_settings.personality_format) : (charPersonality || '');
     const groupNudge = substituteParams(oai_settings.group_nudge_prompt);
-    const impersonationPrompt = oai_settings.impersonation_prompt ? substituteParams(oai_settings.impersonation_prompt) : '';
+    const impersonationPrompt = getEffectiveImpersonationPrompt();
 
     // Create entries for system prompts
     const systemPrompts = [
@@ -5077,7 +5090,7 @@ export async function createGenerationParameters(settings, model, type, messages
         // Don't add a prefill on quiet gens (summarization) and when using continue prefill.
         if (type !== 'quiet' && !(type === 'continue' && settings.continue_prefill)) {
             generate_data.assistant_prefill = type === 'impersonate'
-                ? substituteParams(settings.assistant_impersonation)
+                ? getEffectiveAssistantImpersonationPrefill(settings)
                 : substituteParams(settings.assistant_prefill);
         }
     }

--- a/tests/guided-generations-steering.test.js
+++ b/tests/guided-generations-steering.test.js
@@ -137,7 +137,7 @@ describe('Guided Generations steering commands', () => {
         expect(textarea.dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'input' }));
     });
 
-    test('guided impersonate appends helper prefill blocks to the impersonate prompt', async () => {
+    test('guided impersonate frames first-person voice and appends helper prefill blocks', async () => {
         extensionSettings['guided-generations'].promptImpersonate1st = 'FIRST PERSON: {{input}}';
         extensionSettings['guided-generations'].helperPrefillMessages = `[system]
 Stay terse.
@@ -151,8 +151,10 @@ I | begin`;
 
         expect(context.executeSlashCommandsWithOptions).toHaveBeenCalledTimes(1);
         const command = context.executeSlashCommandsWithOptions.mock.calls[0][0];
+        expect(command).toContain('/inject id=gg-impersonate-voice position=chat ephemeral=true scan=true depth=0 role=system Guided Impersonate: write only as {{user}} in first person.');
         expect(command).toContain('/impersonate await=true FIRST PERSON: aim for a colder, suspicious reply');
         expect(command).toContain('SYSTEM:\nStay terse.');
         expect(command).toContain('ASSISTANT:\nI \\| begin');
+        expect(command).toContain('/flushinject gg-impersonate-voice |');
     });
 });

--- a/tests/openai-impersonate-defaults.test.js
+++ b/tests/openai-impersonate-defaults.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const openAiSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'openai.js'), 'utf8').replace(/\r\n/g, '\n');
+
+describe('OpenAI impersonate defaults', () => {
+    test('falls back to first-person impersonation prompts when user fields are empty', () => {
+        expect(openAiSource).toContain("const default_assistant_impersonation = '{{user}}:';");
+        expect(openAiSource).toContain('assistant_impersonation: default_assistant_impersonation,');
+        expect(openAiSource).toContain('function getEffectiveImpersonationPrompt()');
+        expect(openAiSource).toContain("String(oai_settings.impersonation_prompt ?? '').trim() || default_impersonation_prompt");
+        expect(openAiSource).toContain('const impersonationPrompt = getEffectiveImpersonationPrompt();');
+        expect(openAiSource).toContain('function getEffectiveAssistantImpersonationPrefill(settings)');
+        expect(openAiSource).toContain("String(settings?.assistant_impersonation ?? '').trim() || default_assistant_impersonation");
+        expect(openAiSource).toContain('? getEffectiveAssistantImpersonationPrefill(settings)');
+    });
+
+    test('does not add the impersonate control prompt when prompt manager disables it', () => {
+        expect(openAiSource).toContain("if (type === 'impersonate' && !promptManager.isPromptDisabledForActiveCharacter('impersonate')) {");
+        expect(openAiSource).toContain('controlPrompts.add(impersonateMessage);');
+    });
+});


### PR DESCRIPTION
## What?
Keep chat-completion impersonation in first-person user voice by default and strengthen Guided Generations impersonate steering.

## Why?
When impersonation prompt fields were empty, chat-completion backends could receive weak or empty first-person framing, allowing character/system framing to produce a normal character reply instead of a user impersonation.

## How?
Core OpenAI prompt prep now falls back to the default impersonation prompt when the editable field is empty, uses a default `{{user}}:` assistant impersonation prefill, and respects prompt-manager disabling before adding the impersonate control prompt. Guided Generations now uses stronger default text and injects a temporary system frame around the `/impersonate` command so helper prefill context cannot override the intended speaker.

## Testing?
- `npm run test:unit --prefix tests -- openai-impersonate-defaults.test.js guided-generations-steering.test.js`
- `node --check public/scripts/openai.js`
- `node --check public/scripts/extensions/guided-generations/index.js`
- `node --check public/scripts/extensions/guided-generations/scripts/guidedImpersonate.js`
- `npm run check:frontend-budgets`
- `npm run lint`
- `git diff --check origin/staging HEAD`

## Screenshots (optional)
Not included; this is prompt-generation behavior covered by source and steering tests.

## Anything Else?
Includes an upstream touch ledger entry for the core impersonation default behavior.