### PR TITLE
fix: harden queued chat saves

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -503,6 +503,7 @@ export let swipeState = SWIPE_STATE.NONE;
 let chatSaveTimeout = null;
 let chatSavePromise = null;
 let chatSaveQueue = Promise.resolve();
+const queuedChatIntegrityByFile = new Map();
 let chatGeneration = 0;
 let chatSaveActivityCount = 0;
 let importFlashTimeout;
@@ -3262,6 +3263,36 @@ function setChatSaveActive(isActive) {
     chatSaveActivityCount += isActive ? 1 : -1;
     chatSaveActivityCount = Math.max(0, chatSaveActivityCount);
     isChatSaving = chatSaveActivityCount > 0;
+}
+
+function getQueuedChatIntegrityKey(avatarUrl, chatName) {
+    if (!avatarUrl || !chatName) {
+        return '';
+    }
+
+    return `${avatarUrl}\0${chatName}`;
+}
+
+function cloneChatSavePayload(chatData) {
+    return structuredClone(chatData);
+}
+
+function applyQueuedChatIntegrity(metadata, integrityKey, isActiveChatSave) {
+    if (isActiveChatSave && typeof chat_metadata.integrity === 'string' && chat_metadata.integrity) {
+        metadata.integrity = chat_metadata.integrity;
+        return;
+    }
+
+    const queuedIntegrity = integrityKey ? queuedChatIntegrityByFile.get(integrityKey) : undefined;
+    if (typeof queuedIntegrity === 'string' && queuedIntegrity) {
+        metadata.integrity = queuedIntegrity;
+    }
+}
+
+function rememberQueuedChatIntegrity(integrityKey, integrity) {
+    if (integrityKey && typeof integrity === 'string' && integrity) {
+        queuedChatIntegrityByFile.set(integrityKey, integrity);
+    }
 }
 
 /**
@@ -10071,12 +10102,13 @@ export function saveChat(...saveChatArguments) {
 
     if (options) {
         const mesId = options.mesId;
-        const chatData = Array.isArray(options.chatData)
+        const sourceChatData = Array.isArray(options.chatData)
             ? options.chatData
             : (mesId !== undefined && mesId >= 0 && mesId < chat.length)
                 ? chat.slice(0, Number(mesId) + 1)
                 : chat.slice();
-        const metadataSnapshot = { ...chat_metadata, ...(options.withMetadata || {}) };
+        const chatData = cloneChatSavePayload(sourceChatData);
+        const metadataSnapshot = structuredClone({ ...chat_metadata, ...(options.withMetadata || {}) });
         const activeCharacter = characters[this_chid];
         queuedSaveArguments = [{
             ...options,
@@ -10110,10 +10142,14 @@ async function saveChatImmediately({ chatName, withMetadata, metadataSnapshot, m
         [chatName, withMetadata, mesId, force, throwOnError] = arguments;
     }
 
-    const metadata = metadataSnapshot || { ...chat_metadata, ...(withMetadata || {}) };
+    const metadata = structuredClone(metadataSnapshot || { ...chat_metadata, ...(withMetadata || {}) });
     const fileName = chatName ?? activeChatName;
     const currentActiveChatName = characters[this_chid]?.chat;
     const isActiveChatSave = fileName === currentActiveChatName;
+    const fallbackCharacter = characters[this_chid] || {};
+    const resolvedCharacterName = characterName || fallbackCharacter.name;
+    const resolvedAvatarUrl = avatarUrl || fallbackCharacter.avatar;
+    const integrityKey = getQueuedChatIntegrityKey(resolvedAvatarUrl, fileName);
 
     if (!fileName && name2 === neutralCharacterName) {
         // TODO: Do something for a temporary chat with no character.
@@ -10125,7 +10161,7 @@ async function saveChatImmediately({ chatName, withMetadata, metadataSnapshot, m
         return false;
     }
 
-    const activeCharacter = characters.find(character => character?.avatar === avatarUrl) || characters[this_chid];
+    const activeCharacter = characters.find(character => character?.avatar === resolvedAvatarUrl) || characters[this_chid];
     if (activeCharacter) {
         activeCharacter.date_last_chat = Date.now();
     }
@@ -10133,8 +10169,9 @@ async function saveChatImmediately({ chatName, withMetadata, metadataSnapshot, m
     const trimmedChat = Array.isArray(chatData)
         ? chatData
         : (mesId !== undefined && mesId >= 0 && mesId < chat.length)
-            ? chat.slice(0, Number(mesId) + 1)
-            : chat.slice();
+            ? cloneChatSavePayload(chat.slice(0, Number(mesId) + 1))
+            : cloneChatSavePayload(chat);
+    applyQueuedChatIntegrity(metadata, integrityKey, isActiveChatSave);
 
     /** @type {ChatHeader} */
     const chatHeader = {
@@ -10149,10 +10186,10 @@ async function saveChatImmediately({ chatName, withMetadata, metadataSnapshot, m
             cache: 'no-cache',
             headers: getRequestHeaders(),
             body: JSON.stringify({
-                ch_name: characterName || characters[this_chid].name,
+                ch_name: resolvedCharacterName,
                 file_name: fileName,
                 chat: [chatHeader, ...trimmedChat],
-                avatar_url: avatarUrl || characters[this_chid].avatar,
+                avatar_url: resolvedAvatarUrl,
                 force: force,
             }),
         });
@@ -10160,6 +10197,7 @@ async function saveChatImmediately({ chatName, withMetadata, metadataSnapshot, m
 
         if (result.ok) {
             const responseData = await result.json().catch(() => ({}));
+            rememberQueuedChatIntegrity(integrityKey, responseData?.integrity);
             if (isActiveChatSave && typeof responseData?.integrity === 'string' && responseData.integrity) {
                 chat_metadata.integrity = responseData.integrity;
             }

--- a/public/script.js
+++ b/public/script.js
@@ -503,6 +503,8 @@ export let swipeState = SWIPE_STATE.NONE;
 let chatSaveTimeout = null;
 let chatSavePromise = null;
 let chatSaveQueue = Promise.resolve();
+let chatGeneration = 0;
+let chatSaveActivityCount = 0;
 let importFlashTimeout;
 export let isChatSaving = false;
 export let firstRun = false;
@@ -3252,6 +3254,16 @@ export function cancelDebouncedChatSave() {
     }
 }
 
+export function incrementChatGeneration() {
+    chatGeneration++;
+}
+
+function setChatSaveActive(isActive) {
+    chatSaveActivityCount += isActive ? 1 : -1;
+    chatSaveActivityCount = Math.max(0, chatSaveActivityCount);
+    isChatSaving = chatSaveActivityCount > 0;
+}
+
 /**
  * Visually removes all chat message elements.
  * @param {object} [options] Options
@@ -3278,7 +3290,10 @@ export async function clearChat({ clearData = false } = {}) {
     await saveItemizedPrompts(getCurrentChatId());
     itemizedPrompts.length = 0;
 
-    if (clearData) chat.length = 0;
+    if (clearData) {
+        chat.length = 0;
+        incrementChatGeneration();
+    }
 }
 
 export async function deleteLastMessage() {
@@ -9935,6 +9950,7 @@ export function saveChatDebounced() {
     const chid = this_chid;
     const selectedGroup = selected_group;
     const chatId = getCurrentChatId();
+    const generation = chatGeneration;
 
     cancelDebouncedChatSave();
 
@@ -9949,6 +9965,8 @@ export function saveChatDebounced() {
             currentCharacterId: this_chid,
             scheduledChatId: chatId,
             currentChatId: getCurrentChatId(),
+            scheduledGeneration: generation,
+            currentGeneration: chatGeneration,
         });
 
         if (abortReason) {
@@ -10005,16 +10023,10 @@ export async function flushPendingChatSaves() {
         }
     }
 
-    await waitUntilCondition(() => !isChatSaving, debounce_timeout.extended, 100, { rejectOnTimeout: false });
-    if (isChatSaving) {
-        toastr.error(t`The current chat is still saving. Try again in a moment.`, t`Chat save still in progress`);
-        return false;
-    }
-
     toastr.info(t`Saving chat...`, t`Saving chat`);
 
     try {
-        isChatSaving = true;
+        setChatSaveActive(true);
 
         const didSave = selected_group
             ? await saveGroupChat(selected_group, true, false, true)
@@ -10032,7 +10044,7 @@ export async function flushPendingChatSaves() {
         console.error('Error flushing pending chat saves', error);
         return false;
     } finally {
-        isChatSaving = false;
+        setChatSaveActive(false);
     }
 }
 
@@ -10049,16 +10061,46 @@ export async function flushPendingChatSaves() {
  * @returns {Promise<boolean>}
  */
 export function saveChat(...saveChatArguments) {
+    const [firstArgument] = saveChatArguments;
+    const options = firstArgument && typeof firstArgument === 'object'
+        ? firstArgument
+        : saveChatArguments.length === 0
+            ? {}
+            : undefined;
+    let queuedSaveArguments = saveChatArguments;
+
+    if (options) {
+        const mesId = options.mesId;
+        const chatData = Array.isArray(options.chatData)
+            ? options.chatData
+            : (mesId !== undefined && mesId >= 0 && mesId < chat.length)
+                ? chat.slice(0, Number(mesId) + 1)
+                : chat.slice();
+        const metadataSnapshot = { ...chat_metadata, ...(options.withMetadata || {}) };
+        const activeCharacter = characters[this_chid];
+        queuedSaveArguments = [{
+            ...options,
+            chatData,
+            metadataSnapshot,
+            activeChatName: activeCharacter?.chat,
+            characterName: activeCharacter?.name,
+            avatarUrl: activeCharacter?.avatar,
+            wasGroupChat: Boolean(selected_group),
+        }];
+    }
+
+    setChatSaveActive(true);
     const saveTask = chatSaveQueue
         .catch(error => console.warn('Previous chat save failed before queued save.', error))
-        .then(() => saveChatImmediately(...saveChatArguments));
+        .then(() => saveChatImmediately(...queuedSaveArguments))
+        .finally(() => setChatSaveActive(false));
 
     chatSaveQueue = saveTask.catch(() => {});
     return saveTask;
 }
 
-async function saveChatImmediately({ chatName, withMetadata, mesId, force = false, chatData = undefined, throwOnError = false } = {}) {
-    if (selected_group) {
+async function saveChatImmediately({ chatName, withMetadata, metadataSnapshot, mesId, force = false, chatData = undefined, throwOnError = false, activeChatName, characterName, avatarUrl, wasGroupChat = false } = {}) {
+    if (wasGroupChat || (selected_group && !activeChatName)) {
         toastr.error(t`Operation was aborted to prevent data corruption.`, t`saveChat called for a group chat`);
         throw new Error('saveChat called for a group chat');
     }
@@ -10068,10 +10110,10 @@ async function saveChatImmediately({ chatName, withMetadata, mesId, force = fals
         [chatName, withMetadata, mesId, force, throwOnError] = arguments;
     }
 
-    const metadata = { ...chat_metadata, ...(withMetadata || {}) };
-    const activeChatName = characters[this_chid]?.chat;
+    const metadata = metadataSnapshot || { ...chat_metadata, ...(withMetadata || {}) };
     const fileName = chatName ?? activeChatName;
-    const isActiveChatSave = fileName === activeChatName;
+    const currentActiveChatName = characters[this_chid]?.chat;
+    const isActiveChatSave = fileName === currentActiveChatName;
 
     if (!fileName && name2 === neutralCharacterName) {
         // TODO: Do something for a temporary chat with no character.
@@ -10083,7 +10125,10 @@ async function saveChatImmediately({ chatName, withMetadata, mesId, force = fals
         return false;
     }
 
-    characters[this_chid].date_last_chat = Date.now();
+    const activeCharacter = characters.find(character => character?.avatar === avatarUrl) || characters[this_chid];
+    if (activeCharacter) {
+        activeCharacter.date_last_chat = Date.now();
+    }
 
     const trimmedChat = Array.isArray(chatData)
         ? chatData
@@ -10104,10 +10149,10 @@ async function saveChatImmediately({ chatName, withMetadata, mesId, force = fals
             cache: 'no-cache',
             headers: getRequestHeaders(),
             body: JSON.stringify({
-                ch_name: characters[this_chid].name,
+                ch_name: characterName || characters[this_chid].name,
                 file_name: fileName,
                 chat: [chatHeader, ...trimmedChat],
-                avatar_url: characters[this_chid].avatar,
+                avatar_url: avatarUrl || characters[this_chid].avatar,
                 force: force,
             }),
         });
@@ -10144,7 +10189,7 @@ async function saveChatImmediately({ chatName, withMetadata, mesId, force = fals
             return false;
         }
 
-        return await saveChatImmediately({ chatName, withMetadata, mesId, force: true, chatData, throwOnError });
+        return await saveChatImmediately({ chatName, withMetadata, metadataSnapshot: metadata, mesId, force: true, chatData, throwOnError, activeChatName, characterName, avatarUrl, wasGroupChat });
     } catch (error) {
         console.error(error);
         toastr.error(t`Check the server connection and reload the page to prevent data loss.`, t`Chat could not be saved`);
@@ -10435,6 +10480,7 @@ export async function unshallowCharacter(characterId) {
 
 export async function getChat({ allowMissingPersisted = false, switchMenu = true } = {}) {
     try {
+        incrementChatGeneration();
         await unshallowCharacter(this_chid);
         const resolvedChat = await resolveCharacterChatForLoad(this_chid, { allowCreate: true, allowMissingPersisted });
 
@@ -13816,16 +13862,9 @@ export async function saveMetadata() {
 
 export async function saveChatConditional() {
     try {
-        await waitUntilCondition(() => !isChatSaving, DEFAULT_SAVE_EDIT_TIMEOUT, 100);
-    } catch {
-        console.warn('Timeout waiting for chat to save');
-        return;
-    }
-
-    try {
         cancelDebouncedChatSave();
 
-        isChatSaving = true;
+        setChatSaveActive(true);
 
         if (selected_group) {
             await saveGroupChat(selected_group, true);
@@ -13839,7 +13878,7 @@ export async function saveChatConditional() {
     } catch (error) {
         console.error('Error saving chat', error);
     } finally {
-        isChatSaving = false;
+        setChatSaveActive(false);
     }
 }
 

--- a/public/scripts/chat-save-guard.js
+++ b/public/scripts/chat-save-guard.js
@@ -5,6 +5,8 @@ export function getDebouncedChatSaveAbortReason({
     currentCharacterId,
     scheduledChatId,
     currentChatId,
+    scheduledGeneration,
+    currentGeneration,
 } = {}) {
     if (scheduledGroupId !== currentGroupId) {
         return 'group';
@@ -16,6 +18,10 @@ export function getDebouncedChatSaveAbortReason({
 
     if (scheduledChatId !== currentChatId) {
         return 'chat';
+    }
+
+    if (scheduledGeneration !== currentGeneration) {
+        return 'chat generation';
     }
 
     return '';

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -83,6 +83,7 @@ import {
     chatElement,
     ensureMessageMediaIsArray,
     syncCharacterMenuActiveEntity,
+    incrementChatGeneration,
 } from '../script.js';
 import { printTagList, createTagMapFromList, applyTagsOnCharacterSelect, tag_map, applyTagsOnGroupSelect, printTagFilters, tag_filter_type } from './tags.js';
 import { FILTER_TYPES, FilterHelper } from './filters.js';
@@ -126,6 +127,7 @@ let group_generation_id = null;
 let fav_grp_checked = false;
 let openGroupId = null;
 let newGroupMembers = [];
+let groupChatSaveQueue = Promise.resolve();
 
 const GROUP_MEMBER_MODELS_KEY = 'member_models';
 const GROUP_AUTO_MODE_KEY = 'SillyBunny.groupAutoModeEnabled';
@@ -1234,6 +1236,8 @@ async function validateGroup(group) {
  * @returns {Promise<void>} A promise that resolves when the chat messages have been loaded.
  */
 export async function getGroupChat(groupId, reload = false, { switchMenu = true } = {}) {
+    incrementChatGeneration();
+
     const group = groups.find((x) => x.id === groupId);
     if (!group) {
         console.warn('Group not found', groupId);
@@ -1560,13 +1564,39 @@ function resetSelectedGroup() {
  * @param {boolean} throwOnError Rethrow save errors after notifying the user
  * @returns {Promise<boolean>} A promise that resolves when the group chat has been saved.
  */
-async function saveGroupChat(groupId, shouldSaveGroup, force = false, throwOnError = false) {
+function saveGroupChat(groupId, shouldSaveGroup, force = false, throwOnError = false) {
+    const group = groups.find(x => x.id == groupId);
+    if (!group) {
+        console.warn('Group not found', groupId);
+        return Promise.resolve(false);
+    }
+
+    const chatSnapshot = chat.slice();
+    const metadataSnapshot = { ...chat_metadata };
+    const chatIdSnapshot = group.chat_id;
+    const saveTask = groupChatSaveQueue
+        .catch(error => console.warn('Previous group chat save failed before queued save.', error))
+        .then(() => saveGroupChatImmediately({
+            groupId,
+            shouldSaveGroup,
+            force,
+            throwOnError,
+            chatId: chatIdSnapshot,
+            chatData: chatSnapshot,
+            metadata: metadataSnapshot,
+        }));
+
+    groupChatSaveQueue = saveTask.catch(() => {});
+    return saveTask;
+}
+
+async function saveGroupChatImmediately({ groupId, shouldSaveGroup, force = false, throwOnError = false, chatId, chatData, metadata }) {
     const group = groups.find(x => x.id == groupId);
     if (!group) {
         console.warn('Group not found', groupId);
         return false;
     }
-    const chatId = group.chat_id;
+
     if (chatId && Array.isArray(group.chats) && !group.chats.includes(chatId)) {
         group.chats.push(chatId);
         shouldSaveGroup = true;
@@ -1574,14 +1604,15 @@ async function saveGroupChat(groupId, shouldSaveGroup, force = false, throwOnErr
     group.date_last_chat = Date.now();
     /** @type {ChatHeader} */
     const chatHeader = {
-        chat_metadata: { ...chat_metadata },
+        chat_metadata: metadata,
         user_name: 'unused',
         character_name: 'unused',
     };
+    const chatMessages = Array.isArray(chatData) ? chatData : chat;
     const saveGroupChatRequest = await compressRequest({
         method: 'POST',
         headers: getRequestHeaders(),
-        body: JSON.stringify({ id: chatId, chat: [chatHeader, ...chat], force: force }),
+        body: JSON.stringify({ id: chatId, chat: [chatHeader, ...chatMessages], force: force }),
     });
     const response = await fetch('/api/chats/group/save', saveGroupChatRequest);
 
@@ -1613,11 +1644,12 @@ async function saveGroupChat(groupId, shouldSaveGroup, force = false, throwOnErr
             return false;
         }
 
-        return await saveGroupChat(groupId, shouldSaveGroup, true, throwOnError);
+        return await saveGroupChatImmediately({ groupId, shouldSaveGroup, force: true, throwOnError, chatId, chatData: chatMessages, metadata });
     }
 
     const responseData = await response.json().catch(() => ({}));
-    if (typeof responseData?.integrity === 'string' && responseData.integrity) {
+    const isActiveGroupChatSave = selected_group === groupId && group.chat_id === chatId;
+    if (isActiveGroupChatSave && typeof responseData?.integrity === 'string' && responseData.integrity) {
         chat_metadata.integrity = responseData.integrity;
     }
 

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -128,6 +128,7 @@ let fav_grp_checked = false;
 let openGroupId = null;
 let newGroupMembers = [];
 let groupChatSaveQueue = Promise.resolve();
+const queuedGroupChatIntegrityByFile = new Map();
 
 const GROUP_MEMBER_MODELS_KEY = 'member_models';
 const GROUP_AUTO_MODE_KEY = 'SillyBunny.groupAutoModeEnabled';
@@ -1556,6 +1557,28 @@ function resetSelectedGroup() {
     is_group_generating = false;
 }
 
+function cloneGroupChatSavePayload(chatData) {
+    return structuredClone(chatData);
+}
+
+function applyQueuedGroupChatIntegrity(metadata, chatId, isActiveGroupChatSave) {
+    if (isActiveGroupChatSave && typeof chat_metadata.integrity === 'string' && chat_metadata.integrity) {
+        metadata.integrity = chat_metadata.integrity;
+        return;
+    }
+
+    const queuedIntegrity = chatId ? queuedGroupChatIntegrityByFile.get(chatId) : undefined;
+    if (typeof queuedIntegrity === 'string' && queuedIntegrity) {
+        metadata.integrity = queuedIntegrity;
+    }
+}
+
+function rememberQueuedGroupChatIntegrity(chatId, integrity) {
+    if (chatId && typeof integrity === 'string' && integrity) {
+        queuedGroupChatIntegrityByFile.set(chatId, integrity);
+    }
+}
+
 /**
  * Saves a group chat to the server.
  * @param {string} groupId Group ID
@@ -1571,8 +1594,8 @@ function saveGroupChat(groupId, shouldSaveGroup, force = false, throwOnError = f
         return Promise.resolve(false);
     }
 
-    const chatSnapshot = chat.slice();
-    const metadataSnapshot = { ...chat_metadata };
+    const chatSnapshot = cloneGroupChatSavePayload(chat);
+    const metadataSnapshot = structuredClone(chat_metadata);
     const chatIdSnapshot = group.chat_id;
     const saveTask = groupChatSaveQueue
         .catch(error => console.warn('Previous group chat save failed before queued save.', error))
@@ -1602,13 +1625,16 @@ async function saveGroupChatImmediately({ groupId, shouldSaveGroup, force = fals
         shouldSaveGroup = true;
     }
     group.date_last_chat = Date.now();
+    const isActiveGroupChatSave = selected_group === groupId && group.chat_id === chatId;
+    const metadataForSave = structuredClone(metadata || chat_metadata);
+    applyQueuedGroupChatIntegrity(metadataForSave, chatId, isActiveGroupChatSave);
     /** @type {ChatHeader} */
     const chatHeader = {
-        chat_metadata: metadata,
+        chat_metadata: metadataForSave,
         user_name: 'unused',
         character_name: 'unused',
     };
-    const chatMessages = Array.isArray(chatData) ? chatData : chat;
+    const chatMessages = Array.isArray(chatData) ? chatData : cloneGroupChatSavePayload(chat);
     const saveGroupChatRequest = await compressRequest({
         method: 'POST',
         headers: getRequestHeaders(),
@@ -1644,11 +1670,11 @@ async function saveGroupChatImmediately({ groupId, shouldSaveGroup, force = fals
             return false;
         }
 
-        return await saveGroupChatImmediately({ groupId, shouldSaveGroup, force: true, throwOnError, chatId, chatData: chatMessages, metadata });
+        return await saveGroupChatImmediately({ groupId, shouldSaveGroup, force: true, throwOnError, chatId, chatData: chatMessages, metadata: metadataForSave });
     }
 
     const responseData = await response.json().catch(() => ({}));
-    const isActiveGroupChatSave = selected_group === groupId && group.chat_id === chatId;
+    rememberQueuedGroupChatIntegrity(chatId, responseData?.integrity);
     if (isActiveGroupChatSave && typeof responseData?.integrity === 'string' && responseData.integrity) {
         chat_metadata.integrity = responseData.integrity;
     }

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -67,9 +67,19 @@ function backupChat(directory, name, data, backupPrefix = CHAT_BACKUPS_PREFIX) {
 
 function backupChatPreWrite(directory, name, data) {
     try {
-        backupChat(directory, name, data, CHAT_PRE_WRITE_BACKUPS_PREFIX);
+        if (!isBackupEnabled) { return; }
+        if (!fs.existsSync(directory)) {
+            console.error(`The chat couldn't be backed up because no directory exists at ${directory}!`);
+        }
         name = sanitize(name).replace(/[^a-z0-9]/gi, '_').toLowerCase();
+        const backupFile = path.join(directory, `${CHAT_PRE_WRITE_BACKUPS_PREFIX}${name}_${generateTimestamp()}_${uuidv4()}.jsonl`);
+
+        tryWriteFileSync(backupFile, data);
         removeOldBackups(directory, `${CHAT_PRE_WRITE_BACKUPS_PREFIX}${name}_`, PRE_WRITE_BACKUP_RING_SIZE);
+        if (isNaN(maxTotalChatBackups) || maxTotalChatBackups < 0) {
+            return;
+        }
+        removeOldBackups(directory, CHAT_PRE_WRITE_BACKUPS_PREFIX, maxTotalChatBackups);
     } catch (err) {
         console.error(`Could not create pre-write chat backup for ${name}`, err);
     }

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -32,6 +32,8 @@ const checkIntegrity = !!getConfigValue('backups.chat.checkIntegrity', true, 'bo
 
 export const CHAT_BACKUPS_PREFIX = 'chat_';
 const CHAT_FORCED_OVERWRITE_BACKUPS_PREFIX = 'chat_forced_overwrite_';
+const CHAT_PRE_WRITE_BACKUPS_PREFIX = 'chat_pre_write_';
+const PRE_WRITE_BACKUP_RING_SIZE = 3;
 
 /**
  * Saves a chat to the backups directory.
@@ -61,6 +63,33 @@ function backupChat(directory, name, data, backupPrefix = CHAT_BACKUPS_PREFIX) {
     } catch (err) {
         console.error(`Could not backup chat for ${name}`, err);
     }
+}
+
+function backupChatPreWrite(directory, name, data) {
+    try {
+        backupChat(directory, name, data, CHAT_PRE_WRITE_BACKUPS_PREFIX);
+        name = sanitize(name).replace(/[^a-z0-9]/gi, '_').toLowerCase();
+        removeOldBackups(directory, `${CHAT_PRE_WRITE_BACKUPS_PREFIX}${name}_`, PRE_WRITE_BACKUP_RING_SIZE);
+    } catch (err) {
+        console.error(`Could not create pre-write chat backup for ${name}`, err);
+    }
+}
+
+function countSerializedChatLines(serializedChat) {
+    if (!serializedChat) {
+        return 0;
+    }
+
+    return String(serializedChat).split('\n').filter(line => line.trim()).length;
+}
+
+function isSuspiciousChatShrink(newData, existingSerializedChat) {
+    const existingLines = countSerializedChatLines(existingSerializedChat);
+    if (existingLines <= 5) {
+        return false;
+    }
+
+    return Array.isArray(newData) && newData.length < existingLines * 0.5;
 }
 
 /**
@@ -524,10 +553,18 @@ export async function trySaveChat(chatData, filePath, skipIntegrityCheck = false
         : chatData;
     const jsonlData = savedChatData?.map(m => JSON.stringify(m)).join('\n');
 
-    if (skipIntegrityCheck && fs.existsSync(filePath)) {
+    if (fs.existsSync(filePath)) {
         const currentChatData = tryReadFileSync(filePath);
         if (currentChatData) {
-            backupChat(backupDirectory, cardName, currentChatData, CHAT_FORCED_OVERWRITE_BACKUPS_PREFIX);
+            backupChatPreWrite(backupDirectory, cardName, currentChatData);
+
+            if (isSuspiciousChatShrink(savedChatData, currentChatData)) {
+                console.warn(`Suspicious chat shrink while saving "${cardName}": incoming payload has ${savedChatData.length} JSONL rows, existing file has ${countSerializedChatLines(currentChatData)} rows.`);
+            }
+
+            if (skipIntegrityCheck) {
+                backupChat(backupDirectory, cardName, currentChatData, CHAT_FORCED_OVERWRITE_BACKUPS_PREFIX);
+            }
         }
     }
 

--- a/tests/__snapshots__/script-export-surface.test.js.snap
+++ b/tests/__snapshots__/script-export-surface.test.js.snap
@@ -130,6 +130,7 @@ exports[`public/script.js named export surface matches the parser-derived export
   "handleDeleteCharacter",
   "hideSwipeButtons",
   "importCharacterChat",
+  "incrementChatGeneration",
   "isChatSaving",
   "isGenerating",
   "isMessageSwipeable",

--- a/tests/chat-integrity-rotation.test.js
+++ b/tests/chat-integrity-rotation.test.js
@@ -146,6 +146,47 @@ describe('chat integrity rotation', () => {
         await expect(fs.readFile(path.join(backupDir, preWriteBackup), 'utf8')).resolves.toBe(originalContent);
     });
 
+    test('keeps distinct pre-write backups for rapid overwrites in the same second', async () => {
+        const { trySaveChat } = await import('../src/endpoints/chats.js');
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-integrity-prewrite-rapid-'));
+        const chatFile = path.join(tempDir, 'chat.jsonl');
+        const backupDir = path.join(tempDir, 'backups');
+        await fs.mkdir(backupDir);
+        jest.setSystemTime(new Date('2026-06-06T12:34:56.000Z'));
+
+        await fs.writeFile(chatFile, chatWithIntegrity('valid-integrity', 'original disk chat').map(JSON.stringify).join('\n'));
+        const firstResult = await trySaveChat(
+            chatWithIntegrity('valid-integrity', 'first replacement'),
+            chatFile,
+            false,
+            'test-user',
+            'Test Card',
+            backupDir,
+        );
+        const secondResult = await trySaveChat(
+            chatWithIntegrity(firstResult.integrity, 'second replacement'),
+            chatFile,
+            false,
+            'test-user',
+            'Test Card',
+            backupDir,
+        );
+        await trySaveChat(
+            chatWithIntegrity(secondResult.integrity, 'third replacement'),
+            chatFile,
+            false,
+            'test-user',
+            'Test Card',
+            backupDir,
+        );
+
+        const backupFiles = await fs.readdir(backupDir);
+        const preWriteBackups = backupFiles.filter(fileName => fileName.startsWith('chat_pre_write_test_card_'));
+
+        expect(new Set(preWriteBackups).size).toBe(3);
+        expect(preWriteBackups).toHaveLength(3);
+    });
+
     test('warns on suspicious shrink but still preserves the existing chat', async () => {
         const { trySaveChat } = await import('../src/endpoints/chats.js');
         const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-integrity-shrink-'));
@@ -221,7 +262,8 @@ describe('chat integrity rotation', () => {
 
         expect(scriptSource).toContain('let chatSaveQueue = Promise.resolve();');
         expect(scriptSource).toContain('export function saveChat(...saveChatArguments)');
-        expect(scriptSource).toContain('const metadataSnapshot = { ...chat_metadata, ...(options.withMetadata || {}) };');
+        expect(scriptSource).toContain('const metadataSnapshot = structuredClone({ ...chat_metadata, ...(options.withMetadata || {}) });');
+        expect(scriptSource).toContain('const chatData = cloneChatSavePayload(sourceChatData);');
         expect(scriptSource).toContain('activeChatName: activeCharacter?.chat');
         expect(scriptSource).toContain('characterName: activeCharacter?.name');
         expect(scriptSource).toContain('avatarUrl: activeCharacter?.avatar');
@@ -230,6 +272,8 @@ describe('chat integrity rotation', () => {
         expect(scriptSource).toContain('.then(() => saveChatImmediately(...queuedSaveArguments))');
         expect(scriptSource).toContain('.finally(() => setChatSaveActive(false));');
         expect(scriptSource).toContain('async function saveChatImmediately');
+        expect(scriptSource).toContain('applyQueuedChatIntegrity(metadata, integrityKey, isActiveChatSave);');
+        expect(scriptSource).toContain('rememberQueuedChatIntegrity(integrityKey, responseData?.integrity);');
         expect(scriptSource).toContain('return await saveChatImmediately({ chatName, withMetadata, metadataSnapshot: metadata, mesId, force: true, chatData, throwOnError, activeChatName, characterName, avatarUrl, wasGroupChat });');
     });
 
@@ -265,10 +309,12 @@ describe('chat integrity rotation', () => {
 
         expect(groupChatSource).toContain('let groupChatSaveQueue = Promise.resolve();');
         expect(groupChatSource).toContain('function saveGroupChat(groupId, shouldSaveGroup, force = false, throwOnError = false)');
-        expect(groupChatSource).toContain('const chatSnapshot = chat.slice();');
-        expect(groupChatSource).toContain('const metadataSnapshot = { ...chat_metadata };');
+        expect(groupChatSource).toContain('const chatSnapshot = cloneGroupChatSavePayload(chat);');
+        expect(groupChatSource).toContain('const metadataSnapshot = structuredClone(chat_metadata);');
         expect(groupChatSource).toContain('.then(() => saveGroupChatImmediately({');
-        expect(groupChatSource).toContain('return await saveGroupChatImmediately({ groupId, shouldSaveGroup, force: true, throwOnError, chatId, chatData: chatMessages, metadata });');
+        expect(groupChatSource).toContain('applyQueuedGroupChatIntegrity(metadataForSave, chatId, isActiveGroupChatSave);');
+        expect(groupChatSource).toContain('rememberQueuedGroupChatIntegrity(chatId, responseData?.integrity);');
+        expect(groupChatSource).toContain('return await saveGroupChatImmediately({ groupId, shouldSaveGroup, force: true, throwOnError, chatId, chatData: chatMessages, metadata: metadataForSave });');
         expect(groupChatSource).toContain('const isActiveGroupChatSave = selected_group === groupId && group.chat_id === chatId;');
         expect(groupChatSource).toContain('if (isActiveGroupChatSave && typeof responseData?.integrity === \'string\' && responseData.integrity)');
     });

--- a/tests/chat-integrity-rotation.test.js
+++ b/tests/chat-integrity-rotation.test.js
@@ -24,6 +24,22 @@ function chatWithIntegrity(integrity, message) {
     ];
 }
 
+function chatWithMessages(integrity, messages) {
+    return [
+        {
+            chat_metadata: { integrity },
+            user_name: 'unused',
+            character_name: 'unused',
+        },
+        ...messages.map((message, index) => ({
+            name: index % 2 === 0 ? 'User' : 'Assistant',
+            is_user: index % 2 === 0,
+            send_date: `2026-06-06T00:00:${String(index).padStart(2, '0')}.000Z`,
+            mes: message,
+        })),
+    ];
+}
+
 async function readHeader(filePath) {
     const content = await fs.readFile(filePath, 'utf8');
     return JSON.parse(content.split('\n')[0]);
@@ -96,11 +112,69 @@ describe('chat integrity rotation', () => {
         const forcedBackup = backupFiles.find(fileName => fileName.startsWith('chat_forced_overwrite_test_card_'));
         const postSaveBackup = backupFiles.find(fileName => fileName.startsWith('chat_test_card_'));
 
-        expect(backupFiles).toHaveLength(2);
+        expect(backupFiles).toHaveLength(3);
         expect(forcedBackup).toEqual(expect.any(String));
         expect(postSaveBackup).toEqual(expect.any(String));
+        expect(backupFiles.some(fileName => fileName.startsWith('chat_pre_write_test_card_'))).toBe(true);
         await expect(fs.readFile(path.join(backupDir, forcedBackup), 'utf8')).resolves.toContain('original disk chat');
         await expect(fs.readFile(path.join(backupDir, postSaveBackup), 'utf8')).resolves.toContain('forced overwrite chat');
+    });
+
+    test('creates a pre-write backup before every valid overwrite', async () => {
+        const { trySaveChat } = await import('../src/endpoints/chats.js');
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-integrity-prewrite-'));
+        const chatFile = path.join(tempDir, 'chat.jsonl');
+        const backupDir = path.join(tempDir, 'backups');
+        await fs.mkdir(backupDir);
+
+        const originalContent = chatWithIntegrity('valid-integrity', 'original disk chat').map(JSON.stringify).join('\n');
+        await fs.writeFile(chatFile, originalContent);
+
+        await trySaveChat(
+            chatWithIntegrity('valid-integrity', 'new disk chat'),
+            chatFile,
+            false,
+            'test-user',
+            'Test Card',
+            backupDir,
+        );
+
+        const backupFiles = await fs.readdir(backupDir);
+        const preWriteBackup = backupFiles.find(fileName => fileName.startsWith('chat_pre_write_test_card_'));
+
+        expect(preWriteBackup).toEqual(expect.any(String));
+        await expect(fs.readFile(path.join(backupDir, preWriteBackup), 'utf8')).resolves.toBe(originalContent);
+    });
+
+    test('warns on suspicious shrink but still preserves the existing chat', async () => {
+        const { trySaveChat } = await import('../src/endpoints/chats.js');
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-integrity-shrink-'));
+        const chatFile = path.join(tempDir, 'chat.jsonl');
+        const backupDir = path.join(tempDir, 'backups');
+        await fs.mkdir(backupDir);
+        const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const originalChat = chatWithMessages('valid-integrity', ['one', 'two', 'three', 'four', 'five', 'six']);
+        const originalContent = originalChat.map(JSON.stringify).join('\n');
+        await fs.writeFile(chatFile, originalContent);
+
+        await trySaveChat(
+            chatWithIntegrity('valid-integrity', 'short replacement'),
+            chatFile,
+            false,
+            'test-user',
+            'Test Card',
+            backupDir,
+        );
+
+        const backupFiles = await fs.readdir(backupDir);
+        const preWriteBackup = backupFiles.find(fileName => fileName.startsWith('chat_pre_write_test_card_'));
+
+        expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('Suspicious chat shrink'));
+        expect(preWriteBackup).toEqual(expect.any(String));
+        await expect(fs.readFile(path.join(backupDir, preWriteBackup), 'utf8')).resolves.toBe(originalContent);
+
+        consoleWarn.mockRestore();
     });
 
     test('rejects invalid save payloads without overwriting an existing chat', async () => {
@@ -137,8 +211,8 @@ describe('chat integrity rotation', () => {
     test('adopts returned integrity only for the active chat file', async () => {
         const scriptSource = await fs.readFile(fileURLToPath(new URL('../public/script.js', import.meta.url)), 'utf8');
 
-        expect(scriptSource).toContain('const activeChatName = characters[this_chid]?.chat;');
-        expect(scriptSource).toContain('const isActiveChatSave = fileName === activeChatName;');
+        expect(scriptSource).toContain('const currentActiveChatName = characters[this_chid]?.chat;');
+        expect(scriptSource).toContain('const isActiveChatSave = fileName === currentActiveChatName;');
         expect(scriptSource).toContain('if (isActiveChatSave && typeof responseData?.integrity === \'string\' && responseData.integrity)');
     });
 
@@ -147,8 +221,55 @@ describe('chat integrity rotation', () => {
 
         expect(scriptSource).toContain('let chatSaveQueue = Promise.resolve();');
         expect(scriptSource).toContain('export function saveChat(...saveChatArguments)');
-        expect(scriptSource).toContain('.then(() => saveChatImmediately(...saveChatArguments));');
+        expect(scriptSource).toContain('const metadataSnapshot = { ...chat_metadata, ...(options.withMetadata || {}) };');
+        expect(scriptSource).toContain('activeChatName: activeCharacter?.chat');
+        expect(scriptSource).toContain('characterName: activeCharacter?.name');
+        expect(scriptSource).toContain('avatarUrl: activeCharacter?.avatar');
+        expect(scriptSource).toContain('wasGroupChat: Boolean(selected_group)');
+        expect(scriptSource).toContain('setChatSaveActive(true);');
+        expect(scriptSource).toContain('.then(() => saveChatImmediately(...queuedSaveArguments))');
+        expect(scriptSource).toContain('.finally(() => setChatSaveActive(false));');
         expect(scriptSource).toContain('async function saveChatImmediately');
-        expect(scriptSource).toContain('return await saveChatImmediately({ chatName, withMetadata, mesId, force: true, chatData, throwOnError });');
+        expect(scriptSource).toContain('return await saveChatImmediately({ chatName, withMetadata, metadataSnapshot: metadata, mesId, force: true, chatData, throwOnError, activeChatName, characterName, avatarUrl, wasGroupChat });');
+    });
+
+    test('debounced chat saves abort after the active chat generation changes', async () => {
+        const guardSource = await fs.readFile(fileURLToPath(new URL('../public/scripts/chat-save-guard.js', import.meta.url)), 'utf8');
+        const scriptSource = await fs.readFile(fileURLToPath(new URL('../public/script.js', import.meta.url)), 'utf8');
+
+        expect(scriptSource).toContain('let chatGeneration = 0;');
+        expect(scriptSource).toContain('export function incrementChatGeneration()');
+        expect(scriptSource).toContain('const generation = chatGeneration;');
+        expect(scriptSource).toContain('scheduledGeneration: generation');
+        expect(scriptSource).toContain('currentGeneration: chatGeneration');
+        expect(guardSource).toContain('scheduledGeneration !== currentGeneration');
+    });
+
+    test('saveChatConditional delegates ordering to the save queues instead of dropping slow saves', async () => {
+        const scriptSource = await fs.readFile(fileURLToPath(new URL('../public/script.js', import.meta.url)), 'utf8');
+        const saveConditionalBody = scriptSource.slice(
+            scriptSource.indexOf('export async function saveChatConditional()'),
+            scriptSource.indexOf('export async function importCharacterChat', scriptSource.indexOf('export async function saveChatConditional()')),
+        );
+
+        expect(saveConditionalBody).not.toContain('waitUntilCondition(() => !isChatSaving');
+        expect(saveConditionalBody).toContain('await saveChat();');
+        expect(saveConditionalBody).toContain('await saveGroupChat(selected_group, true);');
+        expect(scriptSource).toContain('let chatSaveActivityCount = 0;');
+        expect(scriptSource).toContain('function setChatSaveActive(isActive)');
+        expect(scriptSource).toContain('isChatSaving = chatSaveActivityCount > 0;');
+    });
+
+    test('queues group chat saves and keeps forced overwrites inside the active queue task', async () => {
+        const groupChatSource = await fs.readFile(fileURLToPath(new URL('../public/scripts/group-chats.js', import.meta.url)), 'utf8');
+
+        expect(groupChatSource).toContain('let groupChatSaveQueue = Promise.resolve();');
+        expect(groupChatSource).toContain('function saveGroupChat(groupId, shouldSaveGroup, force = false, throwOnError = false)');
+        expect(groupChatSource).toContain('const chatSnapshot = chat.slice();');
+        expect(groupChatSource).toContain('const metadataSnapshot = { ...chat_metadata };');
+        expect(groupChatSource).toContain('.then(() => saveGroupChatImmediately({');
+        expect(groupChatSource).toContain('return await saveGroupChatImmediately({ groupId, shouldSaveGroup, force: true, throwOnError, chatId, chatData: chatMessages, metadata });');
+        expect(groupChatSource).toContain('const isActiveGroupChatSave = selected_group === groupId && group.chat_id === chatId;');
+        expect(groupChatSource).toContain('if (isActiveGroupChatSave && typeof responseData?.integrity === \'string\' && responseData.integrity)');
     });
 });

--- a/tests/chat-save-guard.test.js
+++ b/tests/chat-save-guard.test.js
@@ -45,4 +45,17 @@ describe('getDebouncedChatSaveAbortReason', () => {
             currentChatId: 'Chat B',
         })).toBe('chat');
     });
+
+    test('aborts when the active chat generation changes for the same chat file', () => {
+        expect(getDebouncedChatSaveAbortReason({
+            scheduledGroupId: null,
+            currentGroupId: null,
+            scheduledCharacterId: 1,
+            currentCharacterId: 1,
+            scheduledChatId: 'Chat A',
+            currentChatId: 'Chat A',
+            scheduledGeneration: 1,
+            currentGeneration: 2,
+        })).toBe('chat generation');
+    });
 });


### PR DESCRIPTION
## What?
Hardens chat saving against rapid prompt, agent, regex, and edit-triggered save races.

This follow-up to #368 captures solo-chat save snapshots when the save is requested, serializes group chat saves, aborts stale debounced saves after active chat replacement, and creates pre-write recovery backups before overwriting existing chat files.

## Why?
Rapid overlapping save triggers can otherwise write the wrong in-memory chat state, drop slow conditional saves, or leave little recovery material when a valid-but-wrong payload reaches the server.

## How?
Solo `saveChat()` now queues a captured chat, metadata, character, avatar, and file snapshot, and the exported save-active flag is counter-based so overlapping saves do not mark saving as complete early.

Debounced saves now carry a chat generation token that changes when the active chat is cleared or reloaded. Group chat saves use their own promise queue and captured chat metadata/message snapshots, with returned integrity applied only when the same group chat is still active.

Server-side `trySaveChat()` now keeps an unthrottled three-entry pre-write backup ring before each overwrite, preserves the forced-overwrite backup path, and logs drastic incoming chat shrinkage without blocking legitimate message deletion.

## Testing?
- `node node_modules/eslint/bin/eslint.js public/script.js public/scripts/chat-save-guard.js public/scripts/group-chats.js src/endpoints/chats.js tests/chat-integrity-rotation.test.js tests/chat-save-guard.test.js`
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.json chat-save-guard.test.js chat-integrity-rotation.test.js script-export-surface.test.js --runInBand`
- `npm run test:unit -- --runInBand`

## Screenshots (optional)
No UI changes.

## Anything Else?
This keeps the existing chat save HTTP contract and `.jsonl` format unchanged.