### PR TITLE
fix: ignore generation event payloads in agent UI refresh

### DIFF
--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -4249,7 +4249,7 @@ async function refinePromptWithAI(currentPrompt, category, phase, connectionProf
         event_types.GENERATION_ENDED,
         event_types.GENERATION_STOPPED,
     ]) {
-        eventSource.on(eventName, refreshGenerationUi);
+        eventSource.on(eventName, () => refreshGenerationUi());
     }
 
     // Listen for Prompt Manager "Send to Agents" events

--- a/tests/in-chat-agents-generation-ui-wiring.test.js
+++ b/tests/in-chat-agents-generation-ui-wiring.test.js
@@ -46,4 +46,12 @@ describe('in-chat agents generation UI wiring', () => {
         expect(indexSource).toContain("$(document).on('click', '#mes_stop'");
         expect(indexSource).toContain('cancelAgentGeneration();');
     });
+
+    test('refreshes generation UI from core events without forwarding payloads', () => {
+        expect(indexSource).toContain('event_types.GENERATION_STARTED');
+        expect(indexSource).toContain('event_types.GENERATION_ENDED');
+        expect(indexSource).toContain('event_types.GENERATION_STOPPED');
+        expect(indexSource).toContain('eventSource.on(eventName, () => refreshGenerationUi());');
+        expect(indexSource).not.toContain('eventSource.on(eventName, refreshGenerationUi);');
+    });
 });


### PR DESCRIPTION
## What?
Wrap the in-chat agents core generation event listeners so they call `refreshGenerationUi()` without forwarding event payloads. Add a regression guard that checks the generation UI wiring keeps using the no-argument wrapper.

## Why?
PR #356 made the send-bar stop button visible during in-chat agent generation, but the core generation event bus passes payloads to listeners. Passing those payloads directly into `refreshGenerationUi(active = isAgentGenerationActive())` turns values like generation type or `chat.length` into truthy active states, which can leave `document.body.dataset.generating` stuck on and the stop button visible after generation ends.

## How?
The listener loop now registers `() => refreshGenerationUi()` for `GENERATION_STARTED`, `GENERATION_ENDED`, and `GENERATION_STOPPED`. That preserves the existing default-state lookup and leaves the agent-state listener plus stop-click handling unchanged.

## Testing?
- `node --check public/scripts/extensions/in-chat-agents/index.js`
- `npm --prefix tests run test:unit -- in-chat-agents-generation-ui-wiring.test.js generation-lifecycle.test.js generation-lifecycle-wiring.test.js`

## Screenshots (optional)
Not included; this is a wiring fix covered by targeted syntax and unit checks.

## Anything Else?
Follow-up fix for the regression introduced by merged PR #356.