### PR TITLE
fix: cap chat backups and deduplicate pre-write snapshots

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## v1.6.5
 
+### Fixed
+- Chat backup count is now capped to 25 by default (`backups.chat.maxTotalBackups`) instead of unlimited, preventing unbounded accumulation over time.
+- Pre-write chat backups now skip writing when the on-disk content is unchanged (duplicate detection), reducing redundant snapshots during rapid save flows like swiping.
+
 ### Merged Staging PRs
 - PR #402 (2026-06-10) `chore: bump version to 1.6.5`
 - PR #404 (2026-06-10) `chore: route mobile rail and quick-action models through mobile-shell-lifecycle`

--- a/default/config.yaml
+++ b/default/config.yaml
@@ -223,8 +223,8 @@ backups:
     enabled: true
     # Verify integrity of chat files before saving
     checkIntegrity: true
-    # Maximum number of chat backups to keep per user (starting from the most recent). Set to -1 to keep all backups.
-    maxTotalBackups: -1
+    # Maximum number of chat backups to keep per user (starting from the most recent). Set to -1 to keep all backups. Cap applies to regular chat_, forced_overwrite_, and pre_write_ backups.
+    maxTotalBackups: 25
     # Interval in milliseconds to throttle chat backups per user
     throttleInterval: 10000
     # Log chat and settings backup writes/skips for diagnosing backup frequency

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -27,7 +27,7 @@ import {
 } from '../util.js';
 
 const isBackupEnabled = !!getConfigValue('backups.chat.enabled', true, 'boolean');
-const maxTotalChatBackups = Number(getConfigValue('backups.chat.maxTotalBackups', -1, 'number'));
+const maxTotalChatBackups = Number(getConfigValue('backups.chat.maxTotalBackups', 25, 'number'));
 const throttleInterval = Number(getConfigValue('backups.chat.throttleInterval', 10_000, 'number'));
 const checkIntegrity = !!getConfigValue('backups.chat.checkIntegrity', true, 'boolean');
 const isBackupLoggingEnabled = !!getConfigValue('backups.chat.logging', false, 'boolean');
@@ -118,6 +118,18 @@ function isDuplicateRegularChatBackup(directory, backupPrefix, data) {
         && normalizeSerializedChatForBackupComparison(latestBackupData) === normalizeSerializedChatForBackupComparison(data);
 }
 
+function isDuplicatePreWriteBackup(directory, backupPrefix, data) {
+    const prefix = `${backupPrefix}`;
+    const latestBackupFile = getLatestBackupFilePath(directory, prefix);
+    if (!latestBackupFile) {
+        return false;
+    }
+
+    const latestBackupData = tryReadFileSync(latestBackupFile);
+    return Boolean(latestBackupData)
+        && normalizeSerializedChatForBackupComparison(latestBackupData) === normalizeSerializedChatForBackupComparison(data);
+}
+
 /**
  * Saves a chat to the backups directory.
  * @param {string} directory The user's backup directory.
@@ -190,8 +202,21 @@ function backupChatPreWrite(directory, name, data, handle = '') {
             logBackupEvent('chat-backup-skipped', { type: 'pre-write', handle, chat: originalName, reason: 'missing-directory' });
         }
         name = sanitize(name).replace(/[^a-z0-9]/gi, '_').toLowerCase();
-        const backupFile = path.join(directory, `${CHAT_PRE_WRITE_BACKUPS_PREFIX}${name}_${generateTimestamp()}_${uuidv4()}.jsonl`);
         const sizeDetails = getSerializedBackupSizeDetails(data);
+
+        if (isDuplicatePreWriteBackup(directory, `${CHAT_PRE_WRITE_BACKUPS_PREFIX}${name}_`, data)) {
+            logBackupEvent('chat-backup-skipped', {
+                type: 'pre-write',
+                handle,
+                chat: originalName,
+                sanitizedName: name,
+                reason: 'duplicate',
+                ...sizeDetails,
+            });
+            return;
+        }
+
+        const backupFile = path.join(directory, `${CHAT_PRE_WRITE_BACKUPS_PREFIX}${name}_${generateTimestamp()}_${uuidv4()}.jsonl`);
 
         tryWriteFileSync(backupFile, data);
         logBackupEvent('chat-backup-written', {

--- a/tests/chat-integrity-rotation.test.js
+++ b/tests/chat-integrity-rotation.test.js
@@ -178,6 +178,49 @@ describe('chat integrity rotation', () => {
         const preWriteBackups = backupFiles.filter(fileName => fileName.startsWith('chat_pre_write_test_card_'));
 
         expect(postSaveBackups).toHaveLength(1);
+        expect(preWriteBackups).toHaveLength(1);
+    });
+
+    test('skips duplicate pre-write backups when on-disk content is unchanged', async () => {
+        const { trySaveChat } = await import('../src/endpoints/chats.js');
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-chat-integrity-prewrite-dedup-'));
+        const chatFile = path.join(tempDir, 'chat.jsonl');
+        const backupDir = path.join(tempDir, 'backups');
+        await fs.mkdir(backupDir);
+        jest.setSystemTime(new Date('2026-06-06T12:34:56.000Z'));
+
+        await fs.writeFile(chatFile, chatWithIntegrity('original-integrity', 'original content').map(JSON.stringify).join('\n'));
+
+        const firstResult = await trySaveChat(
+            chatWithIntegrity('original-integrity', 'original content'),
+            chatFile,
+            false,
+            'prewrite-dedup-user',
+            'Test Card',
+            backupDir,
+        );
+
+        const secondResult = await trySaveChat(
+            chatWithIntegrity(firstResult.integrity, 'different content'),
+            chatFile,
+            false,
+            'prewrite-dedup-user',
+            'Test Card',
+            backupDir,
+        );
+
+        await trySaveChat(
+            chatWithIntegrity(secondResult.integrity, 'final content'),
+            chatFile,
+            false,
+            'prewrite-dedup-user',
+            'Test Card',
+            backupDir,
+        );
+
+        const backupFiles = await fs.readdir(backupDir);
+        const preWriteBackups = backupFiles.filter(fileName => fileName.startsWith('chat_pre_write_test_card_'));
+
         expect(preWriteBackups).toHaveLength(2);
     });
 


### PR DESCRIPTION
## Summary
Closes #373

Two changes to reduce backup accumulation reported by users:

### 1. Cap regular chat backups to 25 (was unlimited)
`backups.chat.maxTotalBackups` now defaults to 25 instead of -1 (unlimited). The cap is enforced via the existing `removeOldBackups` logic and applies to `chat_`, `chat_forced_overwrite_`, and `chat_pre_write_` prefixes. Users who want unlimited backups can still set `maxTotalBackups: -1` in config.

### 2. Skip duplicate pre-write backups
`backupChatPreWrite` now uses `normalizeSerializedChatForBackupComparison` (same function used by regular backup dedup) to compare the on-disk content against the latest pre-write backup before writing. If only the integrity hash differs, the snapshot is skipped.

Previously, pre-write backups had no content comparison and fired on every `trySaveChat` call where the chat file existed. During a swipe flow this produced ~3-4 pre-write snapshots of near-identical content within seconds.

## Tests
- Updated existing test assertion: pre-write count 2 to 1 in "skips duplicate post-save backups when only chat integrity changes"
- New test: "skips duplicate pre-write backups when on-disk content is unchanged" verifies dedup skips identical content and allows different content through

All 15 tests in `chat-integrity-rotation.test.js` pass.