### PR TITLE
feat: in-app ZIP auto-update for non-git installs

### DIFF
--- a/Update-Instructions.txt
+++ b/Update-Instructions.txt
@@ -32,7 +32,19 @@ intentionally, or move them out of the way before pulling the update.
 
 ZIP installs
 
-ZIP updates require copying your user data into a fresh download.
+The preferred ZIP update method is the in-app updater.
+
+1. Start SillyBunny normally.
+2. Open Customize > Server.
+3. Click Check for updates.
+4. If a release ZIP update is available, click Update & Restart.
+
+The updater downloads the latest GitHub release ZIP, replaces app files in place,
+backs up replaced files under backups/zip-update-*, keeps your data folder, and
+restarts SillyBunny automatically.
+
+If the in-app updater is unavailable, use the manual fallback. Manual ZIP updates
+require copying your user data into a fresh download.
 
 1. Download the new SillyBunny release ZIP.
 2. Extract it into a new folder, outside your current SillyBunny install.

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -9177,7 +9177,9 @@ function renderServerAdminStatus(data) {
     }
 
     const repository = data?.repository ?? {};
+    const release = data?.release ?? null;
     const version = data?.version ?? {};
+    const isGitInstall = Boolean(repository?.supported && repository?.isRepo);
     const statusGrid = refs.statusGrid;
     statusGrid.replaceChildren();
 
@@ -9187,16 +9189,17 @@ function renderServerAdminStatus(data) {
     // Branch selector instead of static text
     const branchContainer = createElement('div', { className: 'sb-server-stat' });
     const branchLabel = createElement('div', { className: 'sb-server-stat-label' });
-    branchLabel.textContent = 'Branch';
+    branchLabel.textContent = isGitInstall ? 'Branch' : 'Install';
     const branchValue = createElement('div', { className: 'sb-server-stat-value' });
     const branchSelect = createElement('select', {
         id: 'sb-branch-select',
         className: 'text_pole',
         attrs: { style: 'width: 100%; max-width: 200px;' },
     });
-    const currentBranch = repository?.displayBranch || repository?.branch || version?.gitBranch || '';
+    branchSelect.disabled = !isGitInstall;
+    const currentBranch = isGitInstall ? (repository?.displayBranch || repository?.branch || version?.gitBranch || '') : 'Release ZIP';
     const currentOptionAttributes = { value: currentBranch, selected: 'selected' };
-    if (!currentBranch) {
+    if (!currentBranch || !isGitInstall) {
         currentOptionAttributes.disabled = 'disabled';
     }
     const currentOption = createElement('option', { attrs: currentOptionAttributes });
@@ -9207,7 +9210,7 @@ function renderServerAdminStatus(data) {
     statusGrid.appendChild(branchContainer);
 
     // Load available branches
-    if (repository?.supported && repository?.isRepo) {
+    if (isGitInstall) {
         loadServerAdminBranches(branchSelect, currentBranch);
     }
 
@@ -9215,6 +9218,9 @@ function renderServerAdminStatus(data) {
     appendServerAdminStat(statusGrid, 'Tracking', repository?.trackingBranch || 'Not set');
     appendServerAdminStat(statusGrid, 'Ahead', String(repository?.ahead ?? 0));
     appendServerAdminStat(statusGrid, 'Behind', String(repository?.behind ?? 0));
+    if (release) {
+        appendServerAdminStat(statusGrid, 'Latest ZIP', release?.latestVersion ? `v${release.latestVersion}` : 'Unknown');
+    }
     appendServerAdminStat(statusGrid, 'Config', data?.configPath || 'Unknown');
 
     state.lastStatusData = {
@@ -9222,12 +9228,13 @@ function renderServerAdminStatus(data) {
         configPath: data?.configPath || '',
         version,
         repository,
+        release,
     };
 
     let pillLabel = 'Unavailable';
     let pillTone = 'neutral';
 
-    if (repository?.supported && repository?.isRepo) {
+    if (isGitInstall) {
         if (repository?.hasLocalChanges && !repository?.autoStash) {
             pillLabel = 'Update Blocked';
             pillTone = 'danger';
@@ -9244,12 +9251,29 @@ function renderServerAdminStatus(data) {
             pillLabel = 'Up To Date';
             pillTone = 'good';
         }
+    } else if (release?.canUpdate) {
+        pillLabel = release?.latestVersion ? `Update Available (v${release.latestVersion})` : 'Update Available';
+        pillTone = 'warn';
+    } else if (release?.checked && release?.assetAvailable && release?.latestVersion === release?.currentVersion) {
+        pillLabel = 'Up To Date';
+        pillTone = 'good';
+    } else if (release?.checked && release?.assetAvailable) {
+        pillLabel = 'ZIP Install';
+        pillTone = 'neutral';
+    } else if (release?.checked && !release?.assetAvailable) {
+        pillLabel = 'ZIP Unavailable';
+        pillTone = 'warn';
+    } else if (release?.supported && !release?.checked) {
+        pillLabel = 'Check Failed';
+        pillTone = 'warn';
     }
 
     setServerAdminPill(refs.statusPill, pillLabel, pillTone);
-    refs.updateButton.dataset.sbCanUpdate = String(Boolean(repository?.canUpdate));
+    const updateMode = repository?.canUpdate ? 'git' : release?.canUpdate ? 'zip' : '';
+    refs.updateButton.dataset.sbCanUpdate = String(Boolean(updateMode));
+    refs.updateButton.dataset.sbUpdateMode = updateMode;
 
-    const noteParts = [String(repository?.message ?? '').trim()].filter(Boolean);
+    const noteParts = [String((isGitInstall ? repository?.message : release?.message || repository?.message) ?? '').trim()].filter(Boolean);
 
     if ((repository?.changedFilesCount ?? 0) > 0) {
         const changedPreview = Array.isArray(repository?.changedFiles)
@@ -9262,6 +9286,7 @@ function renderServerAdminStatus(data) {
 
     if (refs.autoStashCheckbox) {
         refs.autoStashCheckbox.checked = Boolean(repository?.autoStash);
+        refs.autoStashCheckbox.disabled = !isGitInstall;
     }
     updateServerAdminInteractivity();
 }
@@ -9300,7 +9325,7 @@ function renderServerThumbnailSettings(data) {
     setServerAdminMessage(refs.thumbnailNote, 'Thumbnail settings loaded. Saving applies to new thumbnails immediately.', 'neutral');
 }
 
-async function waitForServerReturn(expectedRevision = '', { clearCacheBeforeReload = false } = {}) {
+async function waitForServerReturn(expectedRevision = '', { clearCacheBeforeReload = false, expectedVersion = '' } = {}) {
     let sawOffline = false;
 
     async function reloadAfterOptionalCacheClear() {
@@ -9321,8 +9346,14 @@ async function waitForServerReturn(expectedRevision = '', { clearCacheBeforeRelo
 
             const version = await response.json().catch(() => ({}));
             const revision = String(version?.gitRevision ?? '').trim();
+            const pkgVersion = String(version?.pkgVersion ?? '').trim();
 
             if (expectedRevision && revision === expectedRevision) {
+                await reloadAfterOptionalCacheClear();
+                return true;
+            }
+
+            if (expectedVersion && pkgVersion === expectedVersion) {
                 await reloadAfterOptionalCacheClear();
                 return true;
             }
@@ -9650,6 +9681,11 @@ async function handleServerAdminUpdate() {
         return;
     }
 
+    if (refs.updateButton?.dataset.sbUpdateMode === 'zip') {
+        await handleServerAdminZipUpdate();
+        return;
+    }
+
     state.busy = true;
     updateServerAdminInteractivity();
     setServerAdminButtonLabel(refs.updateButton, true, 'Updating…');
@@ -9717,6 +9753,69 @@ async function handleServerAdminUpdate() {
         }
         setServerAdminMessage(refs.updateNote, [error.message || 'Failed to update SillyBunny.', stashMessage].filter(Boolean).join('\n'), 'danger');
         toastr.error(error.message || 'Failed to update SillyBunny.', 'Server update');
+    } finally {
+        setServerAdminButtonLabel(refs.updateButton, false, 'Updating…');
+
+        if (!state.restarting) {
+            state.busy = false;
+            updateServerAdminInteractivity();
+        }
+    }
+}
+
+async function handleServerAdminZipUpdate() {
+    const state = getServerAdminState();
+    const refs = getServerAdminRefs();
+
+    if (!refs || state.busy || state.restarting) {
+        return;
+    }
+
+    state.busy = true;
+    updateServerAdminInteractivity();
+    setServerAdminButtonLabel(refs.updateButton, true, 'Updating…');
+    setServerAdminMessage(refs.updateNote, 'Downloading the latest GitHub release ZIP and preparing a safe restart…');
+    refs.updateOutput.hidden = true;
+    refs.updateOutput.textContent = '';
+
+    try {
+        const result = await requestServerAdmin('/api/server-admin/zip-update');
+        const nextStatus = {
+            ...(state.lastStatusData ?? {}),
+            configPath: refs.configPath?.textContent || state.lastStatusData?.configPath || '',
+            version: result?.version ?? state.lastStatusData?.version ?? {},
+            repository: result?.repository ?? state.lastStatusData?.repository ?? {},
+            release: result?.release ?? state.lastStatusData?.release ?? null,
+        };
+
+        if (!result?.updated) {
+            renderServerAdminStatus(nextStatus);
+            setServerAdminMessage(refs.updateNote, result?.message || 'Already up to date.', 'good');
+            toastr.success(result?.message || 'Already up to date.', 'Server update');
+            return;
+        }
+
+        renderServerAdminStatus(nextStatus);
+        state.busy = false;
+        state.restarting = true;
+        updateServerAdminInteractivity();
+        setServerAdminMessage(refs.updateNote, result?.message || 'ZIP update downloaded. Restarting SillyBunny…', 'warn');
+        toastr.info(result?.message || 'ZIP update downloaded. Restarting SillyBunny…', 'Server update');
+
+        const expectedVersion = String(result?.release?.latestVersion ?? '').trim();
+        const autoClearCacheEnabled = Boolean(document.getElementById('auto_clear_cache_on_update')?.checked);
+        const restarted = await waitForServerReturn('', { clearCacheBeforeReload: autoClearCacheEnabled, expectedVersion });
+
+        if (!restarted) {
+            state.restarting = false;
+            setServerAdminMessage(refs.updateNote, 'ZIP update started, but restart is taking longer than expected. Refresh manually once the server is back.', 'warn');
+            toastr.warning('ZIP update started, but restart is taking longer than expected. Refresh manually once the server is back.', 'Restart pending');
+        }
+    } catch (error) {
+        console.error('Failed to update SillyBunny from release ZIP.', error);
+        state.busy = false;
+        setServerAdminMessage(refs.updateNote, error.message || 'Failed to update SillyBunny from release ZIP.', 'danger');
+        toastr.error(error.message || 'Failed to update SillyBunny from release ZIP.', 'Server update');
     } finally {
         setServerAdminButtonLabel(refs.updateButton, false, 'Updating…');
 
@@ -9836,7 +9935,7 @@ function buildServerAdminPanel() {
     const callout = createElement('div', { className: 'sb-shell-callout' });
     callout.innerHTML = `
         <strong>Server Tools</strong>
-        <p>Edit <code>config.yaml</code>, check for Git updates, and restart the app from inside Customize. Auto-update only runs when the repository can fast-forward cleanly.</p>
+        <p>Edit <code>config.yaml</code>, check for Git or release ZIP updates, and restart the app from inside Customize. Git auto-update only runs when the repository can fast-forward cleanly.</p>
     `;
 
     const statusCard = createElement('section', { className: 'sb-admin-card sb-server-card' });
@@ -9860,7 +9959,7 @@ function buildServerAdminPanel() {
     const refreshButton = createElement('button', { className: 'menu_button menu_button_icon sb-server-action', text: 'Check for updates', attrs: { type: 'button' } });
     const updateButton = createElement('button', { className: 'menu_button menu_button_icon sb-server-action menu_button_primary', text: 'Update & Restart', attrs: { type: 'button' } });
     const restartButton = createElement('button', { className: 'menu_button menu_button_icon sb-server-action', text: 'Restart server', attrs: { type: 'button' } });
-    const updateNote = createElement('div', { className: 'sb-server-note', text: 'Fast-forward updates restart automatically after the pull finishes.' });
+    const updateNote = createElement('div', { className: 'sb-server-note', text: 'Git fast-forward updates and release ZIP updates restart automatically after preparation finishes.' });
     const autoStashLabel = createElement('label', { className: 'checkbox_label' });
     const autoStashCheckbox = createElement('input', { attrs: { type: 'checkbox', id: 'auto_stash_before_pull' } });
     const autoStashText = createElement('small', { text: 'Auto-stash local changes before pulling' });

--- a/src/endpoints/server-admin.js
+++ b/src/endpoints/server-admin.js
@@ -20,6 +20,7 @@ import {
     resolveRemoteBranchName,
 } from '../server-admin-git.js';
 import { getServerLogSnapshot } from '../server-log-buffer.js';
+import { getLatestZipReleaseStatus, stageZipReleaseUpdate } from '../server-admin-zip-update.js';
 import { serverDirectory } from '../server-directory.js';
 import { requireAdminMiddleware } from '../users.js';
 import { getConfigValue, getVersion, isPathUnderParent, tryWriteFileSync } from '../util.js';
@@ -305,6 +306,22 @@ function getRestartPayload() {
     return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64');
 }
 
+function getZipUpdatePayload(stagedUpdate) {
+    const payload = {
+        parentPid: process.pid,
+        installDir: serverDirectory,
+        stagingRoot: stagedUpdate.stagingRoot,
+        releaseRoot: stagedUpdate.releaseRoot,
+        version: stagedUpdate.version,
+        assetName: stagedUpdate.assetName,
+        command: [process.argv[0], ...process.argv.slice(1)],
+        envPatch: { SILLYBUNNY_SKIP_BROWSER_AUTO_LAUNCH: '1' },
+        visibleRelaunch: process.platform === 'win32',
+    };
+
+    return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64');
+}
+
 function isLauncherManagedRestart() {
     return process.env[RESTART_LAUNCHER_ENV] === '1';
 }
@@ -341,6 +358,29 @@ function scheduleRestart(response) {
             } catch (error) {
                 console.error('Failed to stop current process during restart.', error);
             }
+        }, RESTART_RESPONSE_DELAY_MS);
+    });
+}
+
+function scheduleZipUpdate(response, stagedUpdate) {
+    const helperScriptPath = path.join(serverDirectory, 'src', 'zip-update-helper.js');
+    const helper = spawn(process.argv[0], [helperScriptPath, getZipUpdatePayload(stagedUpdate)], {
+        cwd: serverDirectory,
+        detached: true,
+        stdio: process.platform === 'win32' ? ['ignore', 'inherit', 'inherit'] : 'ignore',
+        env: process.env,
+        windowsHide: false,
+    });
+
+    helper.once('error', (error) => {
+        console.error('Failed to start ZIP update helper.', error);
+    });
+    helper.unref();
+
+    response.once('finish', () => {
+        setTimeout(() => {
+            console.info('ZIP update staged; exiting current server so the helper can replace files safely.');
+            process.exit(0);
         }, RESTART_RESPONSE_DELAY_MS);
     });
 }
@@ -522,11 +562,13 @@ router.post('/status', requireAdminMiddleware, async (_request, response) => {
     try {
         const version = await getVersion();
         const repository = await getRepositoryStatus();
+        const release = repository.isRepo ? null : await getLatestZipReleaseStatus(version.pkgVersion);
         response.json({
             runtime: formatRuntimeLabel(),
             configPath: getConfigFilePath(),
             version,
             repository,
+            release,
         });
     } catch (error) {
         console.error('Failed to get server admin status.', error);
@@ -745,6 +787,59 @@ router.post('/restart', requireAdminMiddleware, async (_request, response) => {
     } catch (error) {
         console.error('Failed to restart server.', error);
         response.status(500).json({ error: error.message || 'Failed to restart server.' });
+    }
+});
+
+router.post('/zip-update', requireAdminMiddleware, async (_request, response) => {
+    let stagedUpdate = null;
+
+    try {
+        const version = await getVersion();
+        const repository = await getRepositoryStatus();
+
+        if (repository.isRepo) {
+            return response.status(400).json({ error: 'This install is a Git checkout. Use the Git update path instead.', repository });
+        }
+
+        const release = await getLatestZipReleaseStatus(version.pkgVersion);
+
+        if (!release.checked) {
+            return response.status(502).json({ error: release.message || 'Failed to check GitHub releases.', release });
+        }
+
+        if (!release.canUpdate) {
+            return response.json({
+                updated: false,
+                restarting: false,
+                message: release.message || 'Already up to date.',
+                version,
+                repository,
+                release,
+            });
+        }
+
+        stagedUpdate = await stageZipReleaseUpdate(release);
+        scheduleZipUpdate(response, stagedUpdate);
+
+        response.status(202).json({
+            updated: true,
+            restarting: true,
+            message: `ZIP release v${release.latestVersion} downloaded. Restarting SillyBunny to replace app files safely.`,
+            version,
+            repository,
+            release: {
+                ...release,
+                staged: true,
+            },
+        });
+
+        stagedUpdate = null;
+    } catch (error) {
+        if (stagedUpdate?.stagingRoot) {
+            fs.rmSync(stagedUpdate.stagingRoot, { recursive: true, force: true });
+        }
+        console.error('Failed to start ZIP update.', error);
+        response.status(500).json({ error: error.message || 'Failed to start ZIP update.' });
     }
 });
 

--- a/src/server-admin-git.js
+++ b/src/server-admin-git.js
@@ -2,7 +2,7 @@ const ORIGIN_REMOTE_PREFIX = 'origin/';
 const RUNTIME_BRANCH_PREFIX = 'runtime/';
 const BUN_LOCK_FILE = 'bun.lock';
 
-export const NON_GIT_REPOSITORY_MESSAGE = 'This install is not running from a Git repository. Built-in updates require a Git checkout; release ZIP installs need to download and extract the latest release.';
+export const NON_GIT_REPOSITORY_MESSAGE = 'This install is not running from a Git repository. Use Customize > Server to check for a release ZIP update, or install with git clone for Git updates.';
 
 function uniqueSorted(values) {
     return [...new Set(values)].sort((a, b) => a.localeCompare(b));

--- a/src/server-admin-zip-update.js
+++ b/src/server-admin-zip-update.js
@@ -1,0 +1,366 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+
+import fetch from 'node-fetch';
+import yauzl from 'yauzl';
+
+const GITHUB_OWNER = 'platberlitz';
+const GITHUB_REPO = 'SillyBunny';
+const GITHUB_RELEASE_API_URL = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases/latest`;
+const GITHUB_RELEASE_DOWNLOAD_PREFIX = `/${GITHUB_OWNER}/${GITHUB_REPO}/releases/download/`;
+const RELEASE_ZIP_PREFIX = 'SillyBunny-v';
+const RELEASE_ZIP_SUFFIX = '-github.zip';
+const REQUEST_TIMEOUT_MS = 15000;
+const USER_AGENT = 'SillyBunny ZIP updater';
+
+function normalizeVersion(value) {
+    return String(value ?? '').trim().replace(/^v/i, '');
+}
+
+function parseVersion(value) {
+    const match = normalizeVersion(value).match(/^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/);
+
+    if (!match) {
+        return null;
+    }
+
+    return match.slice(1, 4).map(part => Number.parseInt(part, 10));
+}
+
+function compareVersions(left, right) {
+    const leftParts = parseVersion(left);
+    const rightParts = parseVersion(right);
+
+    if (!leftParts || !rightParts) {
+        return null;
+    }
+
+    for (let index = 0; index < leftParts.length; index++) {
+        if (leftParts[index] > rightParts[index]) {
+            return 1;
+        }
+        if (leftParts[index] < rightParts[index]) {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+function buildReleaseZipAssetName(version) {
+    return `${RELEASE_ZIP_PREFIX}${normalizeVersion(version)}${RELEASE_ZIP_SUFFIX}`;
+}
+
+function createTimeoutSignal() {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    return {
+        signal: controller.signal,
+        clear: () => clearTimeout(timeout),
+    };
+}
+
+async function fetchWithTimeout(url, options = {}) {
+    const timeout = createTimeoutSignal();
+
+    try {
+        return await fetch(url, {
+            ...options,
+            signal: timeout.signal,
+            headers: {
+                'Accept': 'application/vnd.github+json',
+                'User-Agent': USER_AGENT,
+                ...(options.headers ?? {}),
+            },
+        });
+    } finally {
+        timeout.clear();
+    }
+}
+
+async function fetchLatestRelease() {
+    const response = await fetchWithTimeout(GITHUB_RELEASE_API_URL);
+
+    if (!response.ok) {
+        throw new Error(`GitHub release check failed with HTTP ${response.status}.`);
+    }
+
+    return await response.json();
+}
+
+function validateReleaseAssetUrl(assetUrl, version) {
+    const parsedUrl = new URL(String(assetUrl ?? ''));
+    const assetName = decodeURIComponent(parsedUrl.pathname.split('/').pop() || '');
+
+    if (parsedUrl.protocol !== 'https:' || parsedUrl.hostname !== 'github.com') {
+        throw new Error('Release ZIP download URL did not come from github.com over HTTPS.');
+    }
+
+    if (!parsedUrl.pathname.startsWith(GITHUB_RELEASE_DOWNLOAD_PREFIX)) {
+        throw new Error(`Release ZIP download URL does not match ${GITHUB_OWNER}/${GITHUB_REPO}.`);
+    }
+
+    if (assetName !== buildReleaseZipAssetName(version)) {
+        throw new Error(`Release ZIP asset must be named ${buildReleaseZipAssetName(version)}.`);
+    }
+
+    return parsedUrl.toString();
+}
+
+function createBaseReleaseStatus(currentVersion) {
+    return {
+        supported: true,
+        checked: false,
+        currentVersion: normalizeVersion(currentVersion),
+        latestVersion: '',
+        releaseName: '',
+        releaseUrl: '',
+        assetName: '',
+        assetUrl: '',
+        assetAvailable: false,
+        canUpdate: false,
+        message: '',
+    };
+}
+
+export async function getLatestZipReleaseStatus(currentVersion) {
+    const status = createBaseReleaseStatus(currentVersion);
+
+    try {
+        const release = await fetchLatestRelease();
+        const latestVersion = normalizeVersion(release?.tag_name || release?.name);
+        const assetName = buildReleaseZipAssetName(latestVersion);
+        const asset = Array.isArray(release?.assets)
+            ? release.assets.find(item => item?.name === assetName)
+            : null;
+        const comparison = compareVersions(latestVersion, status.currentVersion);
+
+        status.checked = true;
+        status.latestVersion = latestVersion;
+        status.releaseName = String(release?.name ?? release?.tag_name ?? '').trim();
+        status.releaseUrl = String(release?.html_url ?? '').trim();
+        status.assetName = assetName;
+
+        if (!parseVersion(latestVersion)) {
+            status.message = 'The latest GitHub release does not use a supported vX.Y.Z version tag.';
+            return status;
+        }
+
+        if (!asset) {
+            status.message = `Latest GitHub release v${latestVersion} does not include ${assetName}.`;
+            return status;
+        }
+
+        status.assetUrl = validateReleaseAssetUrl(asset.browser_download_url, latestVersion);
+        status.assetAvailable = true;
+
+        if (comparison === null) {
+            status.message = 'Could not compare the installed version with the latest GitHub release.';
+        } else if (comparison > 0) {
+            status.canUpdate = true;
+            status.message = `ZIP release v${latestVersion} is available.`;
+        } else if (comparison === 0) {
+            status.message = `Latest ZIP release v${latestVersion} is already installed.`;
+        } else {
+            status.message = `Installed version v${status.currentVersion} is newer than latest ZIP release v${latestVersion}.`;
+        }
+    } catch (error) {
+        status.checked = false;
+        status.canUpdate = false;
+        status.message = error?.name === 'AbortError'
+            ? 'GitHub release check timed out.'
+            : error?.message || 'Failed to check GitHub releases.';
+    }
+
+    return status;
+}
+
+function getSafeZipEntryPath(fileName) {
+    const rawName = String(fileName ?? '').replaceAll('\\', '/');
+
+    if (!rawName || rawName.includes('\0') || rawName.startsWith('/')) {
+        throw new Error(`Unsafe ZIP entry path: ${fileName}`);
+    }
+
+    const parts = rawName.split('/').filter(Boolean);
+
+    if (parts.some(part => part === '.' || part === '..' || part.includes(':'))) {
+        throw new Error(`Unsafe ZIP entry path: ${fileName}`);
+    }
+
+    return parts.join(path.sep);
+}
+
+function isPathInside(parent, candidate) {
+    const relative = path.relative(parent, candidate);
+    return relative === '' || (relative && !relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function openZip(zipPath) {
+    return new Promise((resolve, reject) => {
+        yauzl.open(zipPath, { lazyEntries: true }, (error, zipFile) => {
+            if (error || !zipFile) {
+                reject(error || new Error('Failed to open release ZIP.'));
+                return;
+            }
+
+            resolve(zipFile);
+        });
+    });
+}
+
+function getZipMode(entry, fallback) {
+    const mode = (entry.externalFileAttributes >>> 16) & 0o777;
+    return mode || fallback;
+}
+
+async function extractZip(zipPath, destination) {
+    const root = path.resolve(destination);
+    const zipFile = await openZip(zipPath);
+
+    await new Promise((resolve, reject) => {
+        let finished = false;
+
+        function fail(error) {
+            if (finished) {
+                return;
+            }
+            finished = true;
+            zipFile.close();
+            reject(error);
+        }
+
+        zipFile.once('error', fail);
+        zipFile.once('end', () => {
+            if (!finished) {
+                finished = true;
+                resolve();
+            }
+        });
+
+        zipFile.on('entry', entry => {
+            let relativePath = '';
+
+            try {
+                relativePath = getSafeZipEntryPath(entry.fileName);
+            } catch (error) {
+                fail(error);
+                return;
+            }
+
+            if (!relativePath) {
+                zipFile.readEntry();
+                return;
+            }
+
+            const targetPath = path.resolve(root, relativePath);
+
+            if (!isPathInside(root, targetPath)) {
+                fail(new Error(`ZIP entry escapes the extraction directory: ${entry.fileName}`));
+                return;
+            }
+
+            if (entry.fileName.endsWith('/')) {
+                fs.mkdirSync(targetPath, { recursive: true, mode: getZipMode(entry, 0o755) });
+                zipFile.readEntry();
+                return;
+            }
+
+            fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+            zipFile.openReadStream(entry, (error, readStream) => {
+                if (error || !readStream) {
+                    fail(error || new Error(`Failed to read ZIP entry: ${entry.fileName}`));
+                    return;
+                }
+
+                pipeline(readStream, fs.createWriteStream(targetPath, { mode: getZipMode(entry, 0o644) }))
+                    .then(() => {
+                        fs.chmodSync(targetPath, getZipMode(entry, 0o644));
+                        zipFile.readEntry();
+                    })
+                    .catch(fail);
+            });
+        });
+
+        zipFile.readEntry();
+    });
+}
+
+function resolveReleaseRoot(extractRoot) {
+    const entries = fs.readdirSync(extractRoot, { withFileTypes: true })
+        .filter(entry => entry.name !== '__MACOSX' && entry.name !== '.DS_Store');
+
+    if (entries.length === 1 && entries[0].isDirectory()) {
+        return path.join(extractRoot, entries[0].name);
+    }
+
+    return extractRoot;
+}
+
+function validateExtractedRelease(releaseRoot, version) {
+    const packageJsonPath = path.join(releaseRoot, 'package.json');
+
+    if (!fs.existsSync(packageJsonPath)) {
+        throw new Error('Release ZIP did not contain package.json at the app root.');
+    }
+
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    const packageVersion = normalizeVersion(packageJson?.version);
+
+    if (packageVersion !== normalizeVersion(version)) {
+        throw new Error(`Release ZIP package.json version is v${packageVersion}, expected v${normalizeVersion(version)}.`);
+    }
+
+    return {
+        name: String(packageJson?.name ?? '').trim(),
+        version: packageVersion,
+    };
+}
+
+async function downloadReleaseAsset(assetUrl, zipPath) {
+    const response = await fetchWithTimeout(assetUrl, { headers: { Accept: 'application/octet-stream' } });
+
+    if (!response.ok || !response.body) {
+        throw new Error(`Release ZIP download failed with HTTP ${response.status}.`);
+    }
+
+    await pipeline(response.body, fs.createWriteStream(zipPath));
+
+    const stats = fs.statSync(zipPath);
+    if (!stats.isFile() || stats.size <= 0) {
+        throw new Error('Downloaded release ZIP was empty.');
+    }
+}
+
+export async function stageZipReleaseUpdate(releaseStatus) {
+    const latestVersion = normalizeVersion(releaseStatus?.latestVersion);
+    const assetName = buildReleaseZipAssetName(latestVersion);
+    const assetUrl = validateReleaseAssetUrl(releaseStatus?.assetUrl, latestVersion);
+    const stagingRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sillybunny-zip-update-'));
+    const zipPath = path.join(stagingRoot, assetName);
+    const extractRoot = path.join(stagingRoot, 'extract');
+
+    try {
+        fs.mkdirSync(extractRoot, { recursive: true });
+        await downloadReleaseAsset(assetUrl, zipPath);
+        await extractZip(zipPath, extractRoot);
+
+        const releaseRoot = resolveReleaseRoot(extractRoot);
+        const packageInfo = validateExtractedRelease(releaseRoot, latestVersion);
+
+        return {
+            stagingRoot,
+            zipPath,
+            extractRoot,
+            releaseRoot,
+            version: latestVersion,
+            assetName,
+            packageInfo,
+        };
+    } catch (error) {
+        fs.rmSync(stagingRoot, { recursive: true, force: true });
+        throw error;
+    }
+}

--- a/src/zip-update-helper.js
+++ b/src/zip-update-helper.js
@@ -1,0 +1,303 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { spawn, spawnSync } from 'node:child_process';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const PROTECTED_TOP_LEVEL = new Set(['.git', 'backups', 'cache', 'data', 'node_modules']);
+
+function decodePayload(encoded) {
+    const decoded = Buffer.from(String(encoded ?? ''), 'base64').toString('utf8');
+    return JSON.parse(decoded);
+}
+
+function isProcessAlive(pid) {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch (error) {
+        return error?.code !== 'ESRCH';
+    }
+}
+
+function isPathInside(parent, candidate) {
+    const relative = path.relative(parent, candidate);
+    return relative === '' || (relative && !relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function buildVisibleWindowsCommand(command, cwd) {
+    const quoted = command.map(value => `"${String(value).replace(/"/g, '\\"')}"`).join(' ');
+    const title = 'SillyBunny Server';
+    return [
+        'cmd.exe',
+        [
+            '/d',
+            '/s',
+            '/c',
+            'start',
+            `"${title}"`,
+            '/D',
+            `"${cwd}"`,
+            'cmd.exe',
+            '/k',
+            quoted,
+        ],
+    ];
+}
+
+async function waitForParentExit(pid) {
+    while (isProcessAlive(pid)) {
+        await delay(250);
+    }
+}
+
+function createTimestamp() {
+    return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+function appendLog(logPath, message) {
+    fs.appendFileSync(logPath, `[${new Date().toISOString()}] ${message}\n`);
+}
+
+function shouldSkipRelativePath(relativePath) {
+    const topLevel = String(relativePath ?? '').split(path.sep)[0];
+    return PROTECTED_TOP_LEVEL.has(topLevel);
+}
+
+function collectReleaseEntries(releaseRoot, currentDirectory = releaseRoot, entries = []) {
+    for (const entry of fs.readdirSync(currentDirectory, { withFileTypes: true })) {
+        const sourcePath = path.join(currentDirectory, entry.name);
+        const relativePath = path.relative(releaseRoot, sourcePath);
+
+        if (shouldSkipRelativePath(relativePath)) {
+            continue;
+        }
+
+        if (entry.isDirectory()) {
+            entries.push({ type: 'directory', sourcePath, relativePath, mode: fs.statSync(sourcePath).mode & 0o777 });
+            collectReleaseEntries(releaseRoot, sourcePath, entries);
+        } else if (entry.isFile()) {
+            entries.push({ type: 'file', sourcePath, relativePath, mode: fs.statSync(sourcePath).mode & 0o777 });
+        }
+    }
+
+    return entries;
+}
+
+function backupDestination(destinationPath, backupRoot, installDir, state) {
+    if (!fs.existsSync(destinationPath) || state.backups.has(destinationPath)) {
+        return;
+    }
+
+    const backupPath = path.join(backupRoot, path.relative(installDir, destinationPath));
+    fs.mkdirSync(path.dirname(backupPath), { recursive: true });
+    fs.cpSync(destinationPath, backupPath, { recursive: true, force: true, verbatimSymlinks: true });
+    state.backups.set(destinationPath, backupPath);
+}
+
+function removePath(targetPath) {
+    fs.rmSync(targetPath, { recursive: true, force: true });
+}
+
+function copyFileWithMode(sourcePath, destinationPath, mode) {
+    fs.copyFileSync(sourcePath, destinationPath);
+    fs.chmodSync(destinationPath, mode || 0o644);
+}
+
+function applyReleaseOverlay({ releaseRoot, installDir, backupRoot, logPath }, state) {
+    const entries = collectReleaseEntries(releaseRoot);
+
+    appendLog(logPath, `Applying ${entries.length} release entries from ${releaseRoot}.`);
+
+    for (const entry of entries) {
+        const destinationPath = path.resolve(installDir, entry.relativePath);
+
+        if (!isPathInside(installDir, destinationPath)) {
+            throw new Error(`Release entry escapes the install directory: ${entry.relativePath}`);
+        }
+
+        if (entry.type === 'directory') {
+            if (fs.existsSync(destinationPath) && !fs.statSync(destinationPath).isDirectory()) {
+                backupDestination(destinationPath, backupRoot, installDir, state);
+                removePath(destinationPath);
+            }
+
+            if (!fs.existsSync(destinationPath)) {
+                fs.mkdirSync(destinationPath, { recursive: true, mode: entry.mode || 0o755 });
+                state.createdPaths.push(destinationPath);
+            }
+            continue;
+        }
+
+        fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+
+        if (fs.existsSync(destinationPath)) {
+            backupDestination(destinationPath, backupRoot, installDir, state);
+            if (fs.statSync(destinationPath).isDirectory()) {
+                removePath(destinationPath);
+            }
+        } else {
+            state.createdPaths.push(destinationPath);
+        }
+
+        copyFileWithMode(entry.sourcePath, destinationPath, entry.mode);
+    }
+}
+
+function rollbackOverlay(installDir, state, logPath) {
+    appendLog(logPath, 'Rolling back ZIP update overlay.');
+
+    for (const createdPath of [...state.createdPaths].sort((left, right) => right.length - left.length)) {
+        removePath(createdPath);
+    }
+
+    const backups = [...state.backups.entries()].sort(([left], [right]) => right.length - left.length);
+    for (const [destinationPath, backupPath] of backups) {
+        if (!isPathInside(installDir, destinationPath)) {
+            continue;
+        }
+        removePath(destinationPath);
+        fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+        fs.cpSync(backupPath, destinationPath, { recursive: true, force: true, verbatimSymlinks: true });
+    }
+}
+
+function hasCommand(command) {
+    const result = spawnSync(command, ['--version'], { stdio: 'ignore', windowsHide: true });
+    return result.status === 0;
+}
+
+function runInstallCommand(installDir, logPath) {
+    const hasDevDependencies = fs.existsSync(path.join(installDir, 'node_modules', 'eslint', 'package.json'));
+    let command = '';
+    let args = [];
+
+    if (fs.existsSync(path.join(installDir, 'bun.lock')) && hasCommand('bun')) {
+        command = 'bun';
+        args = hasDevDependencies ? ['install'] : ['install', '--production'];
+    } else if (fs.existsSync(path.join(installDir, 'package-lock.json')) && hasCommand('npm')) {
+        command = 'npm';
+        args = hasDevDependencies
+            ? ['ci', '--no-audit', '--no-fund']
+            : ['ci', '--no-audit', '--no-fund', '--omit=dev'];
+    } else if (fs.existsSync(path.join(installDir, 'package.json')) && hasCommand('npm')) {
+        command = 'npm';
+        args = hasDevDependencies
+            ? ['install', '--no-audit', '--no-fund']
+            : ['install', '--no-audit', '--no-fund', '--omit=dev'];
+    }
+
+    if (!command) {
+        appendLog(logPath, 'Dependency install skipped because Bun/npm was unavailable.');
+        return;
+    }
+
+    appendLog(logPath, `Running dependency install: ${[command, ...args].join(' ')}`);
+    const result = spawnSync(command, args, {
+        cwd: installDir,
+        env: process.env,
+        encoding: 'utf8',
+        maxBuffer: 20 * 1024 * 1024,
+        windowsHide: false,
+    });
+
+    if (result.stdout) {
+        appendLog(logPath, result.stdout.trimEnd());
+    }
+    if (result.stderr) {
+        appendLog(logPath, result.stderr.trimEnd());
+    }
+
+    if (result.status !== 0) {
+        throw new Error(`Dependency install failed with exit code ${result.status}.`);
+    }
+}
+
+function relaunchServer(payload) {
+    const command = Array.isArray(payload?.command) ? payload.command : [];
+    const cwd = String(payload?.installDir ?? process.cwd());
+    const envPatch = payload?.envPatch && typeof payload.envPatch === 'object' ? payload.envPatch : {};
+    const visibleRelaunch = Boolean(payload?.visibleRelaunch);
+
+    if (command.length < 2) {
+        return;
+    }
+
+    const relaunch = visibleRelaunch && process.platform === 'win32'
+        ? buildVisibleWindowsCommand(command, cwd)
+        : [command[0], command.slice(1)];
+
+    const child = spawn(relaunch[0], relaunch[1], {
+        cwd,
+        detached: true,
+        stdio: visibleRelaunch && process.platform === 'win32' ? ['ignore', 'inherit', 'inherit'] : 'ignore',
+        env: { ...process.env, ...envPatch },
+        windowsHide: false,
+    });
+
+    child.unref();
+}
+
+function validatePayload(payload) {
+    const parentPid = Number(payload?.parentPid);
+    const installDir = path.resolve(String(payload?.installDir ?? ''));
+    const stagingRoot = path.resolve(String(payload?.stagingRoot ?? ''));
+    const releaseRoot = path.resolve(String(payload?.releaseRoot ?? ''));
+
+    if (!Number.isFinite(parentPid) || parentPid <= 0) {
+        throw new Error('ZIP update helper payload did not include a valid parent process ID.');
+    }
+
+    if (!fs.existsSync(path.join(installDir, 'package.json'))) {
+        throw new Error('ZIP update helper install directory is not a SillyBunny app folder.');
+    }
+
+    if (!isPathInside(stagingRoot, releaseRoot) || !fs.existsSync(path.join(releaseRoot, 'package.json'))) {
+        throw new Error('ZIP update helper release staging directory is invalid.');
+    }
+
+    return { parentPid, installDir, stagingRoot, releaseRoot };
+}
+
+async function main() {
+    const payload = decodePayload(process.argv[2]);
+    const { parentPid, installDir, stagingRoot, releaseRoot } = validatePayload(payload);
+    const backupRoot = path.join(installDir, 'backups', `zip-update-${createTimestamp()}`);
+    const logPath = path.join(backupRoot, 'zip-update.log');
+    const state = { backups: new Map(), createdPaths: [] };
+    let failure = null;
+
+    fs.mkdirSync(backupRoot, { recursive: true });
+    appendLog(logPath, `Waiting for parent process ${parentPid} to exit before applying ZIP update.`);
+    await waitForParentExit(parentPid);
+    await delay(800);
+
+    try {
+        applyReleaseOverlay({ releaseRoot, installDir, backupRoot, logPath }, state);
+        runInstallCommand(installDir, logPath);
+        fs.rmSync(stagingRoot, { recursive: true, force: true });
+        appendLog(logPath, 'ZIP update applied successfully. Relaunching SillyBunny.');
+    } catch (error) {
+        failure = error;
+        appendLog(logPath, `ZIP update failed: ${error?.message || error}`);
+        try {
+            rollbackOverlay(installDir, state, logPath);
+        } catch (rollbackError) {
+            appendLog(logPath, `Rollback failed: ${rollbackError?.message || rollbackError}`);
+        }
+    } finally {
+        relaunchServer(payload);
+    }
+
+    if (failure) {
+        throw failure;
+    }
+}
+
+try {
+    await main();
+    process.exit(0);
+} catch (error) {
+    console.error('ZIP update helper failed.', error);
+    process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add GitHub release ZIP status checks for non-git installs in Customize > Server
- download and stage validated SillyBunny-vX-github.zip assets, then swap app files with backup/rollback and relaunch helper
- keep data/cache/node_modules/backups protected during ZIP overlays and document the in-app updater as the preferred ZIP flow

## Testing
- npm run lint
- npm run test:unit --prefix tests
- npm run check:frontend-budgets
- npm run build:frontend
- bun src/server-init.js
- node src/server-init.js
- node --check src/server-admin-zip-update.js
- node --check src/zip-update-helper.js
- targeted ZIP helper overlay smoke test in /tmp/opencode