### PR TITLE
fix: reduce chat backup bloat

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -245,6 +245,7 @@ import { NOTE_MODULE_NAME, initAuthorsNote, metadata_keys, setFloatingPrompt, sh
 import { registerPromptManagerMigration } from './scripts/PromptManager.js';
 import { getRegexedString, regex_placement } from './scripts/extensions/regex/engine.js';
 import { AGENT_REGEX_PLACEMENT, applyRegexScriptList } from './scripts/extensions/in-chat-agents/regex-scripts.js';
+import { resolveRegexScriptsForSnapshot } from './scripts/extensions/in-chat-agents/regex-snapshot-store.js';
 import { initLogprobs, saveLogprobsForActiveMessage } from './scripts/logprobs.js';
 import { FILTER_STATES, FILTER_TYPES, FilterHelper, isFilterState } from './scripts/filters.js';
 import { getCfgPrompt, getGuidanceScale, initCfg } from './scripts/cfg-scale.js';
@@ -3546,9 +3547,7 @@ export function messageFormatting(mes, ch_name, isSystem, isUser, messageId, san
         const usableMessages = chat.map((x, index) => ({ message: x, index: index })).filter(x => !x.message.is_system);
         const indexOf = usableMessages.findIndex(x => x.index === resolvedMessageId);
         const depth = resolvedMessageId >= 0 && indexOf !== -1 ? (usableMessages.length - indexOf - 1) : undefined;
-        const agentRegexScripts = Array.isArray(chatMessage?.extra?.inChatAgents?.regexScripts)
-            ? chatMessage.extra.inChatAgents.regexScripts
-            : [];
+        const agentRegexScripts = resolveRegexScriptsForSnapshot(chatMessage?.extra?.inChatAgents);
 
         if (!isUser && !isReasoning && agentRegexScripts.length > 0) {
             mes = applyRegexScriptList(mes, agentRegexScripts, AGENT_REGEX_PLACEMENT.AI_OUTPUT, {

--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -52,6 +52,7 @@ import { getPathfinderToolDefinitions } from './pathfinder/tool-definitions.js';
 import { getContextualLorebooks } from './pathfinder/pathfinder-tool-bridge.js';
 import { PATHFINDER_RETRIEVAL_PROMPT_KEYS, runSidecarRetrieval } from './pathfinder/sidecar-retrieval.js';
 import { markAutoSummaryComplete, shouldAutoSummarize } from './pathfinder/auto-summary.js';
+import { buildRegexScriptRefsForAgent, cacheAgentRegexScripts } from './regex-snapshot-store.js';
 
 const PROMPT_KEY_PREFIX = 'inchat_agent_';
 const PATHFINDER_AUTO_SUMMARY_PROMPT_KEY = 'pathfinder_zz_auto_summary';
@@ -1785,9 +1786,13 @@ export function buildPromptDynamicMacros(messageText = '', message = null, agent
 
 function updateMessageRegexSnapshot(message, activeAgents, generationType) {
     message.extra ??= {};
-    const regexScripts = activeAgents.flatMap(agent => getAgentRegexScripts(agent));
+    const regexScriptRefs = activeAgents.flatMap(agent => {
+        const scripts = getAgentRegexScripts(agent);
+        cacheAgentRegexScripts(agent?.id, scripts);
+        return buildRegexScriptRefsForAgent(agent?.id, scripts);
+    });
 
-    if (regexScripts.length === 0) {
+    if (regexScriptRefs.length === 0) {
         if (hasAgentExtraValue(message, MESSAGE_EXTRA_KEY)) {
             deleteAgentExtraValue(message, MESSAGE_EXTRA_KEY);
             return true;
@@ -1800,7 +1805,7 @@ function updateMessageRegexSnapshot(message, activeAgents, generationType) {
     const nextSnapshot = {
         activeAgentIds: activeAgents.map(agent => agent.id),
         generationType: normalizeGenerationType(generationType),
-        regexScripts: structuredClone(regexScripts),
+        regexScriptRefs,
         edited: Boolean(previousSnapshot?.edited),
     };
 
@@ -1808,7 +1813,7 @@ function updateMessageRegexSnapshot(message, activeAgents, generationType) {
         ? {
             activeAgentIds: previousSnapshot.activeAgentIds,
             generationType: previousSnapshot.generationType,
-            regexScripts: previousSnapshot.regexScripts,
+            regexScriptRefs: previousSnapshot.regexScriptRefs,
             edited: Boolean(previousSnapshot.edited),
         }
         : null;

--- a/public/scripts/extensions/in-chat-agents/agent-store.js
+++ b/public/scripts/extensions/in-chat-agents/agent-store.js
@@ -6,6 +6,11 @@ import {
     AGENT_REGEX_SUBSTITUTE,
     normalizeRegexScript,
 } from './regex-scripts.js';
+import {
+    cacheAgentRegexScripts,
+    clearCachedAgentRegexScripts,
+    deleteCachedAgentRegexScripts,
+} from './regex-snapshot-store.js';
 
 /**
  * @typedef {object} AgentInjection
@@ -769,6 +774,17 @@ export function getAgentRegexScripts(rawAgent = {}) {
     return legacyScript ? [legacyScript] : [];
 }
 
+function cacheAgentRegexScriptsForAgent(agent) {
+    cacheAgentRegexScripts(agent?.id, getAgentRegexScripts(agent));
+}
+
+function refreshAgentRegexScriptCache() {
+    clearCachedAgentRegexScripts();
+    for (const agent of agents) {
+        cacheAgentRegexScriptsForAgent(agent);
+    }
+}
+
 /**
  * Creates a new agent with default values.
  * @returns {InChatAgent}
@@ -1040,6 +1056,7 @@ export function isToolAgent(agent) {
 export function loadAgents(data) {
     if (Array.isArray(data)) {
         agents = data.map(normalizeAgent);
+        refreshAgentRegexScriptCache();
     }
 }
 
@@ -1056,6 +1073,7 @@ export async function saveAgent(agent) {
     } else {
         agents.push(normalizedAgent);
     }
+    cacheAgentRegexScriptsForAgent(normalizedAgent);
 
     const response = await fetch('/api/in-chat-agents/save', {
         method: 'POST',
@@ -1074,6 +1092,7 @@ export async function saveAgent(agent) {
  */
 export async function deleteAgent(id) {
     agents = agents.filter(agent => agent.id !== id);
+    deleteCachedAgentRegexScripts(id);
     const scopedStateChanged = removeAgentIdFromScopedEnabledAgentIds(id);
 
     const response = await fetch('/api/in-chat-agents/delete', {

--- a/public/scripts/extensions/in-chat-agents/regex-snapshot-store.js
+++ b/public/scripts/extensions/in-chat-agents/regex-snapshot-store.js
@@ -1,0 +1,101 @@
+const regexScriptsByAgentId = new Map();
+
+const REGEX_SCRIPT_REVISION_FIELDS = [
+    'findRegex',
+    'replaceString',
+    'trimStrings',
+    'placement',
+    'disabled',
+    'markdownOnly',
+    'promptOnly',
+    'runOnEdit',
+    'substituteRegex',
+    'minDepth',
+    'maxDepth',
+];
+
+function cloneValue(value) {
+    if (value === undefined) {
+        return undefined;
+    }
+
+    return typeof structuredClone === 'function'
+        ? structuredClone(value)
+        : JSON.parse(JSON.stringify(value));
+}
+
+function hashString(value) {
+    let hash = 2166136261;
+    for (let index = 0; index < value.length; index++) {
+        hash ^= value.charCodeAt(index);
+        hash = Math.imul(hash, 16777619);
+    }
+
+    return `${value.length.toString(36)}-${(hash >>> 0).toString(36)}`;
+}
+
+function getRegexScriptRevisionPayload(script = {}) {
+    return REGEX_SCRIPT_REVISION_FIELDS.reduce((payload, field) => {
+        payload[field] = script?.[field] ?? null;
+        return payload;
+    }, {});
+}
+
+export function getRegexScriptRevision(script = {}) {
+    return hashString(JSON.stringify(getRegexScriptRevisionPayload(script)));
+}
+
+export function buildRegexScriptRefsForAgent(agentId, scripts = []) {
+    if (!agentId || !Array.isArray(scripts)) {
+        return [];
+    }
+
+    return scripts
+        .filter(script => script?.id)
+        .map(script => ({
+            agentId: String(agentId),
+            scriptId: String(script.id),
+            revision: getRegexScriptRevision(script),
+        }));
+}
+
+export function cacheAgentRegexScripts(agentId, scripts = []) {
+    if (!agentId) {
+        return;
+    }
+
+    regexScriptsByAgentId.set(String(agentId), Array.isArray(scripts) ? cloneValue(scripts) : []);
+}
+
+export function deleteCachedAgentRegexScripts(agentId) {
+    if (!agentId) {
+        return;
+    }
+
+    regexScriptsByAgentId.delete(String(agentId));
+}
+
+export function clearCachedAgentRegexScripts() {
+    regexScriptsByAgentId.clear();
+}
+
+export function resolveRegexScriptsForSnapshot(snapshot) {
+    if (!snapshot || typeof snapshot !== 'object') {
+        return [];
+    }
+
+    if (Array.isArray(snapshot.regexScriptRefs)) {
+        const resolvedScripts = [];
+        for (const ref of snapshot.regexScriptRefs) {
+            const cachedScripts = regexScriptsByAgentId.get(String(ref?.agentId ?? '')) ?? [];
+            const script = cachedScripts.find(item => String(item?.id ?? '') === String(ref?.scriptId ?? ''));
+            if (script) {
+                resolvedScripts.push(script);
+            }
+        }
+
+        return resolvedScripts;
+    }
+
+    return Array.isArray(snapshot.regexScripts) ? snapshot.regexScripts : [];
+}

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -35,6 +35,55 @@ const CHAT_FORCED_OVERWRITE_BACKUPS_PREFIX = 'chat_forced_overwrite_';
 const CHAT_PRE_WRITE_BACKUPS_PREFIX = 'chat_pre_write_';
 const PRE_WRITE_BACKUP_RING_SIZE = 3;
 
+function normalizeSerializedChatForBackupComparison(data) {
+    const serialized = String(data ?? '');
+    const lines = serialized.split('\n');
+
+    if (!lines[0]) {
+        return serialized;
+    }
+
+    try {
+        const header = JSON.parse(lines[0]);
+        if (!isPlainObject(header?.chat_metadata)) {
+            return serialized;
+        }
+
+        const chatMetadata = { ...header.chat_metadata };
+        delete chatMetadata.integrity;
+        lines[0] = JSON.stringify({ ...header, chat_metadata: chatMetadata });
+        return lines.join('\n');
+    } catch {
+        return serialized;
+    }
+}
+
+function getLatestBackupFilePath(directory, prefix) {
+    const backupFiles = fs.readdirSync(directory)
+        .filter(fileName => fileName.startsWith(prefix))
+        .map(fileName => ({
+            fileName,
+            filePath: path.join(directory, fileName),
+        }))
+        .sort((a, b) => {
+            const mtimeDifference = fs.statSync(b.filePath).mtimeMs - fs.statSync(a.filePath).mtimeMs;
+            return mtimeDifference || b.fileName.localeCompare(a.fileName);
+        });
+
+    return backupFiles[0]?.filePath ?? null;
+}
+
+function isDuplicateRegularChatBackup(directory, backupPrefix, data) {
+    const latestBackupFile = getLatestBackupFilePath(directory, backupPrefix);
+    if (!latestBackupFile) {
+        return false;
+    }
+
+    const latestBackupData = tryReadFileSync(latestBackupFile);
+    return Boolean(latestBackupData)
+        && normalizeSerializedChatForBackupComparison(latestBackupData) === normalizeSerializedChatForBackupComparison(data);
+}
+
 /**
  * Saves a chat to the backups directory.
  * @param {string} directory The user's backup directory.
@@ -48,14 +97,20 @@ function backupChat(directory, name, data, backupPrefix = CHAT_BACKUPS_PREFIX) {
         if (!isBackupEnabled) { return; }
         if (!fs.existsSync(directory)) {
             console.error(`The chat couldn't be backed up because no directory exists at ${directory}!`);
+            return;
         }
         // replace non-alphanumeric characters with underscores
         name = sanitize(name).replace(/[^a-z0-9]/gi, '_').toLowerCase();
+        const prefix = `${backupPrefix}${name}_`;
+
+        if (backupPrefix === CHAT_BACKUPS_PREFIX && isDuplicateRegularChatBackup(directory, prefix, data)) {
+            return;
+        }
 
         const backupFile = path.join(directory, `${backupPrefix}${name}_${generateTimestamp()}.jsonl`);
 
         tryWriteFileSync(backupFile, data);
-        removeOldBackups(directory, `${backupPrefix}${name}_`);
+        removeOldBackups(directory, prefix);
         if (isNaN(maxTotalChatBackups) || maxTotalChatBackups < 0) {
             return;
         }

--- a/tests/chat-integrity-rotation.test.js
+++ b/tests/chat-integrity-rotation.test.js
@@ -146,6 +146,41 @@ describe('chat integrity rotation', () => {
         await expect(fs.readFile(path.join(backupDir, preWriteBackup), 'utf8')).resolves.toBe(originalContent);
     });
 
+    test('skips duplicate post-save backups when only chat integrity changes', async () => {
+        const { trySaveChat } = await import('../src/endpoints/chats.js');
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-integrity-duplicate-backup-'));
+        const chatFile = path.join(tempDir, 'chat.jsonl');
+        const backupDir = path.join(tempDir, 'backups');
+        await fs.mkdir(backupDir);
+        jest.setSystemTime(new Date('2026-06-06T12:34:56.000Z'));
+
+        await fs.writeFile(chatFile, chatWithIntegrity('valid-integrity', 'same chat').map(JSON.stringify).join('\n'));
+        const firstResult = await trySaveChat(
+            chatWithIntegrity('valid-integrity', 'same chat'),
+            chatFile,
+            false,
+            'duplicate-backup-user',
+            'Test Card',
+            backupDir,
+        );
+        await trySaveChat(
+            chatWithIntegrity(firstResult.integrity, 'same chat'),
+            chatFile,
+            false,
+            'duplicate-backup-user',
+            'Test Card',
+            backupDir,
+        );
+        jest.runOnlyPendingTimers();
+
+        const backupFiles = await fs.readdir(backupDir);
+        const postSaveBackups = backupFiles.filter(fileName => fileName.startsWith('chat_test_card_'));
+        const preWriteBackups = backupFiles.filter(fileName => fileName.startsWith('chat_pre_write_test_card_'));
+
+        expect(postSaveBackups).toHaveLength(1);
+        expect(preWriteBackups).toHaveLength(2);
+    });
+
     test('keeps distinct pre-write backups for rapid overwrites in the same second', async () => {
         const { trySaveChat } = await import('../src/endpoints/chats.js');
         const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-integrity-prewrite-rapid-'));

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -494,6 +494,22 @@ describe('in-chat agent post-processing runner', () => {
         }];
     }
 
+    function expectCompactRegexSnapshot(snapshot, { generationType = 'normal', edited = false } = {}) {
+        expect(snapshot).toEqual({
+            activeAgentIds: ['agent-regex-only'],
+            generationType,
+            regexScriptRefs: [{
+                agentId: 'agent-regex-only',
+                scriptId: 'regex-script-1',
+                revision: expect.any(String),
+            }],
+            edited,
+        });
+        expect(snapshot.regexScripts).toBeUndefined();
+        expect(JSON.stringify(snapshot)).not.toContain(enabledAgents[0].regexScripts[0].findRegex);
+        expect(JSON.stringify(snapshot)).not.toContain(enabledAgents[0].regexScripts[0].replaceString);
+    }
+
     function useImpersonateTransformAgent({ runOnImpersonate = false } = {}) {
         enabledAgents = [{
             id: 'agent-impersonate-transform',
@@ -1349,12 +1365,7 @@ describe('in-chat agent post-processing runner', () => {
         await eventSource.emit(eventTypes.MESSAGE_RECEIVED, 0, 'normal');
 
         expect(chat[0].mes).toBe('[STATUS|ready]');
-        expect(chat[0].extra.inChatAgents).toEqual({
-            activeAgentIds: ['agent-regex-only'],
-            generationType: 'normal',
-            regexScripts: enabledAgents[0].regexScripts,
-            edited: false,
-        });
+        expectCompactRegexSnapshot(chat[0].extra.inChatAgents);
         expect(saveChatDebounced).toHaveBeenCalledTimes(1);
 
         await eventSource.emit(eventTypes.CHARACTER_MESSAGE_RENDERED, 0, 'normal');
@@ -1364,7 +1375,7 @@ describe('in-chat agent post-processing runner', () => {
         await eventSource.emit(eventTypes.GENERATION_ENDED, chat.length);
         await new Promise(resolve => setTimeout(resolve, 75));
 
-        expect(chat[0].extra.inChatAgents.regexScripts).toEqual(enabledAgents[0].regexScripts);
+        expectCompactRegexSnapshot(chat[0].extra.inChatAgents);
         expect(saveChatDebounced).toHaveBeenCalledTimes(1);
     });
 
@@ -1372,7 +1383,13 @@ describe('in-chat agent post-processing runner', () => {
         useRegexOnlyAgent();
 
         const { initAgentRunner, refreshRegexSnapshotsForAgent } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        const { buildRegexScriptRefsForAgent } = await import('../public/scripts/extensions/in-chat-agents/regex-snapshot-store.js');
         initAgentRunner();
+        const oldScript = {
+            ...enabledAgents[0].regexScripts[0],
+            replaceString: '<div class="status old">$1</div>',
+        };
+        const oldRevision = buildRegexScriptRefsForAgent('agent-regex-only', [oldScript])[0].revision;
 
         chat.push({
             name: 'Assistant',
@@ -1383,10 +1400,7 @@ describe('in-chat agent post-processing runner', () => {
                 inChatAgents: {
                     activeAgentIds: ['agent-regex-only'],
                     generationType: 'normal',
-                    regexScripts: [{
-                        ...enabledAgents[0].regexScripts[0],
-                        replaceString: '<div class="status old">$1</div>',
-                    }],
+                    regexScripts: [oldScript],
                     edited: false,
                 },
             },
@@ -1399,8 +1413,9 @@ describe('in-chat agent post-processing runner', () => {
 
         expect(refreshRegexSnapshotsForAgent('agent-regex-only')).toBe(1);
 
-        expect(chat[0].extra.inChatAgents.regexScripts[0].replaceString).toBe('<div class="status new">$1</div>');
-        expect(chat[0].swipe_info[0].extra.inChatAgents.regexScripts[0].replaceString).toBe('<div class="status new">$1</div>');
+        expectCompactRegexSnapshot(chat[0].extra.inChatAgents);
+        expectCompactRegexSnapshot(chat[0].swipe_info[0].extra.inChatAgents);
+        expect(chat[0].extra.inChatAgents.regexScriptRefs[0].revision).not.toBe(oldRevision);
         expect(saveChatDebounced).toHaveBeenCalledTimes(1);
 
         await new Promise(resolve => setTimeout(resolve, 5));
@@ -1424,12 +1439,7 @@ describe('in-chat agent post-processing runner', () => {
         const result = await runAgentOnMessage('agent-regex-only', 0);
 
         expect(result.status).toBe('skipped-empty-prompt');
-        expect(chat[0].extra.inChatAgents).toEqual({
-            activeAgentIds: ['agent-regex-only'],
-            generationType: 'normal',
-            regexScripts: enabledAgents[0].regexScripts,
-            edited: false,
-        });
+        expectCompactRegexSnapshot(chat[0].extra.inChatAgents);
         expect(saveChatDebounced).toHaveBeenCalled();
 
         await new Promise(resolve => setTimeout(resolve, 5));
@@ -1461,12 +1471,7 @@ describe('in-chat agent post-processing runner', () => {
 
         await eventSource.emit(eventTypes.STREAM_TOKEN_RECEIVED, '[STATUS|ready]');
 
-        expect(chat[0].extra.inChatAgents).toEqual({
-            activeAgentIds: ['agent-regex-only'],
-            generationType: 'normal',
-            regexScripts: enabledAgents[0].regexScripts,
-            edited: false,
-        });
+        expectCompactRegexSnapshot(chat[0].extra.inChatAgents);
         expect(saveChatDebounced).not.toHaveBeenCalled();
         await new Promise(resolve => setTimeout(resolve, 5));
         expect(saveChat).not.toHaveBeenCalled();
@@ -1965,14 +1970,15 @@ Helper context.`;
 
         await eventSource.emit(eventTypes.MESSAGE_RECEIVED, 0, 'normal');
 
-        expect(chat[0].swipe_info[0].extra.inChatAgents.regexScripts).toEqual(enabledAgents[0].regexScripts);
+        expect(chat[0].swipe_info[0].extra.inChatAgents.regexScriptRefs).toHaveLength(1);
+        expectCompactRegexSnapshot(chat[0].swipe_info[0].extra.inChatAgents);
 
         chat[0].extra = {};
         switchToSwipe(chat[0], 0);
 
-        expect(chat[0].extra.inChatAgents.regexScripts).toEqual(enabledAgents[0].regexScripts);
+        expectCompactRegexSnapshot(chat[0].extra.inChatAgents);
         await eventSource.emit(eventTypes.CHARACTER_MESSAGE_RENDERED, 0, 'normal');
-        expect(chat[0].extra.inChatAgents.regexScripts).toEqual(enabledAgents[0].regexScripts);
+        expectCompactRegexSnapshot(chat[0].extra.inChatAgents);
     });
 
     test('ignores impersonate post-processing without clearing existing regex metadata', async () => {

--- a/tests/in-chat-agents-store.test.js
+++ b/tests/in-chat-agents-store.test.js
@@ -100,6 +100,27 @@ describe('in-chat agent scoped enabled state', () => {
         expect(store.getGlobalSettings().helperPrefillMessages).toBe('');
     });
 
+    test('resolves compact regex snapshots from runtime cache', async () => {
+        const store = await importStore();
+        const snapshotStore = await import('../public/scripts/extensions/in-chat-agents/regex-snapshot-store.js');
+        const regexScript = {
+            id: 'script-1',
+            findRegex: '/foo/g',
+            replaceString: '<div>bar</div>',
+        };
+
+        store.loadAgents([{
+            id: 'agent-1',
+            name: 'Regex Agent',
+            regexScripts: [regexScript],
+        }]);
+
+        const refs = snapshotStore.buildRegexScriptRefsForAgent('agent-1', store.getAgentById('agent-1').regexScripts);
+        expect(snapshotStore.resolveRegexScriptsForSnapshot({ regexScriptRefs: refs })).toEqual(store.getAgentById('agent-1').regexScripts);
+        expect(JSON.stringify({ regexScriptRefs: refs })).not.toContain(regexScript.replaceString);
+        expect(snapshotStore.resolveRegexScriptsForSnapshot({ regexScripts: [regexScript] })).toEqual([regexScript]);
+    });
+
     test('recovers legacy enabled agents missing from initialized scoped settings', async () => {
         const store = await importStore();
         store.setGlobalSettings({


### PR DESCRIPTION
Closes #373

## Summary
- Store in-chat agent regex snapshots as compact refs/revisions and resolve scripts from the runtime agent cache, with legacy regexScripts fallback for existing chats.
- Stop duplicating full regex script bodies into active swipe metadata.
- Skip duplicate regular chat backups when only chat_metadata.integrity changed, while preserving pre-write and forced overwrite backups.

## Testing
- (cd tests && node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.json in-chat-agents-runner.test.js in-chat-agents-store.test.js chat-integrity-rotation.test.js)
- npx eslint "public/scripts/extensions/in-chat-agents/regex-snapshot-store.js" "public/scripts/extensions/in-chat-agents/agent-runner.js" "public/scripts/extensions/in-chat-agents/agent-store.js" "public/script.js" "src/endpoints/chats.js"
- (cd tests && npx eslint "in-chat-agents-runner.test.js" "in-chat-agents-store.test.js" "chat-integrity-rotation.test.js")