### PR TITLE
chore: narrow top bar height and reduce message text padding

### DIFF
--- a/public/css/sillybunny-chat-styles.css
+++ b/public/css/sillybunny-chat-styles.css
@@ -25,9 +25,9 @@
     --messageLineHeight: calc(var(--mainFontSize) + .5rem);
     --messageTextLetterSpacing: inherit;
     --customlastInContext: 1px solid var(--customThemeColor);
-    --custom-EchoAvatarWidth: 25%;
+    --custom-EchoAvatarWidth: 22%;
     --custom-EchoAvatarHeight: 300px;
-    --custom-EchoAvatarMobileWidth: 25%;
+    --custom-EchoAvatarMobileWidth: 22%;
     --custom-EchoAvatarMobileHeight: 250px;
     --customWhisperAvatarWidth: 50%;
     --customWhisperAvatarAlign: center;
@@ -231,11 +231,11 @@ body.echostyle #chat {
 
             .mes_text,
             .last_mes .mes_text {
-                padding: 10px 20px 10px var(--custom-EchoAvatarWidth, 25%) !important;
+                padding: 8px 14px 8px var(--custom-EchoAvatarWidth, 22%) !important;
                 background-color: var(--moonlit-sb-user-message-bg);
 
                 @media screen and (max-width: 1000px) {
-                    padding: 10px 20px 10px var(--custom-EchoAvatarMobileWidth, 25%) !important;
+                    padding: 8px 14px 8px var(--custom-EchoAvatarMobileWidth, 22%) !important;
                 }
             }
         }
@@ -278,10 +278,10 @@ body.echostyle #chat {
             }
             .mes_text,
             .last_mes .mes_text {
-                padding: 10px var(--custom-EchoAvatarWidth, 25%) 10px 20px !important;
+                padding: 8px var(--custom-EchoAvatarWidth, 22%) 8px 14px !important;
 
                 @media screen and (max-width: 1000px) {
-                    padding: 10px var(--custom-EchoAvatarMobileWidth, 25%) 10px 20px !important;
+                    padding: 8px var(--custom-EchoAvatarMobileWidth, 22%) 8px 14px !important;
                 }
             }
         }
@@ -376,8 +376,8 @@ body.whisperstyle #chat {
         width: 100%;
         color: var(--SmartThemeBodyColor);
         position: relative;
-        padding: 1em;
-        padding-top: 45px !important;
+        padding: 0.8em;
+        padding-top: 40px !important;
         border-radius: 15px;
 
         &::before {
@@ -570,7 +570,7 @@ body.hushstyle #chat {
         width: 100%;
         color: var(--SmartThemeBodyColor);
         position: relative;
-        padding: 1.3em 1.2em;
+        padding: 1em;
         border-radius: 15px;
 
         &.last_mes::before {
@@ -779,9 +779,9 @@ body.ripplestyle #chat {
             border: none !important;
             box-shadow: none !important;
             box-sizing: border-box;
-            padding-top: 20px;
-            padding-left: 12px;
-            padding-right: 24px;
+            padding-top: 16px;
+            padding-left: 10px;
+            padding-right: 18px;
 
             .ch_name::after {
                 content: "";
@@ -894,10 +894,10 @@ body.ripplestyle.big-avatars #chat .mes {
 /* --- Chat Style: Tide 聊天風格：「潮汐」 --- */
 
 body.tidestyle #chat {
-    padding: 0 15px;
+    padding: 0 12px;
 
     @media screen and (max-width: 1000px) {
-        padding: 0 1em;
+        padding: 0 0.8em;
     }
 
     .mes {
@@ -933,9 +933,9 @@ body.tidestyle #chat {
             display: inline-block;
             overflow: hidden;
             border-radius: 0;
-            padding-top: 10px;
+            padding-top: 8px;
             padding-bottom: 0 !important;
-            max-width: 70%;
+            max-width: 74%;
 
             p {
                 display: block;
@@ -943,12 +943,12 @@ body.tidestyle #chat {
                 margin: 0;
                 margin-bottom: 8px !important;
                 background: var(--moonlit-sb-bot-message-bg);
-                padding: 6px 14px !important;
+                padding: 5px 11px !important;
                 border-radius: 18px;
             }
 
             @media screen and (max-width: 1000px) {
-                max-width: 90%;
+                max-width: 92%;
             }
         }
 

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -41,14 +41,14 @@
     --sb-connection-strip-padding-x-base: 10px;
     --sb-connection-strip-radius-base: 14px;
     --sb-proxy-button-padding-x-base: 15px;
-    --sb-proxy-button-height-base: 40px;
+    --sb-proxy-button-height-base: 36px;
     --sb-proxy-button-min-width-base: 104px;
     --sb-proxy-button-gap-base: 8px;
     --sb-proxy-icon-scale-base: 0.92;
     --sb-proxy-label-scale-base: 0.76;
     --sb-proxy-underline-inset-base: 12px;
     --sb-proxy-underline-bottom-base: 5px;
-    --sb-mobile-toggle-size-base: 44px;
+    --sb-mobile-toggle-size-base: 40px;
     --sb-home-toggle-min-width-base: 92px;
     --sb-topbar-compact-icon-scale-base: 0.84;
     --sb-mobile-tools-padding-top-base: 10px;

--- a/public/css/toggle-dependent.css
+++ b/public/css/toggle-dependent.css
@@ -306,8 +306,9 @@ body.big-avatars .collage_4 .img_4 {
 
 /*bubble chat style*/
 
+/* SillyBunny: denser chat-style spacing so message text has more room. */
 body.bubblechat .mes {
-    padding: 10px;
+    padding: 8px;
     border-radius: 10px;
     background-color: var(--SmartThemeBotMesBlurTintColor);
     margin-bottom: 5px;
@@ -323,7 +324,7 @@ body.bubblechat .mes[is_user="true"] {
 /* Document Style */
 
 body.documentstyle #chat .mes:not(.last_mes) {
-    padding: 5px 10px 0px 10px;
+    padding: 4px 8px 0px 8px;
 }
 
 body.documentstyle .last_mes {
@@ -335,15 +336,15 @@ body.documentstyle #chat .mes .mes_text {
 }
 
 body.documentstyle #chat .mes .mes_block {
-    margin-right: 30px;
+    margin-right: 24px;
 }
 
 body.documentstyle #chat .mes .mes_text {
-    margin-left: 20px;
+    margin-left: 16px;
 }
 
 body.documentstyle #chat .last_mes .mes_text {
-    margin-left: 20px;
+    margin-left: 16px;
     min-height: 70px;
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -1310,7 +1310,8 @@ body .panelControlBar {
     align-items: flex-start;
     contain: layout paint style;
     contain-intrinsic-size: auto 180px;
-    padding: 12px 14px 4px 14px;
+    /* SillyBunny: keep chat text denser without collapsing message breathing room. */
+    padding: 8px 10px 3px 10px;
     margin-top: 0;
     width: 100%;
     color: var(--SmartThemeBodyColor);
@@ -1640,7 +1641,8 @@ img[src*="sillybunny-pixel-logo"] {
 
 .mes_block {
     padding-top: 0;
-    padding-left: 10px;
+    /* SillyBunny: reduce the avatar-to-text gutter for denser chat styles. */
+    padding-left: 8px;
     width: 100%;
     overflow-x: hidden;
     overflow-y: clip;
@@ -1661,7 +1663,8 @@ img[src*="sillybunny-pixel-logo"] {
 }
 
 .mes_text {
-    padding: 5px var(--mes-right-spacing) 5px 0;
+    /* SillyBunny: let rendered chat text occupy more horizontal space. */
+    padding: 3px calc(var(--mes-right-spacing) - 6px) 3px 0;
 }
 
 .mes_text hr {


### PR DESCRIPTION
## Summary
- Narrow the SillyBunny top bar by reducing the proxy/toggle base heights modestly.
- Reduce rendered message padding/gutters for Flat, Bubbles, Document, Echo, Whisper, Hush, Ripple, and Tide chat styles.
- Let Echo and Tide text regions occupy a little more horizontal space without changing the overall chat-style structure.

## Testing
- PASS: git diff --check
- BLOCKED: npm run build:frontend (missing package terser imported from scripts/build-frontend-assets.js in this worktree)