### PR TITLE
fix: correct mobile persona action spacing

### DIFF
--- a/public/css/personas.css
+++ b/public/css/personas.css
@@ -956,9 +956,10 @@
 
     #persona_controls .persona_controls_buttons_block > .menu_button,
     #persona_controls .persona-controls-actions > .menu_button {
-        flex: 1 1 44px;
-        width: auto;
+        flex: 0 0 44px;
+        width: 44px;
         min-width: 44px;
+        max-width: 44px;
         height: 44px;
         min-height: 44px;
     }
@@ -991,9 +992,10 @@
 
     #persona_controls .persona_controls_buttons_block > .menu_button,
     #persona_controls .persona-controls-actions > .menu_button {
-        flex-basis: 44px;
-        width: auto;
+        flex: 0 0 44px;
+        width: 44px;
         min-width: 44px;
+        max-width: 44px;
         height: 44px;
         min-height: 44px;
     }

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -5458,12 +5458,17 @@ input[type='range']::-moz-range-thumb {
         grid-template-columns: 1fr;
     }
 
-    #persona_connections_buttons {
-        flex-direction: column;
+    #PersonaManagement #persona_connections_buttons {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 6px;
     }
 
-    #persona_connections_buttons > .menu_button {
+    #PersonaManagement #persona_connections_buttons > .menu_button {
         width: 100%;
+        min-width: 0;
+        min-height: 44px;
+        justify-content: center;
     }
 
     #persona_description {


### PR DESCRIPTION
## Summary
- keep Persona Connections actions in a three-column mobile grid instead of inheriting the stale flex-column override
- keep Persona icon-only action buttons fixed at 44px tap targets so they do not stretch into odd mobile spacing

## Testing
- npm ci
- npm run lint
- npm run build:frontend
- mobile smoke check at 390x844 against local Node server