### PR TITLE
fix: support claude-fable-5 in Claude and OpenAI-compatible request builders

### DIFF
--- a/docs/upstream-touch-ledger.md
+++ b/docs/upstream-touch-ledger.md
@@ -284,6 +284,19 @@ This ledger tracks intentional SillyBunny divergence in upstream-origin files. I
 | Last reviewed | 2026-05-28 prompt manager lifecycle wiring. |
 | Owner | Refactor integrator and prompt manager owner. |
 
+### `src/endpoints/backends/chat-completions.js`, `public/scripts/openai.js`, and `public/index.html` - claude-fable-5 request compatibility
+| Field | Value |
+| --- | --- |
+| Area | Generation lifecycle and settings (Claude chat-completion request builders). |
+| Divergence reason | `claude-fable-5` rejects `temperature`/`top_p`/`top_k`, explicit `thinking:{type:'disabled'}`, and assistant prefill with HTTP 400, and upstream's Claude model gating, dropdown, 1M-context regex, and vision list do not know the model. SillyBunny gates fable into the existing per-model flags, strips the removed samplers on both the native and OpenAI-compatible paths, and forwards real upstream error bodies on non-streaming failures instead of a generic 500. |
+| Target seam | None yet; the core fix follows upstream's existing per-model regex/delete-block patterns so it can be contributed to SillyTavern and dropped here on a future upstream sync. |
+| Adapter shape | `isFableModel` flag OR'd into existing gating regexes plus a sampler delete-block in `sendClaudeRequest`; a source-aware delete-block in `createGenerationParameters`; one dropdown option, one regex alternation, one vision-list entry; error passthrough kept as a separate commit. |
+| Protecting tests | None yet; current protection is static validation and the PR #403 relay isolation test record (minimal 200, +samplers 400, adaptive+effort 200, thinking-disabled 400, system-message 400 on non-converting relay). Add focused unit coverage if fable gating grows beyond regex alternations. |
+| Validation | `npm run lint`, `node --check src/endpoints/backends/chat-completions.js`, `node --check public/scripts/openai.js`, direct relay curls against `https://api.linkapi.ai/v1/messages` and `/chat/completions` (2026-06-10), regression check that opus-4-6/sonnet-4-6/sonnet-4-5 payloads are unchanged. |
+| Rollback path | Revert the fable regex alternations and delete-blocks to restore stock behavior (fable then 400s again on samplers); the error passthrough commit can be reverted independently. |
+| Last reviewed | 2026-06-10 PR #403 claude-fable-5 400 fix. |
+| Owner | Bugfix integrator. |
+
 ## Candidate Entries To Add Later
 | File or area | Add entry when |
 | --- | --- |

--- a/public/index.html
+++ b/public/index.html
@@ -3088,7 +3088,7 @@
                                 <h4 data-i18n="Available Models">Available Models</h4>
                                 <select id="model_claude_select">
                                     <optgroup label="Versions">
-                                        <option value="claude-fable-5">claude-fable-5</option>
+                                        <option value="claude-fable-5">claude-fable-5</option><!-- SillyBunny: claude-fable-5 support -->
                                         <option value="claude-opus-4-7">claude-opus-4-7</option>
                                         <option value="claude-opus-4-6">claude-opus-4-6</option>
                                         <option value="claude-opus-4-5">claude-opus-4-5</option>

--- a/public/index.html
+++ b/public/index.html
@@ -3088,6 +3088,7 @@
                                 <h4 data-i18n="Available Models">Available Models</h4>
                                 <select id="model_claude_select">
                                     <optgroup label="Versions">
+                                        <option value="claude-fable-5">claude-fable-5</option>
                                         <option value="claude-opus-4-7">claude-opus-4-7</option>
                                         <option value="claude-opus-4-6">claude-opus-4-6</option>
                                         <option value="claude-opus-4-5">claude-opus-4-5</option>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -5319,7 +5319,7 @@ export async function createGenerationParameters(settings, model, type, messages
         }
     }
 
-    // Claude Fable models reject sampling parameters with HTTP 400, including via OpenAI-compatible proxies.
+    // SillyBunny: Claude Fable models reject sampling parameters with HTTP 400, including via OpenAI-compatible proxies.
     // Substring match to also catch router ids like 'anthropic/claude-fable-5'.
     if (/claude-fable/.test(model)) {
         delete generate_data.temperature;
@@ -5327,8 +5327,12 @@ export async function createGenerationParameters(settings, model, type, messages
         delete generate_data.top_k;
         delete generate_data.frequency_penalty;
         delete generate_data.presence_penalty;
-        delete generate_data.reasoning_effort;
-        delete generate_data.custom_reasoning_param_name;
+        // Keep reasoning_effort for the native Claude source (the backend maps it to adaptive thinking);
+        // strip it for proxies, which may translate it into a thinking budget that fable rejects.
+        if (settings.chat_completion_source !== chat_completion_sources.CLAUDE) {
+            delete generate_data.reasoning_effort;
+            delete generate_data.custom_reasoning_param_name;
+        }
     }
 
     if (jsonSchema) {
@@ -8057,7 +8061,7 @@ async function onModelChange() {
     if (oai_settings.chat_completion_source == chat_completion_sources.CLAUDE) {
         if (maxContextUnlocked) {
             $('#openai_max_context').attr('max', unlocked_max);
-        } else if (/^claude-(sonnet-4-(?:[5-9]|\d{2,})|opus-4-(?:[6-9]|\d{2,})|fable)/.test(value)) {
+        } else if (/^claude-(sonnet-4-(?:[5-9]|\d{2,})|opus-4-(?:[6-9]|\d{2,})|fable)/.test(value)) { // SillyBunny: |fable — claude-fable-5 has a 1M context window
             $('#openai_max_context').attr('max', max_1mil);
         } else if (/^claude-(3|opus|haiku|sonnet)/.test(value)) {
             $('#openai_max_context').attr('max', max_200k);
@@ -8657,7 +8661,7 @@ export function isImageInliningSupported() {
         'o4-mini',
         // Claude
         'claude-3',
-        'claude-fable',
+        'claude-fable', // SillyBunny: claude-fable-5 vision support
         'claude-opus-4',
         'claude-sonnet-4',
         'claude-haiku-4',

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -5319,6 +5319,18 @@ export async function createGenerationParameters(settings, model, type, messages
         }
     }
 
+    // Claude Fable models reject sampling parameters with HTTP 400, including via OpenAI-compatible proxies.
+    // Substring match to also catch router ids like 'anthropic/claude-fable-5'.
+    if (/claude-fable/.test(model)) {
+        delete generate_data.temperature;
+        delete generate_data.top_p;
+        delete generate_data.top_k;
+        delete generate_data.frequency_penalty;
+        delete generate_data.presence_penalty;
+        delete generate_data.reasoning_effort;
+        delete generate_data.custom_reasoning_param_name;
+    }
+
     if (jsonSchema) {
         generate_data.json_schema = jsonSchema;
     }
@@ -8045,7 +8057,7 @@ async function onModelChange() {
     if (oai_settings.chat_completion_source == chat_completion_sources.CLAUDE) {
         if (maxContextUnlocked) {
             $('#openai_max_context').attr('max', unlocked_max);
-        } else if (/^claude-(sonnet-4-(?:[5-9]|\d{2,})|opus-4-(?:[6-9]|\d{2,}))/.test(value)) {
+        } else if (/^claude-(sonnet-4-(?:[5-9]|\d{2,})|opus-4-(?:[6-9]|\d{2,})|fable)/.test(value)) {
             $('#openai_max_context').attr('max', max_1mil);
         } else if (/^claude-(3|opus|haiku|sonnet)/.test(value)) {
             $('#openai_max_context').attr('max', max_200k);
@@ -8645,6 +8657,7 @@ export function isImageInliningSupported() {
         'o4-mini',
         // Claude
         'claude-3',
+        'claude-fable',
         'claude-opus-4',
         'claude-sonnet-4',
         'claude-haiku-4',

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -340,12 +340,14 @@ async function sendClaudeRequest(request, response) {
         const useTools = Array.isArray(request.body.tools) && request.body.tools.length > 0;
         const useSystemPrompt = Boolean(request.body.use_sysprompt);
         const convertedPrompt = convertClaudeMessages(request.body.messages, request.body.assistant_prefill, useSystemPrompt, useTools, getPromptNames(request));
-        const useThinking = /^claude-(3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6|opus-4-7|sonnet-4-6)/.test(request.body.model);
-        const useWebSearch = /^claude-(3-5|3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6|opus-4-7|sonnet-4-6)/.test(request.body.model) && Boolean(request.body.enable_web_search);
+        // Substring match: also catches router ids like 'anthropic/claude-fable-5'
+        const isFableModel = /claude-fable/.test(request.body.model);
+        const useThinking = /^claude-(3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6|opus-4-7|sonnet-4-6)/.test(request.body.model) || (isFableModel && enableAdaptiveThinking);
+        const useWebSearch = (/^claude-(3-5|3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6|opus-4-7|sonnet-4-6)/.test(request.body.model) || isFableModel) && Boolean(request.body.enable_web_search);
         const isLimitedSampling = /^claude-(opus-4-1|sonnet-4-5|haiku-4-5|opus-4-5|opus-4-6|opus-4-7|sonnet-4-6)/.test(request.body.model);
-        const useVerbosity = /^claude-(opus-4-5|opus-4-6|opus-4-7|sonnet-4-6)/.test(request.body.model);
-        const noPrefillModel = /^claude-(opus-4-6|opus-4-7|sonnet-4-6)/.test(request.body.model);
-        const isAdaptiveModel = enableAdaptiveThinking && /^claude-(opus-4-6|opus-4-7|sonnet-4-6)/.test(request.body.model);
+        const useVerbosity = /^claude-(opus-4-5|opus-4-6|opus-4-7|sonnet-4-6)/.test(request.body.model) || isFableModel;
+        const noPrefillModel = /^claude-(opus-4-6|opus-4-7|sonnet-4-6)/.test(request.body.model) || isFableModel;
+        const isAdaptiveModel = enableAdaptiveThinking && (/^claude-(opus-4-6|opus-4-7|sonnet-4-6)/.test(request.body.model) || isFableModel);
         let fixThinkingPrefill = false;
         // Add custom stop sequences
         const stopSequences = [];
@@ -428,6 +430,13 @@ async function sendClaudeRequest(request, response) {
 
         if (request.body.claude_disable_top_p) {
             delete requestBody.top_p;
+        }
+
+        // claude-fable-* removed temperature/top_p/top_k entirely; sending any of them returns HTTP 400.
+        if (isFableModel) {
+            delete requestBody.temperature;
+            delete requestBody.top_p;
+            delete requestBody.top_k;
         }
 
         const reasoningEffort = request.body.reasoning_effort;

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -507,7 +507,9 @@ async function sendClaudeRequest(request, response) {
             if (!generateResponse.ok) {
                 const generateResponseText = await generateResponse.text();
                 console.warn(color.red(`Claude API returned error: ${generateResponse.status} ${generateResponse.statusText}\n${generateResponseText}\n${divider}`));
-                return response.status(500).send({ error: true });
+                // SillyBunny: forward upstream error body/status so the client toast shows the real cause (401→400 per forwardFetchResponse convention)
+                const errorBody = tryParse(generateResponseText) ?? { error: { message: generateResponseText || generateResponse.statusText } };
+                return response.status(generateResponse.status === 401 ? 400 : generateResponse.status).send(errorBody);
             }
 
             /** @type {any} */

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -340,7 +340,7 @@ async function sendClaudeRequest(request, response) {
         const useTools = Array.isArray(request.body.tools) && request.body.tools.length > 0;
         const useSystemPrompt = Boolean(request.body.use_sysprompt);
         const convertedPrompt = convertClaudeMessages(request.body.messages, request.body.assistant_prefill, useSystemPrompt, useTools, getPromptNames(request));
-        // Substring match: also catches router ids like 'anthropic/claude-fable-5'
+        // SillyBunny: claude-fable-5 support (substring match also catches router ids like 'anthropic/claude-fable-5')
         const isFableModel = /claude-fable/.test(request.body.model);
         const useThinking = /^claude-(3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6|opus-4-7|sonnet-4-6)/.test(request.body.model) || (isFableModel && enableAdaptiveThinking);
         const useWebSearch = (/^claude-(3-5|3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6|opus-4-7|sonnet-4-6)/.test(request.body.model) || isFableModel) && Boolean(request.body.enable_web_search);
@@ -432,7 +432,7 @@ async function sendClaudeRequest(request, response) {
             delete requestBody.top_p;
         }
 
-        // claude-fable-* removed temperature/top_p/top_k entirely; sending any of them returns HTTP 400.
+        // SillyBunny: claude-fable-* removed temperature/top_p/top_k entirely; sending any of them returns HTTP 400.
         if (isFableModel) {
             delete requestBody.temperature;
             delete requestBody.top_p;


### PR DESCRIPTION
## Problem

Every generation against `claude-fable-5` fails with HTTP 400 (`bad response status code 400` via OpenAI-compatible relays, or swallowed into a generic 500 on the native source). The model removed `temperature`/`top_p`/`top_k` (sending any returns 400), rejects assistant prefill, and accepts only adaptive thinking — the `thinking` key must be omitted entirely otherwise (an explicit `{type:"disabled"}` also 400s, unique to fable).

Root cause: the six Claude model-gating regexes in `sendClaudeRequest` only match `claude-3/opus/sonnet/haiku` prefixes. `claude-fable-5` matches none, so samplers are sent unconditionally, prefill-stripping never runs, and adaptive thinking is unavailable. The client (`createGenerationParameters`) has no Claude model gating at all, so OpenAI-compatible proxies receive and forward the removed params.

## Changes

**Commit 1 — core fix (upstream contribution candidate):**
- `src/endpoints/backends/chat-completions.js`: add `isFableModel` (substring `/claude-fable/` to also catch router ids like `anthropic/claude-fable-5`), OR it into `useThinking`/`useWebSearch`/`useVerbosity`/`noPrefillModel`/`isAdaptiveModel`, and unconditionally strip all three samplers for fable. Resulting thinking semantics: adaptive + effort when enabled, key omitted entirely when reasoning effort is Auto/None or `claude.enableAdaptiveThinking: false` — the `budget_tokens` and `disabled` shapes are unreachable for fable.
- `public/scripts/openai.js`: fable delete-block following the kimi-k2.5/o-series/gpt-5 precedent — strips `temperature`, `top_p`, `top_k`, `frequency_penalty`, `presence_penalty`, `reasoning_effort`, and `custom_reasoning_param_name` (the last makes Custom Reasoning Parameter injection structurally impossible for fable, regardless of preset state). Also adds fable to the 1M-context gate and `visionSupportedModels`.
- `public/index.html`: add `claude-fable-5` to the Claude model dropdown.

**Commit 2 — error diagnosability (fork-marked, drop if undesired):**
- Non-streaming Claude errors now forward the parsed upstream body and status (with the same 401→400 remap streaming's `forwardFetchResponse` applies) instead of a generic `{error:true}` 500 that hid the actual API validation message.

## Verification

- Regex corpus check: `/claude-fable/` matches `claude-fable-5`, `anthropic/claude-fable-5`, `~anthropic/claude-fable-latest`; no false positives on opus/sonnet/haiku/3.x ids; existing gates unchanged for older models (opus-4-6/sonnet-4-6 adaptive path, sonnet-4-5 integer budget path intact).
- Direct relay isolation tests (new-api gateway, Anthropic-native shape): minimal request → 200; `thinking:{type:"adaptive"}` + `output_config.effort` → 200; `thinking:{type:"disabled"}` → 400 (confirms omit-entirely rule); existing `anthropic-beta` headers → 200. OpenAI shape: + samplers → 400 (reproduces the reported toast exactly); post-patch payload carries none of the rejected params.
- `node --check` passes on both patched files.

## Notes

Known limitation outside this PR's scope: some OpenAI-compatible relay channels do not lift `role:"system"` messages into Anthropic's top-level `system` param for this model; the native Claude source (optionally with a reverse proxy) is the fully supported fable path.