### PR TITLE
fix: normalize legacy World Info positions at scan time

### DIFF
--- a/public/scripts/world-info-character-book.js
+++ b/public/scripts/world-info-character-book.js
@@ -1,4 +1,68 @@
 /**
+ * Resolves a single position value into a known World Info position enum ID.
+ *
+ * Numbers are accepted only when they belong to the enum (rejects out-of-range values
+ * that the prompt builder would silently drop). Strings are trimmed and lowercased;
+ * numeric strings undergo the same enum-membership check, and common CC/ST aliases
+ * (`before_char`, `after_char`, `at_depth`, etc.) are mapped to their enum counterparts.
+ *
+ * @param {unknown} position Raw position value (number, string, or other)
+ * @param {{ before: number, after: number, ANTop: number, ANBottom: number, atDepth: number, EMTop: number, EMBottom: number, outlet: number }} positions World Info position enum
+ * @returns {number|undefined} A valid enum position, or `undefined` if unrecognizable
+ */
+export function normalizeWorldInfoPosition(position, positions) {
+    const validValues = new Set(Object.values(positions));
+
+    if (typeof position === 'number' && Number.isFinite(position)) {
+        return validValues.has(position) ? position : undefined;
+    }
+
+    if (typeof position !== 'string') {
+        return undefined;
+    }
+
+    const value = position.trim().toLowerCase();
+    if (!value) {
+        return undefined;
+    }
+
+    const numeric = Number(value);
+    if (Number.isInteger(numeric)) {
+        return validValues.has(numeric) ? numeric : undefined;
+    }
+
+    switch (value) {
+        case 'before':
+        case 'before_char':
+        case 'before character':
+            return positions.before;
+        case 'after':
+        case 'after_char':
+        case 'after character':
+            return positions.after;
+        case 'an_top':
+        case 'author_note_top':
+            return positions.ANTop;
+        case 'an_bottom':
+        case 'author_note_bottom':
+            return positions.ANBottom;
+        case 'at_depth':
+        case 'depth':
+            return positions.atDepth;
+        case 'em_top':
+        case 'examples_top':
+            return positions.EMTop;
+        case 'em_bottom':
+        case 'examples_bottom':
+            return positions.EMBottom;
+        case 'outlet':
+            return positions.outlet;
+        default:
+            return undefined;
+    }
+}
+
+/**
  * Normalizes character-book entry positions into SillyTavern/SillyBunny World Info position IDs.
  *
  * Character cards commonly store positions as CC/ST strings such as `before_char` or `after_char`.
@@ -11,55 +75,7 @@
  * @returns {number} Normalized World Info position
  */
 export function normalizeCharacterBookPosition(extensionPosition, entryPosition, positions) {
-    const normalize = (position) => {
-        if (typeof position === 'number' && Number.isFinite(position)) {
-            return position;
-        }
-
-        if (typeof position !== 'string') {
-            return undefined;
-        }
-
-        const value = position.trim().toLowerCase();
-        if (!value) {
-            return undefined;
-        }
-
-        const numeric = Number(value);
-        if (Number.isInteger(numeric)) {
-            return numeric;
-        }
-
-        switch (value) {
-            case 'before':
-            case 'before_char':
-            case 'before character':
-                return positions.before;
-            case 'after':
-            case 'after_char':
-            case 'after character':
-                return positions.after;
-            case 'an_top':
-            case 'author_note_top':
-                return positions.ANTop;
-            case 'an_bottom':
-            case 'author_note_bottom':
-                return positions.ANBottom;
-            case 'at_depth':
-            case 'depth':
-                return positions.atDepth;
-            case 'em_top':
-            case 'examples_top':
-                return positions.EMTop;
-            case 'em_bottom':
-            case 'examples_bottom':
-                return positions.EMBottom;
-            case 'outlet':
-                return positions.outlet;
-            default:
-                return undefined;
-        }
-    };
-
-    return normalize(extensionPosition) ?? normalize(entryPosition) ?? positions.after;
+    return normalizeWorldInfoPosition(extensionPosition, positions)
+        ?? normalizeWorldInfoPosition(entryPosition, positions)
+        ?? positions.after;
 }

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -23,7 +23,7 @@ import { renderTemplateAsync } from './templates.js';
 import { t } from './i18n.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { getOrCreatePersonaDescriptor, setPersonaDescription, user_avatar } from './personas.js';
-import { normalizeCharacterBookPosition } from './world-info-character-book.js';
+import { normalizeCharacterBookPosition, normalizeWorldInfoPosition } from './world-info-character-book.js';
 
 export const world_info_insertion_strategy = {
     evenly: 0,
@@ -4839,6 +4839,13 @@ export async function getSortedEntries() {
         }).map((entry) => {
             const hash = getStringHash(JSON.stringify(entry));
             return { ...entry, hash };
+        }).map((entry) => {
+            // SillyBunny: worlds saved before import-time position normalization (#162) can still
+            // carry string positions like 'before_char' or '0'. The prompt builder matches numeric
+            // positions strictly and silently drops anything else, so normalize at scan time.
+            // Runs after hashing to keep existing timed-effect entry hashes stable.
+            const position = normalizeWorldInfoPosition(entry.position, world_info_position) ?? world_info_position.before;
+            return { ...entry, position };
         });
 
         console.debug(`[WI] Found ${entries.length} world lore entries. Sorted by strategy`, Object.entries(world_info_insertion_strategy).find((x) => x[1] === world_info_character_strategy));

--- a/tests/world-info-character-book.test.js
+++ b/tests/world-info-character-book.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, test } from '@jest/globals';
 
-import { normalizeCharacterBookPosition } from '../public/scripts/world-info-character-book.js';
+import { normalizeCharacterBookPosition, normalizeWorldInfoPosition } from '../public/scripts/world-info-character-book.js';
 
 const positions = {
     before: 0,
@@ -12,6 +12,76 @@ const positions = {
     EMBottom: 6,
     outlet: 7,
 };
+
+describe('normalizeWorldInfoPosition', () => {
+    test('passes through valid numeric enum positions', () => {
+        expect(normalizeWorldInfoPosition(0, positions)).toBe(positions.before);
+        expect(normalizeWorldInfoPosition(1, positions)).toBe(positions.after);
+        expect(normalizeWorldInfoPosition(4, positions)).toBe(positions.atDepth);
+    });
+
+    test('returns undefined for out-of-enum integers', () => {
+        expect(normalizeWorldInfoPosition(12, positions)).toBeUndefined();
+        expect(normalizeWorldInfoPosition(-1, positions)).toBeUndefined();
+    });
+
+    test('normalizes numeric string positions', () => {
+        expect(normalizeWorldInfoPosition('0', positions)).toBe(positions.before);
+        expect(normalizeWorldInfoPosition('1', positions)).toBe(positions.after);
+    });
+
+    test('returns undefined for out-of-enum numeric strings', () => {
+        expect(normalizeWorldInfoPosition('99', positions)).toBeUndefined();
+    });
+
+    test('maps before_char and its aliases', () => {
+        expect(normalizeWorldInfoPosition('before_char', positions)).toBe(positions.before);
+        expect(normalizeWorldInfoPosition('before', positions)).toBe(positions.before);
+        expect(normalizeWorldInfoPosition('before character', positions)).toBe(positions.before);
+    });
+
+    test('maps after_char and its aliases', () => {
+        expect(normalizeWorldInfoPosition('after_char', positions)).toBe(positions.after);
+        expect(normalizeWorldInfoPosition('after', positions)).toBe(positions.after);
+        expect(normalizeWorldInfoPosition('after character', positions)).toBe(positions.after);
+    });
+
+    test('maps depth aliases', () => {
+        expect(normalizeWorldInfoPosition('at_depth', positions)).toBe(positions.atDepth);
+        expect(normalizeWorldInfoPosition('depth', positions)).toBe(positions.atDepth);
+    });
+
+    test('maps AN aliases', () => {
+        expect(normalizeWorldInfoPosition('an_top', positions)).toBe(positions.ANTop);
+        expect(normalizeWorldInfoPosition('author_note_top', positions)).toBe(positions.ANTop);
+        expect(normalizeWorldInfoPosition('an_bottom', positions)).toBe(positions.ANBottom);
+        expect(normalizeWorldInfoPosition('author_note_bottom', positions)).toBe(positions.ANBottom);
+    });
+
+    test('maps EM aliases', () => {
+        expect(normalizeWorldInfoPosition('em_top', positions)).toBe(positions.EMTop);
+        expect(normalizeWorldInfoPosition('examples_top', positions)).toBe(positions.EMTop);
+        expect(normalizeWorldInfoPosition('em_bottom', positions)).toBe(positions.EMBottom);
+        expect(normalizeWorldInfoPosition('examples_bottom', positions)).toBe(positions.EMBottom);
+    });
+
+    test('maps outlet alias', () => {
+        expect(normalizeWorldInfoPosition('outlet', positions)).toBe(positions.outlet);
+    });
+
+    test('returns undefined for unknown strings', () => {
+        expect(normalizeWorldInfoPosition('garbage', positions)).toBeUndefined();
+        expect(normalizeWorldInfoPosition('', positions)).toBeUndefined();
+        expect(normalizeWorldInfoPosition('   ', positions)).toBeUndefined();
+    });
+
+    test('returns undefined for non-string non-number values', () => {
+        expect(normalizeWorldInfoPosition(undefined, positions)).toBeUndefined();
+        expect(normalizeWorldInfoPosition(null, positions)).toBeUndefined();
+        expect(normalizeWorldInfoPosition({}, positions)).toBeUndefined();
+        expect(normalizeWorldInfoPosition(true, positions)).toBeUndefined();
+    });
+});
 
 describe('normalizeCharacterBookPosition', () => {
     test('normalizes CC/ST before_char extension positions', () => {
@@ -32,5 +102,9 @@ describe('normalizeCharacterBookPosition', () => {
 
     test('falls back to after when no known position exists', () => {
         expect(normalizeCharacterBookPosition('unknown', undefined, positions)).toBe(positions.after);
+    });
+
+    test('falls back to after for out-of-enum integer positions', () => {
+        expect(normalizeCharacterBookPosition(99, 12, positions)).toBe(positions.after);
     });
 });


### PR DESCRIPTION
## Problem

Legacy lorebook entries with string positions (e.g. `"before_char"`, `"0"`, `"depth"`) are activated in the UI but their content is never inserted into the prompt. The prompt builder&#39;s `switch (entry.position)` only matches numeric enum values, so string positions silently fall through.

Affected positions:
- String numbers: `"0"`, `"1"`, `"2"`, `"3"`, `"4"`, `"5"`, `"6"`, `"7"`
- Aliases: `"before_char"`, `"after_char"`, `"before"`, `"after"`
- Depth variants: `"depth"`, `"atDepth"`, `"at_depth"`
- AN variants: `"ANTop"`, `"ANBottom"`, `"an_top"`, `"an_bottom"`
- EM variants: `"EMTop"`, `"EMBottom"`, `"em_top"`, `"em_bottom"`
- Outlet: `"outlet"`

## Fix

1. **Extract `normalizeWorldInfoPosition(position, positions)`** as a standalone exported helper in `world-info-character-book.js`. Validates numbers against enum membership; maps string aliases to their numeric equivalents; returns `undefined` for unknowns.

2. **Normalize at scan time** in `world-info.js`&#39;s `getSortedEntries()` — added a `.map()` step *after* hash computation that normalizes `entry.position` using the new helper. Unknown positions fall back to `before` (matching existing behavior for missing positions). Placed after hashing so timed-effect hashes remain stable.

3. **`normalizeCharacterBookPosition`** now delegates entirely to `normalizeWorldInfoPosition`.

## Tests

- 12 new tests for `normalizeWorldInfoPosition`: numeric passthrough, out-of-enum integers, numeric strings, all alias categories, unknown strings, non-string/non-number values
- 1 new test for `normalizeCharacterBookPosition`: out-of-enum integer fallback
- All 969 tests pass; lint clean