### PR TITLE
fix: surface iOS WebKit boot failures

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,7 +18,7 @@
         }
     </style>
     <link rel="preload" as="style" href="style.css?v=20260610a">
-    <link rel="modulepreload" href="script.js">
+    <link rel="modulepreload" href="script.js?v=20260611a">
     <link rel="modulepreload" href="scripts/sillybunny-tabs.js?v=20260609a">
     <link rel="preload" as="font" type="font/woff2" href="webfonts/Figtree/Figtree-Regular.woff2?v=20260422b" crossorigin>
     <link rel="manifest" crossorigin="use-credentials" href="manifest.json">
@@ -8847,6 +8847,7 @@
     <div id="secrets_datalists" class="displayNone"></div>
 
     <!-- Script includes -->
+    <script src="scripts/sillybunny-boot-guard.js"></script>
     <script src="lib/polyfill.js" defer></script>
     <script src="lib/jquery-3.5.1.min.js" defer></script>
     <script src="lib/jquery-ui.min.js" defer></script>
@@ -8866,7 +8867,7 @@
     <script type="module" src="lib/eventemitter.js"></script>
     <script type="module" src="scripts/i18n.js"></script>
     <script type="module" src="scripts/performance-loader.js"></script>
-    <script type="module" src="script.js"></script>
+    <script type="module" src="script.js?v=20260611a"></script>
     <script type="module" src="scripts/sillybunny-tabs.js?v=20260609a"></script>
     <script>
         window.addEventListener('load', (event) => {

--- a/public/scripts/action-loader.js
+++ b/public/scripts/action-loader.js
@@ -608,6 +608,7 @@ async function hideOverlay() {
  */
 function yoinkPreloader() {
     if (preloaderYoinked) return;
+    window.SillyBunnyBootGuard?.bootCompleted?.();
     document.getElementById('preloader')?.remove();
     preloaderYoinked = true;
 }

--- a/public/scripts/i18n.js
+++ b/public/scripts/i18n.js
@@ -2,11 +2,21 @@ import { registerDebugFunction } from './power-user.js';
 import { updateSecretDisplay } from './secrets.js';
 
 const storageKey = 'language';
-const overrideLanguage = localStorage.getItem(storageKey);
+const overrideLanguage = getStoredLanguage();
 const localeFile = String(overrideLanguage || navigator.language || navigator.userLanguage || 'en').toLowerCase();
 var langs;
 // Don't change to let/const! It will break module loading.
 var localeData;
+
+function getStoredLanguage() {
+    try {
+        return localStorage.getItem(storageKey);
+    } catch (error) {
+        // SillyBunny: iOS WebKit can throw on localStorage before the boot UI exists.
+        console.warn('Unable to read stored language override.', error);
+        return null;
+    }
+}
 
 /** @type {Set<string>|null} Array of translations keys if they should be tracked - if not tracked then null */
 let trackMissingDynamicTranslate = null;

--- a/public/scripts/sillybunny-boot-guard.js
+++ b/public/scripts/sillybunny-boot-guard.js
@@ -1,0 +1,191 @@
+// SillyBunny: surface iOS/WebKit boot failures that otherwise leave the preloader up forever.
+(function () {
+    'use strict';
+
+    var bootCompleted = false;
+    var failureShown = false;
+    var lastFailure = null;
+    var timeoutId = null;
+    var BOOT_TIMEOUT_MS = 25000;
+
+    function describeError(error) {
+        try {
+            if (!error) {
+                return 'Unknown startup error.';
+            }
+
+            if (typeof error === 'string') {
+                return error;
+            }
+
+            if (error.stack) {
+                return String(error.stack);
+            }
+
+            if (error.message) {
+                return String(error.message);
+            }
+
+            return String(error);
+        } catch (_error) {
+            return 'Unable to read startup error details.';
+        }
+    }
+
+    function recordFailure(message, error) {
+        var details = message || 'SillyBunny startup failed.';
+        var errorDetails = describeError(error);
+
+        if (errorDetails && details.indexOf(errorDetails) === -1) {
+            details += '\n' + errorDetails;
+        }
+
+        lastFailure = details;
+        window.setTimeout(function () {
+            showFailure(details);
+        }, 0);
+    }
+
+    function clearBrowserCaches() {
+        var tasks = [];
+
+        try {
+            if ('caches' in window && window.caches.keys) {
+                tasks.push(window.caches.keys().then(function (keys) {
+                    return Promise.all(keys.map(function (key) {
+                        return window.caches.delete(key);
+                    }));
+                }));
+            }
+        } catch (error) {
+            console.warn('Unable to access frontend caches before reload.', error);
+        }
+
+        try {
+            if (navigator.serviceWorker && navigator.serviceWorker.getRegistrations) {
+                tasks.push(navigator.serviceWorker.getRegistrations().then(function (registrations) {
+                    return Promise.all(registrations.map(function (registration) {
+                        return registration.unregister();
+                    }));
+                }));
+            }
+        } catch (error) {
+            console.warn('Unable to access service worker registrations before reload.', error);
+        }
+
+        return Promise.all(tasks);
+    }
+
+    function reloadAfterCacheClear(button) {
+        button.disabled = true;
+        button.textContent = 'Clearing cache...';
+
+        clearBrowserCaches()
+            .catch(function (error) {
+                console.warn('Unable to clear frontend caches before reload.', error);
+            })
+            .then(function () {
+                window.location.reload();
+            });
+    }
+
+    function showFailure(details) {
+        if (bootCompleted || failureShown) {
+            return;
+        }
+
+        var preloader = document.getElementById('preloader');
+        if (!preloader) {
+            return;
+        }
+
+        failureShown = true;
+        preloader.innerHTML = '';
+        preloader.removeAttribute('aria-hidden');
+        preloader.style.cssText = 'position:fixed;inset:0;z-index:99999;display:flex;align-items:center;justify-content:center;padding:24px;box-sizing:border-box;background:#1d2128;color:#f4f7fb;font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;';
+
+        var panel = document.createElement('div');
+        panel.style.cssText = 'width:min(100%,520px);max-height:calc(100vh - 48px);overflow:auto;border:1px solid rgba(255,255,255,.16);border-radius:18px;background:rgba(14,18,24,.96);box-shadow:0 20px 60px rgba(0,0,0,.45);padding:22px;line-height:1.45;';
+
+        var title = document.createElement('h1');
+        title.textContent = 'SillyBunny could not finish loading';
+        title.style.cssText = 'margin:0 0 10px;font-size:22px;line-height:1.2;';
+
+        var message = document.createElement('p');
+        message.textContent = 'Your browser stopped during startup. This can happen on iOS WebKit when stale cached files or blocked storage prevent the app modules from loading.';
+        message.style.cssText = 'margin:0 0 16px;color:#cbd5e1;';
+
+        var button = document.createElement('button');
+        button.type = 'button';
+        button.textContent = 'Clear frontend cache and reload';
+        button.style.cssText = 'width:100%;border:0;border-radius:12px;background:#6ee7b7;color:#0f172a;font-weight:700;font-size:16px;padding:12px 14px;';
+        button.addEventListener('click', function () {
+            reloadAfterCacheClear(button);
+        });
+
+        var hint = document.createElement('p');
+        hint.textContent = 'If this keeps happening, clear this site\'s Safari/Chrome website data and reload.';
+        hint.style.cssText = 'margin:14px 0 0;color:#94a3b8;font-size:14px;';
+
+        var summary = document.createElement('details');
+        summary.style.cssText = 'margin-top:16px;color:#cbd5e1;';
+
+        var summaryTitle = document.createElement('summary');
+        summaryTitle.textContent = 'Startup error details';
+
+        var pre = document.createElement('pre');
+        pre.textContent = details || lastFailure || 'Startup timed out before SillyBunny removed the preloader.';
+        pre.style.cssText = 'white-space:pre-wrap;word-break:break-word;margin:10px 0 0;padding:12px;border-radius:10px;background:rgba(15,23,42,.9);color:#e2e8f0;font-size:12px;';
+
+        summary.appendChild(summaryTitle);
+        summary.appendChild(pre);
+        panel.appendChild(title);
+        panel.appendChild(message);
+        panel.appendChild(button);
+        panel.appendChild(hint);
+        panel.appendChild(summary);
+        preloader.appendChild(panel);
+    }
+
+    window.SillyBunnyBootGuard = {
+        bootCompleted: function () {
+            bootCompleted = true;
+            if (timeoutId) {
+                window.clearTimeout(timeoutId);
+            }
+        },
+        showFailure: showFailure,
+    };
+
+    window.addEventListener('error', function (event) {
+        if (bootCompleted) {
+            return;
+        }
+
+        if (event.target && event.target !== window) {
+            var target = event.target;
+            var tagName = target.tagName;
+            var rel = target.rel || '';
+            var url = target.src || target.href || '';
+
+            if (tagName === 'SCRIPT' || (tagName === 'LINK' && rel.indexOf('modulepreload') !== -1)) {
+                recordFailure('Failed to load startup resource: ' + url, event.error);
+            }
+
+            return;
+        }
+
+        var source = event.filename ? ' at ' + event.filename + ':' + event.lineno + ':' + event.colno : '';
+        recordFailure(String(event.message || 'Startup script error') + source, event.error);
+    }, true);
+
+    window.addEventListener('unhandledrejection', function (event) {
+        if (!bootCompleted) {
+            recordFailure('Unhandled startup promise rejection.', event.reason);
+        }
+    });
+
+    timeoutId = window.setTimeout(function () {
+        showFailure(lastFailure || 'Startup timed out before SillyBunny removed the preloader.');
+    }, BOOT_TIMEOUT_MS);
+}());

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -162,7 +162,18 @@ const SAMPLER_VISIBILITY_EXTENSION_KEY = 'samplerVisibility';
 // (7 days later) The future has come.
 const MANCER_SERVER_KEY = 'mancer_server';
 const MANCER_SERVER_DEFAULT = 'https://neuro.mancer.tech';
-export let MANCER_SERVER = localStorage.getItem(MANCER_SERVER_KEY) ?? MANCER_SERVER_DEFAULT;
+
+function getStoredMancerServer() {
+    try {
+        return localStorage.getItem(MANCER_SERVER_KEY);
+    } catch (error) {
+        // SillyBunny: iOS WebKit can throw on localStorage before the boot UI exists.
+        console.warn('Unable to read stored Mancer server.', error);
+        return null;
+    }
+}
+
+export let MANCER_SERVER = getStoredMancerServer() ?? MANCER_SERVER_DEFAULT;
 export let TOGETHERAI_SERVER = 'https://api.together.xyz';
 export let INFERMATICAI_SERVER = 'https://api.totalgpt.ai';
 export let DREAMGEN_SERVER = 'https://dreamgen.com';

--- a/src/middleware/frontend-assets.js
+++ b/src/middleware/frontend-assets.js
@@ -8,7 +8,13 @@ import {
 } from '../frontend-assets.js';
 
 export function setPublicAssetHeaders(res, requestPath) {
-    if (/\.(?:html?|json|map|m?js)$/i.test(requestPath)) {
+    if (/\.(?:m?js)$/i.test(requestPath)) {
+        // SillyBunny: public JS modules are mostly unversioned; iOS WebKit can keep stale module graphs over plain HTTP.
+        res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
+        return;
+    }
+
+    if (/\.(?:html?|json|map)$/i.test(requestPath)) {
         res.setHeader('Cache-Control', 'no-cache');
         return;
     }

--- a/tests/frontend-asset-middleware.test.js
+++ b/tests/frontend-asset-middleware.test.js
@@ -11,14 +11,17 @@ function getCacheControlFor(requestPath) {
 }
 
 describe('frontend asset fallback headers', () => {
-    test('keeps html, json, maps, and raw JavaScript revalidating', () => {
+    test('keeps html, json, and maps revalidating', () => {
         expect(getCacheControlFor('/index.html')).toBe('no-cache');
         expect(getCacheControlFor('/login.html')).toBe('no-cache');
         expect(getCacheControlFor('/manifest.json')).toBe('no-cache');
         expect(getCacheControlFor('/script.js.map')).toBe('no-cache');
-        expect(getCacheControlFor('/script.js')).toBe('no-cache');
-        expect(getCacheControlFor('/scripts/chat-render-lifecycle/render-window.js')).toBe('no-cache');
-        expect(getCacheControlFor('/scripts/bootstrap.mjs')).toBe('no-cache');
+    });
+
+    test('bypasses the browser cache for unversioned public JavaScript modules', () => {
+        expect(getCacheControlFor('/script.js')).toBe('no-store, no-cache, must-revalidate');
+        expect(getCacheControlFor('/scripts/chat-render-lifecycle/render-window.js')).toBe('no-store, no-cache, must-revalidate');
+        expect(getCacheControlFor('/scripts/bootstrap.mjs')).toBe('no-store, no-cache, must-revalidate');
     });
 
     test('keeps static non-code fallback assets short-lived', () => {

--- a/tests/frontend-assets.test.js
+++ b/tests/frontend-assets.test.js
@@ -73,12 +73,11 @@ describe('frontend asset manifest rewriting', () => {
         expect(FRONTEND_ASSET_PREFIX).toBe('/frontend-assets/');
     });
 
-    test('loads the main app module through the canonical URL', () => {
+    test('loads the main app module through a versioned URL', () => {
         const indexHtml = fs.readFileSync(path.join(process.cwd(), '..', 'public', 'index.html'), 'utf8');
 
-        expect(indexHtml).toContain('<link rel="modulepreload" href="script.js">');
-        expect(indexHtml).toContain('<script type="module" src="script.js"></script>');
-        expect(indexHtml).not.toMatch(/(?:href|src)="script\.js\?/);
+        expect(indexHtml).toContain('<link rel="modulepreload" href="script.js?v=20260611a">');
+        expect(indexHtml).toContain('<script type="module" src="script.js?v=20260611a"></script>');
     });
 
     test('only treats fingerprinted frontend asset names as immutable', () => {


### PR DESCRIPTION
## Summary
- add an early boot guard so WebKit startup failures replace the permanent dark preloader with an actionable reload panel
- guard top-level localStorage reads that can throw before the app boot UI exists
- revalidate the stale iOS asset lifecycle by versioning script.js and sending no-store for unversioned public JS modules over plain HTTP

## Verification
- node --check public/scripts/sillybunny-boot-guard.js
- node --check public/scripts/action-loader.js
- node --check public/scripts/i18n.js
- node --check public/scripts/textgen-settings.js
- node --check src/middleware/frontend-assets.js
- git diff --cached --check

## Notes
- Lifecycle affected: stale public JS module HTTP cache on iOS WebKit during update/reload/hard-refresh paths; service worker is not involved for plain http LAN access.
- Repo-local ESLint was not run because dependencies are not installed in the new worktree, and the system ESLint is too new for this repo's .eslintrc.cjs.