### PR TITLE
fix: restore iOS mobile main screen layout

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -820,6 +820,26 @@
 
 @supports (-webkit-touch-callout: none) {
     @media screen and (max-width: 768px) {
+        /* SillyBunny: iOS 17 WebKit can misresolve dvh for the main shell. */
+        body:not(.movingUI) #sheld {
+            --sb-sheld-ios-available-height: calc(100vh - var(--sb-topbar-layout-offset));
+            top: var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) !important;
+            height: calc(var(--sb-shell-available-height, var(--sb-sheld-ios-available-height)) - 1px) !important;
+            max-height: calc(var(--sb-shell-available-height, var(--sb-sheld-ios-available-height)) - 1px) !important;
+            min-height: 100px !important;
+            min-width: 0 !important;
+            width: 100vw !important;
+            max-width: 100vw !important;
+            left: 0 !important;
+            right: 0 !important;
+            box-sizing: border-box !important;
+        }
+
+        body:not(.movingUI) #chat {
+            flex: 1 1 auto !important;
+            min-height: 0 !important;
+        }
+
         #left-nav-panel.openDrawer,
         #user-settings-block.openDrawer,
         .sb-shell-root.openDrawer,


### PR DESCRIPTION
## Summary
- Add an iOS WebKit mobile shell guardrail so `#sheld` uses the shell's measured visual viewport height instead of relying on `dvh` resolution.
- Make `#chat` a shrinkable flex child on iOS mobile to prevent the main content area from collapsing or becoming blank.

## Testing
- `git diff --check`
- `bun run lint`
- Attempted a full-file CSS parse with `@adobe/css-tools`; the parser fails on an existing modern nested `calc(var(..., calc(...)))` expression near the end of the stylesheet, so this was treated as non-gating.

## Notes
- Not physically tested on an iOS 17.0.2 device.