### PR TITLE
fix: create new group chat branches reliably

### DIFF
--- a/docs/upstream-touch-ledger.md
+++ b/docs/upstream-touch-ledger.md
@@ -63,6 +63,19 @@ This ledger tracks intentional SillyBunny divergence in upstream-origin files. I
 | Last reviewed | 2026-06-06 chat integrity rotation fix. |
 | Owner | Bugfix integrator. |
 
+### `public/script.js` and `public/scripts/group-chats.js` - group chat branch creation
+| Field | Value |
+| --- | --- |
+| Area | Chat lifecycle. |
+| Divergence reason | SillyBunny's Start new chat menu path already flushes pending saves and clears the active chat before delegating to group chat creation, so the group branch creator must not run a second navigation-save guard that can abort and repaint the current chat. |
+| Target seam | None yet; group chat branch creation still lives in the upstream-origin chat modules. |
+| Adapter shape | Keep `doNewChat()` as the stock menu adapter and pass a narrow `chatAlreadyPrepared` option; keep standalone group creation guarded, and tell `getGroupChat()` when the chat id was freshly created so empty group branches are initialized consistently. |
+| Protecting tests | Future focused group-chat new-branch coverage; current protection is static validation. |
+| Validation | `node --check public/script.js`, `node --check public/scripts/group-chats.js`, `npm run lint`, `git diff --check`. |
+| Rollback path | Revert the option plumbing and newly-created load hint to restore the previous `createNewGroupChat(groupId)` path. |
+| Last reviewed | 2026-06-09 group chat Start new chat fix. |
+| Owner | Bugfix integrator. |
+
 ### `public/style.css` - message containment and scroll anchoring
 | Field | Value |
 | --- | --- |

--- a/public/script.js
+++ b/public/script.js
@@ -15046,7 +15046,7 @@ export async function doNewChat({ deleteCurrentChat = false } = {}) {
     }
 
     if (selected_group) {
-        await createNewGroupChat(selected_group);
+        await createNewGroupChat(selected_group, { chatAlreadyPrepared: true });
         if (deleteCurrentChat) await deleteGroupChat(selected_group, chat_file_for_del, { jumpToNewChat: false }); // don't jump, new chat was already created and jumped to above
     } else {
         //RossAscends: added character name to new chat filenames and replaced Date.now() with humanizedDateTime;

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -1234,9 +1234,10 @@ async function validateGroup(group) {
  * @param {boolean} reload - Whether to reload the group chat after loading.
  * @param {object} options - Load options.
  * @param {boolean} [options.switchMenu=true] Whether to switch the right menu to the group editor.
+ * @param {boolean} [options.newlyCreated=false] Whether the active group chat was created before loading.
  * @returns {Promise<void>} A promise that resolves when the chat messages have been loaded.
  */
-export async function getGroupChat(groupId, reload = false, { switchMenu = true } = {}) {
+export async function getGroupChat(groupId, reload = false, { switchMenu = true, newlyCreated = false } = {}) {
     incrementChatGeneration();
 
     const group = groups.find((x) => x.id === groupId);
@@ -1249,7 +1250,7 @@ export async function getGroupChat(groupId, reload = false, { switchMenu = true 
     await validateGroup(group);
     await unshallowGroupMembers(groupId);
 
-    let createdChat = false;
+    let createdChat = newlyCreated;
 
     if (!group.chat_id) {
         const freshChatId = humanizedDateTime();
@@ -3605,27 +3606,33 @@ async function createGroup() {
 /**
  * Creates a new group chat within the specified group.
  * @param {string} groupId Group ID
+ * @param {object} [options] Creation options
+ * @param {boolean} [options.chatAlreadyPrepared=false] Whether the caller already flushed saves and cleared the current chat.
  * @returns {Promise<void>} Promise that resolves when the new group chat is created
  */
-export async function createNewGroupChat(groupId) {
+export async function createNewGroupChat(groupId, { chatAlreadyPrepared = false } = {}) {
     const group = groups.find(x => x.id === groupId);
 
     if (!group) {
         return;
     }
 
-    if (!await flushPendingChatSavesForNavigation()) {
-        return;
+    if (!chatAlreadyPrepared) {
+        if (!await flushPendingChatSavesForNavigation()) {
+            return;
+        }
+
+        await clearChat({ clearData: true });
     }
 
-    await clearChat({ clearData: true });
     const newChatName = humanizedDateTime();
+    group.chats = Array.isArray(group.chats) ? group.chats : [];
     group.chats.push(newChatName);
     group.chat_id = newChatName;
     updateChatMetadata({}, true);
 
     await editGroup(group.id, true, false);
-    await getGroupChat(group.id);
+    await getGroupChat(group.id, false, { newlyCreated: true });
     syncGroupAutoModeToggle();
 }
 


### PR DESCRIPTION
## Summary
- avoid a second pending-save/clear guard when the stock Start new chat handler already prepared navigation for a group chat
- mark explicitly-created group chats as newly created so empty branches initialize and emit `GROUP_CHAT_CREATED` like auto-created group chats
- record the upstream-origin touch in the ledger

## Testing
- `npm ci --ignore-scripts --no-audit --no-fund`
- `node --check public/script.js`
- `node --check public/scripts/group-chats.js`
- `npm run lint`
- `git diff --check`
- `npm run check:frontend-budgets`