### PR TITLE
test: add mobile shell smoke pack and mobile css ratchet budgets

### DIFF
--- a/tests/mobile-css-budgets.test.js
+++ b/tests/mobile-css-budgets.test.js
@@ -1,0 +1,103 @@
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function readPublicFile(...segments) {
+    return readFileSync(path.join(repoRoot, 'public', ...segments), 'utf8');
+}
+
+function countImportant(cssSource) {
+    return (cssSource.match(/!important/g) ?? []).length;
+}
+
+function getMediaQueryPxValues(cssSource) {
+    const pxValues = new Set();
+
+    for (const mediaMatch of cssSource.matchAll(/@media[^{]*/g)) {
+        for (const pxMatch of mediaMatch[0].matchAll(/([0-9]+(?:\.[0-9]+)?)px/g)) {
+            pxValues.add(pxMatch[1]);
+        }
+    }
+
+    return pxValues;
+}
+
+// Ratchet budgets: ceilings match the measured state of staging when this
+// test landed. Lower them as cleanup PRs land; never raise them without a
+// review note explaining the regression.
+const FORK_SHEET_IMPORTANT_BUDGETS = Object.freeze({
+    'sillybunny-mobile-shell.css': 664,
+    'sillybunny-tabs.css': 386,
+    'sillybunny-chat-styles.css': 225,
+    'sillybunny-theme.css': 158,
+});
+
+const FORK_DISTINCT_BREAKPOINT_BUDGET = 20;
+
+const forkSheetSources = Object.fromEntries(
+    Object.keys(FORK_SHEET_IMPORTANT_BUDGETS).map(sheetName => [sheetName, readPublicFile('css', sheetName)]),
+);
+
+describe('mobile css ratchet budgets', () => {
+    describe.each(Object.entries(FORK_SHEET_IMPORTANT_BUDGETS))('%s', (sheetName, importantBudget) => {
+        test(`uses at most ${importantBudget} !important declarations`, () => {
+            const importantCount = countImportant(forkSheetSources[sheetName]);
+
+            expect(importantCount).toBeLessThanOrEqual(importantBudget);
+        });
+    });
+
+    test(`fork sheets declare at most ${FORK_DISTINCT_BREAKPOINT_BUDGET} distinct media-query px values`, () => {
+        const pxValues = new Set();
+
+        for (const cssSource of Object.values(forkSheetSources)) {
+            for (const pxValue of getMediaQueryPxValues(cssSource)) {
+                pxValues.add(pxValue);
+            }
+        }
+
+        const sortedPxValues = [...pxValues].sort((left, right) => Number(left) - Number(right));
+
+        expect(sortedPxValues.length).toBeLessThanOrEqual(FORK_DISTINCT_BREAKPOINT_BUDGET);
+    });
+});
+
+describe('index.html mobile stylesheet gates', () => {
+    const indexHtml = readPublicFile('index.html');
+    const stylesheetTags = [...indexHtml.matchAll(/<link\s[^>]*rel="stylesheet"[^>]*>/g)].map(match => match[0]);
+
+    function findStylesheetTag(href) {
+        return stylesheetTags.find(tag => tag.includes(`href="${href}?`) || tag.includes(`href="${href}"`));
+    }
+
+    test('mobile sheets keep their (max-width: 768px) media gates', () => {
+        for (const href of ['css/mobile-styles.css', 'css/sillybunny-mobile-shell.css']) {
+            const tag = findStylesheetTag(href);
+
+            expect(tag).toBeDefined();
+            expect(tag).toContain('media="(max-width: 768px)"');
+        }
+    });
+
+    test('fork sheets load after upstream styles and before user.css', () => {
+        const loadOrder = [
+            'style.css',
+            'css/mobile-styles.css',
+            'css/sillybunny-theme.css',
+            'css/sillybunny-tabs.css',
+            'css/sillybunny-mobile-shell.css',
+            'css/user.css',
+        ].map(href => {
+            const tag = findStylesheetTag(href);
+
+            expect(tag).toBeDefined();
+
+            return indexHtml.indexOf(tag);
+        });
+
+        expect(loadOrder).toEqual([...loadOrder].sort((left, right) => left - right));
+    });
+});

--- a/tests/mobile-shell-smoke.e2e.js
+++ b/tests/mobile-shell-smoke.e2e.js
@@ -1,0 +1,430 @@
+/* global document, window */
+import { expect, test } from '@playwright/test';
+import { openReadyChat, waitForAnimationFrames } from './chat-scroll-regression-helpers.js';
+
+// Mobile shell smoke pack: pins the current open/close contracts of the
+// SillyBunny mobile shell (drawers, hamburger nav, chat tools, character
+// panel) so the Phase 1 decomposition of sillybunny-tabs.js has a net.
+// Run with: SILLYBUNNY_TEST_BASE_URL=http://127.0.0.1:<port> npx playwright test mobile-shell-smoke.e2e.js
+
+test.describe.configure({ mode: 'serial' });
+
+const IPHONE_USER_AGENT = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+const IPAD_USER_AGENT = 'Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+
+function getOverlayStateSnapshot(page) {
+    return page.evaluate(() => {
+        const isDrawerOpen = id => document.getElementById(id)?.classList.contains('openDrawer') === true;
+        const isOverlayOpen = (id, openClass) => {
+            const overlay = document.getElementById(id);
+
+            return Boolean(overlay
+                && !overlay.hidden
+                && overlay.classList.contains(openClass)
+                && overlay.getAttribute('aria-hidden') === 'false');
+        };
+
+        // The connection strip is a desktop-chatbar surface; on mobile the
+        // exclusion cascades close it via setConnectionStripOpenState(false),
+        // which has no observable mobile DOM, so it is not snapshotted here.
+        return {
+            navOpen: isOverlayOpen('sb-mobile-nav', 'sb-nav-open'),
+            chatToolsOpen: isOverlayOpen('sb-mobile-chat-tools', 'sb-chat-tools-open'),
+            leftShellOpen: isDrawerOpen('left-nav-panel'),
+            rightShellOpen: isDrawerOpen('user-settings-block'),
+            characterPanelOpen: isDrawerOpen('right-nav-panel'),
+        };
+    });
+}
+
+function getDrawerBoundsSnapshot(page, drawerId) {
+    return page.evaluate((id) => {
+        const drawer = document.getElementById(id);
+
+        if (!drawer) {
+            return null;
+        }
+
+        return {
+            isOpen: drawer.classList.contains('openDrawer'),
+            isViewportBound: drawer.dataset.sbMobileViewportBound === 'true',
+            top: drawer.style.top,
+            bottom: drawer.style.bottom,
+            height: drawer.style.height,
+            maxHeight: drawer.style.maxHeight,
+            boxSizing: drawer.style.boxSizing,
+        };
+    }, drawerId);
+}
+
+function getComposerViewportFit(page) {
+    return page.evaluate(() => {
+        const composer = document.getElementById('form_sheld');
+        const rect = composer?.getBoundingClientRect();
+
+        if (!rect) {
+            return null;
+        }
+
+        return {
+            top: rect.top,
+            bottom: rect.bottom,
+            viewportHeight: window.innerHeight,
+        };
+    });
+}
+
+function getHorizontalOverflow(page) {
+    return page.evaluate(() => {
+        const root = document.documentElement;
+
+        return root.scrollWidth - root.clientWidth;
+    });
+}
+
+function openLeftShell(page) {
+    return page.evaluate(() => window.SillyBunnyShell.openTab('left', 'presets'));
+}
+
+// While any drawer or overlay is open, the mobile modal policy marks the page
+// chrome (topbar included) inert, so a trusted pointer click cannot reach the
+// hamburger. Synthetic .click() still runs the toggle cascade under test.
+function clickHamburgerProgrammatically(page) {
+    return page.evaluate(() => document.getElementById('sb-hamburger').click());
+}
+
+async function closeLeftShellThroughUi(page) {
+    const closeButton = page.locator('#left-nav-panel .sb-shell-close');
+
+    if (await closeButton.isVisible().catch(() => false)) {
+        await closeButton.click();
+        return;
+    }
+
+    // Escape routes through closeFocusedShell on the shell root keydown handler.
+    await page.keyboard.press('Escape');
+}
+
+async function captureCheckpoint(page, testInfo, name) {
+    const screenshotPath = testInfo.outputPath(`${name}.png`);
+
+    await page.screenshot({ path: screenshotPath });
+    await testInfo.attach(name, { path: screenshotPath, contentType: 'image/png' });
+}
+
+test.describe('mobile shell smoke at iPhone 390x844', () => {
+    test.use({
+        viewport: { width: 390, height: 844 },
+        isMobile: true,
+        hasTouch: true,
+        userAgent: IPHONE_USER_AGENT,
+    });
+
+    test.beforeEach(async ({ page }) => {
+        await openReadyChat(page, { selectCharacter: false });
+    });
+
+    test('left drawer open and close honor the mobile viewport bound contract', async ({ page }, testInfo) => {
+        await openLeftShell(page);
+
+        // syncMobileShellDrawerBounds binds open drawers to the visual viewport
+        // with inline !important top/height and a dataset marker.
+        await expect.poll(() => getDrawerBoundsSnapshot(page, 'left-nav-panel')).toMatchObject({
+            isOpen: true,
+            isViewportBound: true,
+            bottom: 'auto',
+            boxSizing: 'border-box',
+        });
+
+        const openBounds = await getDrawerBoundsSnapshot(page, 'left-nav-panel');
+
+        expect(openBounds.top).toMatch(/^\d+px$/);
+        expect(Number.parseFloat(openBounds.height)).toBeGreaterThan(0);
+        expect(Number.parseFloat(openBounds.height)).toBeLessThanOrEqual(844);
+        expect(openBounds.maxHeight).toBe(openBounds.height);
+
+        await captureCheckpoint(page, testInfo, 'left-drawer');
+
+        await closeLeftShellThroughUi(page);
+
+        // clearMobileShellDrawerBounds removes every bound property and the
+        // dataset marker once the drawer is no longer open.
+        await expect.poll(() => getDrawerBoundsSnapshot(page, 'left-nav-panel')).toEqual({
+            isOpen: false,
+            isViewportBound: false,
+            top: '',
+            bottom: '',
+            height: '',
+            maxHeight: '',
+            boxSizing: '',
+        });
+
+        expect(await getHorizontalOverflow(page)).toBeLessThanOrEqual(1);
+    });
+
+    test('hamburger nav keeps hidden, aria-hidden, and inert in agreement', async ({ page }, testInfo) => {
+        const getNavAgreementSnapshot = () => page.evaluate(() => {
+            const overlay = document.getElementById('sb-mobile-nav');
+            const button = document.getElementById('sb-hamburger');
+
+            return {
+                hidden: overlay?.hidden ?? null,
+                ariaHidden: overlay?.getAttribute('aria-hidden') ?? null,
+                inert: overlay?.inert === true,
+                openClass: overlay?.classList.contains('sb-nav-open') === true,
+                buttonExpanded: button?.getAttribute('aria-expanded') ?? null,
+                buttonOpenClass: button?.classList.contains('is-open') === true,
+            };
+        });
+
+        await page.locator('#sb-hamburger').click();
+
+        await expect.poll(getNavAgreementSnapshot).toEqual({
+            hidden: false,
+            ariaHidden: 'false',
+            inert: false,
+            openClass: true,
+            buttonExpanded: 'true',
+            buttonOpenClass: true,
+        });
+
+        await captureCheckpoint(page, testInfo, 'nav-open');
+
+        await page.locator('#sb-hamburger').click();
+
+        await expect.poll(getNavAgreementSnapshot).toEqual({
+            hidden: true,
+            ariaHidden: 'true',
+            inert: true,
+            openClass: false,
+            buttonExpanded: 'false',
+            buttonOpenClass: false,
+        });
+
+        expect(await getHorizontalOverflow(page)).toBeLessThanOrEqual(1);
+    });
+
+    test('opening each overlay closes competing mobile surfaces', async ({ page }, testInfo) => {
+        await openLeftShell(page);
+
+        await expect.poll(() => getOverlayStateSnapshot(page)).toMatchObject({ leftShellOpen: true });
+
+        // toggleMobileNav closes shells, the character panel, and chat tools.
+        await clickHamburgerProgrammatically(page);
+
+        await expect.poll(() => getOverlayStateSnapshot(page)).toEqual({
+            navOpen: true,
+            chatToolsOpen: false,
+            leftShellOpen: false,
+            rightShellOpen: false,
+            characterPanelOpen: false,
+        });
+
+        // openMobileChatTools closes the nav, both shells, and the character panel.
+        await page.evaluate(() => window.SillyBunnyShell.openChatTools());
+
+        await expect.poll(() => getOverlayStateSnapshot(page)).toEqual({
+            navOpen: false,
+            chatToolsOpen: true,
+            leftShellOpen: false,
+            rightShellOpen: false,
+            characterPanelOpen: false,
+        });
+
+        await captureCheckpoint(page, testInfo, 'chat-tools');
+
+        // toggleCharacterPanel routes through closeAllDropdowns({ except: 'characters' }).
+        await page.evaluate(() => window.SillyBunnyShell.openCharacters());
+
+        await expect.poll(() => getOverlayStateSnapshot(page)).toEqual({
+            navOpen: false,
+            chatToolsOpen: false,
+            leftShellOpen: false,
+            rightShellOpen: false,
+            characterPanelOpen: true,
+        });
+
+        expect(await getHorizontalOverflow(page)).toBeLessThanOrEqual(1);
+    });
+
+    test('keyboard-style viewport shrink re-syncs open drawer bounds and recovers', async ({ page }) => {
+        await openLeftShell(page);
+
+        // After a resize the inline height can be handed off to a stylesheet
+        // rule driven by --sb-shell-viewport-height, so this asserts the
+        // rendered geometry (the actual contract), not the inline styles.
+        const getRenderedDrawerFit = () => page.evaluate(() => {
+            const drawer = document.getElementById('left-nav-panel');
+            const rect = drawer.getBoundingClientRect();
+
+            return {
+                isOpen: drawer.classList.contains('openDrawer'),
+                isViewportBound: drawer.dataset.sbMobileViewportBound === 'true',
+                top: Math.round(rect.top),
+                bottom: Math.round(rect.bottom),
+                viewportHeight: window.innerHeight,
+            };
+        });
+
+        await expect.poll(async () => {
+            const fit = await getRenderedDrawerFit();
+
+            return fit.isViewportBound && fit.top > 0 && Math.abs(fit.bottom - 844) <= 2;
+        }).toBe(true);
+
+        // Viewport shrink stands in for the on-screen keyboard: the resize
+        // listener re-runs syncMobileViewportState and rebinds open drawers.
+        await page.setViewportSize({ width: 390, height: 500 });
+
+        await expect.poll(async () => {
+            const fit = await getRenderedDrawerFit();
+
+            return fit.isViewportBound && fit.top > 0 && Math.abs(fit.bottom - 500) <= 2;
+        }).toBe(true);
+
+        await page.setViewportSize({ width: 390, height: 844 });
+
+        await expect.poll(async () => {
+            const fit = await getRenderedDrawerFit();
+
+            return fit.isViewportBound && fit.top > 0 && Math.abs(fit.bottom - 844) <= 2;
+        }).toBe(true);
+
+        await closeLeftShellThroughUi(page);
+
+        await expect.poll(async () => {
+            const bounds = await getDrawerBoundsSnapshot(page, 'left-nav-panel');
+
+            return bounds?.isOpen === false && bounds?.isViewportBound === false;
+        }).toBe(true);
+
+        expect(await getHorizontalOverflow(page)).toBeLessThanOrEqual(1);
+    });
+
+    test('composer stays on screen through keyboard-style viewport shrink', async ({ page }, testInfo) => {
+        await page.setViewportSize({ width: 390, height: 500 });
+
+        await expect.poll(async () => {
+            const fit = await getComposerViewportFit(page);
+
+            return fit !== null && fit.bottom <= fit.viewportHeight + 1;
+        }).toBe(true);
+
+        await expect(page.locator('#send_textarea')).toBeVisible();
+
+        await captureCheckpoint(page, testInfo, 'composer-short-viewport');
+
+        await page.setViewportSize({ width: 390, height: 844 });
+
+        await expect.poll(async () => {
+            const fit = await getComposerViewportFit(page);
+
+            return fit !== null && fit.bottom <= fit.viewportHeight + 1;
+        }).toBe(true);
+
+        expect(await getHorizontalOverflow(page)).toBeLessThanOrEqual(1);
+    });
+});
+
+test.describe('mobile shell smoke at narrow 320x568', () => {
+    test.use({
+        viewport: { width: 320, height: 568 },
+        isMobile: true,
+        hasTouch: true,
+        userAgent: IPHONE_USER_AGENT,
+    });
+
+    test('composer fits and the send target keeps its current floor', async ({ page }) => {
+        await openReadyChat(page, { selectCharacter: false });
+
+        // Compact mode and connection state come from the linked user profile;
+        // normalize both so this measures the stylesheet contract, not the
+        // profile. The displayNone class on #send_but is only a connection
+        // visibility gate (RossAscends-mods.js), not a sizing rule.
+        await page.evaluate(() => {
+            document.documentElement.setAttribute('data-sb-compact-mode', 'false');
+            document.getElementById('send_but')?.classList.remove('displayNone');
+        });
+        await waitForAnimationFrames(page, 2);
+
+        const sendButtonBox = await page.locator('#send_but').boundingBox();
+
+        // Ratchet floor: today's composer renders the send target at
+        // --sb-composer-action-size (26px tall at this width). The mobile UX
+        // redesign raises this floor to 44px; until then this only guards
+        // against shrinking below the current shipped size.
+        expect(sendButtonBox).not.toBeNull();
+        expect(Math.min(sendButtonBox.width, sendButtonBox.height)).toBeGreaterThanOrEqual(24);
+
+        const composerBox = await page.locator('#form_sheld').boundingBox();
+
+        expect(composerBox).not.toBeNull();
+        expect(composerBox.x).toBeGreaterThanOrEqual(-1);
+        expect(composerBox.x + composerBox.width).toBeLessThanOrEqual(321);
+
+        expect(await getHorizontalOverflow(page)).toBeLessThanOrEqual(1);
+    });
+});
+
+test.describe('mobile shell smoke at tablet 768x1024', () => {
+    test.use({
+        viewport: { width: 768, height: 1024 },
+        isMobile: true,
+        hasTouch: true,
+        userAgent: IPAD_USER_AGENT,
+    });
+
+    test('mobile shell stays active at the 768px boundary', async ({ page }) => {
+        await openReadyChat(page, { selectCharacter: false });
+
+        expect(await page.evaluate(() => window.SillyBunnyShell.isMobileViewport())).toBe(true);
+
+        await openLeftShell(page);
+
+        await expect.poll(() => getDrawerBoundsSnapshot(page, 'left-nav-panel')).toMatchObject({
+            isOpen: true,
+            isViewportBound: true,
+        });
+
+        await clickHamburgerProgrammatically(page);
+
+        await expect.poll(() => getOverlayStateSnapshot(page)).toMatchObject({
+            navOpen: true,
+            leftShellOpen: false,
+        });
+
+        expect(await getHorizontalOverflow(page)).toBeLessThanOrEqual(1);
+    });
+});
+
+test.describe('compact desktop smoke at 820x1180', () => {
+    test.use({
+        viewport: { width: 820, height: 1180 },
+        isMobile: true,
+        hasTouch: true,
+        userAgent: IPAD_USER_AGENT,
+    });
+
+    test('mobile chrome stays dormant in the 769-1000px band', async ({ page }) => {
+        await openReadyChat(page, { selectCharacter: false });
+
+        expect(await page.evaluate(() => window.SillyBunnyShell.isMobileViewport())).toBe(false);
+
+        // Shells open as pinned desktop panels without the mobile bound contract.
+        await openLeftShell(page);
+
+        await expect.poll(() => getDrawerBoundsSnapshot(page, 'left-nav-panel')).toMatchObject({
+            isOpen: true,
+            isViewportBound: false,
+        });
+
+        // openChatTools routes to the desktop chat sidebar above 768px; the
+        // mobile chat tools overlay must stay closed.
+        await page.evaluate(() => window.SillyBunnyShell.openChatTools());
+        await waitForAnimationFrames(page, 2);
+
+        expect((await getOverlayStateSnapshot(page)).chatToolsOpen).toBe(false);
+
+        expect(await getHorizontalOverflow(page)).toBeLessThanOrEqual(1);
+    });
+});


### PR DESCRIPTION
## Summary

Phase 0 guardrail PR (PR 0.1 of the mobile shell refactor program). Adds two test files; **no production code changes, no upstream-origin files touched** (`script.js`, `style.css`, `index.html`, `mobile-styles.css` all untouched — no ledger entry needed).

### `tests/mobile-shell-smoke.e2e.js`

Pins the current mobile shell contracts so the upcoming `sillybunny-tabs.js` decomposition has a regression net:

- **390×844 (iPhone)**: drawer open/close viewport bound contract (`syncMobileShellDrawerBounds` inline `top`/`height` + dataset marker, fully cleared on close); hamburger nav `hidden`/`aria-hidden`/`inert`/`aria-expanded` agreement; **overlay mutual exclusion** (left shell → nav → chat tools → character panel, each closes its competitors — this pins the invariant the decomposition later centralizes); keyboard-style viewport shrink to 390×500 → drawer re-bounds + composer stays on screen → recovery on restore; no horizontal overflow after each flow.
- **320×568**: composer fits; send target floor at its current shipped size (26px — documented as a ratchet floor that the mobile UX redesign raises to 44px).
- **768×1024**: mobile shell still active at the boundary (drawer bound contract + nav exclusion).
- **820×1180**: mobile chrome stays dormant in the 769–1000px "compact desktop" band (no viewport binding, mobile chat tools never open).
- Screenshot checkpoints attached per run: `nav-open`, `left-drawer`, `chat-tools`, `composer-short-viewport`.
- No Playwright config changes; reuses `openReadyChat`/`waitForAnimationFrames` from the scroll-regression helpers; per-describe `test.use` viewport/UA blocks follow the existing mobile-describe idiom.

### `tests/mobile-css-budgets.test.js`

Static ratchet budgets frozen at today's measured staging state:

| Sheet | `!important` ceiling |
|---|---|
| `sillybunny-mobile-shell.css` | 664 |
| `sillybunny-tabs.css` | 386 |
| `sillybunny-chat-styles.css` | 225 |
| `sillybunny-theme.css` | 158 |

Plus: ≤ 20 distinct media-query px values across fork sheets, string-pins on the `index.html` `(max-width: 768px)` media gates for `mobile-styles.css`/`sillybunny-mobile-shell.css` (an upstream sync dropping them now fails CI), and a fork-sheet load-order assertion (after upstream styles, before `user.css`). Ceilings only go down as cleanup PRs land; raising one requires a review note.

## Test plan

- [x] `node --check public/scripts/sillybunny-tabs.js`
- [x] `npm run lint` (root) + `npx eslint` on both new files
- [x] `npm run test:unit --prefix tests` — 104 suites / 962 tests pass (7 new)
- [x] `npm run check:frontend-budgets`
- [x] Smoke pack e2e: 8/8 pass against a staging-state server (`SILLYBUNNY_TEST_BASE_URL=http://127.0.0.1:4567`, isolated worktree, user data junction-linked to the runtime profile)

### Notes for reviewers

- `openReadyChat(page, { selectCharacter: false })`: the shell contracts under test don't need a selected character, and the helper's sample-character lookup (`Bunny Guide|Seraphina`) isn't guaranteed to exist in every user profile.
- Hamburger clicks while a drawer/overlay is open use programmatic `.click()` — the mobile modal policy marks page chrome inert while a surface is open, so a trusted pointer click can't reach the topbar (that's the policy working, not a bug; the comment in the test explains it).
- Chromium-only iOS fidelity accepted for now (matches the existing e2e packs).