### PR TITLE
feat: show approximate token estimate in chat selector

### DIFF
--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -4394,6 +4394,28 @@ function formatChatPreview(value) {
     return clampText(String(value ?? '').replace(/\s+/g, ' ').trim() || 'No preview yet.', 120);
 }
 
+function formatChatTokenEstimate(value) {
+    const tokens = Math.round(Number(value) || 0);
+    if (tokens <= 0) {
+        return '';
+    }
+
+    if (tokens >= 1_000_000) {
+        return `~${(tokens / 1_000_000).toFixed(tokens < 10_000_000 ? 1 : 0).replace(/\.0$/, '')}m tokens`;
+    }
+
+    if (tokens >= 1_000) {
+        return `~${(tokens / 1_000).toFixed(tokens < 10_000 ? 1 : 0).replace(/\.0$/, '')}k tokens`;
+    }
+
+    return `~${tokens} tokens`;
+}
+
+function formatChatSelectorLabel(fileName, tokenEstimate = 0) {
+    const tokenLabel = formatChatTokenEstimate(tokenEstimate);
+    return tokenLabel ? `${fileName} (${tokenLabel})` : fileName;
+}
+
 function normalizeChatInfo(chatInfo) {
     const rawFileName = chatInfo?.file_name ?? chatInfo?.id ?? chatInfo?.chat_id ?? chatInfo ?? '';
     const fileName = normalizeChatFileName(rawFileName);
@@ -4404,6 +4426,7 @@ function normalizeChatInfo(chatInfo) {
         lastMessage: chatInfo?.last_mes ?? chatInfo?.updated_at ?? chatInfo?.create_date ?? '',
         sortTimestamp: getChatSortTimestamp(chatInfo?.last_mes ?? chatInfo?.updated_at ?? chatInfo?.create_date ?? ''),
         chatItems: Number(chatInfo?.chat_items ?? chatInfo?.message_count ?? 0) || 0,
+        tokenEstimate: Number(chatInfo?.token_estimate ?? chatInfo?.tokenEstimate ?? 0) || 0,
         fileSize: String(chatInfo?.file_size ?? '').trim(),
     };
 }
@@ -4998,17 +5021,27 @@ function countRegexMatches(value, regex) {
     return Array.from(text.matchAll(regex)).length;
 }
 
-function populateChatSelector(select, chatNames, chatContext, placeholder) {
+function populateChatSelector(select, chatFiles, chatContext, placeholder) {
     if (!(select instanceof HTMLSelectElement)) {
         return;
     }
 
     const currentValue = String(chatContext.chatId ?? '').trim();
-    const uniqueNames = Array.from(new Set(chatNames.map(name => String(name ?? '').trim()).filter(Boolean))).sort((left, right) => left.localeCompare(right));
+    const uniqueChats = Array.from(chatFiles.reduce((map, chatFile) => {
+        const fileName = String(chatFile?.fileName ?? chatFile ?? '').trim();
+        if (fileName && !map.has(fileName)) {
+            map.set(fileName, {
+                fileName,
+                tokenEstimate: Number(chatFile?.tokenEstimate ?? 0) || 0,
+            });
+        }
+
+        return map;
+    }, new Map()).values()).sort((left, right) => left.fileName.localeCompare(right.fileName));
 
     select.replaceChildren();
 
-    if (!uniqueNames.length) {
+    if (!uniqueChats.length) {
         const option = createElement('option', { text: placeholder });
         option.value = '';
         option.selected = true;
@@ -5017,14 +5050,15 @@ function populateChatSelector(select, chatNames, chatContext, placeholder) {
         return;
     }
 
-    for (const chatName of uniqueNames) {
-        const option = createElement('option', { text: chatName });
+    for (const chat of uniqueChats) {
+        const chatName = chat.fileName;
+        const option = createElement('option', { text: formatChatSelectorLabel(chatName, chat.tokenEstimate) });
         option.value = chatName;
         option.selected = chatName === currentValue;
         select.appendChild(option);
     }
 
-    if (currentValue && !uniqueNames.includes(currentValue)) {
+    if (currentValue && !uniqueChats.some(chat => chat.fileName === currentValue)) {
         const option = createElement('option', { text: currentValue });
         option.value = currentValue;
         option.selected = true;
@@ -5032,7 +5066,7 @@ function populateChatSelector(select, chatNames, chatContext, placeholder) {
     }
 
     select.disabled = false;
-    select.value = currentValue || uniqueNames[0];
+    select.value = currentValue || uniqueChats[0].fileName;
 }
 
 function createChatFileButton(chatFile, currentChatId, onSelect, { compact = false } = {}) {
@@ -6092,11 +6126,11 @@ async function refreshChatbarState() {
     const chatNames = files.map(chat => chat.fileName);
 
     if (chatContext.chatId && !chatNames.includes(chatContext.chatId)) {
-        chatNames.unshift(chatContext.chatId);
+        files.unshift({ fileName: chatContext.chatId, tokenEstimate: 0 });
     }
 
-    populateChatSelector(desktopRefs?.chatSelect, chatNames, chatContext, chatContext.canBrowseChats ? 'No saved chats yet' : 'No chat selected');
-    populateChatSelector(mobileRefs?.chatSelect, chatNames, chatContext, chatContext.canBrowseChats ? 'No saved chats yet' : 'No chat selected');
+    populateChatSelector(desktopRefs?.chatSelect, files, chatContext, chatContext.canBrowseChats ? 'No saved chats yet' : 'No chat selected');
+    populateChatSelector(mobileRefs?.chatSelect, files, chatContext, chatContext.canBrowseChats ? 'No saved chats yet' : 'No chat selected');
 
     if (desktopRefs) {
         setButtonDisabled(desktopRefs.managerButton, !chatContext.canBrowseChats);
@@ -14292,20 +14326,22 @@ async function refreshBottomChatSelect() {
     }
 
     try {
-        const chats = (await getChatFilesForContext(chatContext)).map(chat => chat.fileName);
+        const chats = await getChatFilesForContext(chatContext);
+        const chatNames = chats.map(chat => chat.fileName);
 
         chatSelect.replaceChildren();
 
-        for (const chatName of chats) {
+        for (const chat of chats) {
+            const chatName = chat.fileName;
             if (!chatName) continue;
             const option = document.createElement('option');
             option.value = chatName;
-            option.textContent = chatName;
+            option.textContent = formatChatSelectorLabel(chatName, chat.tokenEstimate);
             option.selected = chatName === currentChatName;
             chatSelect.appendChild(option);
         }
 
-        if (!chats.includes(currentChatName)) {
+        if (!chatNames.includes(currentChatName)) {
             const fallback = document.createElement('option');
             fallback.value = '';
             fallback.textContent = currentChatName || 'No chat selected';

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -509,6 +509,7 @@ async function checkChatIntegrity(filePath, integritySlug) {
  * @property {string} [file_name] - The name of the chat file (with extension)
  * @property {string} [file_size] - The size of the chat file in a human-readable format
  * @property {number} [chat_items] - The number of chat items in the file
+ * @property {number} [token_estimate] - The approximate number of tokens in the chat
  * @property {string} [mes] - The last message in the chat
  * @property {number|string} [last_mes] - The timestamp of the last message
  * @property {object} [chat_metadata] - Additional chat metadata
@@ -537,6 +538,7 @@ export async function getChatInfo(pathToFile, additionalData = {}, withMetadata 
             file_name: parsedPath.base,
             file_size: formatBytes(stats.size),
             chat_items: 0,
+            token_estimate: 0,
             mes: '[The chat is empty]',
             last_mes: stats.mtimeMs,
             ...additionalData,
@@ -557,6 +559,7 @@ export async function getChatInfo(pathToFile, additionalData = {}, withMetadata 
             let itemCounter = 0;
             let hasAnyMatch = false;
             let matchBuffer = [];
+            let messageCharacters = 0;
             const previewMessages = [];
             const previewLimit = Math.max(0, Number(previewMessageLimit) || 0);
 
@@ -564,16 +567,22 @@ export async function getChatInfo(pathToFile, additionalData = {}, withMetadata 
             rl.once('error', rej);
 
             rl.on('line', (line) => {
-                if (withMetadata && itemCounter === 0) {
-                    const jsonData = tryParse(line);
+                const isMessageLine = itemCounter > 0;
+                let jsonData = null;
+
+                if (withMetadata && !isMessageLine) {
+                    jsonData = tryParse(line);
                     if (jsonData && _.isObjectLike(jsonData.chat_metadata)) {
                         chatData.chat_metadata = jsonData.chat_metadata;
                     }
                 }
-                // Skip matching if any match was already found
-                if ((hasMatcher && !hasAnyMatch && itemCounter > 0) || (previewLimit > 0 && itemCounter > 0)) {
-                    const jsonData = tryParse(line);
+
+                if (isMessageLine) {
+                    jsonData = tryParse(line);
                     if (jsonData) {
+                        messageCharacters += String(jsonData.mes ?? '').length;
+
+                        // Skip matching if any match was already found
                         if (hasMatcher && !hasAnyMatch) {
                             matchBuffer.push(jsonData.mes || '');
                             if (matcher(matchBuffer)) {
@@ -604,6 +613,8 @@ export async function getChatInfo(pathToFile, additionalData = {}, withMetadata 
                 const jsonData = tryParse(lastLine);
                 if (jsonData && (jsonData.name || jsonData.character_name || jsonData.chat_metadata)) {
                     chatData.chat_items = (itemCounter - 1);
+                    // SillyBunny: expose a cheap chat length indicator for chat selectors.
+                    chatData.token_estimate = Math.round(messageCharacters / 4);
                     chatData.mes = jsonData.mes || '[The message is empty]';
                     chatData.last_mes = jsonData.send_date || new Date(Math.round(stats.mtimeMs)).toISOString();
                     chatData.match = hasMatcher ? hasAnyMatch : true;
@@ -1196,6 +1207,7 @@ router.post('/search', validateAvatarUrlMiddleware, async function (request, res
          * @property {string} [file_name] - The name of the chat file
          * @property {string} [file_size] - The size of the chat file in a human-readable format
          * @property {number} [message_count] - The number of messages in the chat
+         * @property {number} [token_estimate] - The approximate number of tokens in the chat
          * @property {number|string} [last_mes] - The timestamp of the last message
          * @property {string} [preview_message] - A preview of the last message
          */
@@ -1233,6 +1245,7 @@ router.post('/search', validateAvatarUrlMiddleware, async function (request, res
                     file_name: chatInfo.file_id,
                     file_size: chatInfo.file_size,
                     message_count: chatInfo.chat_items,
+                    token_estimate: chatInfo.token_estimate,
                     last_mes: chatInfo.last_mes,
                     preview_message: getPreviewMessage(chatInfo.mes),
                 });


### PR DESCRIPTION
## Summary
- add a cheap approximate token estimate to chat metadata while chat files are already being read
- append the estimate to desktop and mobile chat selector option labels, e.g. (~3.4k tokens)
- keep option values as raw chat filenames so switching chats is unchanged

## Testing
- npm ci --ignore-scripts
- npm run lint
- npm run check:frontend-budgets
- npm run build:frontend
- npm ci --ignore-scripts (tests)
- npm run test:unit (tests)
- bun src/server-init.js
- node src/server-init.js
- Firefox desktop and mobile viewport smoke on local Node server