### PR TITLE
fix: restore generated install metadata before updates

### DIFF
--- a/src/endpoints/server-admin.js
+++ b/src/endpoints/server-admin.js
@@ -11,9 +11,9 @@ import simpleGit from 'simple-git';
 import { APP_NAME, formatRuntimeLabel, isBunRuntime, isNativeTermuxEnvironment } from '../runtime.js';
 import {
     getBranchDisplayNames,
+    getGeneratedInstallChangePaths,
     getRemoteBranchesFromSummary,
     getStatusDisplayBranch,
-    hasOnlyBunLockChange,
     NON_GIT_REPOSITORY_MESSAGE,
     isRuntimeBranch,
     isGitRepository,
@@ -395,19 +395,22 @@ async function restoreAutoStash(git, { reason = 'after update failure' } = {}) {
     }
 }
 
-async function restoreGeneratedBunLockChange(git, gitStatus) {
-    if (!hasOnlyBunLockChange(gitStatus?.files)) {
+async function restoreGeneratedInstallFileChanges(git, gitStatus) {
+    const generatedPaths = getGeneratedInstallChangePaths(gitStatus?.files);
+
+    if (!generatedPaths.length) {
         return gitStatus;
     }
 
     try {
-        await git.raw(['restore', '--staged', '--worktree', '--', 'bun.lock']);
+        await git.raw(['restore', '--staged', '--worktree', '--', ...generatedPaths]);
     } catch {
-        await git.raw(['reset', 'HEAD', '--', 'bun.lock']);
-        await git.raw(['checkout', '--', 'bun.lock']);
+        await git.raw(['reset', 'HEAD', '--', ...generatedPaths]);
+        await git.raw(['checkout', '--', ...generatedPaths]);
     }
 
-    console.info('Restored tracked bun.lock before checking for updates.');
+    // SillyBunny: Windows launchers can rewrite install metadata while recovering from stale Bun locks.
+    console.info(`Restored generated install file changes before checking for updates: ${generatedPaths.join(', ')}.`);
 
     return await git.status();
 }
@@ -508,7 +511,7 @@ async function getRepositoryStatus() {
     status.branch = toTrimmedString(await git.revparse(['--abbrev-ref', 'HEAD']).catch(() => ''));
     status.currentCommit = toTrimmedString(await git.revparse(['--short', 'HEAD']).catch(() => ''));
 
-    const gitStatus = await restoreGeneratedBunLockChange(git, await git.status());
+    const gitStatus = await restoreGeneratedInstallFileChanges(git, await git.status());
     status.hasLocalChanges = !gitStatus.isClean();
     status.changedFilesCount = gitStatus.files.length;
     status.changedFiles = gitStatus.files.slice(0, 12).map(file => ({

--- a/src/server-admin-git.js
+++ b/src/server-admin-git.js
@@ -1,6 +1,6 @@
 const ORIGIN_REMOTE_PREFIX = 'origin/';
 const RUNTIME_BRANCH_PREFIX = 'runtime/';
-const BUN_LOCK_FILE = 'bun.lock';
+const GENERATED_INSTALL_FILES = Object.freeze(['bun.lock', 'package-lock.json', 'package.json']);
 
 export const NON_GIT_REPOSITORY_MESSAGE = 'This install is not running from a Git repository. Use Customize > Server to check for a release ZIP update, or install with git clone for Git updates.';
 
@@ -45,12 +45,20 @@ export function getRemoteBranchesFromSummary(branchSummary) {
         .filter(branch => branch && !branch.endsWith('/HEAD') && !branch.includes('/HEAD -> ')));
 }
 
-export function hasOnlyBunLockChange(files) {
-    const changedPaths = (Array.isArray(files) ? files : [])
-        .map(file => String(file?.path ?? file ?? '').trim().replaceAll('\\', '/'))
-        .filter(Boolean);
+export function getGeneratedInstallChangePaths(files) {
+    const fileEntries = Array.isArray(files) ? files : [];
+    const changedEntries = fileEntries
+        .map(file => ({
+            path: String(file?.path ?? file ?? '').trim().replaceAll('\\', '/'),
+            isUntracked: file?.index === '?' || file?.working_dir === '?',
+        }))
+        .filter(file => file.path);
 
-    return changedPaths.length === 1 && changedPaths[0] === BUN_LOCK_FILE;
+    if (!changedEntries.length || changedEntries.some(file => file.isUntracked || !GENERATED_INSTALL_FILES.includes(file.path))) {
+        return [];
+    }
+
+    return uniqueSorted(changedEntries.map(file => file.path));
 }
 
 export function getBranchDisplayNames(remoteBranches) {

--- a/tests/server-admin-git.test.js
+++ b/tests/server-admin-git.test.js
@@ -2,9 +2,9 @@ import { describe, expect, jest, test } from '@jest/globals';
 
 import {
     getBranchDisplayNames,
+    getGeneratedInstallChangePaths,
     getRemoteBranchesFromSummary,
     getStatusDisplayBranch,
-    hasOnlyBunLockChange,
     NON_GIT_REPOSITORY_MESSAGE,
     isGitRepository,
     isRuntimeBranch,
@@ -59,10 +59,30 @@ describe('server admin git helpers', () => {
         expect(isRuntimeBranch('main')).toBe(false);
     });
 
-    test('detects only a generated bun.lock status change', () => {
-        expect(hasOnlyBunLockChange([{ path: 'bun.lock', index: ' ', working_dir: 'M' }])).toBe(true);
-        expect(hasOnlyBunLockChange([{ path: 'bun.lock' }, { path: 'package.json' }])).toBe(false);
-        expect(hasOnlyBunLockChange([{ path: 'package-lock.json' }])).toBe(false);
+    test('detects only generated install metadata changes', () => {
+        expect(getGeneratedInstallChangePaths([{ path: 'bun.lock', index: ' ', working_dir: 'M' }])).toEqual(['bun.lock']);
+        expect(getGeneratedInstallChangePaths([{ path: 'bun.lock' }, { path: 'package.json' }])).toEqual(['bun.lock', 'package.json']);
+        expect(getGeneratedInstallChangePaths([{ path: 'package-lock.json' }])).toEqual(['package-lock.json']);
+    });
+
+    test('detects deleted generated install metadata changes', () => {
+        expect(getGeneratedInstallChangePaths([
+            { path: 'bun.lock', index: ' ', working_dir: 'D' },
+            { path: 'package.json', index: ' ', working_dir: 'D' },
+        ])).toEqual(['bun.lock', 'package.json']);
+    });
+
+    test('rejects generated install metadata mixed with other changes', () => {
+        expect(getGeneratedInstallChangePaths([{ path: 'bun.lock' }, { path: 'public/script.js' }])).toEqual([]);
+        expect(getGeneratedInstallChangePaths([
+            { path: 'bun.lock', index: ' ', working_dir: 'M' },
+            { path: 'public/script.js', index: '?', working_dir: '?' },
+        ])).toEqual([]);
+    });
+
+    test('rejects empty and untracked generated install metadata changes', () => {
+        expect(getGeneratedInstallChangePaths([])).toEqual([]);
+        expect(getGeneratedInstallChangePaths([{ path: 'package-lock.json', index: '?', working_dir: '?' }])).toEqual([]);
     });
 
     test('explains how non-Git installs update', () => {


### PR DESCRIPTION
## Summary
- Restore tracked generated install metadata when it is the only local change set: bun.lock, package-lock.json, and package.json.
- Handle modified and deleted generated files before status/update checks so launcher install drift does not block auto-update.
- Preserve the safety block when any non-allowlisted or untracked file is present.

## Testing
- npm run test:unit --prefix tests -- server-admin-git.test.js
- npm run test:unit --prefix tests
- npm run lint

Refs https://github.com/platberlitz/SillyBunny/issues/412#issuecomment-4676189120