### PR TITLE
fix: respect reverse proxies for agent profile requests

### DIFF
--- a/public/scripts/extensions/shared.js
+++ b/public/scripts/extensions/shared.js
@@ -38,6 +38,36 @@ export function getChatCompletionProfileRequestOverrides(profile, overridePayloa
     return { overrides, profileFieldNames };
 }
 
+function getReverseProxyRequestFields(proxyPreset) {
+    if (!proxyPreset?.url) {
+        return {};
+    }
+
+    return {
+        reverse_proxy: proxyPreset.url,
+        proxy_password: proxyPreset.password,
+    };
+}
+
+export function getChatCompletionProfileReverseProxy(profile, chatCompletionSource) {
+    const profileProxy = proxies.find((preset) => preset.name === profile?.proxy);
+    const profileProxyFields = getReverseProxyRequestFields(profileProxy);
+    if (profileProxyFields.reverse_proxy) {
+        return profileProxyFields;
+    }
+
+    const sourceProxy = proxies.find((preset) => preset.name !== 'None' && preset.source === chatCompletionSource && preset.url);
+    const sourceProxyFields = getReverseProxyRequestFields(sourceProxy);
+    if (sourceProxyFields.reverse_proxy) {
+        return sourceProxyFields;
+    }
+
+    return getReverseProxyRequestFields({
+        url: oai_settings.reverse_proxy,
+        password: oai_settings.proxy_password,
+    });
+}
+
 /**
  * Generates a caption for an image using a multimodal model.
  * @param {string} base64Img Base64 encoded image
@@ -468,7 +498,7 @@ export class ConnectionManagerRequestService {
                         throw new Error(`API type ${selectedApiMap.selected} does not support chat completions`);
                     }
 
-                    const proxyPreset = proxies.find((p) => p.name === profile.proxy);
+                    const reverseProxyFields = getChatCompletionProfileReverseProxy(profile, selectedApiMap.source);
 
                     const model = typeof modelOverride === 'string' && modelOverride.trim()
                         ? modelOverride.trim()
@@ -481,8 +511,9 @@ export class ConnectionManagerRequestService {
                         model,
                         chat_completion_source: selectedApiMap.source,
                         secret_id: profile['secret-id'],
-                        reverse_proxy: proxyPreset?.url,
-                        proxy_password: proxyPreset?.password,
+                        // SillyBunny: direct profile requests do not run the profile's slash commands,
+                        // so recover reverse proxy fields from the profile preset or current proxy state.
+                        ...reverseProxyFields,
                         custom_prompt_post_processing: profile['prompt-post-processing'],
                         // SillyBunny: persist profile-scoped reasoning and image request settings through the shared request path.
                         ...profileRequestOverrides.overrides,

--- a/tests/connection-profile-request-fields.test.js
+++ b/tests/connection-profile-request-fields.test.js
@@ -1,4 +1,7 @@
-import { describe, expect, jest, test } from '@jest/globals';
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+const mockOpenAiSettings = {};
+const mockProxies = [];
 
 await jest.unstable_mockModule('../public/script.js', () => ({
     CONNECT_API_MAP: {},
@@ -18,8 +21,8 @@ await jest.unstable_mockModule('../public/scripts/i18n.js', () => ({
 }));
 
 await jest.unstable_mockModule('../public/scripts/openai.js', () => ({
-    oai_settings: {},
-    proxies: [],
+    oai_settings: mockOpenAiSettings,
+    proxies: mockProxies,
     ZAI_ENDPOINT: {
         COMMON: 'common',
     },
@@ -45,7 +48,10 @@ await jest.unstable_mockModule('../public/scripts/utils.js', () => ({
     isValidUrl: jest.fn(() => true),
 }));
 
-const { getChatCompletionProfileRequestOverrides } = await import('../public/scripts/extensions/shared.js');
+const {
+    getChatCompletionProfileRequestOverrides,
+    getChatCompletionProfileReverseProxy,
+} = await import('../public/scripts/extensions/shared.js');
 
 const mappedRequestFieldNames = [
     'include_reasoning',
@@ -84,6 +90,13 @@ function createReasoningProfile(overrides = {}) {
         ...overrides,
     };
 }
+
+beforeEach(() => {
+    for (const key of Object.keys(mockOpenAiSettings)) {
+        delete mockOpenAiSettings[key];
+    }
+    mockProxies.splice(0, mockProxies.length);
+});
 
 describe('Connection Profile chat-completion request field mapping', () => {
     test('leaves existing profiles without reasoning request keys unchanged', () => {
@@ -156,5 +169,54 @@ describe('Connection Profile chat-completion request field mapping', () => {
         });
         expect(result.profileFieldNames).toEqual(mappedRequestFieldNames.filter(field => !Object.hasOwn(overridePayload, field)));
         expect({ ...result.overrides, ...overridePayload }).toEqual(expect.objectContaining(overridePayload));
+    });
+});
+
+describe('Connection Profile reverse proxy request mapping', () => {
+    test('uses the saved profile proxy preset before fallbacks', () => {
+        mockOpenAiSettings.reverse_proxy = 'https://active.example/v1';
+        mockOpenAiSettings.proxy_password = 'active-secret';
+        mockProxies.push(
+            { name: 'Profile proxy', url: 'https://profile.example/v1', password: 'profile-secret', source: 'openai' },
+            { name: 'Source proxy', url: 'https://source.example/v1', password: 'source-secret', source: 'makersuite' },
+        );
+
+        expect(getChatCompletionProfileReverseProxy({ proxy: 'Profile proxy' }, 'makersuite')).toEqual({
+            reverse_proxy: 'https://profile.example/v1',
+            proxy_password: 'profile-secret',
+        });
+    });
+
+    test('falls back to a backend-bound proxy preset when the profile preset has no URL', () => {
+        mockProxies.push(
+            { name: 'None', url: '', password: '', source: '' },
+            { name: 'Gemini proxy', url: 'https://proxy.example/google', password: '', source: 'makersuite' },
+        );
+
+        expect(getChatCompletionProfileReverseProxy({ proxy: 'None' }, 'makersuite')).toEqual({
+            reverse_proxy: 'https://proxy.example/google',
+            proxy_password: '',
+        });
+        expect(getChatCompletionProfileReverseProxy({ proxy: 'Deleted proxy' }, 'makersuite')).toEqual({
+            reverse_proxy: 'https://proxy.example/google',
+            proxy_password: '',
+        });
+    });
+
+    test('falls back to the active reverse proxy for unsaved manual proxy URLs', () => {
+        mockOpenAiSettings.reverse_proxy = 'https://manual.example/v1';
+        mockOpenAiSettings.proxy_password = 'manual-secret';
+        mockProxies.push({ name: 'None', url: '', password: '', source: '' });
+
+        expect(getChatCompletionProfileReverseProxy({ proxy: 'None' }, 'openai')).toEqual({
+            reverse_proxy: 'https://manual.example/v1',
+            proxy_password: 'manual-secret',
+        });
+    });
+
+    test('omits reverse proxy fields when no usable proxy is available', () => {
+        mockProxies.push({ name: 'None', url: '', password: '', source: '' });
+
+        expect(getChatCompletionProfileReverseProxy({ proxy: 'None' }, 'openai')).toEqual({});
     });
 });


### PR DESCRIPTION
## Summary
- resolve reverse proxy fields for direct agent connection-profile requests through a shared helper
- prefer the saved profile proxy preset, then a backend-bound preset, then the active manual reverse proxy URL
- add regression coverage for saved, source-bound, stale, manual, and unavailable proxy cases

## Testing
- node --experimental-vm-modules /home/platinum/SillyBunny/tests/node_modules/jest/bin/jest.js --config tests/jest.config.json connection-profile-request-fields.test.js