### PR TITLE
fix: correct SillyBunny→SillyTavern version mapping for extension compatibility

### DIFF
--- a/public/scripts/sillybunny-version-map.js
+++ b/public/scripts/sillybunny-version-map.js
@@ -1,0 +1,37 @@
+/**
+ * Maps SillyBunny minor versions to their corresponding SillyTavern minor versions.
+ * When SB syncs to a new ST minor release, add a new entry to this table.
+ * Key: SB minor version (e.g., 6 for SB 1.6.x)
+ * Value: ST minor version it tracks (e.g., 18 for ST 1.18.x)
+ */
+export const SILLYBUNNY_TO_ST_MINOR = {
+    6: 18,
+};
+
+/**
+ * Converts a SillyBunny version string to its SillyTavern equivalent.
+ * Used by versionCompare() to check if the current SB version meets extension requirements.
+ * @param {string} version - A semver-like version string (e.g., "1.6.4")
+ * @returns {string} The mapped ST version (e.g., "1.18.4"), or the original if no mapping exists
+ */
+export function mapSillyBunnyVersionToStEquivalent(version) {
+    const match = String(version).match(/^(\d+)\.(\d+)\.(\d+)(.*)$/);
+    if (!match) {
+        return version;
+    }
+
+    const [, major, minor, patch, suffix] = match;
+    const numericMajor = Number(major);
+    const numericMinor = Number(minor);
+
+    if (numericMajor !== 1 || !Number.isInteger(numericMinor)) {
+        return version;
+    }
+
+    const mappedMinor = SILLYBUNNY_TO_ST_MINOR[numericMinor];
+    if (mappedMinor === undefined) {
+        return version;
+    }
+
+    return `${numericMajor}.${mappedMinor}.${patch}${suffix}`;
+}

--- a/public/scripts/utils.js
+++ b/public/scripts/utils.js
@@ -17,6 +17,7 @@ import { getTagsList } from './tags.js';
 import { groups, selected_group } from './group-chats.js';
 import { getCurrentLocale, t } from './i18n.js';
 import { importWorldInfo } from './world-info.js';
+import { mapSillyBunnyVersionToStEquivalent } from './sillybunny-version-map.js';
 
 export const shiftUpByOne = (e, i, a) => a[i] = e + 1;
 export const shiftDownByOne = (e, i, a) => a[i] = e - 1;
@@ -2909,23 +2910,6 @@ export function versionCompare(srcVersion, minVersion, options = {}) {
     }
 
     return s.localeCompare(m, undefined, { numeric: true, sensitivity: 'base' }) > -1;
-}
-
-function mapSillyBunnyVersionToStEquivalent(version) {
-    const match = String(version).match(/^(\d+)\.(\d+)\.(\d+)(.*)$/);
-    if (!match) {
-        return version;
-    }
-
-    const [, major, minor, patch, suffix] = match;
-    const numericMajor = Number(major);
-    const numericMinor = Number(minor);
-
-    if (numericMajor !== 1 || !Number.isInteger(numericMinor) || numericMinor >= 10) {
-        return version;
-    }
-
-    return `${numericMajor}.${numericMinor + 10}.${patch}${suffix}`;
 }
 
 /**

--- a/tests/sillybunny-version-map.test.js
+++ b/tests/sillybunny-version-map.test.js
@@ -1,0 +1,52 @@
+import { describe, test, expect } from '@jest/globals';
+import {
+    mapSillyBunnyVersionToStEquivalent,
+    SILLYBUNNY_TO_ST_MINOR,
+} from '../public/scripts/sillybunny-version-map.js';
+
+describe('mapSillyBunnyVersionToStEquivalent', () => {
+    test('maps SB 1.6.x to ST 1.18.x', () => {
+        expect(mapSillyBunnyVersionToStEquivalent('1.6.4')).toBe('1.18.4');
+        expect(mapSillyBunnyVersionToStEquivalent('1.6.0')).toBe('1.18.0');
+        expect(mapSillyBunnyVersionToStEquivalent('1.6.99')).toBe('1.18.99');
+    });
+
+    test('preserves suffix', () => {
+        expect(mapSillyBunnyVersionToStEquivalent('1.6.4-beta')).toBe('1.18.4-beta');
+    });
+
+    test('passes through unmapped SB minor versions', () => {
+        expect(mapSillyBunnyVersionToStEquivalent('1.7.0')).toBe('1.7.0');
+        expect(mapSillyBunnyVersionToStEquivalent('1.99.5')).toBe('1.99.5');
+    });
+
+    test('passes through non-1.x major versions', () => {
+        expect(mapSillyBunnyVersionToStEquivalent('2.0.0')).toBe('2.0.0');
+        expect(mapSillyBunnyVersionToStEquivalent('0.9.1')).toBe('0.9.1');
+    });
+
+    test('passes through invalid version strings', () => {
+        expect(mapSillyBunnyVersionToStEquivalent('not-a-version')).toBe('not-a-version');
+        expect(mapSillyBunnyVersionToStEquivalent('1.6')).toBe('1.6');
+        expect(mapSillyBunnyVersionToStEquivalent('')).toBe('');
+    });
+
+    test('handles version with v prefix stripped', () => {
+        // versionCompare strips 'v' before calling this function
+        expect(mapSillyBunnyVersionToStEquivalent('1.6.4')).toBe('1.18.4');
+    });
+});
+
+describe('SILLYBUNNY_TO_ST_MINOR table', () => {
+    test('documents current SB-to-ST minor mapping', () => {
+        // SB 1.6.x tracks ST 1.18.x
+        expect(SILLYBUNNY_TO_ST_MINOR[6]).toBe(18);
+    });
+
+    test('contains only integer keys and values', () => {
+        for (const [sbMinor, stMinor] of Object.entries(SILLYBUNNY_TO_ST_MINOR)) {
+            expect(Number.isInteger(Number(sbMinor))).toBe(true);
+            expect(Number.isInteger(stMinor)).toBe(true);
+        }
+    });
+});


### PR DESCRIPTION
## Problem

Extensions requiring SillyTavern 1.17+ fail to activate on SillyBunny because SB 1.6.4 maps to ST 1.16.4 (not 1.18.x). The `+10` offset in `mapSillyBunnyVersionToStEquivalent()` was correct before ST 1.18, but now causes a false negative.

Closes #409

## Changes

- **Extract** `mapSillyBunnyVersionToStEquivalent` + `SILLYBUNNY_TO_ST_MINOR` table into a pure module (`public/scripts/sillybunny-version-map.js`) with zero browser deps
- **Replace** magic arithmetic (`minor + 10`) with an explicit lookup table (`{ 6: 18 }`) — trivially updatable on future ST syncs
- **Add** 8 unit tests covering mapping behavior and table integrity

## Verification

- Lint: clean
- New tests: 8/8 passed
- Existing `extension-boot-lifecycle` tests: 16/16 passed

## Files changed

| File | Change |
|------|--------|
| `public/scripts/sillybunny-version-map.js` | New pure module |
| `public/scripts/utils.js` | Import from new module, remove inline function |
| `tests/sillybunny-version-map.test.js` | New test file |
