### PR TITLE
chore: add backup diagnostic logging

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@ This update prepares SillyBunny 1.6.4 by refreshing the visible app version, Hor
 - Older in-chat agent regex snapshots now compact on load when they can be safely resolved, and interim agent saves can defer regular chat backups until the final post-processed save.
 
 ### Added
+- Optional backup diagnostic logging can be enabled with `backups.chat.logging` to trace chat and settings backup writes, skips, and autosave triggers while investigating backup frequency.
 - A 1.6.4 Discord release post is available under `releases/` for announcement publishing.
 - Regression expectations were refreshed so release automation coverage tracks the current package version.
 

--- a/default/config.yaml
+++ b/default/config.yaml
@@ -227,6 +227,8 @@ backups:
     maxTotalBackups: -1
     # Interval in milliseconds to throttle chat backups per user
     throttleInterval: 10000
+    # Log chat and settings backup writes/skips for diagnosing backup frequency
+    logging: false
 
 # THUMBNAILING CONFIGURATION
 thumbnails:

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -17,6 +17,7 @@ import {
     generateTimestamp,
     removeOldBackups,
     formatBytes,
+    color,
     tryWriteFileSync,
     tryReadFileSync,
     tryDeleteFile,
@@ -29,11 +30,44 @@ const isBackupEnabled = !!getConfigValue('backups.chat.enabled', true, 'boolean'
 const maxTotalChatBackups = Number(getConfigValue('backups.chat.maxTotalBackups', -1, 'number'));
 const throttleInterval = Number(getConfigValue('backups.chat.throttleInterval', 10_000, 'number'));
 const checkIntegrity = !!getConfigValue('backups.chat.checkIntegrity', true, 'boolean');
+const isBackupLoggingEnabled = !!getConfigValue('backups.chat.logging', false, 'boolean');
 
 export const CHAT_BACKUPS_PREFIX = 'chat_';
 const CHAT_FORCED_OVERWRITE_BACKUPS_PREFIX = 'chat_forced_overwrite_';
 const CHAT_PRE_WRITE_BACKUPS_PREFIX = 'chat_pre_write_';
 const PRE_WRITE_BACKUP_RING_SIZE = 3;
+
+function logBackupEvent(action, details = {}) {
+    if (!isBackupLoggingEnabled) {
+        return;
+    }
+
+    const fields = Object.entries(details)
+        .filter(([, value]) => value !== undefined && value !== null && value !== '')
+        .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
+        .join(' ');
+    console.info(color.cyan(`[Backup] ${action}${fields ? ` ${fields}` : ''}`));
+}
+
+function getSerializedBackupSizeDetails(data) {
+    const sizeBytes = Buffer.byteLength(String(data ?? ''), 'utf8');
+    return {
+        bytes: sizeBytes,
+        size: formatBytes(sizeBytes),
+    };
+}
+
+function getChatBackupType(backupPrefix) {
+    if (backupPrefix === CHAT_FORCED_OVERWRITE_BACKUPS_PREFIX) {
+        return 'forced-overwrite';
+    }
+
+    if (backupPrefix === CHAT_PRE_WRITE_BACKUPS_PREFIX) {
+        return 'pre-write';
+    }
+
+    return 'regular';
+}
 
 function normalizeSerializedChatForBackupComparison(data) {
     const serialized = String(data ?? '');
@@ -90,26 +124,50 @@ function isDuplicateRegularChatBackup(directory, backupPrefix, data) {
  * @param {string} name The name of the chat.
  * @param {string} data The serialized chat to save.
  * @param {string} backupPrefix The file prefix. Typically CHAT_BACKUPS_PREFIX.
+ * @param {string} handle User handle for diagnostic logging.
  * @returns
  */
-function backupChat(directory, name, data, backupPrefix = CHAT_BACKUPS_PREFIX) {
+function backupChat(directory, name, data, backupPrefix = CHAT_BACKUPS_PREFIX, handle = '') {
+    const originalName = name;
+    const backupType = getChatBackupType(backupPrefix);
     try {
-        if (!isBackupEnabled) { return; }
+        if (!isBackupEnabled) {
+            logBackupEvent('chat-backup-skipped', { type: backupType, handle, chat: originalName, reason: 'disabled' });
+            return;
+        }
         if (!fs.existsSync(directory)) {
             console.error(`The chat couldn't be backed up because no directory exists at ${directory}!`);
+            logBackupEvent('chat-backup-skipped', { type: backupType, handle, chat: originalName, reason: 'missing-directory' });
             return;
         }
         // replace non-alphanumeric characters with underscores
         name = sanitize(name).replace(/[^a-z0-9]/gi, '_').toLowerCase();
         const prefix = `${backupPrefix}${name}_`;
+        const sizeDetails = getSerializedBackupSizeDetails(data);
 
         if (backupPrefix === CHAT_BACKUPS_PREFIX && isDuplicateRegularChatBackup(directory, prefix, data)) {
+            logBackupEvent('chat-backup-skipped', {
+                type: backupType,
+                handle,
+                chat: originalName,
+                sanitizedName: name,
+                reason: 'duplicate',
+                ...sizeDetails,
+            });
             return;
         }
 
         const backupFile = path.join(directory, `${backupPrefix}${name}_${generateTimestamp()}.jsonl`);
 
         tryWriteFileSync(backupFile, data);
+        logBackupEvent('chat-backup-written', {
+            type: backupType,
+            handle,
+            chat: originalName,
+            sanitizedName: name,
+            file: path.basename(backupFile),
+            ...sizeDetails,
+        });
         removeOldBackups(directory, prefix);
         if (isNaN(maxTotalChatBackups) || maxTotalChatBackups < 0) {
             return;
@@ -120,16 +178,30 @@ function backupChat(directory, name, data, backupPrefix = CHAT_BACKUPS_PREFIX) {
     }
 }
 
-function backupChatPreWrite(directory, name, data) {
+function backupChatPreWrite(directory, name, data, handle = '') {
+    const originalName = name;
     try {
-        if (!isBackupEnabled) { return; }
+        if (!isBackupEnabled) {
+            logBackupEvent('chat-backup-skipped', { type: 'pre-write', handle, chat: originalName, reason: 'disabled' });
+            return;
+        }
         if (!fs.existsSync(directory)) {
             console.error(`The chat couldn't be backed up because no directory exists at ${directory}!`);
+            logBackupEvent('chat-backup-skipped', { type: 'pre-write', handle, chat: originalName, reason: 'missing-directory' });
         }
         name = sanitize(name).replace(/[^a-z0-9]/gi, '_').toLowerCase();
         const backupFile = path.join(directory, `${CHAT_PRE_WRITE_BACKUPS_PREFIX}${name}_${generateTimestamp()}_${uuidv4()}.jsonl`);
+        const sizeDetails = getSerializedBackupSizeDetails(data);
 
         tryWriteFileSync(backupFile, data);
+        logBackupEvent('chat-backup-written', {
+            type: 'pre-write',
+            handle,
+            chat: originalName,
+            sanitizedName: name,
+            file: path.basename(backupFile),
+            ...sizeDetails,
+        });
         removeOldBackups(directory, `${CHAT_PRE_WRITE_BACKUPS_PREFIX}${name}_`, PRE_WRITE_BACKUP_RING_SIZE);
         if (isNaN(maxTotalChatBackups) || maxTotalChatBackups < 0) {
             return;
@@ -619,25 +691,36 @@ export async function trySaveChat(chatData, filePath, skipIntegrityCheck = false
             : message)
         : chatData;
     const jsonlData = savedChatData?.map(m => JSON.stringify(m)).join('\n');
+    const savedChatSizeDetails = getSerializedBackupSizeDetails(jsonlData);
+    logBackupEvent('chat-save', {
+        handle,
+        chat: cardName,
+        rows: Array.isArray(savedChatData) ? savedChatData.length : undefined,
+        force: Boolean(skipIntegrityCheck),
+        deferBackup: Boolean(deferBackup),
+        ...savedChatSizeDetails,
+    });
 
     if (fs.existsSync(filePath)) {
         const currentChatData = tryReadFileSync(filePath);
         if (currentChatData) {
-            backupChatPreWrite(backupDirectory, cardName, currentChatData);
+            backupChatPreWrite(backupDirectory, cardName, currentChatData, handle);
 
             if (isSuspiciousChatShrink(savedChatData, currentChatData)) {
                 console.warn(`Suspicious chat shrink while saving "${cardName}": incoming payload has ${savedChatData.length} JSONL rows, existing file has ${countSerializedChatLines(currentChatData)} rows.`);
             }
 
             if (skipIntegrityCheck) {
-                backupChat(backupDirectory, cardName, currentChatData, CHAT_FORCED_OVERWRITE_BACKUPS_PREFIX);
+                backupChat(backupDirectory, cardName, currentChatData, CHAT_FORCED_OVERWRITE_BACKUPS_PREFIX, handle);
             }
         }
     }
 
     tryWriteFileSync(filePath, jsonlData);
     if (!deferBackup) {
-        getBackupFunction(handle)(backupDirectory, cardName, jsonlData);
+        getBackupFunction(handle)(backupDirectory, cardName, jsonlData, CHAT_BACKUPS_PREFIX, handle);
+    } else {
+        logBackupEvent('chat-backup-skipped', { type: 'regular', handle, chat: cardName, reason: 'deferred', ...savedChatSizeDetails });
     }
     return { integrity: nextIntegrity };
 }

--- a/src/endpoints/settings.js
+++ b/src/endpoints/settings.js
@@ -6,7 +6,14 @@ import _ from 'lodash';
 import bytes from 'bytes';
 
 import { SETTINGS_FILE } from '../constants.js';
-import { getConfigValue, generateTimestamp, removeOldBackups, tryWriteFileSync } from '../util.js';
+import {
+    getConfigValue,
+    generateTimestamp,
+    removeOldBackups,
+    tryWriteFileSync,
+    formatBytes,
+    color,
+} from '../util.js';
 import { getAllUserHandles, getUserDirectories } from '../users.js';
 import { getFileNameValidationFunction } from '../middleware/validateFileName.js';
 
@@ -17,6 +24,7 @@ const ENABLE_REQUEST_COMPRESSION = !!getConfigValue('performance.requestCompress
 const REQUEST_COMPRESSION_MIN = bytes.parse(getConfigValue('performance.requestCompression.minPayloadSize', '256kb'));
 const REQUEST_COMPRESSION_MAX = bytes.parse(getConfigValue('performance.requestCompression.maxPayloadSize', '8mb'));
 const REQUEST_COMPRESSION_TIMEOUT = Number(getConfigValue('performance.requestCompression.timeout', 3000, 'number'));
+const isBackupLoggingEnabled = !!getConfigValue('backups.chat.logging', false, 'boolean');
 
 // 10 minutes
 const AUTOSAVE_INTERVAL = 10 * 60 * 1000;
@@ -27,6 +35,26 @@ const AUTOSAVE_INTERVAL = 10 * 60 * 1000;
  */
 const AUTOSAVE_FUNCTIONS = new Map();
 
+function logBackupEvent(action, details = {}) {
+    if (!isBackupLoggingEnabled) {
+        return;
+    }
+
+    const fields = Object.entries(details)
+        .filter(([, value]) => value !== undefined && value !== null && value !== '')
+        .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
+        .join(' ');
+    console.info(color.cyan(`[Backup] ${action}${fields ? ` ${fields}` : ''}`));
+}
+
+function getSettingsBackupSizeDetails(sourceFile) {
+    const sizeBytes = fs.statSync(sourceFile).size;
+    return {
+        bytes: sizeBytes,
+        size: formatBytes(sizeBytes),
+    };
+}
+
 /**
  * Triggers autosave for a user every 10 minutes.
  * @param {string} handle User handle
@@ -34,12 +62,16 @@ const AUTOSAVE_FUNCTIONS = new Map();
  */
 function triggerAutoSave(handle) {
     if (!AUTOSAVE_FUNCTIONS.has(handle)) {
-        const throttledAutoSave = _.throttle(() => backupUserSettings(handle, true), AUTOSAVE_INTERVAL);
+        const throttledAutoSave = _.throttle(() => {
+            logBackupEvent('settings-autosave-fired', { handle });
+            backupUserSettings(handle, true);
+        }, AUTOSAVE_INTERVAL);
         AUTOSAVE_FUNCTIONS.set(handle, throttledAutoSave);
     }
 
     const functionToCall = AUTOSAVE_FUNCTIONS.get(handle);
     if (functionToCall && typeof functionToCall === 'function') {
+        logBackupEvent('settings-autosave-requested', { handle });
         functionToCall();
     }
 }
@@ -147,6 +179,7 @@ function backupUserSettings(handle, preventDuplicates) {
     const userDirectories = getUserDirectories(handle);
 
     if (!fs.existsSync(userDirectories.root)) {
+        logBackupEvent('settings-backup-skipped', { handle, reason: 'missing-user-root' });
         return;
     }
 
@@ -154,14 +187,22 @@ function backupUserSettings(handle, preventDuplicates) {
     const sourceFile = path.join(userDirectories.root, SETTINGS_FILE);
 
     if (preventDuplicates && isDuplicateBackup(handle, sourceFile)) {
+        logBackupEvent('settings-backup-skipped', {
+            handle,
+            reason: 'duplicate',
+            ...getSettingsBackupSizeDetails(sourceFile),
+        });
         return;
     }
 
     if (!fs.existsSync(sourceFile)) {
+        logBackupEvent('settings-backup-skipped', { handle, reason: 'missing-source' });
         return;
     }
 
+    const sizeDetails = getSettingsBackupSizeDetails(sourceFile);
     fs.copyFileSync(sourceFile, backupFile);
+    logBackupEvent('settings-backup-written', { handle, file: path.basename(backupFile), ...sizeDetails });
     removeOldBackups(userDirectories.backups, `settings_${handle}`);
 }
 

--- a/tests/chat-integrity-rotation.test.js
+++ b/tests/chat-integrity-rotation.test.js
@@ -228,6 +228,24 @@ describe('chat integrity rotation', () => {
         await expect(fs.readFile(path.join(backupDir, postSaveBackups[0]), 'utf8')).resolves.toContain('final post-processed chat');
     });
 
+    test('exposes default-off backup diagnostic logging for chat and settings backups', async () => {
+        const configSource = await fs.readFile(fileURLToPath(new URL('../default/config.yaml', import.meta.url)), 'utf8');
+        const chatsSource = await fs.readFile(fileURLToPath(new URL('../src/endpoints/chats.js', import.meta.url)), 'utf8');
+        const settingsSource = await fs.readFile(fileURLToPath(new URL('../src/endpoints/settings.js', import.meta.url)), 'utf8');
+
+        expect(configSource).toContain('logging: false');
+        expect(chatsSource).toContain('const isBackupLoggingEnabled = !!getConfigValue(\'backups.chat.logging\', false, \'boolean\');');
+        expect(chatsSource).toContain('console.info(color.cyan(`[Backup] ${action}${fields ? ` ${fields}` : \'\'}`));');
+        expect(chatsSource).toContain('chat-backup-written');
+        expect(chatsSource).toContain('chat-backup-skipped');
+        expect(chatsSource).toContain('reason: \'deferred\'');
+        expect(chatsSource).toContain('reason: \'duplicate\'');
+        expect(settingsSource).toContain('settings-autosave-requested');
+        expect(settingsSource).toContain('settings-autosave-fired');
+        expect(settingsSource).toContain('settings-backup-written');
+        expect(settingsSource).toContain('settings-backup-skipped');
+    });
+
     test('keeps distinct pre-write backups for rapid overwrites in the same second', async () => {
         const { trySaveChat } = await import('../src/endpoints/chats.js');
         const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-integrity-prewrite-rapid-'));


### PR DESCRIPTION
## Summary
- add a default-off `backups.chat.logging` toggle for backup diagnostics
- log chat backup writes/skips for regular, pre-write, forced-overwrite, duplicate, and deferred paths
- log settings backup writes/skips plus throttled autosave requests/fires

## Tests
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.json chat-integrity-rotation.test.js in-chat-agents-store.test.js`
- `./node_modules/.bin/eslint src/endpoints/chats.js src/endpoints/settings.js`
- `./node_modules/.bin/eslint chat-integrity-rotation.test.js`
- `git diff --check`

Follow-up for #373 and TRUEDarkAngel's request for temporary backup logging.