### PR TITLE
fix: clarify Windows ZIP update guidance

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -129,6 +129,8 @@ bash start-termux-node.sh
   
 ### How to Update
 
+Built-in and launcher updates require a Git checkout. ZIP/release folders do not self-update; download and extract the latest release ZIP instead.
+
 | What you want | Command |
 |---------------|---------|
 | Update from the running app | Open Customize > Server and use the built-in updater |

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ bash start-termux-node.sh
   
 ### How to Update
 
+Built-in and launcher updates require a Git checkout. ZIP/release folders do not self-update; download and extract the latest release ZIP instead.
+
 | What you want | Command |
 |---------------|---------|
 | Update from the running app | Open Customize > Server and use the built-in updater |

--- a/Start.bat
+++ b/Start.bat
@@ -51,6 +51,12 @@ if "%_need_git%"=="1" if "%_auto_update%"=="1" (
     if !errorlevel! neq 0 goto end
 )
 
+if "%_need_git%"=="0" if "%_auto_update%"=="1" (
+    echo [SillyBunny] Self-update skipped: this folder is not a Git checkout.
+    echo [SillyBunny] Download the latest release ZIP, or install with git clone to enable automatic updates.
+    echo.
+)
+
 set NODE_ENV=production
 set NODE_NO_WARNINGS=1
 set SILLYBUNNY_LAUNCHER=1

--- a/src/endpoints/server-admin.js
+++ b/src/endpoints/server-admin.js
@@ -14,6 +14,7 @@ import {
     getRemoteBranchesFromSummary,
     getStatusDisplayBranch,
     hasOnlyBunLockChange,
+    NON_GIT_REPOSITORY_MESSAGE,
     isRuntimeBranch,
     isGitRepository,
     resolveRemoteBranchName,
@@ -461,7 +462,7 @@ async function getRepositoryStatus() {
     const isRepo = await isGitRepository(git);
 
     if (!isRepo) {
-        status.message = 'This install is not running from a Git repository.';
+        status.message = NON_GIT_REPOSITORY_MESSAGE;
         return status;
     }
 
@@ -758,7 +759,7 @@ router.post('/update', requireAdminMiddleware, async (_request, response) => {
         }
 
         if (!repository.isRepo) {
-            return response.status(400).json({ error: repository.message || 'This install is not running from a Git repository.' });
+            return response.status(400).json({ error: repository.message || NON_GIT_REPOSITORY_MESSAGE });
         }
 
         if (!repository.trackingBranch) {
@@ -870,7 +871,7 @@ router.post('/branches', requireAdminMiddleware, async (_request, response) => {
         const isRepo = await isGitRepository(git);
 
         if (!isRepo) {
-            return response.status(400).json({ error: 'This install is not running from a Git repository.' });
+            return response.status(400).json({ error: NON_GIT_REPOSITORY_MESSAGE });
         }
 
         // Get current branch
@@ -911,7 +912,7 @@ router.post('/switch-branch', requireAdminMiddleware, async (request, response) 
         const isRepo = await isGitRepository(git);
 
         if (!isRepo) {
-            return response.status(400).json({ error: 'This install is not running from a Git repository.' });
+            return response.status(400).json({ error: NON_GIT_REPOSITORY_MESSAGE });
         }
 
         // Check for local changes

--- a/src/server-admin-git.js
+++ b/src/server-admin-git.js
@@ -2,6 +2,8 @@ const ORIGIN_REMOTE_PREFIX = 'origin/';
 const RUNTIME_BRANCH_PREFIX = 'runtime/';
 const BUN_LOCK_FILE = 'bun.lock';
 
+export const NON_GIT_REPOSITORY_MESSAGE = 'This install is not running from a Git repository. Built-in updates require a Git checkout; release ZIP installs need to download and extract the latest release.';
+
 function uniqueSorted(values) {
     return [...new Set(values)].sort((a, b) => a.localeCompare(b));
 }

--- a/tests/server-admin-git.test.js
+++ b/tests/server-admin-git.test.js
@@ -5,6 +5,7 @@ import {
     getRemoteBranchesFromSummary,
     getStatusDisplayBranch,
     hasOnlyBunLockChange,
+    NON_GIT_REPOSITORY_MESSAGE,
     isGitRepository,
     isRuntimeBranch,
     resolveRemoteBranchName,
@@ -62,5 +63,10 @@ describe('server admin git helpers', () => {
         expect(hasOnlyBunLockChange([{ path: 'bun.lock', index: ' ', working_dir: 'M' }])).toBe(true);
         expect(hasOnlyBunLockChange([{ path: 'bun.lock' }, { path: 'package.json' }])).toBe(false);
         expect(hasOnlyBunLockChange([{ path: 'package-lock.json' }])).toBe(false);
+    });
+
+    test('explains how non-Git installs update', () => {
+        expect(NON_GIT_REPOSITORY_MESSAGE).toContain('Git repository');
+        expect(NON_GIT_REPOSITORY_MESSAGE).toContain('release ZIP');
     });
 });


### PR DESCRIPTION
## Summary
- show a Windows Start.bat notice when self-update is skipped outside a Git checkout
- reuse an actionable non-Git update message in Server update/branch endpoints
- document that built-in and launcher updates require Git checkouts, while release ZIP installs need a fresh ZIP

## Tests
- npm run test:unit --prefix tests -- server-admin-git.test.js
- npm run lint
- npx eslint server-admin-git.test.js (from tests/)
- bash scripts/sync-readme-mirror.sh --check

Note: npm run lint --prefix tests still fails on existing unrelated style violations in core-message-transparency.test.js, mobile-shell-button-scale.test.js, openai-impersonate-defaults.test.js, and tool-call-recurse-limit-wiring.test.js.