### PR TITLE
fix: compact agent snapshots and defer interim backups

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,7 +12,7 @@ This update prepares SillyBunny 1.6.4 by refreshing the visible app version, Hor
 - Release documentation now has 1.6.4 README, changelog, GitHub mirror, and Discord-ready summary copy.
 
 ### Fixed
-- No targeted bug fixes were included in this release-readiness pass.
+- Older in-chat agent regex snapshots now compact on load when they can be safely resolved, and interim agent saves can defer regular chat backups until the final post-processed save.
 
 ### Added
 - A 1.6.4 Discord release post is available under `releases/` for announcement publishing.

--- a/public/script.js
+++ b/public/script.js
@@ -9976,7 +9976,7 @@ async function renamePastChats(oldAvatar, newAvatar, newName) {
     }
 }
 
-export function saveChatDebounced() {
+export function saveChatDebounced(options = {}) {
     const chid = this_chid;
     const selectedGroup = selected_group;
     const chatId = getCurrentChatId();
@@ -10005,7 +10005,7 @@ export function saveChatDebounced() {
         }
 
         console.debug('Chat save timeout triggered');
-        chatSavePromise = saveChatConditional();
+        chatSavePromise = saveChatConditional(options);
         try {
             await chatSavePromise;
             console.debug('Chat saved');
@@ -10087,6 +10087,7 @@ export async function flushPendingChatSaves() {
  * @param {boolean} [options.force] Force the saving despite the integrity check result
  * @param {ChatMessage[]} [options.chatData] Chat snapshot to save instead of the current in-memory chat
  * @param {boolean} [options.throwOnError] Rethrow save errors after notifying the user
+ * @param {boolean} [options.deferBackup] Save chat data without creating a regular chat backup yet
  *
  * @returns {Promise<boolean>}
  */
@@ -10130,7 +10131,7 @@ export function saveChat(...saveChatArguments) {
     return saveTask;
 }
 
-async function saveChatImmediately({ chatName, withMetadata, metadataSnapshot, mesId, force = false, chatData = undefined, throwOnError = false, activeChatName, characterName, avatarUrl, wasGroupChat = false } = {}) {
+async function saveChatImmediately({ chatName, withMetadata, metadataSnapshot, mesId, force = false, chatData = undefined, throwOnError = false, deferBackup = false, activeChatName, characterName, avatarUrl, wasGroupChat = false } = {}) {
     if (wasGroupChat || (selected_group && !activeChatName)) {
         toastr.error(t`Operation was aborted to prevent data corruption.`, t`saveChat called for a group chat`);
         throw new Error('saveChat called for a group chat');
@@ -10190,6 +10191,7 @@ async function saveChatImmediately({ chatName, withMetadata, metadataSnapshot, m
                 chat: [chatHeader, ...trimmedChat],
                 avatar_url: resolvedAvatarUrl,
                 force: force,
+                deferBackup: Boolean(deferBackup),
             }),
         });
         const result = await fetch('/api/chats/save', saveChatRequest);
@@ -10226,7 +10228,7 @@ async function saveChatImmediately({ chatName, withMetadata, metadataSnapshot, m
             return false;
         }
 
-        return await saveChatImmediately({ chatName, withMetadata, metadataSnapshot: metadata, mesId, force: true, chatData, throwOnError, activeChatName, characterName, avatarUrl, wasGroupChat });
+        return await saveChatImmediately({ chatName, withMetadata, metadataSnapshot: metadata, mesId, force: true, chatData, throwOnError, deferBackup, activeChatName, characterName, avatarUrl, wasGroupChat });
     } catch (error) {
         console.error(error);
         toastr.error(t`Check the server connection and reload the page to prevent data loss.`, t`Chat could not be saved`);
@@ -13897,16 +13899,16 @@ export async function saveMetadata() {
     return await saveChatConditional();
 }
 
-export async function saveChatConditional() {
+export async function saveChatConditional(options = {}) {
     try {
         cancelDebouncedChatSave();
 
         setChatSaveActive(true);
 
         if (selected_group) {
-            await saveGroupChat(selected_group, true);
+            await saveGroupChat(selected_group, true, false, false, options);
         } else {
-            await saveChat();
+            await saveChat(options);
         }
 
         // Save token and prompts cache to IndexedDB storage

--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -52,7 +52,7 @@ import { getPathfinderToolDefinitions } from './pathfinder/tool-definitions.js';
 import { getContextualLorebooks } from './pathfinder/pathfinder-tool-bridge.js';
 import { PATHFINDER_RETRIEVAL_PROMPT_KEYS, runSidecarRetrieval } from './pathfinder/sidecar-retrieval.js';
 import { markAutoSummaryComplete, shouldAutoSummarize } from './pathfinder/auto-summary.js';
-import { buildRegexScriptRefsForAgent, cacheAgentRegexScripts } from './regex-snapshot-store.js';
+import { buildRegexScriptRefsForAgent, cacheAgentRegexScripts, migrateLegacyRegexSnapshotsInMessages } from './regex-snapshot-store.js';
 
 const PROMPT_KEY_PREFIX = 'inchat_agent_';
 const PATHFINDER_AUTO_SUMMARY_PROMPT_KEY = 'pathfinder_zz_auto_summary';
@@ -67,6 +67,7 @@ const MAX_PATHFINDER_RETRIEVAL_CACHE = 6;
 const PATHFINDER_RETRIEVAL_CONTEXT_MESSAGE_LIMIT = 10;
 const pendingRefreshTimeouts = new Map();
 const pendingRegexSnapshotSaves = new WeakSet();
+const migratedLegacyRegexSnapshotChatIds = new Set();
 const GREETING_GENERATION_TYPE = 'first_message';
 const IMPERSONATE_GENERATION_TYPE = 'impersonate';
 const PREPEND_PROMPT_TRANSFORM_TEMPLATE_IDS = new Set([
@@ -125,6 +126,35 @@ let swipeNavigationPending = false;
 const activePathfinderRetrievalAbortControllers = new Set();
 let activePathfinderRetrievalToast = null;
 let activeInitialGenerationToast = null;
+
+function shouldDeferAgentRegularBackup() {
+    return Boolean(isGenerationInProgress || internalPromptTransformDepth > 0 || isMainGenerationStillActive());
+}
+
+function saveChatDebouncedForAgent({ deferBackup = shouldDeferAgentRegularBackup() } = {}) {
+    saveChatDebounced({ deferBackup: Boolean(deferBackup) });
+}
+
+async function saveChatForAgent(context, { deferBackup = shouldDeferAgentRegularBackup() } = {}) {
+    if (typeof context?.saveChat !== 'function') {
+        return;
+    }
+
+    await context.saveChat({ deferBackup: Boolean(deferBackup) });
+}
+
+function migrateLegacyRegexSnapshotsForCurrentChat(chatId = getCurrentChatId()) {
+    const migrationKey = String(chatId ?? '');
+    if (!migrationKey || migratedLegacyRegexSnapshotChatIds.has(migrationKey) || chat.length === 0) {
+        return;
+    }
+
+    migratedLegacyRegexSnapshotChatIds.add(migrationKey);
+    const migrated = migrateLegacyRegexSnapshotsInMessages(chat, MESSAGE_EXTRA_KEY);
+    if (migrated > 0) {
+        saveChatDebounced();
+    }
+}
 
 /** Track which tool names were registered by the agent system so we can cleanly unregister only our own. */
 const agentRegisteredToolNames = new Set();
@@ -1176,7 +1206,7 @@ function storePathfinderRetrievalCache(message, signature) {
     caches.push(cacheEntry);
 
     setAgentExtraValue(message, PATHFINDER_RETRIEVAL_CACHE_EXTRA_KEY, caches.slice(-MAX_PATHFINDER_RETRIEVAL_CACHE));
-    saveChatDebounced();
+    saveChatDebouncedForAgent();
 }
 
 function hasProcessedPostProcessingRun(message, runKey, messageIndex = null, indexRunKey = '') {
@@ -1850,7 +1880,7 @@ function ensureMessageRegexSnapshot(messageIndex, generationType, activationSnap
     if (!updateMessageRegexSnapshot(message, activeAgents, generationType)) {
         if (save && pendingRegexSnapshotSaves.has(message)) {
             pendingRegexSnapshotSaves.delete(message);
-            saveChatDebounced();
+            saveChatDebouncedForAgent();
         }
 
         return false;
@@ -1858,13 +1888,13 @@ function ensureMessageRegexSnapshot(messageIndex, generationType, activationSnap
 
     if (save) {
         pendingRegexSnapshotSaves.delete(message);
-        saveChatDebounced();
+        saveChatDebouncedForAgent();
     } else {
         pendingRegexSnapshotSaves.add(message);
     }
 
     if (refresh) {
-        scheduleMessageRefresh(numericMessageIndex, message);
+        scheduleMessageRefresh(numericMessageIndex, message, { deferBackup: shouldDeferAgentRegularBackup() });
     }
 
     return true;
@@ -1946,13 +1976,13 @@ function refreshRegexSnapshotForAgentOnMessage(agentId, messageIndex, options = 
 
     if (save) {
         pendingRegexSnapshotSaves.delete(message);
-        saveChatDebounced();
+        saveChatDebouncedForAgent();
     } else if (markPendingSave) {
         pendingRegexSnapshotSaves.add(message);
     }
 
     if (refresh) {
-        scheduleMessageRefresh(numericMessageIndex, message);
+        scheduleMessageRefresh(numericMessageIndex, message, { deferBackup: shouldDeferAgentRegularBackup() });
     }
 
     return true;
@@ -1971,7 +2001,7 @@ export function refreshRegexSnapshotsForAgent(agentId, { generationType = 'norma
     }
 
     if (refreshed > 0) {
-        saveChatDebounced();
+        saveChatDebouncedForAgent();
     }
 
     return refreshed;
@@ -3140,7 +3170,7 @@ async function runPromptTransformAppendBatch(agents, message, generationType, me
     };
 }
 
-async function refreshMessageAfterMutation(messageIndex, message) {
+async function refreshMessageAfterMutation(messageIndex, message, { deferBackup = false } = {}) {
     const context = getContext();
     const messageElement = document.querySelector(`.mes[mesid="${messageIndex}"]`);
 
@@ -3154,9 +3184,7 @@ async function refreshMessageAfterMutation(messageIndex, message) {
         return;
     }
 
-    if (typeof context?.saveChat === 'function') {
-        await context.saveChat();
-    }
+    await saveChatForAgent(context, { deferBackup });
 
     if (typeof context?.reloadCurrentChat === 'function') {
         await context.reloadCurrentChat();
@@ -3173,7 +3201,7 @@ async function refreshMessageAfterMutation(messageIndex, message) {
     }
 }
 
-function scheduleMessageRefresh(messageIndex, expectedMessage) {
+function scheduleMessageRefresh(messageIndex, expectedMessage, { deferBackup = false } = {}) {
     const existingTimeout = pendingRefreshTimeouts.get(messageIndex);
     if (existingTimeout) {
         clearTimeout(existingTimeout);
@@ -3187,7 +3215,7 @@ function scheduleMessageRefresh(messageIndex, expectedMessage) {
             return;
         }
 
-        await refreshMessageAfterMutation(messageIndex, liveMessage);
+        await refreshMessageAfterMutation(messageIndex, liveMessage, { deferBackup });
     }, 0);
 
     pendingRefreshTimeouts.set(messageIndex, timeoutId);
@@ -3631,11 +3659,11 @@ async function processReceivedMessage(messageIndex, generationType, activationSn
 
         if (chatStateChanged) {
             syncAssistantMessageStateToSwipe(message, messageIndex);
-            saveChatDebounced();
+            saveChatDebouncedForAgent({ deferBackup: false });
         }
 
         if (messageDisplayChanged) {
-            scheduleMessageRefresh(messageIndex, message);
+            scheduleMessageRefresh(messageIndex, message, { deferBackup: true });
         }
     } finally {
         postProcessingInFlightKeys.delete(inFlightKey);
@@ -3763,7 +3791,7 @@ function onMessageEdited(messageIndex) {
 
     snapshot.edited = true;
     setAgentExtraValue(message, MESSAGE_EXTRA_KEY, snapshot);
-    saveChatDebounced();
+    saveChatDebouncedForAgent();
 }
 
 async function runPromptTransformAgentsForText(promptTransformAgents, initialText, generationType) {
@@ -4445,7 +4473,7 @@ export async function undoPromptTransform(messageIndex) {
     const lastEntry = history[history.length - 1];
     message.mes = lastEntry.beforeText;
     await syncPromptTransformMessageStateAsync(message, messageIndex);
-    saveChatDebounced();
+    saveChatDebouncedForAgent();
     scheduleMessageRefresh(messageIndex, message);
     return true;
 }
@@ -4465,7 +4493,7 @@ export async function redoPromptTransform(messageIndex) {
     const lastEntry = history[history.length - 1];
     message.mes = lastEntry.afterText;
     await syncPromptTransformMessageStateAsync(message, messageIndex);
-    saveChatDebounced();
+    saveChatDebouncedForAgent();
     scheduleMessageRefresh(messageIndex, message);
     return true;
 }
@@ -4533,12 +4561,15 @@ export function initAgentRunner() {
     }
 
     if (event_types.CHAT_CHANGED) {
+        eventSource.on(event_types.CHAT_CHANGED, migrateLegacyRegexSnapshotsForCurrentChat);
         eventSource.on(event_types.CHAT_CHANGED, onChatChangedToolSync);
     }
 
     if (event_types.WORLDINFO_UPDATED) {
         eventSource.on(event_types.WORLDINFO_UPDATED, onWorldInfoUpdatedToolSync);
     }
+
+    migrateLegacyRegexSnapshotsForCurrentChat();
 }
 
 async function executeManualAgentRun(agentId, messageIndex, cancelRevision = agentGenerationCancelRevision) {
@@ -4577,13 +4608,13 @@ async function executeManualAgentRun(agentId, messageIndex, cancelRevision = age
 
     const promptTransformRunsChanged = updatePromptTransformRuns(message, [result]);
     if (regexSnapshotChanged || promptTransformRunsChanged) {
-        saveChatDebounced();
+        saveChatDebouncedForAgent();
     }
 
     const historyChanged = updatePromptTransformHistory(message, result);
     if (historyChanged) {
         syncAssistantMessageStateToSwipe(message, messageIndex);
-        saveChatDebounced();
+        saveChatDebouncedForAgent();
     }
 
     if (result.changed || regexSnapshotChanged) {

--- a/public/scripts/extensions/in-chat-agents/regex-snapshot-store.js
+++ b/public/scripts/extensions/in-chat-agents/regex-snapshot-store.js
@@ -59,6 +59,97 @@ export function buildRegexScriptRefsForAgent(agentId, scripts = []) {
         }));
 }
 
+function getCachedRegexScript(agentId, scriptId) {
+    const cachedScripts = regexScriptsByAgentId.get(String(agentId ?? '')) ?? [];
+    return cachedScripts.find(item => String(item?.id ?? '') === String(scriptId ?? '')) ?? null;
+}
+
+function buildResolvedLegacyRegexScriptRef(activeAgentIds, legacyScript) {
+    if (!legacyScript?.id || !Array.isArray(activeAgentIds)) {
+        return null;
+    }
+
+    const legacyRevision = getRegexScriptRevision(legacyScript);
+    const matchingRefs = [];
+    for (const agentId of activeAgentIds) {
+        const cachedScript = getCachedRegexScript(agentId, legacyScript.id);
+        if (!cachedScript || getRegexScriptRevision(cachedScript) !== legacyRevision) {
+            continue;
+        }
+
+        matchingRefs.push({
+            agentId: String(agentId),
+            scriptId: String(legacyScript.id),
+            revision: legacyRevision,
+        });
+    }
+
+    return matchingRefs.length === 1 ? matchingRefs[0] : null;
+}
+
+export function migrateLegacyRegexSnapshot(snapshot) {
+    if (!snapshot || typeof snapshot !== 'object' || Array.isArray(snapshot.regexScriptRefs) || !Array.isArray(snapshot.regexScripts)) {
+        return { changed: false, snapshot };
+    }
+
+    if (snapshot.regexScripts.length === 0) {
+        return { changed: false, snapshot };
+    }
+
+    const regexScriptRefs = [];
+    for (const legacyScript of snapshot.regexScripts) {
+        const ref = buildResolvedLegacyRegexScriptRef(snapshot.activeAgentIds, legacyScript);
+        if (!ref) {
+            return { changed: false, snapshot };
+        }
+
+        regexScriptRefs.push(ref);
+    }
+
+    const nextSnapshot = { ...snapshot, regexScriptRefs };
+    delete nextSnapshot.regexScripts;
+    return { changed: true, snapshot: nextSnapshot };
+}
+
+function migrateLegacyRegexSnapshotInExtra(extra, extraKey) {
+    if (!extra || typeof extra !== 'object' || !Object.hasOwn(extra, extraKey)) {
+        return false;
+    }
+
+    const migration = migrateLegacyRegexSnapshot(extra[extraKey]);
+    if (!migration.changed) {
+        return false;
+    }
+
+    extra[extraKey] = migration.snapshot;
+    return true;
+}
+
+export function migrateLegacyRegexSnapshotsInMessages(messages = [], extraKey = 'inChatAgents') {
+    if (!Array.isArray(messages)) {
+        return 0;
+    }
+
+    let migrated = 0;
+    for (const message of messages) {
+        if (migrateLegacyRegexSnapshotInExtra(message?.extra, extraKey)) {
+            migrated++;
+        }
+
+        if (!Array.isArray(message?.swipe_info)) {
+            continue;
+        }
+
+        for (const swipeInfo of message.swipe_info) {
+            if (migrateLegacyRegexSnapshotInExtra(swipeInfo?.extra, extraKey)) {
+                migrated++;
+            }
+        }
+    }
+
+    return migrated;
+}
+
 export function cacheAgentRegexScripts(agentId, scripts = []) {
     if (!agentId) {
         return;

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -1585,9 +1585,11 @@ function rememberQueuedGroupChatIntegrity(chatId, integrity) {
  * @param {boolean} shouldSaveGroup Whether to save the group after saving the chat
  * @param {boolean} force Force the saving on integrity error
  * @param {boolean} throwOnError Rethrow save errors after notifying the user
+ * @param {object} [options] Additional save options
+ * @param {boolean} [options.deferBackup] Save chat data without creating a regular chat backup yet
  * @returns {Promise<boolean>} A promise that resolves when the group chat has been saved.
  */
-function saveGroupChat(groupId, shouldSaveGroup, force = false, throwOnError = false) {
+function saveGroupChat(groupId, shouldSaveGroup, force = false, throwOnError = false, options = {}) {
     const group = groups.find(x => x.id == groupId);
     if (!group) {
         console.warn('Group not found', groupId);
@@ -1607,13 +1609,14 @@ function saveGroupChat(groupId, shouldSaveGroup, force = false, throwOnError = f
             chatId: chatIdSnapshot,
             chatData: chatSnapshot,
             metadata: metadataSnapshot,
+            deferBackup: Boolean(options.deferBackup),
         }));
 
     groupChatSaveQueue = saveTask.catch(() => {});
     return saveTask;
 }
 
-async function saveGroupChatImmediately({ groupId, shouldSaveGroup, force = false, throwOnError = false, chatId, chatData, metadata }) {
+async function saveGroupChatImmediately({ groupId, shouldSaveGroup, force = false, throwOnError = false, chatId, chatData, metadata, deferBackup = false }) {
     const group = groups.find(x => x.id == groupId);
     if (!group) {
         console.warn('Group not found', groupId);
@@ -1638,7 +1641,7 @@ async function saveGroupChatImmediately({ groupId, shouldSaveGroup, force = fals
     const saveGroupChatRequest = await compressRequest({
         method: 'POST',
         headers: getRequestHeaders(),
-        body: JSON.stringify({ id: chatId, chat: [chatHeader, ...chatMessages], force: force }),
+        body: JSON.stringify({ id: chatId, chat: [chatHeader, ...chatMessages], force: force, deferBackup: Boolean(deferBackup) }),
     });
     const response = await fetch('/api/chats/group/save', saveGroupChatRequest);
 
@@ -1670,7 +1673,7 @@ async function saveGroupChatImmediately({ groupId, shouldSaveGroup, force = fals
             return false;
         }
 
-        return await saveGroupChatImmediately({ groupId, shouldSaveGroup, force: true, throwOnError, chatId, chatData: chatMessages, metadata: metadataForSave });
+        return await saveGroupChatImmediately({ groupId, shouldSaveGroup, force: true, throwOnError, chatId, chatData: chatMessages, metadata: metadataForSave, deferBackup });
     }
 
     const responseData = await response.json().catch(() => ({}));

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -597,8 +597,10 @@ function isValidChatSavePayload(chatData) {
  * @param {string} handle The users handle, passed to getBackupFunction.
  * @param {string} cardName Passed to backupChat.
  * @param {string} backupDirectory Passed to backupChat.
+ * @param {object} [options] Additional save options.
+ * @param {boolean} [options.deferBackup] Skip the regular chat backup for this save.
  */
-export async function trySaveChat(chatData, filePath, skipIntegrityCheck = false, handle, cardName, backupDirectory) {
+export async function trySaveChat(chatData, filePath, skipIntegrityCheck = false, handle, cardName, backupDirectory, { deferBackup = false } = {}) {
     if (!isValidChatSavePayload(chatData)) {
         throw new InvalidChatDataError('Invalid chat save payload. Expected a non-empty chat array with a metadata header.');
     }
@@ -634,7 +636,9 @@ export async function trySaveChat(chatData, filePath, skipIntegrityCheck = false
     }
 
     tryWriteFileSync(filePath, jsonlData);
-    getBackupFunction(handle)(backupDirectory, cardName, jsonlData);
+    if (!deferBackup) {
+        getBackupFunction(handle)(backupDirectory, cardName, jsonlData);
+    }
     return { integrity: nextIntegrity };
 }
 
@@ -650,7 +654,7 @@ router.post('/save', validateAvatarUrlMiddleware, async function (request, respo
         }
 
         if (Array.isArray(chatData)) {
-            const saveResult = await trySaveChat(chatData, chatFilePath, request.body.force, handle, cardName, request.user.directories.backups);
+            const saveResult = await trySaveChat(chatData, chatFilePath, request.body.force, handle, cardName, request.user.directories.backups, { deferBackup: request.body.deferBackup === true });
             return response.send({ ok: true, integrity: saveResult.integrity });
         } else {
             return response.status(400).send({ error: 'The request\'s body.chat is not an array.' });
@@ -1035,7 +1039,7 @@ router.post('/group/save', async function (request, response) {
         const chatData = request.body.chat;
 
         if (Array.isArray(chatData)) {
-            const saveResult = await trySaveChat(chatData, chatFilePath, request.body.force, handle, String(id), request.user.directories.backups);
+            const saveResult = await trySaveChat(chatData, chatFilePath, request.body.force, handle, String(id), request.user.directories.backups, { deferBackup: request.body.deferBackup === true });
             return response.send({ ok: true, integrity: saveResult.integrity });
         } else {
             return response.status(400).send({ error: 'The request\'s body.chat is not an array.' });

--- a/tests/chat-integrity-rotation.test.js
+++ b/tests/chat-integrity-rotation.test.js
@@ -181,6 +181,53 @@ describe('chat integrity rotation', () => {
         expect(preWriteBackups).toHaveLength(2);
     });
 
+    test('defers regular chat backups until a final non-deferred save', async () => {
+        const { trySaveChat } = await import('../src/endpoints/chats.js');
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-integrity-defer-backup-'));
+        const chatFile = path.join(tempDir, 'chat.jsonl');
+        const backupDir = path.join(tempDir, 'backups');
+        await fs.mkdir(backupDir);
+        jest.setSystemTime(new Date('2026-06-06T12:34:56.000Z'));
+
+        await fs.writeFile(chatFile, chatWithIntegrity('valid-integrity', 'original disk chat').map(JSON.stringify).join('\n'));
+        const firstResult = await trySaveChat(
+            chatWithIntegrity('valid-integrity', 'agent pass one'),
+            chatFile,
+            false,
+            'deferred-backup-user',
+            'Test Card',
+            backupDir,
+            { deferBackup: true },
+        );
+        const secondResult = await trySaveChat(
+            chatWithIntegrity(firstResult.integrity, 'agent pass two'),
+            chatFile,
+            false,
+            'deferred-backup-user',
+            'Test Card',
+            backupDir,
+            { deferBackup: true },
+        );
+        const finalResult = await trySaveChat(
+            chatWithIntegrity(secondResult.integrity, 'final post-processed chat'),
+            chatFile,
+            false,
+            'deferred-backup-user',
+            'Test Card',
+            backupDir,
+        );
+        expect(finalResult?.integrity).toEqual(expect.any(String));
+        jest.runOnlyPendingTimers();
+
+        const backupFiles = await fs.readdir(backupDir);
+        const postSaveBackups = backupFiles.filter(fileName => fileName.startsWith('chat_test_card_'));
+        const preWriteBackups = backupFiles.filter(fileName => fileName.startsWith('chat_pre_write_test_card_'));
+
+        expect(postSaveBackups).toHaveLength(1);
+        expect(preWriteBackups).toHaveLength(3);
+        await expect(fs.readFile(path.join(backupDir, postSaveBackups[0]), 'utf8')).resolves.toContain('final post-processed chat');
+    });
+
     test('keeps distinct pre-write backups for rapid overwrites in the same second', async () => {
         const { trySaveChat } = await import('../src/endpoints/chats.js');
         const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-integrity-prewrite-rapid-'));
@@ -309,7 +356,8 @@ describe('chat integrity rotation', () => {
         expect(scriptSource).toContain('async function saveChatImmediately');
         expect(scriptSource).toContain('applyQueuedChatIntegrity(metadata, integrityKey, isActiveChatSave);');
         expect(scriptSource).toContain('rememberQueuedChatIntegrity(integrityKey, responseData?.integrity);');
-        expect(scriptSource).toContain('return await saveChatImmediately({ chatName, withMetadata, metadataSnapshot: metadata, mesId, force: true, chatData, throwOnError, activeChatName, characterName, avatarUrl, wasGroupChat });');
+        expect(scriptSource).toContain('deferBackup: Boolean(deferBackup)');
+        expect(scriptSource).toContain('return await saveChatImmediately({ chatName, withMetadata, metadataSnapshot: metadata, mesId, force: true, chatData, throwOnError, deferBackup, activeChatName, characterName, avatarUrl, wasGroupChat });');
     });
 
     test('debounced chat saves abort after the active chat generation changes', async () => {
@@ -327,13 +375,13 @@ describe('chat integrity rotation', () => {
     test('saveChatConditional delegates ordering to the save queues instead of dropping slow saves', async () => {
         const scriptSource = await fs.readFile(fileURLToPath(new URL('../public/script.js', import.meta.url)), 'utf8');
         const saveConditionalBody = scriptSource.slice(
-            scriptSource.indexOf('export async function saveChatConditional()'),
-            scriptSource.indexOf('export async function importCharacterChat', scriptSource.indexOf('export async function saveChatConditional()')),
+            scriptSource.indexOf('export async function saveChatConditional(options = {})'),
+            scriptSource.indexOf('export async function importCharacterChat', scriptSource.indexOf('export async function saveChatConditional(options = {})')),
         );
 
         expect(saveConditionalBody).not.toContain('waitUntilCondition(() => !isChatSaving');
-        expect(saveConditionalBody).toContain('await saveChat();');
-        expect(saveConditionalBody).toContain('await saveGroupChat(selected_group, true);');
+        expect(saveConditionalBody).toContain('await saveChat(options);');
+        expect(saveConditionalBody).toContain('await saveGroupChat(selected_group, true, false, false, options);');
         expect(scriptSource).toContain('let chatSaveActivityCount = 0;');
         expect(scriptSource).toContain('function setChatSaveActive(isActive)');
         expect(scriptSource).toContain('isChatSaving = chatSaveActivityCount > 0;');
@@ -343,13 +391,14 @@ describe('chat integrity rotation', () => {
         const groupChatSource = await fs.readFile(fileURLToPath(new URL('../public/scripts/group-chats.js', import.meta.url)), 'utf8');
 
         expect(groupChatSource).toContain('let groupChatSaveQueue = Promise.resolve();');
-        expect(groupChatSource).toContain('function saveGroupChat(groupId, shouldSaveGroup, force = false, throwOnError = false)');
+        expect(groupChatSource).toContain('function saveGroupChat(groupId, shouldSaveGroup, force = false, throwOnError = false, options = {})');
         expect(groupChatSource).toContain('const chatSnapshot = cloneGroupChatSavePayload(chat);');
         expect(groupChatSource).toContain('const metadataSnapshot = structuredClone(chat_metadata);');
         expect(groupChatSource).toContain('.then(() => saveGroupChatImmediately({');
         expect(groupChatSource).toContain('applyQueuedGroupChatIntegrity(metadataForSave, chatId, isActiveGroupChatSave);');
         expect(groupChatSource).toContain('rememberQueuedGroupChatIntegrity(chatId, responseData?.integrity);');
-        expect(groupChatSource).toContain('return await saveGroupChatImmediately({ groupId, shouldSaveGroup, force: true, throwOnError, chatId, chatData: chatMessages, metadata: metadataForSave });');
+        expect(groupChatSource).toContain('deferBackup: Boolean(options.deferBackup)');
+        expect(groupChatSource).toContain('return await saveGroupChatImmediately({ groupId, shouldSaveGroup, force: true, throwOnError, chatId, chatData: chatMessages, metadata: metadataForSave, deferBackup });');
         expect(groupChatSource).toContain('const isActiveGroupChatSave = selected_group === groupId && group.chat_id === chatId;');
         expect(groupChatSource).toContain('if (isActiveGroupChatSave && typeof responseData?.integrity === \'string\' && responseData.integrity)');
     });

--- a/tests/in-chat-agents-store.test.js
+++ b/tests/in-chat-agents-store.test.js
@@ -121,6 +121,117 @@ describe('in-chat agent scoped enabled state', () => {
         expect(snapshotStore.resolveRegexScriptsForSnapshot({ regexScripts: [regexScript] })).toEqual([regexScript]);
     });
 
+    test('migrates legacy regex snapshots in messages and swipe metadata when refs are resolvable', async () => {
+        const store = await importStore();
+        const snapshotStore = await import('../public/scripts/extensions/in-chat-agents/regex-snapshot-store.js');
+        const regexScript = {
+            id: 'script-1',
+            findRegex: '/foo/g',
+            replaceString: 'bar',
+        };
+
+        store.loadAgents([{
+            id: 'agent-1',
+            name: 'Regex Agent',
+            regexScripts: [regexScript],
+        }]);
+
+        const storedRegexScript = store.getAgentById('agent-1').regexScripts[0];
+        const legacySnapshot = {
+            activeAgentIds: ['agent-1'],
+            generationType: 'normal',
+            regexScripts: [structuredClone(storedRegexScript)],
+            edited: true,
+            extraField: 'preserved',
+        };
+        const message = {
+            extra: { inChatAgents: structuredClone(legacySnapshot) },
+            swipe_info: [{ extra: { inChatAgents: structuredClone(legacySnapshot) } }],
+        };
+
+        expect(snapshotStore.migrateLegacyRegexSnapshotsInMessages([message])).toBe(2);
+
+        const expectedRefs = snapshotStore.buildRegexScriptRefsForAgent('agent-1', store.getAgentById('agent-1').regexScripts);
+        expect(message.extra.inChatAgents).toMatchObject({
+            activeAgentIds: ['agent-1'],
+            generationType: 'normal',
+            edited: true,
+            extraField: 'preserved',
+            regexScriptRefs: expectedRefs,
+        });
+        expect(message.extra.inChatAgents.regexScripts).toBeUndefined();
+        expect(message.swipe_info[0].extra.inChatAgents.regexScriptRefs).toEqual(expectedRefs);
+        expect(message.swipe_info[0].extra.inChatAgents.regexScripts).toBeUndefined();
+        expect(snapshotStore.resolveRegexScriptsForSnapshot(message.extra.inChatAgents)).toEqual(store.getAgentById('agent-1').regexScripts);
+    });
+
+    test('leaves legacy regex snapshots inline when refs are missing, changed, or ambiguous', async () => {
+        const store = await importStore();
+        const snapshotStore = await import('../public/scripts/extensions/in-chat-agents/regex-snapshot-store.js');
+        const legacyScript = {
+            id: 'script-1',
+            findRegex: '/foo/g',
+            replaceString: 'old',
+        };
+        store.loadAgents([
+            {
+                id: 'agent-1',
+                name: 'Changed Regex Agent',
+                regexScripts: [{ ...legacyScript, replaceString: 'new' }],
+            },
+            {
+                id: 'agent-2',
+                name: 'Ambiguous Regex Agent A',
+                regexScripts: [legacyScript],
+            },
+            {
+                id: 'agent-3',
+                name: 'Ambiguous Regex Agent B',
+                regexScripts: [legacyScript],
+            },
+        ]);
+        const mismatchedLegacyScript = {
+            ...structuredClone(store.getAgentById('agent-1').regexScripts[0]),
+            replaceString: 'old',
+        };
+        const ambiguousLegacyScript = structuredClone(store.getAgentById('agent-2').regexScripts[0]);
+        const mismatchMessage = {
+            extra: {
+                inChatAgents: {
+                    activeAgentIds: ['agent-1'],
+                    generationType: 'normal',
+                    regexScripts: [structuredClone(mismatchedLegacyScript)],
+                },
+            },
+        };
+        const ambiguousMessage = {
+            extra: {
+                inChatAgents: {
+                    activeAgentIds: ['agent-2', 'agent-3'],
+                    generationType: 'normal',
+                    regexScripts: [structuredClone(ambiguousLegacyScript)],
+                },
+            },
+        };
+        const missingMessage = {
+            extra: {
+                inChatAgents: {
+                    activeAgentIds: ['missing-agent'],
+                    generationType: 'normal',
+                    regexScripts: [structuredClone(ambiguousLegacyScript)],
+                },
+            },
+        };
+
+        expect(snapshotStore.migrateLegacyRegexSnapshotsInMessages([mismatchMessage, ambiguousMessage, missingMessage])).toBe(0);
+        expect(mismatchMessage.extra.inChatAgents.regexScripts).toEqual([mismatchedLegacyScript]);
+        expect(mismatchMessage.extra.inChatAgents.regexScriptRefs).toBeUndefined();
+        expect(ambiguousMessage.extra.inChatAgents.regexScripts).toEqual([ambiguousLegacyScript]);
+        expect(ambiguousMessage.extra.inChatAgents.regexScriptRefs).toBeUndefined();
+        expect(missingMessage.extra.inChatAgents.regexScripts).toEqual([ambiguousLegacyScript]);
+        expect(missingMessage.extra.inChatAgents.regexScriptRefs).toBeUndefined();
+    });
+
     test('recovers legacy enabled agents missing from initialized scoped settings', async () => {
         const store = await importStore();
         store.setGlobalSettings({


### PR DESCRIPTION
## Summary
- Migrate legacy in-chat agent regex snapshots on load only when every inline script safely resolves to the current cached agent script revision.
- Defer regular chat backups for interim in-chat-agent saves during generation while keeping pre-write safety backups and final normal backups.
- Add focused regression coverage for safe migration and deferred backup behavior.

## Tests
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.json in-chat-agents-store.test.js chat-integrity-rotation.test.js` from `tests/`
- `./node_modules/.bin/eslint public/scripts/extensions/in-chat-agents/regex-snapshot-store.js public/scripts/extensions/in-chat-agents/agent-runner.js public/script.js public/scripts/group-chats.js src/endpoints/chats.js`
- `./node_modules/.bin/eslint in-chat-agents-store.test.js chat-integrity-rotation.test.js` from `tests/`

Refs #373