### PR TITLE
fix: restore public JS revalidation caching

### DIFF
--- a/src/middleware/frontend-assets.js
+++ b/src/middleware/frontend-assets.js
@@ -9,8 +9,8 @@ import {
 
 export function setPublicAssetHeaders(res, requestPath) {
     if (/\.(?:m?js)$/i.test(requestPath)) {
-        // SillyBunny: public JS modules are mostly unversioned; iOS WebKit can keep stale module graphs over plain HTTP.
-        res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
+        // SillyBunny: revalidate unversioned JS modules to avoid stale iOS WebKit graphs without forcing full reloads.
+        res.setHeader('Cache-Control', 'no-cache');
         return;
     }
 

--- a/tests/frontend-asset-middleware.test.js
+++ b/tests/frontend-asset-middleware.test.js
@@ -18,10 +18,10 @@ describe('frontend asset fallback headers', () => {
         expect(getCacheControlFor('/script.js.map')).toBe('no-cache');
     });
 
-    test('bypasses the browser cache for unversioned public JavaScript modules', () => {
-        expect(getCacheControlFor('/script.js')).toBe('no-store, no-cache, must-revalidate');
-        expect(getCacheControlFor('/scripts/chat-render-lifecycle/render-window.js')).toBe('no-store, no-cache, must-revalidate');
-        expect(getCacheControlFor('/scripts/bootstrap.mjs')).toBe('no-store, no-cache, must-revalidate');
+    test('revalidates unversioned public JavaScript modules', () => {
+        expect(getCacheControlFor('/script.js')).toBe('no-cache');
+        expect(getCacheControlFor('/scripts/chat-render-lifecycle/render-window.js')).toBe('no-cache');
+        expect(getCacheControlFor('/scripts/bootstrap.mjs')).toBe('no-cache');
     });
 
     test('keeps static non-code fallback assets short-lived', () => {


### PR DESCRIPTION
Fixes the #412 follow-up reports of slower frontend loads after the iOS WebKit boot hardening. Public .js/.mjs files still require revalidation with Cache-Control: no-cache, which protects against stale unversioned module graphs while allowing ETag/304 reuse instead of forcing every module to fully re-download on each page load. Also updates the asset middleware test expectations.