### PR TITLE
fix: strip hidden content from closed details in screenshots

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -11272,6 +11272,13 @@ function sanitizeMessageElementForScreenshot(messageElement) {
     messageElement.classList.remove('selected', 'slide', 'fade');
     messageElement.querySelectorAll('[id]').forEach(element => element.removeAttribute('id'));
     messageElement.querySelectorAll(removableSelector).forEach(element => element.remove());
+    messageElement.querySelectorAll('details:not([open])').forEach(details => {
+        Array.from(details.children).forEach(child => {
+            if (child.tagName !== 'SUMMARY') {
+                child.remove();
+            }
+        });
+    });
 }
 
 function buildMessageScreenshotElements(startId, endId) {


### PR DESCRIPTION
## The bug

When a message's reasoning/thinking block (`<details class="mes_reasoning_details">`) is **collapsed**, taking a screenshot produces a corrupted PNG with text layers overlapping. The collapsed reasoning content bleeds through alongside the visible message body.

## Root cause

`html2canvas` has a long-standing limitation: it does **not** respect the closed state of `<details>` elements. It renders **all** inner content, including nodes hidden by the browser.

In `sanitizeMessageElementForScreenshot()`, the cloned message element was passed to `html2canvas` as-is. For a closed reasoning block, the clone still contained the full `.mes_reasoning` tree, so the renderer painted both the summary and the hidden reasoning body — causing the layering artifact.

## The fix

In `sanitizeMessageElementForScreenshot()` (after the existing UI-chrome removal pass), iterate every closed `<details>` inside the cloned message element and remove all children **except** the `<summary>`. The live DOM is never touched — only the screenshot clone is mutated.

```js
messageElement.querySelectorAll('details:not([open])').forEach(details => {
    Array.from(details.children).forEach(child => {
        if (child.tagName !== 'SUMMARY') {
            child.remove();
        }
    });
});
```

## Scope

- Single file: `public/script.js`
- Adds 6 lines to one existing function
- No CSS, DOM, or API changes
- Live message rendering is unaffected

## Verification

1. Open a chat with reasoning/thinking blocks enabled.
2. Collapse one or more reasoning blocks.
3. Use the message screenshot action.
4. The exported PNG should show only the visible closed-state summary — no overlapping reasoning text.