### PR TITLE
fix: abort agent generation requests on cancel

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -5169,18 +5169,33 @@ export function getStoppingStrings(isImpersonate, isContinue, api = main_api) {
  * @prop {object} [jsonSchema] JSON schema to use for the structured generation. Usually requires a special instruction.
  * @prop {boolean} [removeReasoning] Parses and removes the reasoning block according to reasoning format preferences
  * @prop {boolean} [trimToSentence] Whether to trim the response to the last complete sentence
+ * @prop {AbortSignal} [signal] Optional signal to abort the request.
  * @prop {'main'|'auxiliary'|'none'} [cacheScope] Prompt cache lane for local backends.
  * @param {GenerateQuietPromptParams} params Parameters for the quiet prompt generation
  * @returns {Promise<string>} Generated text. If using structured output, will contain a serialized JSON object.
  */
-export async function generateQuietPrompt({ quietPrompt = '', quietToLoud = false, skipWIAN = false, quietImage = null, quietName = null, responseLength = null, forceChId = null, jsonSchema = null, removeReasoning = true, trimToSentence = false, cacheScope = 'auxiliary' } = {}) {
+export async function generateQuietPrompt({ quietPrompt = '', quietToLoud = false, skipWIAN = false, quietImage = null, quietName = null, responseLength = null, forceChId = null, jsonSchema = null, removeReasoning = true, trimToSentence = false, signal = null, cacheScope = 'auxiliary' } = {}) {
     if (arguments.length > 0 && typeof arguments[0] !== 'object') {
         console.trace('generateQuietPrompt called with positional arguments. Please use an object instead.');
         [quietPrompt, quietToLoud, skipWIAN, quietImage, quietName, responseLength, forceChId, jsonSchema] = arguments;
     }
 
     const responseLengthCustomized = typeof responseLength === 'number' && responseLength > 0;
+    const externalSignal = signal instanceof AbortSignal ? signal : null;
+    const quietAbortController = externalSignal ? new AbortController() : null;
+    const abortFromExternalSignal = quietAbortController
+        ? () => quietAbortController.abort(externalSignal.reason ?? new Error('Cancelled by external signal'))
+        : null;
     let eventHook = () => { };
+
+    if (externalSignal) {
+        if (externalSignal.aborted) {
+            abortFromExternalSignal();
+        } else {
+            externalSignal.addEventListener('abort', abortFromExternalSignal, { once: true });
+        }
+    }
+
     try {
         /** @type {GenerateOptions} */
         const generateOptions = {
@@ -5192,17 +5207,24 @@ export async function generateQuietPrompt({ quietPrompt = '', quietToLoud = fals
             quietName: quietName ?? null,
             force_chid: forceChId ?? null,
             jsonSchema: jsonSchema ?? null,
+            signal: quietAbortController?.signal ?? null,
             cacheScope,
         };
         if (responseLengthCustomized) {
             TempResponseLength.save(main_api, responseLength);
             eventHook = TempResponseLength.setupEventHook(main_api);
         }
+        if (quietAbortController) {
+            abortController = quietAbortController;
+        }
         let result = await Generate('quiet', generateOptions);
         result = trimToSentence ? trimToEndSentence(result) : result;
         result = removeReasoning ? removeReasoningFromString(result) : result;
         return result;
     } finally {
+        if (externalSignal && abortFromExternalSignal) {
+            externalSignal.removeEventListener('abort', abortFromExternalSignal);
+        }
         if (responseLengthCustomized && TempResponseLength.isCustomized()) {
             TempResponseLength.restore(main_api);
             TempResponseLength.removeEventHook(main_api, eventHook);

--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -123,6 +123,7 @@ let lastMainGenerationEndedAt = 0;
 let currentMainGenerationType = 'normal';
 let postProcessingGenerationRunId = 0;
 let swipeNavigationPending = false;
+const activeAgentRequestAbortControllers = new Set();
 const activePathfinderRetrievalAbortControllers = new Set();
 let activePathfinderRetrievalToast = null;
 let activeInitialGenerationToast = null;
@@ -255,6 +256,7 @@ export function cancelAgentGeneration() {
     clearAllPromptTransformRunningToasts();
     clearInitialGenerationToast();
     clearPathfinderRetrievalToast();
+    abortActiveAgentRequests('Agent generation cancelled by user.');
     abortActivePathfinderRetrieval('Pathfinder retrieval cancelled by user.');
 
     const stopped = internalPromptTransformDepth > 0 || activeManualAgentRun ? stopGeneration() : false;
@@ -267,6 +269,20 @@ export function cancelAgentGeneration() {
 
     toastr.info('No agent generation is currently running.');
     return false;
+}
+
+function abortActiveAgentRequests(reason = 'Agent generation cancelled.') {
+    const error = reason instanceof Error ? reason : new Error(String(reason));
+
+    for (const controller of activeAgentRequestAbortControllers) {
+        controller.abort(error);
+    }
+
+    activeAgentRequestAbortControllers.clear();
+}
+
+function isAbortSignalTriggered(error, signal = null) {
+    return Boolean(signal?.aborted || error?.name === 'AbortError');
 }
 
 function abortActivePathfinderRetrieval(reason = 'Pathfinder retrieval cancelled.') {
@@ -2783,13 +2799,14 @@ function canUseMainChatCompletionHelper(context) {
     return context?.mainApi === 'openai' && typeof context?.generateRaw === 'function';
 }
 
-async function requestMainChatCompletionPromptTransform(context, promptMessages, maxTokens, options = {}) {
+async function requestMainChatCompletionPromptTransform(context, promptMessages, maxTokens, options = {}, signal = null) {
     const output = await context.generateRaw({
         prompt: getUserFinalPromptTransformMessages(promptMessages, options),
         api: 'openai',
         instructOverride: true,
         responseLength: maxTokens,
         trimNames: false,
+        signal,
         cacheScope: 'auxiliary',
     });
 
@@ -2800,12 +2817,13 @@ async function requestMainChatCompletionPromptTransform(context, promptMessages,
     };
 }
 
-async function requestProfilePromptTransform(CMRS, profileId, promptMessages, maxTokens, modelOverride = '') {
+async function requestProfilePromptTransform(CMRS, profileId, promptMessages, maxTokens, modelOverride = '', signal = null) {
     const requestOptions = {
         extractData: true,
         includePreset: true,
         includeInstruct: true,
         stream: false,
+        signal,
     };
 
     if (modelOverride && modelOverride.trim()) {
@@ -2823,6 +2841,10 @@ async function requestProfilePromptTransform(CMRS, profileId, promptMessages, ma
             };
         }
     } catch (error) {
+        if (isAbortSignalTriggered(error, signal)) {
+            throw error;
+        }
+
         console.warn(`[InChatAgents] Primary prompt transform request via ${describePromptTransformTarget(profileId, 'profile')} failed, retrying with fallback prompt formatting.`, error);
     }
 
@@ -2844,6 +2866,7 @@ async function requestProfilePromptTransform(CMRS, profileId, promptMessages, ma
         includePreset: true,
         includeInstruct: false,
         stream: false,
+        signal,
     };
 
     if (modelOverride && modelOverride.trim()) {
@@ -2864,6 +2887,7 @@ async function requestPromptTransform(agent, promptMessages, maxTokens, options 
     const modelOverride = typeof agent.modelOverride === 'string' ? agent.modelOverride.trim() : '';
     const context = getContext();
     const CMRS = context?.ConnectionManagerRequestService;
+    const requestAbortController = new AbortController();
     const runAsInternalPromptTransform = async (requestFn) => {
         internalPromptTransformDepth++;
         notifyAgentGenerationStateChanged();
@@ -2876,48 +2900,55 @@ async function requestPromptTransform(agent, promptMessages, maxTokens, options 
         }
     };
 
-    if (profileId) {
-        if (!CMRS || typeof CMRS.sendRequest !== 'function') {
-            throw new Error(`${describePromptTransformTarget(profileId, 'profile')} is set, but Connection Manager is unavailable.`);
-        }
-
-        return await runAsInternalPromptTransform(async () =>
-            await requestProfilePromptTransform(CMRS, profileId, promptMessages, maxTokens, modelOverride),
-        );
-    }
-
-    if (canUseMainChatCompletionHelper(context)) {
-        return await runAsInternalPromptTransform(async () =>
-            await requestMainChatCompletionPromptTransform(context, promptMessages, maxTokens, options),
-        );
-    }
-
-    const quietPrompt = promptMessages
-        .map(message => `${message.role.toUpperCase()}:\n${normalizeContentText(message?.content)}`)
-        .join('\n\n');
-    const preservedPrompts = Object.entries(extension_prompts)
-        .filter(([key]) => key.startsWith(PROMPT_KEY_PREFIX));
-
-    for (const [key] of preservedPrompts) {
-        delete extension_prompts[key];
-    }
+    activeAgentRequestAbortControllers.add(requestAbortController);
 
     try {
-        return await runAsInternalPromptTransform(async () => ({
-            output: await generateQuietPrompt({
-                quietPrompt,
-                quietName: 'In-Chat Agent',
-                skipWIAN: true,
-                responseLength: maxTokens,
-                removeReasoning: true,
-            }),
-            runner: 'main',
-            profileId: '',
-        }));
-    } finally {
-        for (const [key, value] of preservedPrompts) {
-            extension_prompts[key] = value;
+        if (profileId) {
+            if (!CMRS || typeof CMRS.sendRequest !== 'function') {
+                throw new Error(`${describePromptTransformTarget(profileId, 'profile')} is set, but Connection Manager is unavailable.`);
+            }
+
+            return await runAsInternalPromptTransform(async () =>
+                await requestProfilePromptTransform(CMRS, profileId, promptMessages, maxTokens, modelOverride, requestAbortController.signal),
+            );
         }
+
+        if (canUseMainChatCompletionHelper(context)) {
+            return await runAsInternalPromptTransform(async () =>
+                await requestMainChatCompletionPromptTransform(context, promptMessages, maxTokens, options, requestAbortController.signal),
+            );
+        }
+
+        const quietPrompt = promptMessages
+            .map(message => `${message.role.toUpperCase()}:\n${normalizeContentText(message?.content)}`)
+            .join('\n\n');
+        const preservedPrompts = Object.entries(extension_prompts)
+            .filter(([key]) => key.startsWith(PROMPT_KEY_PREFIX));
+
+        for (const [key] of preservedPrompts) {
+            delete extension_prompts[key];
+        }
+
+        try {
+            return await runAsInternalPromptTransform(async () => ({
+                output: await generateQuietPrompt({
+                    quietPrompt,
+                    quietName: 'In-Chat Agent',
+                    skipWIAN: true,
+                    responseLength: maxTokens,
+                    removeReasoning: true,
+                    signal: requestAbortController.signal,
+                }),
+                runner: 'main',
+                profileId: '',
+            }));
+        } finally {
+            for (const [key, value] of preservedPrompts) {
+                extension_prompts[key] = value;
+            }
+        }
+    } finally {
+        activeAgentRequestAbortControllers.delete(requestAbortController);
     }
 }
 
@@ -3071,6 +3102,23 @@ async function runPromptTransformAgent(agent, message, generationType, messageTe
 
         return result;
     } catch (error) {
+        if (agentGenerationCancelRevision !== cancelRevision || generationStopRequested || isAbortSignalTriggered(error)) {
+            return {
+                agentId: agent.id,
+                agentName: agent.name,
+                changed: false,
+                status: 'cancelled',
+                mode: promptTransformMode,
+                profileId,
+                ...runMetadata,
+                runner: 'cancelled',
+                timestamp: new Date().toISOString(),
+                outputText: '',
+                nextMessageText: currentMessageText,
+                beforeText: currentMessageText,
+            };
+        }
+
         console.warn(`[InChatAgents] ${describePromptTransformMode(promptTransformMode)} failed in agent "${agent.name}":`, error);
         const result = {
             agentId: agent.id,
@@ -3945,6 +3993,17 @@ async function runContextInterceptAgent(agent, currentContextText, generationTyp
             profileId: response.profileId,
             runner: response.runner,
         };
+    } catch (error) {
+        if (agentGenerationCancelRevision !== cancelRevision || generationStopRequested || isAbortSignalTriggered(error)) {
+            return {
+                ...baseResult,
+                status: 'cancelled',
+                profileId,
+                runner: 'cancelled',
+            };
+        }
+
+        throw error;
     } finally {
         clearPromptTransformRunningToast(runningToast);
     }


### PR DESCRIPTION
## Summary
- add abort controllers for active in-chat agent prompt-transform requests
- pass abort signals through profile, generateRaw, and quiet prompt generation paths
- treat cancelled agent/intercept requests as cancelled instead of failed runs

## Testing
- ./node_modules/.bin/eslint public/script.js public/scripts/extensions/in-chat-agents/agent-runner.js
- npm run build:frontend
- npm run lint