### PR TITLE
fix: release generation lock when aborting generation

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -8080,7 +8080,7 @@ export function stopGeneration() {
     }
 
     if (stopState.shouldStop) {
-        unblockGeneration(stopState.unblockType, { emitGenerationEnded: false });
+        unblockGeneration(stopState.unblockType, { emitGenerationEnded: false, force: true });
     }
 
     return stopState.shouldStop;
@@ -8156,12 +8156,17 @@ function flushWIInjections() {
 /**
  * Unblocks the UI after a generation is complete.
  * @param {string} [type] Generation type (optional)
+ * @param {object} [options] Options.
+ * @param {boolean} [options.emitGenerationEnded=true] Whether to emit generation-ended UI events.
+ * @param {boolean} [options.force=false] Whether to bypass stream-wait guards.
  */
-function unblockGeneration(type, { emitGenerationEnded = true } = {}) {
+function unblockGeneration(type, { emitGenerationEnded = true, force = false } = {}) {
     const unblockState = resolveGenerationUnblockState({
         type,
         hasStreamingProcessor: Boolean(streamingProcessor),
         isStreamingFinished: Boolean(streamingProcessor?.isFinished),
+        // SillyBunny: explicit Stop must always release the UI lock so users can retry.
+        forceUnblock: force,
     });
 
     if (!unblockState.shouldUnblock) {

--- a/public/scripts/generation-lifecycle/index.js
+++ b/public/scripts/generation-lifecycle/index.js
@@ -46,15 +46,18 @@ export function resolveGenerationUiLockState({
  * @param {string|null} [options.type=null] Generation type being unblocked.
  * @param {boolean} [options.hasStreamingProcessor=false] Whether a stream exists.
  * @param {boolean} [options.isStreamingFinished=false] Whether that stream is finished.
+ * @param {boolean} [options.forceUnblock=false] Whether to bypass stream-wait guards.
  * @returns {{shouldUnblock: boolean, shouldActivateSendButtons: boolean, shouldResetProgress: boolean, shouldFlushEphemeralState: boolean}}
  */
 export function resolveGenerationUnblockState({
     type = null,
     hasStreamingProcessor = false,
     isStreamingFinished = false,
+    forceUnblock = false,
 } = {}) {
     const generationType = normalizeGenerationType(type);
-    const shouldWaitForQuietStream = generationType === 'quiet'
+    const shouldWaitForQuietStream = !forceUnblock
+        && generationType === 'quiet'
         && Boolean(hasStreamingProcessor)
         && !isStreamingFinished;
 

--- a/tests/generation-lifecycle-wiring.test.js
+++ b/tests/generation-lifecycle-wiring.test.js
@@ -82,7 +82,7 @@ describe('generation lifecycle wiring', () => {
         expect(stopSource).toContain('streamingType: activeStreamingProcessor?.type');
         expect(stopSource).toContain('activeStreamingProcessor.onStopStreaming();');
         expect(stopSource).toContain('abortController.abort(stopState.abortReason);');
-        expect(stopSource).toContain('unblockGeneration(stopState.unblockType, { emitGenerationEnded: false });');
+        expect(stopSource).toContain('unblockGeneration(stopState.unblockType, { emitGenerationEnded: false, force: true });');
         expect(stopSource).not.toContain('Clicked stop button');
     });
 
@@ -93,6 +93,7 @@ describe('generation lifecycle wiring', () => {
         expect(unblockSource).toContain('type');
         expect(unblockSource).toContain('hasStreamingProcessor: Boolean(streamingProcessor)');
         expect(unblockSource).toContain('isStreamingFinished: Boolean(streamingProcessor?.isFinished)');
+        expect(unblockSource).toContain('forceUnblock: force');
         expect(unblockSource).toContain('unblockState.shouldActivateSendButtons');
         expect(unblockSource).toContain('unblockState.shouldResetProgress');
         expect(unblockSource).toContain('unblockState.shouldFlushEphemeralState');

--- a/tests/generation-lifecycle.test.js
+++ b/tests/generation-lifecycle.test.js
@@ -51,6 +51,20 @@ describe('generation lifecycle helper', () => {
         });
     });
 
+    test('allows forced quiet generation unblock while its stream is still active', () => {
+        expect(resolveGenerationUnblockState({
+            type: 'quiet',
+            hasStreamingProcessor: true,
+            isStreamingFinished: false,
+            forceUnblock: true,
+        })).toEqual({
+            shouldUnblock: true,
+            shouldActivateSendButtons: true,
+            shouldResetProgress: true,
+            shouldFlushEphemeralState: true,
+        });
+    });
+
     test('allows normal and finished quiet generation unblock cleanup', () => {
         expect(resolveGenerationUnblockState({
             type: 'normal',


### PR DESCRIPTION
## Summary

- Add a forced unblock option for generation lifecycle cleanup.
- Use the forced path when the user explicitly clicks Stop so the UI lock is released even if an unfinished quiet-style stream is still present.
- Cover the helper behavior and script wiring with generation-lifecycle tests.

## Testing

- `NODE_OPTIONS=--experimental-vm-modules bunx jest --config tests/jest.config.json --runInBand tests/generation-lifecycle.test.js tests/generation-lifecycle-wiring.test.js`

## Notes

- Manual browser repro validation is pending.
