### PR TITLE
chore: prepare v1.6.4

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -56,7 +56,7 @@ These screenshots show the graphical shell UI across Workspace, Customize, Agent
 * [Project Goals](#project-goals-aka-why-we-made-this-fork)
 * [Changes Compared to SillyTavern](#changes-vs-sillytavern)
 * [Latest Update](#latest-update)
-    * [v1.6.3 (2026-06-07)](#v163-2026-06-07)
+    * [v1.6.4 (2026-06-07)](#v164-2026-06-07)
 * [Upstream Information](#upstream-information)
 * [Contributors](#contributors)
 ***
@@ -221,31 +221,21 @@ SillyBunny includes some extras by default to help you get started right away:
 
 ## Latest Update
 
-### v1.6.3 (2026-06-07)
+### v1.6.4 (2026-06-07)
 
-This update focuses on safer chat switching and cloning, steadier mobile and persona controls, clearer runtime launchers, theme-aware UI polish, and tighter in-chat agent behavior for the 1.6 line.
+This update prepares SillyBunny 1.6.4 by refreshing the visible app version, Horde client fallback, bundled extension metadata, release notes, and mirrored README documentation after the 1.6.3 release.
 
 **Improved**
-* Runtime launcher documentation and scripts now make automatic, Node.js, Bun, macOS, Linux, Windows, and Termux startup paths explicit.
-* Mobile search, persona controls, alternate greetings, top-bar shortcuts, message actions, and shell spacing were polished to stay stable on narrow screens.
-* Theme surfaces now respect toast colors and core message-block transparency without depending on Moonlit Echoes.
-* In-chat agent refresh behavior, generation controls, and tool-call recursion cap handling are more predictable during active generations.
-* Prompt logging and release changelog automation were tightened so verbose payloads and merged staging history are easier to audit.
+* The UI version label, Horde client identifier, and Horde server fallback now consistently advertise SillyBunny 1.6.4.
+* Package metadata, root package-lock entries, and bundled extension manifests now align with the 1.6.4 release line.
+* Release documentation now has 1.6.4 README, changelog, GitHub mirror, and Discord-ready summary copy.
 
 **Fixed**
-* Verbose prompt payload logging now stays gated behind the prompt log preference.
-* Chat cloning, pending swipe saves, and integrity-token rotation now avoid stale writes, cross-device history loss, and chat-switch races.
-* Persona Scenario Notes selection, mobile alternate greeting controls, persona action spacing, and persona icon alignment now persist and render per character card.
-* In-chat agent generation keeps the stop button and message actions visible while ignoring unrelated generation event payloads during UI refresh.
-* Search close handling stabilizes the mobile viewport and auto-focuses search input without pulling the page out of position.
-* Impersonation keeps first-person behavior on chat-completion backends.
-* Top-bar character shortcut buttons now toggle closed instead of staying open.
+* No targeted bug fixes were included in this release-readiness pass.
 
 **Added**
-* Runtime-specific launchers for forcing Bun or Node.js across Windows, macOS, Linux/WSL, and Termux.
-* Runtime wiring for the tool-call recursion limit slider.
-* Helper prefill role controls for Guided Generations and In-Chat Agents.
-* Regression coverage for chat cloning, swipe saves, persona notes, integrity tokens, mobile controls, agent generation, transparency, theme-aware toasts, and launcher/changelog sync behavior.
+* A 1.6.4 Discord release post is available under `releases/` for announcement publishing.
+* Regression expectations were refreshed so release automation coverage tracks the current package version.
 
 **Removed**
 * No user-facing features were removed in this release.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ These screenshots show the graphical shell UI across Workspace, Customize, Agent
 * [Project Goals](#project-goals-aka-why-we-made-this-fork)
 * [Changes Compared to SillyTavern](#changes-vs-sillytavern)
 * [Latest Update](#latest-update)
-    * [v1.6.3 (2026-06-07)](#v163-2026-06-07)
+    * [v1.6.4 (2026-06-07)](#v164-2026-06-07)
 * [Upstream Information](#upstream-information)
 * [Contributors](#contributors)
 ***
@@ -219,31 +219,21 @@ SillyBunny includes some extras by default to help you get started right away:
 
 ## Latest Update
 
-### v1.6.3 (2026-06-07)
+### v1.6.4 (2026-06-07)
 
-This update focuses on safer chat switching and cloning, steadier mobile and persona controls, clearer runtime launchers, theme-aware UI polish, and tighter in-chat agent behavior for the 1.6 line.
+This update prepares SillyBunny 1.6.4 by refreshing the visible app version, Horde client fallback, bundled extension metadata, release notes, and mirrored README documentation after the 1.6.3 release.
 
 **Improved**
-* Runtime launcher documentation and scripts now make automatic, Node.js, Bun, macOS, Linux, Windows, and Termux startup paths explicit.
-* Mobile search, persona controls, alternate greetings, top-bar shortcuts, message actions, and shell spacing were polished to stay stable on narrow screens.
-* Theme surfaces now respect toast colors and core message-block transparency without depending on Moonlit Echoes.
-* In-chat agent refresh behavior, generation controls, and tool-call recursion cap handling are more predictable during active generations.
-* Prompt logging and release changelog automation were tightened so verbose payloads and merged staging history are easier to audit.
+* The UI version label, Horde client identifier, and Horde server fallback now consistently advertise SillyBunny 1.6.4.
+* Package metadata, root package-lock entries, and bundled extension manifests now align with the 1.6.4 release line.
+* Release documentation now has 1.6.4 README, changelog, GitHub mirror, and Discord-ready summary copy.
 
 **Fixed**
-* Verbose prompt payload logging now stays gated behind the prompt log preference.
-* Chat cloning, pending swipe saves, and integrity-token rotation now avoid stale writes, cross-device history loss, and chat-switch races.
-* Persona Scenario Notes selection, mobile alternate greeting controls, persona action spacing, and persona icon alignment now persist and render per character card.
-* In-chat agent generation keeps the stop button and message actions visible while ignoring unrelated generation event payloads during UI refresh.
-* Search close handling stabilizes the mobile viewport and auto-focuses search input without pulling the page out of position.
-* Impersonation keeps first-person behavior on chat-completion backends.
-* Top-bar character shortcut buttons now toggle closed instead of staying open.
+* No targeted bug fixes were included in this release-readiness pass.
 
 **Added**
-* Runtime-specific launchers for forcing Bun or Node.js across Windows, macOS, Linux/WSL, and Termux.
-* Runtime wiring for the tool-call recursion limit slider.
-* Helper prefill role controls for Guided Generations and In-Chat Agents.
-* Regression coverage for chat cloning, swipe saves, persona notes, integrity tokens, mobile controls, agent generation, transparency, theme-aware toasts, and launcher/changelog sync behavior.
+* A 1.6.4 Discord release post is available under `releases/` for announcement publishing.
+* Regression expectations were refreshed so release automation coverage tracks the current package version.
 
 **Removed**
 * No user-facing features were removed in this release.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v1.6.4
+
+Date: 2026-06-07
+
+This update prepares SillyBunny 1.6.4 by refreshing the visible app version, Horde client fallback, bundled extension metadata, release notes, and mirrored README documentation after the 1.6.3 release.
+
+### Improved
+- The UI version label, Horde client identifier, and Horde server fallback now consistently advertise SillyBunny 1.6.4.
+- Package metadata, root package-lock entries, and bundled extension manifests now align with the 1.6.4 release line.
+- Release documentation now has 1.6.4 README, changelog, GitHub mirror, and Discord-ready summary copy.
+
+### Fixed
+- No targeted bug fixes were included in this release-readiness pass.
+
+### Added
+- A 1.6.4 Discord release post is available under `releases/` for announcement publishing.
+- Regression expectations were refreshed so release automation coverage tracks the current package version.
+
+### Removed
+- No user-facing features were removed in this release.
+
+### Merged Staging PRs
+- No merged staging PRs landed after v1.6.3 before this release-prep pass.
+
 ## v1.6.3
 
 Date: 2026-06-07

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sillybunny",
-    "version": "1.6.3",
+    "version": "1.6.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sillybunny",
-            "version": "1.6.3",
+            "version": "1.6.4",
             "license": "AGPL-3.0",
             "dependencies": {
                 "@adobe/css-tools": "^4.4.4",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
         "type": "git",
         "url": "https://github.com/platberlitz/SillyBunny.git"
     },
-    "version": "1.6.3",
+    "version": "1.6.4",
     "scripts": {
         "start": "bun server.js",
         "start:node": "node --no-warnings server.js",

--- a/public/script.js
+++ b/public/script.js
@@ -507,7 +507,7 @@ export let isChatSaving = false;
 export let firstRun = false;
 export let settingsReady = false;
 let currentVersion = '0.0.0';
-const SILLYBUNNY_UI_VERSION = 'SillyBunny v1.6.3';
+const SILLYBUNNY_UI_VERSION = 'SillyBunny v1.6.4';
 
 export let displayVersion = SILLYBUNNY_UI_VERSION;
 
@@ -550,7 +550,7 @@ export function getSillyBunnyFrontendIconSrc({ absolute = false } = {}) {
 export let system_avatar = getSillyBunnyFrontendIconSrc();
 export const comment_avatar = 'img/quill.png';
 export const default_user_avatar = 'img/user-default.png';
-export let CLIENT_VERSION = 'SillyBunny:v1.6.3:platberlitz'; // For Horde header
+export let CLIENT_VERSION = 'SillyBunny:v1.6.4:platberlitz'; // For Horde header
 
 function applySillyBunnyFrontendIcon(iconId = getStoredSillyBunnyFrontendIcon()) {
     const normalizedIconId = normalizeSillyBunnyFrontendIcon(iconId);

--- a/public/scripts/extensions/gallery/manifest.json
+++ b/public/scripts/extensions/gallery/manifest.json
@@ -7,7 +7,7 @@
     "js": "index.js",
     "css": "style.css",
     "author": "City-Unit",
-    "version": "1.6.3",
+    "version": "1.6.4",
     "homePage": "https://github.com/SillyTavern/SillyTavern",
     "hooks": {
         "activate": "init"

--- a/public/scripts/extensions/in-chat-agents/manifest.json
+++ b/public/scripts/extensions/in-chat-agents/manifest.json
@@ -6,6 +6,6 @@
     "js": "index.js",
     "css": "style.css",
     "author": "SillyBunny",
-    "version": "1.6.3",
+    "version": "1.6.4",
     "homePage": "https://github.com/platberlitz/SillyBunny"
 }

--- a/public/scripts/extensions/input-history/manifest.json
+++ b/public/scripts/extensions/input-history/manifest.json
@@ -6,7 +6,7 @@
     "js": "index.js",
     "css": "style.css",
     "author": "LenAnderson",
-    "version": "1.6.3",
+    "version": "1.6.4",
     "homePage": "https://github.com/LenAnderson/SillyTavern-InputHistory",
     "manifest_version": 3
 }

--- a/releases/sillybunny-v1.6.4-discord-post.md
+++ b/releases/sillybunny-v1.6.4-discord-post.md
@@ -1,0 +1,16 @@
+**SillyBunny version 1.6.4 has released**
+This release is a light release-readiness update that refreshes SillyBunny's version metadata and release copy after 1.6.3.
+
+**Detailed Changelog**
+- The visible UI version now reports SillyBunny v1.6.4.
+- Horde client identifiers and the server fallback client string now advertise 1.6.4 consistently.
+- Package metadata, package-lock root entries, and bundled extension manifests now align with the 1.6.4 release.
+- README, changelog, GitHub README mirror, and Discord release summary copy were refreshed for 1.6.4.
+- Release automation test expectations now track the current package version.
+- No targeted bug fixes or user-facing feature removals were included in this release-readiness pass.
+
+**How to update**
+- Built-in updater: open Customize > Server and update from there.
+- Git clone: run `git pull`.
+- Launcher users: close and reopen Start.bat, Start.command, or start.sh.
+- ZIP users: grab the new release directly.

--- a/src/endpoints/horde.js
+++ b/src/endpoints/horde.js
@@ -15,7 +15,7 @@ export const router = express.Router();
  */
 async function getClientAgent() {
     const version = await getVersion();
-    return version?.agent || 'SillyBunny:1.6.3:platberlitz';
+    return version?.agent || 'SillyBunny:1.6.4:platberlitz';
 }
 
 /**

--- a/tests/extensions-disable.test.js
+++ b/tests/extensions-disable.test.js
@@ -44,7 +44,7 @@ function installExtensionModuleMocks() {
     }));
 
     jest.unstable_mockModule('../public/script.js', () => ({
-        CLIENT_VERSION: 'SillyBunny:v1.6.3',
+        CLIENT_VERSION: 'SillyBunny:v1.6.4',
         animation_duration: 0,
         eventSource: { emit: jest.fn(async () => {}) },
         event_types: { EXTENSIONS_FIRST_LOAD: 'extensions_first_load', EXTRAS_CONNECTED: 'extras_connected', EXTENSION_SETTINGS_LOADED: 'extension_settings_loaded' },

--- a/tests/update-changelog-merged-prs.test.js
+++ b/tests/update-changelog-merged-prs.test.js
@@ -30,8 +30,8 @@ describe('update changelog merged PR entries', () => {
     test('creates a missing package version section at the top of the changelog', () => {
         const changelog = '# Changelog\n\n## v1.6.2\n\n### Fixed\n- Existing entry.\n';
 
-        expect(updateChangelog(changelog, 'v1.6.3', [mergedPr])).toBe(
-            '# Changelog\n\n## v1.6.3\n\n### Merged Staging PRs\n- PR #321 (2026-06-04) `fix: unblock changelog sync`\n\n## v1.6.2\n\n### Fixed\n- Existing entry.\n',
+        expect(updateChangelog(changelog, 'v1.6.4', [mergedPr])).toBe(
+            '# Changelog\n\n## v1.6.4\n\n### Merged Staging PRs\n- PR #321 (2026-06-04) `fix: unblock changelog sync`\n\n## v1.6.2\n\n### Fixed\n- Existing entry.\n',
         );
     });
 });


### PR DESCRIPTION
## Summary
- Bump SillyBunny app/UI/Horde/extension metadata from 1.6.3 to 1.6.4
- Refresh README, mirrored GitHub README, changelog, and Discord draft release copy for 1.6.4
- Update release automation test expectations for the current version

## Scope
- Staging-only release-prep PR; no GitHub release, tag, or main merge performed

## Tests
- bash scripts/sync-readme-mirror.sh --check
- npm run lint
- cd tests && npm run test:unit -- extensions-disable.test.js update-changelog-merged-prs.test.js