### PR TITLE
fix: increase Prose Polisher max tokens to 32000

### DIFF
--- a/public/scripts/extensions/in-chat-agents/editor.html
+++ b/public/scripts/extensions/in-chat-agents/editor.html
@@ -221,7 +221,7 @@
                     </select>
                 </label>
                 <label class="flex1">Max Tokens
-                    <input type="number" id="ica--editor-pp-promptMaxTokens" class="text_pole" min="16" max="16000" value="8192" />
+                    <input type="number" id="ica--editor-pp-promptMaxTokens" class="text_pole" min="16" max="32000" value="8192" />
                 </label>
             </div>
             <label class="checkbox_label">

--- a/public/scripts/extensions/in-chat-agents/templates/index.json
+++ b/public/scripts/extensions/in-chat-agents/templates/index.json
@@ -598,7 +598,7 @@
       "promptTransformEnabled": true,
       "promptTransformShowNotifications": true,
       "promptTransformMode": "rewrite",
-      "promptTransformMaxTokens": 8192
+      "promptTransformMaxTokens": 32000
     },
     "enabled": false,
     "conditions": {

--- a/public/scripts/extensions/in-chat-agents/templates/prose-polisher.json
+++ b/public/scripts/extensions/in-chat-agents/templates/prose-polisher.json
@@ -32,7 +32,7 @@
         "promptTransformEnabled": true,
         "promptTransformShowNotifications": true,
         "promptTransformMode": "rewrite",
-        "promptTransformMaxTokens": 8192
+        "promptTransformMaxTokens": 32000
     },
     "enabled": false,
     "conditions": {


### PR DESCRIPTION
Models that use a lot of thinking tokens (e.g. extended thinking / reasoning) can burn through the previous 8192 token limit before producing visible output, causing the Prose Polisher to return an empty response.

Raises the Prose Polisher prompt transform max tokens from 8192 to 32000 in:
- The bundled template (`prose-polisher.json`)
- The template catalog (`templates/index.json`)
- The editor UI max attribute for prompt transform tokens (`editor.html`)

The global `DEFAULT_AGENT_MAX_TOKENS` (8192) is left untouched — this change is scoped to the Prose Polisher specifically.