### PR TITLE
fix: unify graceful shutdown so frontend restart works on Windows

### DIFF
--- a/src/endpoints/server-admin.js
+++ b/src/endpoints/server-admin.js
@@ -26,6 +26,7 @@ import { requireAdminMiddleware } from '../users.js';
 import { getConfigValue, getVersion, isPathUnderParent, tryWriteFileSync } from '../util.js';
 import { getThumbnailDimensions, setThumbnailDimensions } from './image-metadata.js';
 import { getThumbnailRuntimeSettings, setThumbnailRuntimeSettings } from './thumbnails.js';
+import { requestGracefulExit } from '../shutdown.js';
 
 const GIT_OPTIONS = Object.freeze({ timeout: { block: 10 * 60 * 1000 } });
 const RESTART_RESPONSE_DELAY_MS = 200;
@@ -299,7 +300,7 @@ function getRestartPayload() {
         parentPid: process.pid,
         cwd: serverDirectory,
         command: [process.argv[0], ...process.argv.slice(1)],
-        envPatch: isNativeTermuxEnvironment() ? { SILLYBUNNY_SKIP_BROWSER_AUTO_LAUNCH: '1' } : {},
+        envPatch: { SILLYBUNNY_SKIP_BROWSER_AUTO_LAUNCH: '1' },
         visibleRelaunch: process.platform === 'win32',
     };
 
@@ -331,7 +332,7 @@ function scheduleRestart(response) {
         response.once('finish', () => {
             setTimeout(() => {
                 console.info(`Restart requested; exiting with code ${RESTART_EXIT_CODE} for launcher relaunch.`);
-                process.exit(RESTART_EXIT_CODE);
+                requestGracefulExit(RESTART_EXIT_CODE);
             }, RESTART_RESPONSE_DELAY_MS);
         });
         return;
@@ -353,11 +354,8 @@ function scheduleRestart(response) {
 
     response.once('finish', () => {
         setTimeout(() => {
-            try {
-                process.kill(process.pid, 'SIGTERM');
-            } catch (error) {
-                console.error('Failed to stop current process during restart.', error);
-            }
+            console.info(`Restart requested; initiating graceful shutdown with code ${RESTART_EXIT_CODE}.`);
+            requestGracefulExit(RESTART_EXIT_CODE);
         }, RESTART_RESPONSE_DELAY_MS);
     });
 }
@@ -379,8 +377,8 @@ function scheduleZipUpdate(response, stagedUpdate) {
 
     response.once('finish', () => {
         setTimeout(() => {
-            console.info('ZIP update staged; exiting current server so the helper can replace files safely.');
-            process.exit(0);
+            console.info('ZIP update staged; initiating graceful shutdown so the helper can replace files safely.');
+            requestGracefulExit(0);
         }, RESTART_RESPONSE_DELAY_MS);
     });
 }

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -25,6 +25,7 @@ import { serverDirectory } from './server-directory.js';
 
 import { serverEvents, EVENT_NAMES } from './server-events.js';
 import { loadPlugins } from './plugin-loader.js';
+import { registerGracefulShutdown } from './shutdown.js';
 import {
     initUserStorage,
     getCookieSecret,
@@ -489,7 +490,7 @@ async function preSetupTasks() {
     const consoleTitle = process.title;
 
     let isExiting = false;
-    const exitProcess = async () => {
+    const exitProcess = async (exitCode = 0) => {
         if (isExiting) return;
         isExiting = true;
         await statsOnExit();
@@ -498,8 +499,10 @@ async function preSetupTasks() {
         }
         diskCache.dispose();
         setWindowTitle(consoleTitle);
-        process.exit();
+        process.exit(exitCode);
     };
+
+    registerGracefulShutdown(exitProcess);
 
     // Set up event listeners for a graceful shutdown
     process.on('SIGINT', exitProcess);

--- a/src/shutdown.js
+++ b/src/shutdown.js
@@ -1,0 +1,33 @@
+import process from 'node:process';
+
+const SHUTDOWN_TIMEOUT_MS = 10_000;
+
+let registeredShutdownFn = null;
+let isShutdownRequested = false;
+
+export function registerGracefulShutdown(fn) {
+    registeredShutdownFn = fn;
+}
+
+export function isShutdownInProgress() {
+    return isShutdownRequested;
+}
+
+export function requestGracefulExit(exitCode = 0) {
+    if (isShutdownRequested) return;
+    isShutdownRequested = true;
+
+    const forceTimeout = setTimeout(() => {
+        console.error(`Graceful shutdown timed out after ${SHUTDOWN_TIMEOUT_MS}ms; forcing exit with code ${exitCode}.`);
+        process.exit(exitCode);
+    }, SHUTDOWN_TIMEOUT_MS);
+    forceTimeout.unref?.();
+
+    if (typeof registeredShutdownFn === 'function') {
+        Promise.resolve(registeredShutdownFn(exitCode)).catch((error) => {
+            console.error('Error during graceful shutdown:', error);
+        });
+    } else {
+        process.exit(exitCode);
+    }
+}


### PR DESCRIPTION
## What changed

Introduces a shared shutdown coordinator (`src/shutdown.js`) that routes all server-exit paths through the existing `exitProcess` chain in `server-main.js` (stats flush, plugin cleanup, diskCache disposal), with a 10-second hard-timeout safety net that force-exits if any hook hangs.

## Why

On Windows, the non-launcher restart path called `process.kill(process.pid, 'SIGTERM')`. Under libuv on Windows, SIGTERM maps to `TerminateProcess()` which bypasses Node signal handlers entirely. If any shutdown hook (`statsOnExit`, `cleanupPlugins`, `diskCache.dispose`) stalled under Bun, the registered SIGTERM handler in `server-main.js` never yielded `process.exit()`, causing `restart-helper.js`'s `waitForParentExit` to spin forever. The server shut down but the helper never relaunched — matching the "shuts down but does not restart" report in #412.

The launcher path (`Start.bat` exit-code-75 loop) and the zip-update path also bypassed the shutdown chain with raw `process.exit()`, skipping stats flushing and plugin cleanup.

## Details

### Three exit paths fixed
1. **Launcher-managed** (`server-admin.js:334`): `process.exit(RESTART_EXIT_CODE)` → `requestGracefulExit(RESTART_EXIT_CODE)`
2. **Non-launcher** (`server-admin.js:357`): `process.kill(process.pid, 'SIGTERM')` → `requestGracefulExit(RESTART_EXIT_CODE)`
3. **Zip update** (`server-admin.js:383`): `process.exit(0)` → `requestGracefulExit(0)`

### `src/shutdown.js` (new)
- `registerGracefulShutdown(fn)` — called once at boot by `server-main.js` to register the `exitProcess` closure
- `requestGracefulExit(exitCode)` — coordinates the shutdown; sets a 10s unref'd `setTimeout` that force-calls `process.exit(exitCode)` if the registered handler hangs

### `src/server-main.js`
- `exitProcess` now accepts an optional `exitCode` parameter (default `0`, backward-compatible)
- Registers itself with the shutdown coordinator at boot

### `envPatch` fix
- `getRestartPayload()` now always sets `SILLYBUNNY_SKIP_BROWSER_AUTO_LAUNCH: '1'` (previously only on Termux). Prevents the visible `cmd.exe` relaunch window on Windows from opening a duplicate browser tab.

Closes #412