### PR TITLE
fix: revalidate default frontend assets on iOS

### DIFF
--- a/src/server-main.js
+++ b/src/server-main.js
@@ -46,7 +46,7 @@ import {
 
 import getWebpackServeMiddleware from './middleware/webpack-serve.js';
 import { FRONTEND_ASSET_PREFIX, rewriteFrontendHtml } from './frontend-assets.js';
-import { getFrontendAssetMiddleware, shouldServeFrontendAssets } from './middleware/frontend-assets.js';
+import { getFrontendAssetMiddleware, setPublicAssetHeaders, shouldServeFrontendAssets } from './middleware/frontend-assets.js';
 import basicAuthMiddleware from './middleware/basicAuth.js';
 import requireHttpsMiddleware from './middleware/requireHttps.js';
 import { createSession, destroySession, validateCredentials, isSessionAuthEnabled } from './middleware/sessionAuth.js';
@@ -383,6 +383,7 @@ app.get('/', cacheBuster.middleware, (request, response) => {
         return response.send(rewriteFrontendHtml(indexHtml));
     }
 
+    response.set('Cache-Control', 'no-cache');
     return response.sendFile('index.html', { root: path.join(serverDirectory, 'public') });
 });
 
@@ -413,7 +414,7 @@ app.use((request, response, next) => {
 
     return frontendAssetMiddleware.publicAssets(request, response, next);
 });
-app.use(express.static(path.join(serverDirectory, 'public'), {}));
+app.use(express.static(path.join(serverDirectory, 'public'), { setHeaders: setPublicAssetHeaders }));
 
 // Public API
 app.use('/api/users', usersPublicRouter);

--- a/src/users.js
+++ b/src/users.js
@@ -1074,6 +1074,7 @@ export async function loginPageMiddleware(request, response) {
         console.error('Error during auto-login:', error);
     }
 
+    response.set('Cache-Control', 'no-cache');
     return response.sendFile('login.html', { root: path.join(serverDirectory, 'public') });
 }
 

--- a/tests/frontend-asset-middleware.test.js
+++ b/tests/frontend-asset-middleware.test.js
@@ -11,7 +11,12 @@ function getCacheControlFor(requestPath) {
 }
 
 describe('frontend asset fallback headers', () => {
-    test('keeps raw JavaScript modules revalidating in production asset mode', () => {
+    test('keeps html, json, maps, and raw JavaScript revalidating', () => {
+        expect(getCacheControlFor('/index.html')).toBe('no-cache');
+        expect(getCacheControlFor('/login.html')).toBe('no-cache');
+        expect(getCacheControlFor('/manifest.json')).toBe('no-cache');
+        expect(getCacheControlFor('/script.js.map')).toBe('no-cache');
+        expect(getCacheControlFor('/script.js')).toBe('no-cache');
         expect(getCacheControlFor('/scripts/chat-render-lifecycle/render-window.js')).toBe('no-cache');
         expect(getCacheControlFor('/scripts/bootstrap.mjs')).toBe('no-cache');
     });


### PR DESCRIPTION
Summary
- Revalidates the default public static fallback with the existing public asset header policy.
- Adds Cache-Control: no-cache on the default index and login shell responses.
- Extends fallback header tests for HTML, manifest JSON, source maps, and raw JS modules.

Why
- On insecure .local HTTP origins, iOS cannot rely on service worker registration or Clear-Site-Data, so default frontend entrypoints must force browser revalidation.

Verification
- npm run test:unit --prefix tests
- npm run lint
- bun -e header helper assertion