### PR TITLE
fix: mobile character panel close button floating above header

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -405,8 +405,10 @@
         display: none !important;
     }
 
+    /* SillyBunny: was top: -42px, floating above the panel and invisible to the user;
+       changed to 8px to keep the close button inside the header and reachable on mobile */
     #right-nav-panel.openDrawer > .sb-character-shell-header .sb-shell-close {
-        top: -42px !important;
+        top: 8px !important;
         right: 8px !important;
         width: 36px !important;
         min-width: 36px !important;


### PR DESCRIPTION
## Summary

On mobile, the close button for the character panel was positioned at `top: -42px` in the default shell header mode, placing it above the panel boundary and making it effectively invisible and unreachable.

This one-line CSS fix changes that to `top: 8px` so the button sits inside the header, consistent with how the close button behaves in `show`/`auto` header modes and matching the placement of the nav overlay's `.sb-mobile-panel-close` button.

## What changed

`public/css/sillybunny-mobile-shell.css`
- Line 409: `top: -42px !important` → `top: 8px !important`
- Added inline comment explaining the divergence

## What was tested

Visual diff reviewed; the fix aligns the default-mode rule with the already-correct `show`/`auto` mode override at line 444 and the generic mobile rule at line 1894 (which had the right value but was blocked by the `!important` at the broken rule).

No JS changes — the in-panel close button already calls `closeShell()` correctly. The topbar toggle buttons (`toggleShellPanel`) already implement tap-to-close, but are unreachable on mobile while a panel is open because the panel covers the full viewport.

Relates to Discord request from Jimmy: *"the close button on a lot of the windows is awkwardly placed and difficult to spot"*

> AI-assisted (OpenCode)