### PR TITLE
fix: harden frontend boot recovery

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8847,7 +8847,7 @@
     <div id="secrets_datalists" class="displayNone"></div>
 
     <!-- Script includes -->
-    <script src="scripts/sillybunny-boot-guard.js"></script>
+    <script src="scripts/sillybunny-boot-guard.js?v=20260611a"></script>
     <script src="lib/polyfill.js" defer></script>
     <script src="lib/jquery-3.5.1.min.js" defer></script>
     <script src="lib/jquery-ui.min.js" defer></script>

--- a/public/scripts/sillybunny-boot-guard.js
+++ b/public/scripts/sillybunny-boot-guard.js
@@ -7,6 +7,9 @@
     var lastFailure = null;
     var timeoutId = null;
     var BOOT_TIMEOUT_MS = 25000;
+    var BOOT_TIMEOUT_RETRY_MS = 10000;
+    var MAX_BOOT_TIMEOUT_MS = 90000;
+    var bootStartedAt = Date.now();
 
     function describeError(error) {
         try {
@@ -89,6 +92,72 @@
             });
     }
 
+    function removeElement(element) {
+        if (!element) {
+            return;
+        }
+
+        if (typeof element.remove === 'function') {
+            element.remove();
+            return;
+        }
+
+        if (element.parentNode) {
+            element.parentNode.removeChild(element);
+        }
+    }
+
+    function queryAll(selector, root) {
+        try {
+            return Array.prototype.slice.call((root || document).querySelectorAll(selector));
+        } catch (_error) {
+            return [];
+        }
+    }
+
+    function isStartupLoaderActive() {
+        try {
+            return Boolean(document.querySelector('#loader, .splash-screen, #load-spinner, dialog #loader, dialog .splash-screen, dialog #load-spinner'));
+        } catch (_error) {
+            return false;
+        }
+    }
+
+    function removeStartupLoaderArtifacts() {
+        queryAll('dialog').forEach(function (dialog) {
+            try {
+                if (dialog.querySelector('#loader, .splash-screen, #load-spinner')) {
+                    removeElement(dialog);
+                }
+            } catch (_error) {
+                // Keep surfacing the boot failure even if a browser rejects a selector.
+            }
+        });
+
+        queryAll('#loader, .splash-screen, #load-spinner, ._poly_dialog_overlay').forEach(removeElement);
+    }
+
+    function getElapsedBootTimeMs() {
+        return Date.now() - bootStartedAt;
+    }
+
+    function scheduleBootTimeout(delay) {
+        timeoutId = window.setTimeout(handleBootTimeout, delay);
+    }
+
+    function handleBootTimeout() {
+        if (bootCompleted || failureShown) {
+            return;
+        }
+
+        if (!lastFailure && isStartupLoaderActive() && getElapsedBootTimeMs() < MAX_BOOT_TIMEOUT_MS) {
+            scheduleBootTimeout(BOOT_TIMEOUT_RETRY_MS);
+            return;
+        }
+
+        showFailure(lastFailure || 'Startup timed out before SillyBunny removed the preloader.');
+    }
+
     function showFailure(details) {
         if (bootCompleted || failureShown) {
             return;
@@ -100,6 +169,7 @@
         }
 
         failureShown = true;
+        removeStartupLoaderArtifacts();
         preloader.innerHTML = '';
         preloader.removeAttribute('aria-hidden');
         preloader.style.cssText = 'position:fixed;inset:0;z-index:99999;display:flex;align-items:center;justify-content:center;padding:24px;box-sizing:border-box;background:#1d2128;color:#f4f7fb;font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;';
@@ -185,7 +255,5 @@
         }
     });
 
-    timeoutId = window.setTimeout(function () {
-        showFailure(lastFailure || 'Startup timed out before SillyBunny removed the preloader.');
-    }, BOOT_TIMEOUT_MS);
+    scheduleBootTimeout(BOOT_TIMEOUT_MS);
 }());

--- a/src/middleware/frontend-assets.js
+++ b/src/middleware/frontend-assets.js
@@ -7,10 +7,39 @@ import {
     loadFrontendManifest,
 } from '../frontend-assets.js';
 
+export function isIosWebKitUserAgent(userAgent) {
+    const normalizedUserAgent = String(userAgent || '');
+
+    return /\bAppleWebKit\//i.test(normalizedUserAgent)
+        && (
+            /\b(?:iPad|iPhone|iPod)\b/i.test(normalizedUserAgent)
+            || (/\bMacintosh\b/i.test(normalizedUserAgent) && /\bMobile\//i.test(normalizedUserAgent))
+        );
+}
+
+function getRequestUserAgent(res) {
+    return res?.req?.headers?.['user-agent']
+        ?? res?.req?.headers?.['User-Agent']
+        ?? (typeof res?.req?.get === 'function' ? res.req.get('user-agent') : '');
+}
+
+function appendVaryHeader(res, value) {
+    const currentHeader = typeof res.getHeader === 'function' ? res.getHeader('Vary') : '';
+    const values = String(currentHeader || '').split(',').map(header => header.trim()).filter(Boolean);
+    const normalizedValue = value.toLowerCase();
+
+    if (!values.some(header => header === '*' || header.toLowerCase() === normalizedValue)) {
+        values.push(value);
+    }
+
+    res.setHeader('Vary', values.join(', '));
+}
+
 export function setPublicAssetHeaders(res, requestPath) {
     if (/\.(?:m?js)$/i.test(requestPath)) {
-        // SillyBunny: revalidate unversioned JS modules to avoid stale iOS WebKit graphs without forcing full reloads.
-        res.setHeader('Cache-Control', 'no-cache');
+        // SillyBunny: iOS WebKit needs revalidation for unversioned modules; other browsers should avoid reload storms.
+        appendVaryHeader(res, 'User-Agent');
+        res.setHeader('Cache-Control', isIosWebKitUserAgent(getRequestUserAgent(res)) ? 'no-cache' : 'public, max-age=3600');
         return;
     }
 

--- a/tests/frontend-asset-middleware.test.js
+++ b/tests/frontend-asset-middleware.test.js
@@ -1,13 +1,24 @@
 import { describe, expect, test } from '@jest/globals';
 
-import { setPublicAssetHeaders } from '../src/middleware/frontend-assets.js';
+import { isIosWebKitUserAgent, setPublicAssetHeaders } from '../src/middleware/frontend-assets.js';
 
-function getCacheControlFor(requestPath) {
-    const headers = new Map();
+function getHeadersFor(requestPath, { userAgent = '', vary = '' } = {}) {
+    const headers = new Map(vary ? [['Vary', vary]] : []);
+
     setPublicAssetHeaders({
+        req: {
+            headers: { 'user-agent': userAgent },
+            get: name => (name.toLowerCase() === 'user-agent' ? userAgent : undefined),
+        },
+        getHeader: name => headers.get(name),
         setHeader: (name, value) => headers.set(name, value),
     }, requestPath);
-    return headers.get('Cache-Control');
+
+    return headers;
+}
+
+function getCacheControlFor(requestPath, options) {
+    return getHeadersFor(requestPath, options).get('Cache-Control');
 }
 
 describe('frontend asset fallback headers', () => {
@@ -18,13 +29,39 @@ describe('frontend asset fallback headers', () => {
         expect(getCacheControlFor('/script.js.map')).toBe('no-cache');
     });
 
-    test('revalidates unversioned public JavaScript modules', () => {
-        expect(getCacheControlFor('/script.js')).toBe('no-cache');
-        expect(getCacheControlFor('/scripts/chat-render-lifecycle/render-window.js')).toBe('no-cache');
-        expect(getCacheControlFor('/scripts/bootstrap.mjs')).toBe('no-cache');
+    test('keeps non-iOS public JavaScript modules short-lived', () => {
+        expect(getCacheControlFor('/script.js')).toBe('public, max-age=3600');
+        expect(getCacheControlFor('/script.js', {
+            userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/125.0 Safari/537.36',
+        })).toBe('public, max-age=3600');
+        expect(getCacheControlFor('/scripts/bootstrap.mjs', {
+            userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Firefox/126.0',
+        })).toBe('public, max-age=3600');
+    });
+
+    test('revalidates public JavaScript modules only for iOS WebKit', () => {
+        expect(getCacheControlFor('/script.js', {
+            userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+        })).toBe('no-cache');
+        expect(getCacheControlFor('/scripts/chat-render-lifecycle/render-window.js', {
+            userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+        })).toBe('no-cache');
+    });
+
+    test('marks JavaScript cache headers as user-agent variant', () => {
+        expect(getHeadersFor('/script.js', { vary: 'Accept-Encoding' }).get('Vary')).toBe('Accept-Encoding, User-Agent');
+        expect(getHeadersFor('/script.js', { vary: 'user-agent' }).get('Vary')).toBe('user-agent');
+        expect(getHeadersFor('/script.js', { vary: '*' }).get('Vary')).toBe('*');
     });
 
     test('keeps static non-code fallback assets short-lived', () => {
         expect(getCacheControlFor('/img/logo.png')).toBe('public, max-age=3600');
+    });
+
+    test('detects iOS WebKit user agents', () => {
+        expect(isIosWebKitUserAgent('Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148')).toBe(true);
+        expect(isIosWebKitUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 Version/17.5 Mobile/15E148 Safari/604.1')).toBe(true);
+        expect(isIosWebKitUserAgent('Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 Chrome/125.0 Mobile Safari/537.36')).toBe(false);
+        expect(isIosWebKitUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/125.0 Safari/537.36')).toBe(false);
     });
 });

--- a/tests/sillybunny-boot-guard.test.js
+++ b/tests/sillybunny-boot-guard.test.js
@@ -1,0 +1,221 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const bootGuardSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'sillybunny-boot-guard.js'), 'utf8');
+
+class FakeElement {
+    constructor(tagName, { id = '', className = '' } = {}) {
+        this.tagName = tagName.toUpperCase();
+        this.id = id;
+        this.className = className;
+        this.children = [];
+        this.parentNode = null;
+        this.style = { cssText: '' };
+        this.attributes = new Map();
+        this.listeners = new Map();
+        this.textContent = '';
+        this.type = '';
+        this.disabled = false;
+    }
+
+    appendChild(child) {
+        child.parentNode = this;
+        this.children.push(child);
+        return child;
+    }
+
+    removeChild(child) {
+        this.children = this.children.filter(candidate => candidate !== child);
+        child.parentNode = null;
+        return child;
+    }
+
+    remove() {
+        if (this.parentNode) {
+            this.parentNode.removeChild(this);
+        }
+    }
+
+    removeAttribute(name) {
+        this.attributes.delete(name);
+    }
+
+    setAttribute(name, value) {
+        this.attributes.set(name, String(value));
+    }
+
+    addEventListener(type, listener) {
+        this.listeners.set(type, listener);
+    }
+
+    querySelector(selector) {
+        return this.querySelectorAll(selector)[0] || null;
+    }
+
+    querySelectorAll(selector) {
+        const selectors = selector.split(',').map(part => part.trim()).filter(Boolean);
+        return getDescendants(this).filter(element => selectors.some(part => matchesSelector(element, part)));
+    }
+
+    set innerHTML(_value) {
+        this.children.forEach(child => {
+            child.parentNode = null;
+        });
+        this.children = [];
+    }
+}
+
+class FakeDocument {
+    constructor() {
+        this.body = new FakeElement('body');
+    }
+
+    createElement(tagName) {
+        return new FakeElement(tagName);
+    }
+
+    appendChild(element) {
+        return this.body.appendChild(element);
+    }
+
+    getElementById(id) {
+        return getDescendants(this.body).find(element => element.id === id) || null;
+    }
+
+    querySelector(selector) {
+        return this.querySelectorAll(selector)[0] || null;
+    }
+
+    querySelectorAll(selector) {
+        return this.body.querySelectorAll(selector);
+    }
+}
+
+function getDescendants(root) {
+    return root.children.flatMap(child => [child, ...getDescendants(child)]);
+}
+
+function matchesSimpleSelector(element, selector) {
+    if (selector.startsWith('#')) {
+        return element.id === selector.slice(1);
+    }
+
+    if (selector.startsWith('.')) {
+        return element.className.split(/\s+/).includes(selector.slice(1));
+    }
+
+    return element.tagName.toLowerCase() === selector.toLowerCase();
+}
+
+function matchesSelector(element, selector) {
+    const parts = selector.split(/\s+/).filter(Boolean);
+    let currentElement = element;
+
+    for (let index = parts.length - 1; index >= 0; index--) {
+        if (index === parts.length - 1) {
+            if (!matchesSimpleSelector(currentElement, parts[index])) {
+                return false;
+            }
+            currentElement = currentElement.parentNode;
+            continue;
+        }
+
+        while (currentElement && !matchesSimpleSelector(currentElement, parts[index])) {
+            currentElement = currentElement.parentNode;
+        }
+
+        if (!currentElement) {
+            return false;
+        }
+
+        currentElement = currentElement.parentNode;
+    }
+
+    return true;
+}
+
+function createBootGuardHarness() {
+    const document = new FakeDocument();
+    const timers = [];
+    const listeners = new Map();
+    let now = 0;
+
+    const window = {
+        addEventListener: (type, listener) => listeners.set(type, listener),
+        clearTimeout: jest.fn(),
+        location: { reload: jest.fn() },
+        setTimeout: (callback, delay) => {
+            timers.push({ callback, delay });
+            return timers.length;
+        },
+    };
+
+    vm.runInNewContext(bootGuardSource, {
+        console,
+        Date: { now: () => now },
+        document,
+        navigator: {},
+        Promise,
+        window,
+    });
+
+    return {
+        document,
+        listeners,
+        setNow: value => {
+            now = value;
+        },
+        timers,
+        window,
+    };
+}
+
+function addPreloader(document) {
+    const preloader = new FakeElement('div', { id: 'preloader' });
+    preloader.setAttribute('aria-hidden', 'true');
+    document.appendChild(preloader);
+    return preloader;
+}
+
+describe('SillyBunny boot guard', () => {
+    test('removes startup loader artifacts before showing the recovery panel', () => {
+        const { document, window } = createBootGuardHarness();
+        const preloader = addPreloader(document);
+        const dialog = document.appendChild(new FakeElement('dialog'));
+
+        dialog.appendChild(new FakeElement('div', { id: 'loader' }));
+        document.appendChild(new FakeElement('div', { className: '_poly_dialog_overlay' }));
+
+        window.SillyBunnyBootGuard.showFailure('boom');
+
+        expect(document.querySelector('dialog')).toBeNull();
+        expect(document.getElementById('loader')).toBeNull();
+        expect(document.querySelector('._poly_dialog_overlay')).toBeNull();
+        expect(preloader.attributes.has('aria-hidden')).toBe(false);
+        expect(preloader.querySelector('button').textContent).toBe('Clear frontend cache and reload');
+    });
+
+    test('defers timeout failures while the normal startup loader is active', () => {
+        const { document, setNow, timers } = createBootGuardHarness();
+        const preloader = addPreloader(document);
+        const loader = document.appendChild(new FakeElement('div', { id: 'loader' }));
+
+        expect(timers[0].delay).toBe(25000);
+
+        setNow(26000);
+        timers.shift().callback();
+
+        expect(preloader.querySelector('button')).toBeNull();
+        expect(timers[0].delay).toBe(10000);
+
+        loader.remove();
+        setNow(36000);
+        timers.shift().callback();
+
+        expect(preloader.querySelector('button').textContent).toBe('Clear frontend cache and reload');
+    });
+});


### PR DESCRIPTION
## Summary
- keep public JS short-lived cached for non-iOS clients while preserving no-cache revalidation for iOS WebKit
- remove splash/dialog loader artifacts before the boot-guard recovery panel so its cache-clear button is clickable
- defer timeout-only boot failures while the normal startup loader is still active, with a bounded retry window
- cache-bust the boot-guard script URL

## Tests
- npm run test:unit --prefix tests -- frontend-asset-middleware.test.js sillybunny-boot-guard.test.js
- npm run test:unit --prefix tests
- npm run lint