### PR TITLE
fix: keep message actions visible during agent generation

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -9636,8 +9636,8 @@ export function activateSendButtons({ emitGenerationEnded = true } = {}) {
 /**
  * A function mainly used to switch 'generating' state - setting it to true and deactivating the buttons
  */
-export function deactivateSendButtons() {
-    const lockState = resolveGenerationUiLockState({ isGenerating: true });
+export function deactivateSendButtons({ markBodyGenerating = true } = {}) {
+    const lockState = resolveGenerationUiLockState({ isGenerating: true, markBodyGenerating });
     if (lockState.shouldShowStopButton) {
         showStopButton();
     }

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -194,7 +194,8 @@ function updateCancelGenerationButton() {
 
 function updateAgentGenerationSendControls(active = isAgentGenerationActive()) {
     if (active) {
-        deactivateSendButtons();
+        // Agent post-processing should lock send controls without hiding the visible message actions.
+        deactivateSendButtons({ markBodyGenerating: false });
         return;
     }
 

--- a/public/scripts/generation-lifecycle/index.js
+++ b/public/scripts/generation-lifecycle/index.js
@@ -16,10 +16,12 @@ function normalizeGenerationType(type) {
  * Resolves generation UI lock state for send controls.
  * @param {object} options Options.
  * @param {boolean} [options.isGenerating=false] Whether generation controls should lock.
+ * @param {boolean} [options.markBodyGenerating=isGenerating] Whether to mark the document as actively generating.
  * @returns {{state: string, shouldShowStopButton: boolean, shouldHideSwipeButtons: boolean, bodyGeneratingValue: string|null}}
  */
 export function resolveGenerationUiLockState({
     isGenerating = false,
+    markBodyGenerating = isGenerating,
 } = {}) {
     if (!isGenerating) {
         return {
@@ -34,7 +36,7 @@ export function resolveGenerationUiLockState({
         state: GENERATION_LIFECYCLE_UI_STATE.GENERATING,
         shouldShowStopButton: true,
         shouldHideSwipeButtons: true,
-        bodyGeneratingValue: 'true',
+        bodyGeneratingValue: markBodyGenerating ? 'true' : null,
     };
 }
 

--- a/tests/generation-lifecycle-wiring.test.js
+++ b/tests/generation-lifecycle-wiring.test.js
@@ -64,7 +64,8 @@ describe('generation lifecycle wiring', () => {
     test('routes send-button deactivation through lifecycle lock state', () => {
         const deactivateSource = getFunctionSource('deactivateSendButtons', { exported: true });
 
-        expect(deactivateSource).toContain('resolveGenerationUiLockState({ isGenerating: true })');
+        expect(deactivateSource).toContain('markBodyGenerating = true');
+        expect(deactivateSource).toContain('resolveGenerationUiLockState({ isGenerating: true, markBodyGenerating })');
         expect(deactivateSource).toContain('lockState.shouldShowStopButton');
         expect(deactivateSource).toContain('lockState.shouldHideSwipeButtons');
         expect(deactivateSource).toContain('lockState.bodyGeneratingValue');

--- a/tests/generation-lifecycle.test.js
+++ b/tests/generation-lifecycle.test.js
@@ -29,6 +29,15 @@ describe('generation lifecycle helper', () => {
         });
     });
 
+    test('allows generation UI lock state without marking the body as generating', () => {
+        expect(resolveGenerationUiLockState({ isGenerating: true, markBodyGenerating: false })).toEqual({
+            state: GENERATION_LIFECYCLE_UI_STATE.GENERATING,
+            shouldShowStopButton: true,
+            shouldHideSwipeButtons: true,
+            bodyGeneratingValue: null,
+        });
+    });
+
     test('keeps quiet generation blocked while its stream is still active', () => {
         expect(resolveGenerationUnblockState({
             type: 'quiet',

--- a/tests/in-chat-agents-generation-ui-wiring.test.js
+++ b/tests/in-chat-agents-generation-ui-wiring.test.js
@@ -36,14 +36,14 @@ describe('in-chat agents generation UI wiring', () => {
 
         expect(indexSource).toContain('activateSendButtons');
         expect(indexSource).toContain('deactivateSendButtons');
-        expect(updateSource).toContain('deactivateSendButtons();');
+        expect(updateSource).toContain('deactivateSendButtons({ markBodyGenerating: false });');
         expect(updateSource).toContain('if (!is_send_press && !is_group_generating)');
         expect(updateSource).toContain('activateSendButtons();');
     });
 
     test('subscribes agent state changes and routes send-bar stop clicks to agent cancel', () => {
         expect(indexSource).toContain('onAgentGenerationStateChanged(refreshGenerationUi);');
-        expect(indexSource).toContain("$(document).on('click', '#mes_stop'");
+        expect(indexSource).toContain('$(document).on(\'click\', \'#mes_stop\'');
         expect(indexSource).toContain('cancelAgentGeneration();');
     });
 


### PR DESCRIPTION
## Summary
- keep normal generation marking `body[data-generating]` while allowing agent post-processing to lock send controls without that body flag
- prevent post-generation agent activity from triggering CSS that hides `.last_mes .mes_buttons`
- add focused lifecycle and in-chat agent wiring coverage

## Tests
- `npm run test:unit -- generation-lifecycle.test.js generation-lifecycle-wiring.test.js in-chat-agents-generation-ui-wiring.test.js` from `tests/`
- `./node_modules/.bin/eslint public/scripts/generation-lifecycle/index.js public/script.js public/scripts/extensions/in-chat-agents/index.js`
- `./node_modules/.bin/eslint generation-lifecycle.test.js generation-lifecycle-wiring.test.js in-chat-agents-generation-ui-wiring.test.js` from `tests/`