### PR TITLE
fix: align persona icon actions and alt greetings

### DIFF
--- a/public/css/personas.css
+++ b/public/css/personas.css
@@ -321,6 +321,18 @@
     background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 88%, transparent);
 }
 
+/* SillyBunny: equalize Persona editor tab tracks when labels collapse to icon-only/mobile controls. */
+:root[data-sb-desktop-nav-mode='icon-only'] #PersonaManagement .persona-editor-tabs,
+:root[data-sb-mobile-nav-mode='icon-only'] #PersonaManagement .persona-editor-tabs {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+@media screen and (max-width: 760px) {
+    #PersonaManagement .persona-editor-tabs {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+}
+
 #PersonaManagement .persona-editor-tabs .sb-shell-tab {
     width: 100%;
     padding-inline: 10px;

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -5638,10 +5638,13 @@ input[type='range']::-moz-range-thumb {
     }
 
     #PersonaManagement .persona-management-actions {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: center;
-        gap: 8px;
+        /* SillyBunny: keep the icon-only action row evenly distributed on narrow shells. */
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        align-items: stretch;
+        gap: 6px;
+        width: 100%;
+        min-width: 0;
     }
 
     #PersonaManagement .persona-management-browser {
@@ -5654,7 +5657,17 @@ input[type='range']::-moz-range-thumb {
         min-width: 0;
     }
 
-    #PersonaManagement .persona-management-actions > .menu_button,
+    #PersonaManagement .persona-management-actions > .menu_button {
+        width: 100%;
+        min-width: 0;
+        height: 44px;
+        min-height: 44px;
+        max-height: 44px;
+        padding: 0;
+        justify-content: center;
+        gap: 0;
+    }
+
     #PersonaManagement .persona-management-browser > #create_dummy_persona {
         flex: 0 0 44px;
         width: 44px;

--- a/public/style.css
+++ b/public/style.css
@@ -3785,8 +3785,11 @@ grammarly-extension {
     padding-left: 5px;
 }
 
-.alternate_greeting_header {
-    align-items: flex-start;
+.alternate_greeting .alternate_greeting_header.title_restorable {
+    /* SillyBunny: keep Alternate Greeting actions above the textarea instead of inheriting title_restorable's row layout. */
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: flex-start;
     width: 100%;
 }
 
@@ -3795,9 +3798,12 @@ grammarly-extension {
     min-width: 0;
 }
 
-.alternate_greeting_actions {
+.alternate_greeting .alternate_greeting_actions {
     flex: 0 0 auto;
     flex-wrap: nowrap;
+    order: -1;
+    align-self: flex-end;
+    justify-content: flex-end;
 }
 
 .alternate_greeting_actions :is(.menu_button, .right_menu_button) {


### PR DESCRIPTION
## Summary
- Move Alternate Greetings action buttons above the textarea with a scoped title_restorable override.
- Equalize Persona editor tab columns in icon-only/mobile contexts.
- Keep Persona management action buttons on equal-width grid columns on narrow shells.

## Verification
- git diff --check
- Firefox visual fixture at mobile and desktop widths using the project CSS