### PR TITLE
fix: align sillybunny-theme 760px queries to the 768px breakpoint

### DIFF
--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -224,7 +224,7 @@
     --sb-composer-side-rail-width: min(14%, calc(var(--sb-composer-action-size) * 4 + 10px));
 }
 
-@media (pointer: coarse), screen and (max-width: 760px) {
+@media (pointer: coarse), screen and (max-width: 768px) {
     :root,
     :root[data-sb-compact-mode='true'] {
         --sb-control-min-height: var(--sb-mobile-touch-target);
@@ -1293,7 +1293,7 @@ select.text_pole:where(:not([multiple]):not([size]):not(.select2-hidden-accessib
     display: none !important;
 }
 
-@media screen and (min-width: 761px) {
+@media screen and (min-width: 769px) {
     #options_button::before {
         content: '' !important;
         display: block !important;
@@ -1312,7 +1312,7 @@ select.text_pole:where(:not([multiple]):not([size]):not(.select2-hidden-accessib
     }
 }
 
-@media screen and (max-width: 760px) {
+@media screen and (max-width: 768px) {
     #send_form {
         padding: 4px 6px 6px;
     }
@@ -3961,7 +3961,7 @@ input[type='range']::-moz-range-thumb {
     max-height: var(--sb-preset-row-control-size, var(--sb-field-min-height)) !important;
 }
 
-@media screen and (max-width: 760px) {
+@media screen and (max-width: 768px) {
     #openai_api-presets .flex-container.flexNoGap {
         grid-template-columns: 1fr;
     }
@@ -5269,7 +5269,7 @@ input[type='range']::-moz-range-thumb {
     }
 }
 
-@media screen and (max-width: 760px) {
+@media screen and (max-width: 768px) {
     #openai_model_picker {
         gap: 8px;
     }

--- a/tests/mobile-css-budgets.test.js
+++ b/tests/mobile-css-budgets.test.js
@@ -35,7 +35,7 @@ const FORK_SHEET_IMPORTANT_BUDGETS = Object.freeze({
     'sillybunny-theme.css': 158,
 });
 
-const FORK_DISTINCT_BREAKPOINT_BUDGET = 20;
+const FORK_DISTINCT_BREAKPOINT_BUDGET = 18;
 
 const forkSheetSources = Object.fromEntries(
     Object.keys(FORK_SHEET_IMPORTANT_BUDGETS).map(sheetName => [sheetName, readPublicFile('css', sheetName)]),


### PR DESCRIPTION
## What?

Align the remaining `sillybunny-theme.css` mobile breakpoint queries from the old `760px` seam to the canonical `768px` mobile boundary, with the matching desktop query moved from `761px` to `769px`.

## Why?

The fork now documents `768px` as the mobile boundary and `769-1000px` as compact desktop. Leaving this sheet at `760px` created an inconsistent `761-768px` band where some fork styles had already switched out of mobile behavior while the rest of the app still treated the viewport as mobile.

## How?

Updated the theme sheet's max-width queries to `768px` and the paired min-width query to `769px`. Lowered the distinct fork media-query breakpoint ratchet from `20` to `18` so the old seam cannot quietly return in the fork stylesheet set.

## Testing?

- `npm run lint`
- `npm run check:frontend-budgets`
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.json mobile-css-budgets.test.js` from `tests/` - 7 tests passed
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.json` from `tests/` - 109 suites / 1021 tests passed
- `SILLYBUNNY_TEST_BASE_URL=http://127.0.0.1:4567 npx playwright test mobile-shell-smoke.e2e.js` from `tests/` - 8 tests passed
- Live viewport probe at 762, 764, 766, 768, and 769px widths confirmed `#send_form` keeps mobile padding through 768px and switches at 769px.

## Screenshots (optional)

Not included; this is a breakpoint seam fix validated by the existing mobile smoke coverage and a computed-style viewport probe.

## Anything Else?

This is the PR 2.2 slice from the mobile CSS consolidation plan.