### PR TITLE
fix: preserve new group chat id during validation

### DIFF
--- a/docs/upstream-touch-ledger.md
+++ b/docs/upstream-touch-ledger.md
@@ -69,11 +69,11 @@ This ledger tracks intentional SillyBunny divergence in upstream-origin files. I
 | Area | Chat lifecycle. |
 | Divergence reason | SillyBunny's Start new chat menu path already flushes pending saves and clears the active chat before delegating to group chat creation, so the group branch creator must not run a second navigation-save guard that can abort and repaint the current chat. |
 | Target seam | None yet; group chat branch creation still lives in the upstream-origin chat modules. |
-| Adapter shape | Keep `doNewChat()` as the stock menu adapter and pass a narrow `chatAlreadyPrepared` option; keep standalone group creation guarded, and tell `getGroupChat()` when the chat id was freshly created so empty group branches are initialized consistently. |
+| Adapter shape | Keep `doNewChat()` as the stock menu adapter and pass a narrow `chatAlreadyPrepared` option; keep standalone group creation guarded, and tell `getGroupChat()` when the chat id was freshly created so validation trusts the active empty branch until its JSONL exists. |
 | Protecting tests | Future focused group-chat new-branch coverage; current protection is static validation. |
 | Validation | `node --check public/script.js`, `node --check public/scripts/group-chats.js`, `npm run lint`, `git diff --check`. |
 | Rollback path | Revert the option plumbing and newly-created load hint to restore the previous `createNewGroupChat(groupId)` path. |
-| Last reviewed | 2026-06-09 group chat Start new chat fix. |
+| Last reviewed | 2026-06-10 group chat Start new chat validation fix. |
 | Owner | Bugfix integrator. |
 
 ### `public/style.css` - message containment and scroll anchoring

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -1152,9 +1152,11 @@ async function groupChatExists(chatId) {
 /**
  * Validates a group by checking if all members exist and removing duplicates.
  * @param {Group} group Group to validate
+ * @param {object} [options] Validation options
+ * @param {boolean} [options.trustActiveChat=false] Whether to keep the active chat id even before its JSONL exists
  * @returns {Promise<void>}
  */
-async function validateGroup(group) {
+async function validateGroup(group, { trustActiveChat = false } = {}) {
     if (!group) return;
 
     // Validate that all members exist as characters
@@ -1212,7 +1214,8 @@ async function validateGroup(group) {
             dirty = true;
         }
 
-        if (presentChats.length && !presentChats.includes(String(group.chat_id ?? ''))) {
+        // SillyBunny: a newly-created group chat has no JSONL yet, so keep its active branch id.
+        if (!trustActiveChat && presentChats.length && !presentChats.includes(String(group.chat_id ?? ''))) {
             group.chat_id = presentChats[presentChats.length - 1];
             dirty = true;
         }
@@ -1247,7 +1250,7 @@ export async function getGroupChat(groupId, reload = false, { switchMenu = true,
     }
 
     // Run validation before any loading
-    await validateGroup(group);
+    await validateGroup(group, { trustActiveChat: newlyCreated });
     await unshallowGroupMembers(groupId);
 
     let createdChat = newlyCreated;


### PR DESCRIPTION
## Summary
- Keep group validation from falling back to an older present branch while loading a newly-created group chat.
- Pass the newlyCreated hint into validation so the active empty branch is trusted until its JSONL exists.
- Update the upstream touch ledger for this downstream divergence.

## Tests
- node --check public/scripts/group-chats.js
- git diff --check
- npm run lint
- bun run lint
- npm run test:unit --prefix tests -- chat-save-guard.test.js chat-integrity-rotation.test.js

Manual group-chat UI smoke was not run in this environment.