### PR TITLE
chore: bump version to 1.6.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sillybunny",
-    "version": "1.6.4",
+    "version": "1.6.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sillybunny",
-            "version": "1.6.4",
+            "version": "1.6.5",
             "license": "AGPL-3.0",
             "dependencies": {
                 "@adobe/css-tools": "^4.4.4",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
         "type": "git",
         "url": "https://github.com/platberlitz/SillyBunny.git"
     },
-    "version": "1.6.4",
+    "version": "1.6.5",
     "scripts": {
         "start": "bun server.js",
         "start:node": "node --no-warnings server.js",

--- a/public/script.js
+++ b/public/script.js
@@ -512,7 +512,7 @@ export let isChatSaving = false;
 export let firstRun = false;
 export let settingsReady = false;
 let currentVersion = '0.0.0';
-const SILLYBUNNY_UI_VERSION = 'SillyBunny v1.6.4';
+const SILLYBUNNY_UI_VERSION = 'SillyBunny v1.6.5';
 
 export let displayVersion = SILLYBUNNY_UI_VERSION;
 
@@ -555,7 +555,7 @@ export function getSillyBunnyFrontendIconSrc({ absolute = false } = {}) {
 export let system_avatar = getSillyBunnyFrontendIconSrc();
 export const comment_avatar = 'img/quill.png';
 export const default_user_avatar = 'img/user-default.png';
-export let CLIENT_VERSION = 'SillyBunny:v1.6.4:platberlitz'; // For Horde header
+export let CLIENT_VERSION = 'SillyBunny:v1.6.5:platberlitz'; // For Horde header
 
 function applySillyBunnyFrontendIcon(iconId = getStoredSillyBunnyFrontendIcon()) {
     const normalizedIconId = normalizeSillyBunnyFrontendIcon(iconId);

--- a/public/scripts/extensions/gallery/manifest.json
+++ b/public/scripts/extensions/gallery/manifest.json
@@ -7,7 +7,7 @@
     "js": "index.js",
     "css": "style.css",
     "author": "City-Unit",
-    "version": "1.6.4",
+    "version": "1.6.5",
     "homePage": "https://github.com/SillyTavern/SillyTavern",
     "hooks": {
         "activate": "init"

--- a/public/scripts/extensions/in-chat-agents/manifest.json
+++ b/public/scripts/extensions/in-chat-agents/manifest.json
@@ -6,6 +6,6 @@
     "js": "index.js",
     "css": "style.css",
     "author": "SillyBunny",
-    "version": "1.6.4",
+    "version": "1.6.5",
     "homePage": "https://github.com/platberlitz/SillyBunny"
 }

--- a/public/scripts/extensions/input-history/manifest.json
+++ b/public/scripts/extensions/input-history/manifest.json
@@ -6,7 +6,7 @@
     "js": "index.js",
     "css": "style.css",
     "author": "LenAnderson",
-    "version": "1.6.4",
+    "version": "1.6.5",
     "homePage": "https://github.com/LenAnderson/SillyTavern-InputHistory",
     "manifest_version": 3
 }

--- a/src/endpoints/horde.js
+++ b/src/endpoints/horde.js
@@ -15,7 +15,7 @@ export const router = express.Router();
  */
 async function getClientAgent() {
     const version = await getVersion();
-    return version?.agent || 'SillyBunny:1.6.4:platberlitz';
+    return version?.agent || 'SillyBunny:1.6.5:platberlitz';
 }
 
 /**

--- a/tests/extensions-disable.test.js
+++ b/tests/extensions-disable.test.js
@@ -44,7 +44,7 @@ function installExtensionModuleMocks() {
     }));
 
     jest.unstable_mockModule('../public/script.js', () => ({
-        CLIENT_VERSION: 'SillyBunny:v1.6.4',
+        CLIENT_VERSION: 'SillyBunny:v1.6.5',
         animation_duration: 0,
         eventSource: { emit: jest.fn(async () => {}) },
         event_types: { EXTENSIONS_FIRST_LOAD: 'extensions_first_load', EXTRAS_CONNECTED: 'extras_connected', EXTENSION_SETTINGS_LOADED: 'extension_settings_loaded' },


### PR DESCRIPTION
## Summary

Bump all SillyBunny version references from **1.6.4** to **1.6.5**.

## Changes (10 edits across 8 files)

### Package metadata
- `package.json` — version string
- `package-lock.json` — top-level version + root package entry

### UI and client strings
- `public/script.js` — `SILLYBUNNY_UI_VERSION` and `CLIENT_VERSION`

### Horde fallback
- `src/endpoints/horde.js` — server-side Horde client string

### Bundled extension manifests
- `input-history/manifest.json`
- `in-chat-agents/manifest.json`
- `gallery/manifest.json`

### Test mock
- `tests/extensions-disable.test.js` — `CLIENT_VERSION` mock updated