### PR TITLE
fix: prevent WebKit character header overlap

### DIFF
--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -5610,9 +5610,31 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     margin: 0;
 }
 
-#right-nav-panel #result_info #creators_note_styles_button,
-#right-nav-panel #result_info #spoiler_free_desc_button,
-#right-nav-panel #result_info #character_open_media_overrides {
+/* SillyBunny: WebKit keeps flex children at min-width:auto in this sticky header; keep the token text shrinkable and every action icon in a fixed touch target. */
+#right-nav-panel:is([data-menu-type="character_edit"], [data-menu-type="create"]) #rm_button_selected_ch,
+#right-nav-panel:is([data-menu-type="character_edit"], [data-menu-type="create"]) #result_info,
+#right-nav-panel:is([data-menu-type="character_edit"], [data-menu-type="create"]) #result_info_text {
+    min-width: 0;
+}
+
+#right-nav-panel:is([data-menu-type="character_edit"], [data-menu-type="create"]) #result_info {
+    flex: 0 1 auto;
+    max-width: 100%;
+    justify-content: flex-end;
+}
+
+#right-nav-panel:is([data-menu-type="character_edit"], [data-menu-type="create"]) #result_info_text {
+    overflow: hidden;
+}
+
+#right-nav-panel:is([data-menu-type="character_edit"], [data-menu-type="create"]) #result_info_text > div {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+#right-nav-panel:is([data-menu-type="character_edit"], [data-menu-type="create"]) #result_info > .right_menu_button {
+    flex: 0 0 34px;
     width: 34px;
     min-width: 34px;
     max-width: 34px;


### PR DESCRIPTION
Summary
- Allow the character editor header title and token counter to shrink inside the sticky WebKit header.
- Ellipsize token-counter text instead of letting Safari push action icons across the row.
- Normalize character-header action icons to fixed 34px touch targets.

Testing
- npm ci --ignore-scripts --no-audit --no-fund
- npm run lint
- git diff --check