### PR TITLE
docs: ledger the mobile-styles media gate and canonical breakpoints

### DIFF
--- a/DESIGN.json
+++ b/DESIGN.json
@@ -159,6 +159,10 @@
       {
         "name": "narrow-mobile",
         "value": "620px"
+      },
+      {
+        "name": "small-mobile",
+        "value": "420px"
       }
     ]
   },

--- a/DESIGN.json
+++ b/DESIGN.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "generatedAt": "2026-05-05T07:15:15+08:00",
+  "generatedAt": "2026-06-11T00:25:00+05:30",
   "title": "Design System: SillyBunny",
   "extensions": {
     "colorMeta": {

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -66,6 +66,11 @@ spacing:
   "2xl": "24px"
   "3xl": "32px"
   "4xl": "40px"
+breakpoints:
+  compact-desktop-max: "1000px"
+  mobile-max: "768px"
+  narrow-mobile-max: "620px"
+  small-mobile-max: "420px"
 components:
   button-primary:
     backgroundColor: "{colors.warm-signal}"
@@ -238,6 +243,19 @@ The shell is the signature product component. It turns upstream drawers into Wor
 - **Desktop:** Top bar and shell panels use layered surfaces, horizontal tab rows, direct icon/text labels, and global search.
 - **Mobile:** Navigation uses stable `dvh`/safe-area-aware sizing, visible buttons, touch-friendly controls, and `-webkit-overflow-scrolling: touch` where scroll containers need momentum.
 - **Active State:** Active tabs use a tonal accent background, thin border, and an inset bottom accent, not a thick side stripe.
+
+### Breakpoints
+
+Canonical responsive breakpoints are **1000 / 768 / 620 / 420**.
+
+| Breakpoint | Contract |
+| --- | --- |
+| `1000px` | Compact desktop ceiling. Upstream `style.css` 1000px blocks may apply. |
+| `768px` | Mobile shell ceiling. Fork mobile chrome and mobile stylesheet gates stop here. |
+| `620px` | Narrow mobile tuning for dense phone layouts. |
+| `420px` | Small mobile tuning for the tightest phone layouts. |
+
+Compact desktop is `769px` through `1000px`: no fork mobile chrome. The 820x1180 smoke checkpoint pins this contract.
 
 ### Signature Components
 

--- a/docs/upstream-touch-ledger.md
+++ b/docs/upstream-touch-ledger.md
@@ -206,6 +206,19 @@ This ledger tracks intentional SillyBunny divergence in upstream-origin files. I
 | Last reviewed | 2026-06-06 Bug 1 transparency migration. |
 | Owner | Refactor integrator. |
 
+### `public/index.html` - mobile stylesheet media gates
+| Field | Value |
+| --- | --- |
+| Area | Mobile shell and frontend boot. |
+| Divergence reason | SillyBunny keeps upstream `mobile-styles.css` and the fork mobile shell stylesheet gated to `max-width: 768px` so compact desktop widths use desktop chrome while still receiving upstream 1000px layout rules. |
+| Target seam | None; this is static boot markup. |
+| Adapter shape | Keep the `css/mobile-styles.css` and `css/sillybunny-mobile-shell.css` stylesheet links on `media="(max-width: 768px)"`, loaded after upstream `style.css` and before `css/user.css`. |
+| Protecting tests | `tests/mobile-css-budgets.test.js` (`mobile sheets keep their (max-width: 768px) media gates`, `fork sheets load after upstream styles and before user.css`) and the 820x1180 compact desktop smoke checkpoint in `tests/mobile-shell-smoke.e2e.js`. |
+| Validation | `npm run test:unit --prefix tests -- mobile-css-budgets.test.js`, mobile smoke pack before CSS consolidation PRs. |
+| Rollback path | Restore prior stylesheet link gates and load order if compact desktop or mobile shell boot behavior regresses. |
+| Last reviewed | 2026-06-11 PR 2.1 mobile breakpoint ledger. |
+| Owner | Refactor integrator and mobile shell owner. |
+
 ### `public/css/backgrounds.css` - background image transparency
 | Field | Value |
 | --- | --- |


### PR DESCRIPTION
## What?

Adds the missing upstream-touch ledger entry for the `public/index.html` mobile stylesheet media gates.

Documents the canonical responsive breakpoints as `1000 / 768 / 620 / 420` in `DESIGN.md` and keeps the machine-readable `DESIGN.json` breakpoint list aligned.

## Why?

Phase 2 CSS consolidation needs the mobile/compact-desktop boundary declared before changing breakpoints or sheet layering.

This makes `769px` through `1000px` compact desktop by contract: upstream `style.css` 1000px rules may apply there, but fork mobile chrome and mobile stylesheet gates stop at `768px`.

## How?

The upstream-touch ledger now records the `index.html` media gate divergence, the protecting budget/smoke tests, and the rollback path.

The design system docs now state the canonical breakpoint list and call out the 820x1180 smoke checkpoint as the compact-desktop behavior pin.

No runtime code or CSS behavior changes are included.

## Testing?

- `node -e "JSON.parse(require('fs').readFileSync('DESIGN.json','utf8')); console.log('DESIGN.json valid')"`
- `git diff --check`
- `npm run test:unit --prefix tests -- mobile-css-budgets.test.js` -> 7 passed
- `npm run check:frontend-budgets`
- `npm run lint`
- Full Jest suite from `tests/`: 109 suites, 1021 tests passed
- `SILLYBUNNY_TEST_BASE_URL=http://127.0.0.1:4567 npx playwright test mobile-shell-smoke.e2e.js` -> 8 passed

## Screenshots (optional)

Not applicable; documentation-only change.

## Anything Else?

This is the Phase 2.1 documentation slice before the CSS breakpoint and layering PRs.
