### PR TITLE
fix(mobile): strengthen preset select touch guard

### DIFF
--- a/public/scripts/preset-manager.js
+++ b/public/scripts/preset-manager.js
@@ -213,6 +213,7 @@ class PresetManager {
         this._presetSelectPointerMoveHandler = (event) => this._handlePresetSelectPointerMove(event);
         this._presetSelectPointerEndHandler = (event) => this._handlePresetSelectPointerEnd(event);
         this._presetSelectPointerCancelHandler = (event) => this._handlePresetSelectPointerCancel(event);
+        this._presetSelectPointerLeaveHandler = (event) => this._handlePresetSelectPointerLeave(event);
         this._presetSelectClickHandler = (event) => this._handlePresetSelectClick(event);
         // SillyBunny: snapshot and guard all connected text fields before preset
         // changes so unsaved changes in fork-specific drawers can still warn.
@@ -523,6 +524,7 @@ class PresetManager {
         selectElement.addEventListener('pointermove', this._presetSelectPointerMoveHandler, true);
         selectElement.addEventListener('pointerup', this._presetSelectPointerEndHandler, true);
         selectElement.addEventListener('pointercancel', this._presetSelectPointerCancelHandler, true);
+        selectElement.addEventListener('pointerleave', this._presetSelectPointerLeaveHandler, true);
         selectElement.addEventListener('click', this._presetSelectClickHandler, true);
     }
 
@@ -567,6 +569,17 @@ class PresetManager {
     }
 
     _handlePresetSelectPointerCancel(event) {
+        const touchGuardResult = resolvePresetSelectTouchGuardEnd({
+            touchGuardState: this._presetSelectTouchGuardState,
+            pointerId: event.pointerId,
+            forceSuppress: true,
+        });
+
+        this._presetSelectTouchGuardState = touchGuardResult.touchGuardState;
+        this._presetSelectTouchSuppressClick = touchGuardResult.shouldSuppressClick;
+    }
+
+    _handlePresetSelectPointerLeave(event) {
         const touchGuardResult = resolvePresetSelectTouchGuardEnd({
             touchGuardState: this._presetSelectTouchGuardState,
             pointerId: event.pointerId,

--- a/public/scripts/preset-select-touch-guard.js
+++ b/public/scripts/preset-select-touch-guard.js
@@ -1,4 +1,4 @@
-export const PRESET_SELECT_TOUCH_GUARD_DRAG_THRESHOLD_PX = 6;
+export const PRESET_SELECT_TOUCH_GUARD_DRAG_THRESHOLD_PX = 4;
 
 function normalizeNumber(value, fallback = 0) {
     const numberValue = Number(value);
@@ -77,6 +77,27 @@ export function resolvePresetSelectTouchGuardMove({
     return {
         ...touchGuardState,
         dragging,
+    };
+}
+
+/**
+ * Marks active preset select touch guard state as dragging.
+ * @param {object} options Options.
+ * @param {object|null} [options.touchGuardState=null] Existing touch guard state.
+ * @param {number|null} [options.pointerId=null] Pointer identifier.
+ * @returns {object|null} Updated touch guard state.
+ */
+export function markPresetSelectTouchGuardDragging({
+    touchGuardState = null,
+    pointerId = null,
+} = {}) {
+    if (!touchGuardState || !isSamePointer(touchGuardState, pointerId)) {
+        return touchGuardState;
+    }
+
+    return {
+        ...touchGuardState,
+        dragging: true,
     };
 }
 

--- a/tests/preset-select-touch-guard.test.js
+++ b/tests/preset-select-touch-guard.test.js
@@ -2,6 +2,7 @@ import { describe, expect, test } from '@jest/globals';
 
 import {
     createPresetSelectTouchGuardState,
+    markPresetSelectTouchGuardDragging,
     PRESET_SELECT_TOUCH_GUARD_DRAG_THRESHOLD_PX,
     resolvePresetSelectTouchGuardEnd,
     resolvePresetSelectTouchGuardMove,
@@ -10,7 +11,7 @@ import {
 
 describe('preset select touch guard helper', () => {
     test('keeps the mobile drag threshold explicit', () => {
-        expect(PRESET_SELECT_TOUCH_GUARD_DRAG_THRESHOLD_PX).toBe(6);
+        expect(PRESET_SELECT_TOUCH_GUARD_DRAG_THRESHOLD_PX).toBe(4);
     });
 
     test('captures state only for mobile touch or pen input', () => {
@@ -71,7 +72,7 @@ describe('preset select touch guard helper', () => {
             touchGuardState,
             pointerId: 7,
             clientX: 104,
-            clientY: 105,
+            clientY: 103,
         });
 
         expect(movedState).toEqual({
@@ -123,7 +124,52 @@ describe('preset select touch guard helper', () => {
         })).toBe(false);
     });
 
+    test('can mark active mobile guard state as dragging', () => {
+        const touchGuardState = createPresetSelectTouchGuardState({
+            isMobileViewport: true,
+            pointerType: 'touch',
+            pointerId: 7,
+            clientX: 100,
+            clientY: 100,
+        });
+        const movedState = markPresetSelectTouchGuardDragging({
+            touchGuardState,
+            pointerId: 7,
+        });
+
+        expect(movedState).toEqual({
+            ...touchGuardState,
+            dragging: true,
+        });
+        expect(resolvePresetSelectTouchGuardEnd({
+            touchGuardState: movedState,
+            pointerId: 7,
+        })).toEqual({
+            touchGuardState: null,
+            shouldSuppressClick: true,
+        });
+    });
+
     test('suppresses the next click when mobile panning cancels the pointer stream', () => {
+        const touchGuardState = createPresetSelectTouchGuardState({
+            isMobileViewport: true,
+            pointerType: 'touch',
+            pointerId: 7,
+            clientX: 100,
+            clientY: 100,
+        });
+
+        expect(resolvePresetSelectTouchGuardEnd({
+            touchGuardState,
+            pointerId: 7,
+            forceSuppress: true,
+        })).toEqual({
+            touchGuardState: null,
+            shouldSuppressClick: true,
+        });
+    });
+
+    test('suppresses the next click when mobile panning leaves the select', () => {
         const touchGuardState = createPresetSelectTouchGuardState({
             isMobileViewport: true,
             pointerType: 'touch',


### PR DESCRIPTION
## Summary
- Lower preset select drag threshold from 6px to 4px
- Treat pointerleave like pointercancel so mobile scrolls suppress the follow-up click
- Cover the threshold, forced suppression, and explicit drag helper in unit tests

## Tests
- npm run test:unit -- preset-select-touch-guard.test.js