### PR TITLE
fix: center Quick Replies with popout trigger

### DIFF
--- a/public/scripts/extensions/quick-reply/style.css
+++ b/public/scripts/extensions/quick-reply/style.css
@@ -26,6 +26,7 @@
   width: 100%;
   max-width: 100%;
   overflow-x: auto;
+  overflow-y: hidden;
   order: 1;
   position: relative;
 }
@@ -34,14 +35,20 @@
   right: 0.25em;
   top: 0;
 }
+#qr--bar.popoutVisible {
+  box-sizing: border-box;
+  min-height: var(--sb-control-min-height, 2em);
+  padding-inline: 2.5em;
+}
 /*hide QR popout for mobile*/
 @media screen and (max-width: 1000px) {
   #qr--bar > #qr--popoutTrigger {
     display: none;
   }
-}
-#qr--bar.popoutVisible {
-  padding-right: 2.5em;
+  #qr--bar.popoutVisible {
+    min-height: 0;
+    padding-inline: 0;
+  }
 }
 #qr--popout {
   display: flex;

--- a/public/scripts/extensions/quick-reply/style.less
+++ b/public/scripts/extensions/quick-reply/style.less
@@ -30,6 +30,7 @@
     width: 100%;
     max-width: 100%;
     overflow-x: auto;
+    overflow-y: hidden;
     order: 1;
     position: relative;
 
@@ -40,15 +41,22 @@
     }
 }
 
+#qr--bar.popoutVisible {
+    box-sizing: border-box;
+    min-height: var(--sb-control-min-height, 2em);
+    padding-inline: 2.5em;
+}
+
 /*hide QR popout for mobile*/
 @media screen and (max-width: 1000px) {
     #qr--bar>#qr--popoutTrigger {
         display: none;
     }
-}
 
-#qr--bar.popoutVisible {
-    padding-right: 2.5em;
+    #qr--bar.popoutVisible {
+        min-height: 0;
+        padding-inline: 0;
+    }
 }
 
 #qr--popout {

--- a/tests/quick-reply-bar-layout.e2e.js
+++ b/tests/quick-reply-bar-layout.e2e.js
@@ -1,0 +1,91 @@
+/* global document */
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, test } from '@playwright/test';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+test.describe('Quick Reply button bar layout', () => {
+    test('centers popout quick reply buttons against the composer at desktop widths', async ({ page }) => {
+        const quickReplyCss = await fs.readFile(
+            path.join(repoRoot, 'public/scripts/extensions/quick-reply/style.css'),
+            'utf8',
+        );
+
+        for (const composerWidth of [900, 1228]) {
+            await page.setViewportSize({ width: Math.max(1200, composerWidth + 80), height: 400 });
+            await page.setContent(`<!doctype html>
+                <html>
+                <head>
+                    <style>
+                        html,
+                        body {
+                            margin: 0;
+                        }
+
+                        body {
+                            --SmartThemeBodyColor: #ffffff;
+                            --SmartThemeBorderColor: #777777;
+                            --animation-duration-2x: 0ms;
+                            --sb-control-min-height: 32px;
+                            font: 13.333px sans-serif;
+                        }
+
+                        #send_form {
+                            display: flex;
+                            flex-wrap: wrap;
+                            align-items: center;
+                            box-sizing: border-box;
+                            width: ${composerWidth}px;
+                            padding: 4px;
+                            border: 1px solid var(--SmartThemeBorderColor);
+                            overflow: hidden;
+                        }
+
+                        #nonQRFormItems {
+                            width: 100%;
+                            min-height: 48px;
+                        }
+
+                        .menu_button {
+                            box-sizing: border-box;
+                            width: 32px;
+                            height: 32px;
+                        }
+
+                        ${quickReplyCss}
+                    </style>
+                </head>
+                <body>
+                    <div id="send_form">
+                        <div id="qr--bar" class="flex-container flexGap5 popoutVisible">
+                            <div id="qr--popoutTrigger" class="menu_button"></div>
+                            <div class="qr--buttons">
+                                <button type="button" class="qr--button">Memory Sharding</button>
+                            </div>
+                        </div>
+                        <div id="nonQRFormItems"></div>
+                    </div>
+                </body>
+                </html>`);
+
+            const geometry = await page.evaluate(() => {
+                const composer = document.querySelector('#send_form').getBoundingClientRect();
+                const bar = document.querySelector('#qr--bar');
+                const button = document.querySelector('.qr--button').getBoundingClientRect();
+                const composerCenter = composer.left + composer.width / 2;
+                const buttonCenter = button.left + button.width / 2;
+
+                return {
+                    buttonOffsetFromComposerCenter: Math.abs(buttonCenter - composerCenter),
+                    verticalScrollbarGutter: bar.offsetWidth - bar.clientWidth,
+                };
+            });
+
+            expect(geometry.buttonOffsetFromComposerCenter).toBeLessThanOrEqual(1);
+            expect(geometry.verticalScrollbarGutter).toBeLessThanOrEqual(1);
+        }
+    });
+});


### PR DESCRIPTION
## What?
Fixes Quick Reply bar centering when the popout trigger is visible. The visible quick reply buttons now stay centered against the composer at normal and wide desktop widths.

## Why?
The popout trigger reserved space only on the right side of the bar, and its absolute positioning could also create a scrollbar gutter. Together, that made centered Quick Replies appear shifted left, especially when the composer was widened.

## How?
The Quick Reply bar now uses symmetric inline padding while `popoutVisible` is active, keeps that padding inside the bar with `box-sizing: border-box`, and gives the bar a control-height minimum so the popout trigger does not create vertical overflow. Mobile keeps the popout trigger hidden and removes that desktop gutter. The LESS source and generated CSS are updated together.

A Playwright layout regression test loads the real Quick Reply CSS into a minimal composer fixture and asserts that the Quick Reply button center stays within 1px of the composer center at normal and extra-wide widths, with no vertical scrollbar gutter.

## Testing?
- `npm run test:unit --prefix tests -- quick-reply-button-ui.test.js`
- `npm run lint -- --quiet`
- New E2E layout test passed with a Chromium-compatible Edge run because the local managed Playwright Chromium headless shell was unavailable.
- `npm run test:e2e --prefix tests -- quick-reply-bar-layout.e2e.js` could not complete locally: Playwright reported the managed Chromium headless shell missing, and the browser install command did not finish.

## Screenshots (optional)
No screenshot attached. The layout was verified with the regression test and a browser centerline preview across normal, extra-wide, and narrow composer widths.

## Anything Else?
Fixes #367. This PR is scoped to Quick Reply layout only; notification colors and console log length are not changed here.
