### PR TITLE
fix: clip root overflow so search jumps can't shift the fixed viewport

### DIFF
--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -947,7 +947,10 @@
 
     body {
         touch-action: manipulation;
+        /* SillyBunny: keep in sync with style.css — `clip` blocks programmatic
+           viewport scrolling (scrollIntoView) that `hidden` allows. */
         overflow: hidden;
+        overflow: clip;
         position: fixed;
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -17,7 +17,7 @@
             background-color: #1d2128;
         }
     </style>
-    <link rel="preload" as="style" href="style.css?v=20260609a">
+    <link rel="preload" as="style" href="style.css?v=20260610a">
     <link rel="modulepreload" href="script.js">
     <link rel="modulepreload" href="scripts/sillybunny-tabs.js?v=20260609a">
     <link rel="preload" as="font" type="font/woff2" href="webfonts/Figtree/Figtree-Regular.woff2?v=20260422b" crossorigin>
@@ -40,11 +40,11 @@
     <link rel="apple-touch-icon" sizes="114x114" href="img/apple-icon-114x114.png" />
     <link rel="apple-touch-icon" sizes="144x144" href="img/apple-icon-144x144.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="img/apple-icon-180x180.png" />
-    <link rel="stylesheet" type="text/css" href="style.css?v=20260609a">
+    <link rel="stylesheet" type="text/css" href="style.css?v=20260610a">
     <link rel="stylesheet" type="text/css" href="css/st-tailwind.css">
     <link rel="stylesheet" type="text/css" href="css/toggle-dependent.css">
     <link rel="stylesheet" type="text/css" href="css/select2-overrides.css?v=20260609a">
-    <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260516d" media="(max-width: 768px)">
+    <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260610a" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260609a">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260609a">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260609d" media="(max-width: 768px)">

--- a/public/style.css
+++ b/public/style.css
@@ -200,6 +200,11 @@ html {
     -webkit-transform: translateZ(0);
     -webkit-backface-visibility: hidden;
     -webkit-perspective: 1000;
+    /* SillyBunny: `clip` (unlike `hidden`) blocks programmatic viewport
+       scrolling too, so scrollIntoView on search results can't shift the
+       fixed-layout app and strand a black bar at the bottom. */
+    overflow: hidden;
+    overflow: clip;
 }
 
 body {
@@ -218,6 +223,7 @@ body {
     line-height: 1.6;
     color: var(--SmartThemeBodyColor);
     overflow: hidden;
+    overflow: clip;
     color-scheme: only light;
 }
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const SB_SW_CACHE_VERSION = 'sillybunny-cache-v20260609d';
+const SB_SW_CACHE_VERSION = 'sillybunny-cache-v20260610a';
 const SB_STATIC_CACHE = `${SB_SW_CACHE_VERSION}-static`;
 const SB_SHELL_CACHE = `${SB_SW_CACHE_VERSION}-shell`;
 const SB_FRONTEND_ASSET_PREFIX = '/frontend-assets/';


### PR DESCRIPTION
## Problem

Jumping to a universal-search or chat-search result could shift the entire app upward, leaving a dead black bar over the bottom chat bar. The layout stayed broken until a hard reload.

## Root cause

The app is a fixed-height layout (`body { height: 100dvh; overflow: hidden }`), but `overflow: hidden` still permits *programmatic* scrolling. Search-jump paths call `element.scrollIntoView({ block: 'center' })` (e.g. `revealSearchMatch`, `applyChatSearchHighlights` in `public/scripts/sillybunny-tabs.js`), and the browser scrolls every scrollable ancestor of the target — including the document itself. Nothing ever resets the document scroll offset, so the viewport stayed shifted.

## Fix

Declare `overflow: clip` on `html` and `body` in `public/style.css`, and on the mobile `body` override in `public/css/mobile-styles.css` (which re-declares `overflow` inside its max-width media block and would otherwise revert the guard on phone widths). Unlike `hidden`, `clip` forbids all scrolling of the element, including programmatic scrolling, so `scrollIntoView` can no longer move the viewport. Inner scroll containers (chat, drawers, panels) are unaffected and search jump keeps scrolling them normally.

`overflow: hidden` is kept on the preceding line as a graceful fallback for older browsers that don't support `clip` (baseline since Chrome 90 / Firefox 81 / Safari 16). On unsupported browsers (e.g. iOS 15) behavior is unchanged from before this PR.

This covers every jump-to-element path at once (universal search, chat search, tag navigation, welcome screen) instead of patching each `scrollIntoView` call site.

Also bumps the `style.css`/`mobile-styles.css` cache-bust query params and the service worker cache version so clients pick up the change without a manual hard reload.

## Risk / rollback

- CSS-only plus cache-version bumps; revert the two commits to roll back.
- All first-party `scrollIntoView` targets live inside `overflow: auto/scroll` containers (`#chat`, drawer panels, search dropdown), so no jump path depended on document scrolling.
- The mobile viewport-reset guard in `browser-fixes.js` (`scrollingElement.scrollTop > 0` → `scrollTo(0,0)`) becomes inert on supporting browsers but remains a useful defence for the `hidden` fallback path.
- On iOS Safari, keyboard-driven shifts move the *visual* viewport, which CSS cannot block; those remain handled by the existing `browser-fixes.js` logic. This PR addresses the layout-viewport shift caused by `scrollIntoView`.

## Verification

- `npm run check:frontend-budgets` passes (775.3 KiB blocking CSS, under budget).
- Changed-region CSS parses cleanly; both stylesheets' pre-existing parser quirks (`@starting-style` nesting) are unchanged from base.
- ESLint/Jest CI gates don't cover CSS; manual browser verification recommended post-merge: desktop universal-search jump into a closed accordion, chat-search jump to an old message, and mobile (iOS/Android) search jump with keyboard open.