### PR TITLE
fix: refresh stale iOS service worker cache

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,9 +17,9 @@
             background-color: #1d2128;
         }
     </style>
-    <link rel="preload" as="style" href="style.css?v=20260603e">
+    <link rel="preload" as="style" href="style.css?v=20260609a">
     <link rel="modulepreload" href="script.js">
-    <link rel="modulepreload" href="scripts/sillybunny-tabs.js?v=20260603e">
+    <link rel="modulepreload" href="scripts/sillybunny-tabs.js?v=20260609a">
     <link rel="preload" as="font" type="font/woff2" href="webfonts/Figtree/Figtree-Regular.woff2?v=20260422b" crossorigin>
     <link rel="manifest" crossorigin="use-credentials" href="manifest.json">
     <link href="webfonts/Figtree/stylesheet.css?v=20260422b" rel="stylesheet">
@@ -40,14 +40,14 @@
     <link rel="apple-touch-icon" sizes="114x114" href="img/apple-icon-114x114.png" />
     <link rel="apple-touch-icon" sizes="144x144" href="img/apple-icon-144x144.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="img/apple-icon-180x180.png" />
-    <link rel="stylesheet" type="text/css" href="style.css?v=20260603e">
+    <link rel="stylesheet" type="text/css" href="style.css?v=20260609a">
     <link rel="stylesheet" type="text/css" href="css/st-tailwind.css">
     <link rel="stylesheet" type="text/css" href="css/toggle-dependent.css">
-    <link rel="stylesheet" type="text/css" href="css/select2-overrides.css?v=20260603e">
+    <link rel="stylesheet" type="text/css" href="css/select2-overrides.css?v=20260609a">
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260516d" media="(max-width: 768px)">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260603e">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260603e">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260603e" media="(max-width: 768px)">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260609a">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260609a">
+    <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260609a" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->
 </head>
@@ -8866,7 +8866,7 @@
     <script type="module" src="scripts/i18n.js"></script>
     <script type="module" src="scripts/performance-loader.js"></script>
     <script type="module" src="script.js"></script>
-    <script type="module" src="scripts/sillybunny-tabs.js?v=20260603e"></script>
+    <script type="module" src="scripts/sillybunny-tabs.js?v=20260609a"></script>
     <script>
         window.addEventListener('load', (event) => {
             const documentHeight = () => {

--- a/public/script.js
+++ b/public/script.js
@@ -988,7 +988,7 @@ function registerSillyBunnyServiceWorker() {
     }
 
     const register = () => {
-        navigator.serviceWorker.register('/sw.js?v=20260603e', { updateViaCache: 'none' }).then((registration) => {
+        navigator.serviceWorker.register('/sw.js?v=20260609a', { updateViaCache: 'none' }).then((registration) => {
             return registration.update().catch((error) => {
                 console.warn('Failed to update SillyBunny service worker.', error);
             });
@@ -11035,7 +11035,7 @@ export async function clearFrontendCache({ skipConfirmation = false, saveBeforeC
     if (!skipConfirmation) {
         const confirmation = await Popup.show.confirm(
             t`Clear all cache?`,
-            t`This removes browser cache, temporary session data, and IndexedDB cache stores for SillyBunny, then reloads the page. Saved settings and account data stay intact.`,
+            t`This removes browser cache, service worker data, temporary session data, and IndexedDB cache stores for SillyBunny, then reloads the page. Saved settings and account data stay intact.`,
             {
                 okButton: t`Clear cache`,
                 cancelButton: t`Cancel`,
@@ -11077,6 +11077,16 @@ export async function clearFrontendCache({ skipConfirmation = false, saveBeforeC
             await Promise.all(cacheNames.map(cacheName => caches.delete(cacheName)));
         } catch (error) {
             console.error('Failed to clear Cache Storage', error);
+            cacheErrors.push(error);
+        }
+    }
+
+    if (globalThis.navigator?.serviceWorker && typeof globalThis.navigator.serviceWorker.getRegistrations === 'function') {
+        try {
+            const registrations = await globalThis.navigator.serviceWorker.getRegistrations();
+            await Promise.all(registrations.map(registration => registration.unregister()));
+        } catch (error) {
+            console.error('Failed to unregister service workers', error);
             cacheErrors.push(error);
         }
     }

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -77,7 +77,7 @@ const SB_PANEL_STYLESHEETS = Object.freeze({
         { href: 'css/world-info.css?v=20260425b', id: 'deferred-world-info-css' },
     ],
     'characters:persona': [
-        { href: 'css/personas.css?v=20260603e', id: 'deferred-personas-css' },
+        { href: 'css/personas.css?v=20260609a', id: 'deferred-personas-css' },
     ],
     'left:advanced-formatting': [
         { href: 'css/macros.css', id: 'deferred-macros-css' },

--- a/public/style.css
+++ b/public/style.css
@@ -10,7 +10,7 @@
 @import url(css/accounts.css);
 @import url(css/tags.css);
 @import url(css/scrollable-button.css?v=20260517a);
-@import url(css/welcome.css?v=20260603e);
+@import url(css/welcome.css?v=20260609a);
 @import url(css/data-maid.css);
 @import url(css/secrets.css);
 @import url(css/backgrounds.css?v=20260606a);

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const SB_SW_CACHE_VERSION = 'sillybunny-cache-v20260603e';
+const SB_SW_CACHE_VERSION = 'sillybunny-cache-v20260609a';
 const SB_STATIC_CACHE = `${SB_SW_CACHE_VERSION}-static`;
 const SB_SHELL_CACHE = `${SB_SW_CACHE_VERSION}-shell`;
 const SB_FRONTEND_ASSET_PREFIX = '/frontend-assets/';


### PR DESCRIPTION
## Summary
- Bumps SillyBunny frontend cache tokens from 20260603e to 20260609a so old service workers miss stale CSS entries and fetch the fixed mobile shell CSS.
- Bumps the service worker cache version to evict older sillybunny-cache-* stores on activation.
- Updates Clear Cache to unregister service workers so manual clearing also removes stale SW registrations.

## Testing
- bunx eslint public/script.js public/sw.js public/scripts/sillybunny-tabs.js
- bun test frontend-asset-middleware.test.js frontend-assets.test.js (from tests/)
- git diff --check