### PR TITLE
fix(mobile): guard preset dropdown scroll taps

### DIFF
--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -2822,12 +2822,16 @@ input[type='range']::-moz-range-thumb {
     font-size: 0.86rem;
 }
 
-/* Mobile/touch: keep slider thumbs away from card edges and let vertical drags scroll. */
+/* Mobile/touch: keep dense controls scroll-friendly during vertical drags. */
 @media (pointer: coarse) {
     .sb-sampling-control-card input[type='range'].neo-range-slider {
         display: block;
         max-width: min(420px, calc(100% - 48px));
         margin-inline: auto;
+        touch-action: pan-y;
+    }
+
+    select[data-preset-manager-for] {
         touch-action: pan-y;
     }
 

--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -26,6 +26,12 @@ import { convertNovelPreset } from './nai-settings.js';
 import { getChatCompletionPreset, oai_settings, openai_setting_names, openai_settings } from './openai.js';
 import { POPUP_RESULT, POPUP_TYPE, Popup } from './popup.js';
 import { context_presets, getContextSettings, power_user } from './power-user.js';
+import {
+    createPresetSelectTouchGuardState,
+    resolvePresetSelectTouchGuardEnd,
+    resolvePresetSelectTouchGuardMove,
+    shouldSuppressPresetSelectTouchClick,
+} from './preset-select-touch-guard.js';
 import { reasoning_templates } from './reasoning.js';
 import { SlashCommand } from './slash-commands/SlashCommand.js';
 import { ARGUMENT_TYPE, SlashCommandArgument } from './slash-commands/SlashCommandArgument.js';
@@ -198,9 +204,16 @@ class PresetManager {
         this._snapshotTimer = null;
         this._isApplyingPresetChange = false;
         this._allowPresetSelectChange = false;
+        this._presetSelectTouchGuardState = null;
+        this._presetSelectTouchSuppressClick = false;
         this._textInputHandler = () => this._checkDirty();
         this._selectChangeHandler = (event) => this._handleSelectChange(event);
         this._capturePreviousSelectValueHandler = () => this._capturePreviousSelectValue();
+        this._presetSelectPointerDownHandler = (event) => this._handlePresetSelectPointerDown(event);
+        this._presetSelectPointerMoveHandler = (event) => this._handlePresetSelectPointerMove(event);
+        this._presetSelectPointerEndHandler = (event) => this._handlePresetSelectPointerEnd(event);
+        this._presetSelectPointerCancelHandler = (event) => this._handlePresetSelectPointerCancel(event);
+        this._presetSelectClickHandler = (event) => this._handlePresetSelectClick(event);
         // SillyBunny: snapshot and guard all connected text fields before preset
         // changes so unsaved changes in fork-specific drawers can still warn.
         this._bindDirtyGuard();
@@ -506,6 +519,75 @@ class PresetManager {
         selectElement.addEventListener('pointerdown', this._capturePreviousSelectValueHandler, true);
         selectElement.addEventListener('keydown', this._capturePreviousSelectValueHandler, true);
         selectElement.addEventListener('change', this._selectChangeHandler, true);
+        selectElement.addEventListener('pointerdown', this._presetSelectPointerDownHandler, true);
+        selectElement.addEventListener('pointermove', this._presetSelectPointerMoveHandler, true);
+        selectElement.addEventListener('pointerup', this._presetSelectPointerEndHandler, true);
+        selectElement.addEventListener('pointercancel', this._presetSelectPointerCancelHandler, true);
+        selectElement.addEventListener('click', this._presetSelectClickHandler, true);
+    }
+
+    _isMobilePresetSelectTouchGuardEnabled() {
+        return globalThis.SillyBunnyShell?.isMobileViewport?.()
+            ?? Boolean(globalThis.matchMedia?.('(max-width: 768px)')?.matches);
+    }
+
+    _handlePresetSelectPointerDown(event) {
+        this._presetSelectTouchSuppressClick = false;
+        this._presetSelectTouchGuardState = createPresetSelectTouchGuardState({
+            isMobileViewport: this._isMobilePresetSelectTouchGuardEnabled(),
+            pointerType: event.pointerType,
+            pointerId: event.pointerId,
+            clientX: event.clientX,
+            clientY: event.clientY,
+        });
+    }
+
+    _handlePresetSelectPointerMove(event) {
+        this._presetSelectTouchGuardState = resolvePresetSelectTouchGuardMove({
+            touchGuardState: this._presetSelectTouchGuardState,
+            pointerId: event.pointerId,
+            clientX: event.clientX,
+            clientY: event.clientY,
+        });
+    }
+
+    _handlePresetSelectPointerEnd(event) {
+        const touchGuardResult = resolvePresetSelectTouchGuardEnd({
+            touchGuardState: this._presetSelectTouchGuardState,
+            pointerId: event.pointerId,
+        });
+
+        this._presetSelectTouchGuardState = touchGuardResult.touchGuardState;
+        this._presetSelectTouchSuppressClick = touchGuardResult.shouldSuppressClick;
+
+        if (touchGuardResult.shouldSuppressClick) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+        }
+    }
+
+    _handlePresetSelectPointerCancel(event) {
+        const touchGuardResult = resolvePresetSelectTouchGuardEnd({
+            touchGuardState: this._presetSelectTouchGuardState,
+            pointerId: event.pointerId,
+            forceSuppress: true,
+        });
+
+        this._presetSelectTouchGuardState = touchGuardResult.touchGuardState;
+        this._presetSelectTouchSuppressClick = touchGuardResult.shouldSuppressClick;
+    }
+
+    _handlePresetSelectClick(event) {
+        if (!shouldSuppressPresetSelectTouchClick({
+            isMobileViewport: this._isMobilePresetSelectTouchGuardEnabled(),
+            suppressClick: this._presetSelectTouchSuppressClick,
+        })) {
+            return;
+        }
+
+        this._presetSelectTouchSuppressClick = false;
+        event.preventDefault();
+        event.stopImmediatePropagation();
     }
 
     _capturePreviousSelectValue() {

--- a/public/scripts/preset-select-touch-guard.js
+++ b/public/scripts/preset-select-touch-guard.js
@@ -1,0 +1,121 @@
+export const PRESET_SELECT_TOUCH_GUARD_DRAG_THRESHOLD_PX = 6;
+
+function normalizeNumber(value, fallback = 0) {
+    const numberValue = Number(value);
+    return Number.isFinite(numberValue) ? numberValue : fallback;
+}
+
+function normalizePointerId(pointerId) {
+    return pointerId === undefined ? null : pointerId;
+}
+
+function isGuardedPointerType(pointerType) {
+    return pointerType === 'touch' || pointerType === 'pen';
+}
+
+function isSamePointer(touchGuardState, pointerId) {
+    return touchGuardState?.pointerId === normalizePointerId(pointerId);
+}
+
+/**
+ * Creates touch guard state for mobile preset selects.
+ * @param {object} options Options.
+ * @param {boolean} [options.isMobileViewport=false] Whether mobile viewport behavior is active.
+ * @param {string} [options.pointerType=''] Pointer event type.
+ * @param {number|null} [options.pointerId=null] Pointer identifier.
+ * @param {number} [options.clientX=0] Pointer X coordinate.
+ * @param {number} [options.clientY=0] Pointer Y coordinate.
+ * @returns {{pointerId: number|null, startX: number, startY: number, dragging: boolean}|null}
+ */
+export function createPresetSelectTouchGuardState({
+    isMobileViewport = false,
+    pointerType = '',
+    pointerId = null,
+    clientX = 0,
+    clientY = 0,
+} = {}) {
+    if (!isMobileViewport || !isGuardedPointerType(pointerType)) {
+        return null;
+    }
+
+    return {
+        pointerId: normalizePointerId(pointerId),
+        startX: normalizeNumber(clientX),
+        startY: normalizeNumber(clientY),
+        dragging: false,
+    };
+}
+
+/**
+ * Updates preset select touch guard state after pointer movement.
+ * @param {object} options Options.
+ * @param {object|null} [options.touchGuardState=null] Existing touch guard state.
+ * @param {number|null} [options.pointerId=null] Pointer identifier.
+ * @param {number} [options.clientX=0] Pointer X coordinate.
+ * @param {number} [options.clientY=0] Pointer Y coordinate.
+ * @param {number} [options.thresholdPx=PRESET_SELECT_TOUCH_GUARD_DRAG_THRESHOLD_PX] Drag threshold.
+ * @returns {object|null} Updated touch guard state.
+ */
+export function resolvePresetSelectTouchGuardMove({
+    touchGuardState = null,
+    pointerId = null,
+    clientX = 0,
+    clientY = 0,
+    thresholdPx = PRESET_SELECT_TOUCH_GUARD_DRAG_THRESHOLD_PX,
+} = {}) {
+    if (!touchGuardState || !isSamePointer(touchGuardState, pointerId)) {
+        return touchGuardState;
+    }
+
+    const threshold = Math.max(0, normalizeNumber(thresholdPx, PRESET_SELECT_TOUCH_GUARD_DRAG_THRESHOLD_PX));
+    const deltaX = normalizeNumber(clientX) - normalizeNumber(touchGuardState.startX);
+    const deltaY = normalizeNumber(clientY) - normalizeNumber(touchGuardState.startY);
+    const dragging = Boolean(touchGuardState.dragging)
+        || Math.abs(deltaX) > threshold
+        || Math.abs(deltaY) > threshold;
+
+    return {
+        ...touchGuardState,
+        dragging,
+    };
+}
+
+/**
+ * Clears preset select touch guard state and reports whether the following click should be swallowed.
+ * @param {object} options Options.
+ * @param {object|null} [options.touchGuardState=null] Existing touch guard state.
+ * @param {number|null} [options.pointerId=null] Pointer identifier.
+ * @param {boolean} [options.forceSuppress=false] Whether to suppress even if movement was not observed.
+ * @returns {{touchGuardState: object|null, shouldSuppressClick: boolean}}
+ */
+export function resolvePresetSelectTouchGuardEnd({
+    touchGuardState = null,
+    pointerId = null,
+    forceSuppress = false,
+} = {}) {
+    if (!touchGuardState || !isSamePointer(touchGuardState, pointerId)) {
+        return {
+            touchGuardState,
+            shouldSuppressClick: false,
+        };
+    }
+
+    return {
+        touchGuardState: null,
+        shouldSuppressClick: Boolean(forceSuppress || touchGuardState.dragging),
+    };
+}
+
+/**
+ * Resolves whether a preset select click should be suppressed after a mobile drag.
+ * @param {object} options Options.
+ * @param {boolean} [options.isMobileViewport=false] Whether mobile viewport behavior is active.
+ * @param {boolean} [options.suppressClick=false] Pending click suppression flag.
+ * @returns {boolean}
+ */
+export function shouldSuppressPresetSelectTouchClick({
+    isMobileViewport = false,
+    suppressClick = false,
+} = {}) {
+    return Boolean(isMobileViewport && suppressClick);
+}

--- a/tests/preset-select-touch-guard.test.js
+++ b/tests/preset-select-touch-guard.test.js
@@ -1,0 +1,144 @@
+import { describe, expect, test } from '@jest/globals';
+
+import {
+    createPresetSelectTouchGuardState,
+    PRESET_SELECT_TOUCH_GUARD_DRAG_THRESHOLD_PX,
+    resolvePresetSelectTouchGuardEnd,
+    resolvePresetSelectTouchGuardMove,
+    shouldSuppressPresetSelectTouchClick,
+} from '../public/scripts/preset-select-touch-guard.js';
+
+describe('preset select touch guard helper', () => {
+    test('keeps the mobile drag threshold explicit', () => {
+        expect(PRESET_SELECT_TOUCH_GUARD_DRAG_THRESHOLD_PX).toBe(6);
+    });
+
+    test('captures state only for mobile touch or pen input', () => {
+        expect(createPresetSelectTouchGuardState({
+            isMobileViewport: true,
+            pointerType: 'touch',
+            pointerId: 7,
+            clientX: 20,
+            clientY: 40,
+        })).toEqual({
+            pointerId: 7,
+            startX: 20,
+            startY: 40,
+            dragging: false,
+        });
+
+        expect(createPresetSelectTouchGuardState({
+            isMobileViewport: true,
+            pointerType: 'pen',
+            pointerId: 8,
+            clientX: 10,
+            clientY: 12,
+        })).toEqual({
+            pointerId: 8,
+            startX: 10,
+            startY: 12,
+            dragging: false,
+        });
+
+        expect(createPresetSelectTouchGuardState({
+            isMobileViewport: false,
+            pointerType: 'touch',
+            pointerId: 7,
+            clientX: 20,
+            clientY: 40,
+        })).toBeNull();
+    });
+
+    test('does not guard mouse input', () => {
+        expect(createPresetSelectTouchGuardState({
+            isMobileViewport: true,
+            pointerType: 'mouse',
+            pointerId: 1,
+            clientX: 20,
+            clientY: 40,
+        })).toBeNull();
+    });
+
+    test('allows deliberate taps under the drag threshold', () => {
+        const touchGuardState = createPresetSelectTouchGuardState({
+            isMobileViewport: true,
+            pointerType: 'touch',
+            pointerId: 7,
+            clientX: 100,
+            clientY: 100,
+        });
+        const movedState = resolvePresetSelectTouchGuardMove({
+            touchGuardState,
+            pointerId: 7,
+            clientX: 104,
+            clientY: 105,
+        });
+
+        expect(movedState).toEqual({
+            ...touchGuardState,
+            dragging: false,
+        });
+        expect(resolvePresetSelectTouchGuardEnd({
+            touchGuardState: movedState,
+            pointerId: 7,
+        })).toEqual({
+            touchGuardState: null,
+            shouldSuppressClick: false,
+        });
+    });
+
+    test('suppresses the next mobile click after scroll movement', () => {
+        const touchGuardState = createPresetSelectTouchGuardState({
+            isMobileViewport: true,
+            pointerType: 'touch',
+            pointerId: 7,
+            clientX: 100,
+            clientY: 100,
+        });
+        const movedState = resolvePresetSelectTouchGuardMove({
+            touchGuardState,
+            pointerId: 7,
+            clientX: 100,
+            clientY: 108,
+        });
+
+        expect(movedState).toEqual({
+            ...touchGuardState,
+            dragging: true,
+        });
+        expect(resolvePresetSelectTouchGuardEnd({
+            touchGuardState: movedState,
+            pointerId: 7,
+        })).toEqual({
+            touchGuardState: null,
+            shouldSuppressClick: true,
+        });
+        expect(shouldSuppressPresetSelectTouchClick({
+            isMobileViewport: true,
+            suppressClick: true,
+        })).toBe(true);
+        expect(shouldSuppressPresetSelectTouchClick({
+            isMobileViewport: false,
+            suppressClick: true,
+        })).toBe(false);
+    });
+
+    test('suppresses the next click when mobile panning cancels the pointer stream', () => {
+        const touchGuardState = createPresetSelectTouchGuardState({
+            isMobileViewport: true,
+            pointerType: 'touch',
+            pointerId: 7,
+            clientX: 100,
+            clientY: 100,
+        });
+
+        expect(resolvePresetSelectTouchGuardEnd({
+            touchGuardState,
+            pointerId: 7,
+            forceSuppress: true,
+        })).toEqual({
+            touchGuardState: null,
+            shouldSuppressClick: true,
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add a mobile touch/pen guard to preset selects so scroll drags do not open the dropdown.
- Keep clean taps, keyboard, desktop/mouse, and programmatic preset changes unchanged.
- Add coarse-pointer `pan-y` CSS and focused helper coverage.

## Tests
- `npm run test:unit --prefix tests -- preset-select-touch-guard.test.js`
- `npm run test:unit --prefix tests`
- `./tests/node_modules/.bin/eslint tests/preset-select-touch-guard.test.js`
- `node --check public/scripts/preset-manager.js`
- `node --check public/scripts/preset-select-touch-guard.js`
- `npm run lint`
- `npm run check:frontend-budgets`
- `npm run build:frontend`