### PR TITLE
fix: toggle top-bar character shortcuts closed

### DIFF
--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -201,7 +201,7 @@ function activateShortcutTarget(target) {
             void setCharacterListEntityView('characters');
         }
         preloadPanelStylesheets('characters', tab);
-        openCharacterPanelTab(tab);
+        toggleShellPanel(shell, tab);
         return;
     }
 
@@ -6560,6 +6560,24 @@ function isCharacterPanelOpen() {
     return isDrawerActuallyOpen('right-nav-panel');
 }
 
+function getActiveCharacterPanelTab() {
+    const menuType = getCharacterPanel()?.dataset.menuType;
+
+    if (['persona', 'import', 'world-info', 'groups'].includes(menuType)) {
+        return menuType;
+    }
+
+    if (['character_edit', 'group_edit', 'create', 'group_create', 'editor_empty'].includes(menuType)) {
+        return 'editor';
+    }
+
+    return 'characters';
+}
+
+function isCharacterPanelTabOpen(tabId) {
+    return isCharacterPanelOpen() && getActiveCharacterPanelTab() === normalizeCharacterPanelTab(tabId);
+}
+
 function hasActiveCharacterChat(context = getSillyTavernContext()) {
     if (context?.groupId) {
         return true;
@@ -7613,6 +7631,11 @@ function closeAllDropdowns({ except = '' } = {}) {
 
 function toggleShellPanel(shellKey, tabId = null) {
     if (shellKey === 'characters') {
+        if (isCharacterPanelTabOpen(tabId)) {
+            closeCharacterPanel();
+            return;
+        }
+
         openCharacterPanelTab(tabId);
         return;
     }

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -218,6 +218,21 @@ describe('mobile shell lifecycle wiring', () => {
         expect(tabsCssSource).toMatch(/\.sb-search-result,\s*\n\.sb-search-empty\s*\{[\s\S]*position:\s*relative;[\s\S]*isolation:\s*isolate;[\s\S]*background-color:\s*var\(--SmartThemeBlurTintColor\)/);
     });
 
+    test('routes character top-bar shortcuts through toggle-close behavior', () => {
+        const buildTopBarSource = getFunctionSource('buildTopBar');
+        const activateShortcutTargetSource = getFunctionSource('activateShortcutTarget');
+        const toggleShellPanelSource = getFunctionSource('toggleShellPanel');
+        const isCharacterPanelTabOpenSource = getFunctionSource('isCharacterPanelTabOpen');
+
+        expect(buildTopBarSource).toContain('activateShortcutTarget(getShortcutTarget(\'left\'))');
+        expect(buildTopBarSource).toContain('activateShortcutTarget(getShortcutTarget(\'right\'))');
+        expect(activateShortcutTargetSource).toContain('toggleShellPanel(shell, tab);');
+        expect(activateShortcutTargetSource).not.toContain('openCharacterPanelTab(tab);');
+        expect(toggleShellPanelSource).toContain('isCharacterPanelTabOpen(tabId)');
+        expect(toggleShellPanelSource).toContain('closeCharacterPanel();');
+        expect(isCharacterPanelTabOpenSource).toContain('getActiveCharacterPanelTab() === normalizeCharacterPanelTab(tabId)');
+    });
+
     test('routes hamburger toggle intent through the lifecycle seam', () => {
         const toggleMobileNavSource = getFunctionSource('toggleMobileNav');
 


### PR DESCRIPTION
## Summary
- Toggle character-panel top-bar shortcuts closed when their active tab is already open.
- Keep direct/open-only character tab routes intact by routing only shortcut activation through toggle behavior.
- Add source-wiring test coverage for the top-bar character shortcut path.

## Tests
- NODE_OPTIONS=--experimental-vm-modules npx --yes --package jest@29.7.0 jest --config tests/jest.config.json tests/mobile-shell-lifecycle-wiring.test.js
- npx eslint public/scripts/sillybunny-tabs.js tests/mobile-shell-lifecycle-wiring.test.js