### PR TITLE
fix: keep shutdown exit codes numeric

### DIFF
--- a/src/server-main.js
+++ b/src/server-main.js
@@ -505,8 +505,9 @@ async function preSetupTasks() {
     registerGracefulShutdown(exitProcess);
 
     // Set up event listeners for a graceful shutdown
-    process.on('SIGINT', exitProcess);
-    process.on('SIGTERM', exitProcess);
+    // SillyBunny: signal handlers pass signal names, but process.exit needs numeric codes in Bun.
+    process.on('SIGINT', () => exitProcess(0));
+    process.on('SIGTERM', () => exitProcess(0));
     process.on('uncaughtException', (err) => {
         console.error('Uncaught exception:', err);
         exitProcess();

--- a/src/shutdown.js
+++ b/src/shutdown.js
@@ -13,21 +13,28 @@ export function isShutdownInProgress() {
     return isShutdownRequested;
 }
 
+export function normalizeExitCode(exitCode = 0) {
+    const numericExitCode = Number(exitCode ?? 0);
+
+    return Number.isInteger(numericExitCode) ? numericExitCode : 0;
+}
+
 export function requestGracefulExit(exitCode = 0) {
     if (isShutdownRequested) return;
     isShutdownRequested = true;
+    const normalizedExitCode = normalizeExitCode(exitCode);
 
     const forceTimeout = setTimeout(() => {
-        console.error(`Graceful shutdown timed out after ${SHUTDOWN_TIMEOUT_MS}ms; forcing exit with code ${exitCode}.`);
-        process.exit(exitCode);
+        console.error(`Graceful shutdown timed out after ${SHUTDOWN_TIMEOUT_MS}ms; forcing exit with code ${normalizedExitCode}.`);
+        process.exit(normalizedExitCode);
     }, SHUTDOWN_TIMEOUT_MS);
     forceTimeout.unref?.();
 
     if (typeof registeredShutdownFn === 'function') {
-        Promise.resolve(registeredShutdownFn(exitCode)).catch((error) => {
+        Promise.resolve(registeredShutdownFn(normalizedExitCode)).catch((error) => {
             console.error('Error during graceful shutdown:', error);
         });
     } else {
-        process.exit(exitCode);
+        process.exit(normalizedExitCode);
     }
 }

--- a/tests/shutdown.test.js
+++ b/tests/shutdown.test.js
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import process from 'node:process';
+
+const SERVER_MAIN_SOURCE = new URL('../src/server-main.js', import.meta.url);
+
+async function loadShutdownModule() {
+    jest.resetModules();
+    return import('../src/shutdown.js');
+}
+
+describe('graceful shutdown', () => {
+    let exitSpy;
+    let consoleErrorSpy;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined);
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+        exitSpy.mockRestore();
+        consoleErrorSpy.mockRestore();
+        jest.resetModules();
+    });
+
+    test('normalizes signal strings before exiting', async () => {
+        const { normalizeExitCode } = await loadShutdownModule();
+
+        expect(normalizeExitCode('SIGINT')).toBe(0);
+        expect(normalizeExitCode('SIGTERM')).toBe(0);
+        expect(normalizeExitCode('130')).toBe(130);
+        expect(normalizeExitCode(1)).toBe(1);
+    });
+
+    test('passes a numeric exit code to registered shutdown handlers and timeout exits', async () => {
+        const { registerGracefulShutdown, requestGracefulExit } = await loadShutdownModule();
+        const shutdownFn = jest.fn();
+
+        registerGracefulShutdown(shutdownFn);
+        requestGracefulExit('SIGINT');
+
+        expect(shutdownFn).toHaveBeenCalledWith(0);
+        expect(exitSpy).not.toHaveBeenCalled();
+
+        jest.runOnlyPendingTimers();
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('forcing exit with code 0'));
+        expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    test('uses a numeric exit code when no shutdown handler is registered', async () => {
+        const { requestGracefulExit } = await loadShutdownModule();
+
+        requestGracefulExit('SIGTERM');
+
+        expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    test('does not wire process signals directly to the exit function', () => {
+        const source = readFileSync(SERVER_MAIN_SOURCE, 'utf8');
+
+        expect(source).toContain("process.on('SIGINT', () => exitProcess(0));");
+        expect(source).toContain("process.on('SIGTERM', () => exitProcess(0));");
+        expect(source).not.toContain("process.on('SIGINT', exitProcess);");
+        expect(source).not.toContain("process.on('SIGTERM', exitProcess);");
+    });
+});


### PR DESCRIPTION
## Summary
- stop SIGINT/SIGTERM handlers from passing signal names into the shutdown exit function
- normalize graceful-shutdown exit codes before calling registered shutdown handlers or process.exit
- add regression coverage for signal strings, timeout fallback exits, and server signal wiring

## Tests
- npm run test:unit --prefix tests -- shutdown.test.js
- npm run test:unit --prefix tests
- npm run lint