### PR TITLE
fix: protect character saves from stale frontend

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,7 +18,7 @@
         }
     </style>
     <link rel="preload" as="style" href="style.css?v=20260610a">
-    <link rel="modulepreload" href="script.js?v=20260611a">
+    <link rel="modulepreload" href="script.js?v=20260611b">
     <link rel="modulepreload" href="scripts/sillybunny-tabs.js?v=20260609a">
     <link rel="preload" as="font" type="font/woff2" href="webfonts/Figtree/Figtree-Regular.woff2?v=20260422b" crossorigin>
     <link rel="manifest" crossorigin="use-credentials" href="manifest.json">
@@ -8867,7 +8867,7 @@
     <script type="module" src="lib/eventemitter.js"></script>
     <script type="module" src="scripts/i18n.js"></script>
     <script type="module" src="scripts/performance-loader.js"></script>
-    <script type="module" src="script.js?v=20260611a"></script>
+    <script type="module" src="script.js?v=20260611b"></script>
     <script type="module" src="scripts/sillybunny-tabs.js?v=20260609a"></script>
     <script>
         window.addEventListener('load', (event) => {

--- a/public/script.js
+++ b/public/script.js
@@ -40,6 +40,7 @@ import {
 import { shouldRestoreTextGenStatusOnStartup } from './scripts/textgen-startup-status.js';
 import { normalizeCharacterChatName, resolveCharacterChatNameForLoad } from './scripts/character-chat-resolver.js';
 import { getDebouncedChatSaveAbortReason } from './scripts/chat-save-guard.js';
+import { getCharacterDefinitionFormValues, getSuspiciousEmptyCharacterDefinitionSave } from './scripts/character-save-guard.js';
 
 import {
     world_info,
@@ -14310,6 +14311,25 @@ export async function createOrEditCharacter(e) {
                 formData.append('alternate_greetings', value);
             }
 
+            const editedAvatar = String(formData.get('avatar_url') ?? '');
+            const editedCharacter = characters.find(character => character?.avatar === editedAvatar) ?? characters[this_chid];
+            const suspiciousEmptyDefinitionSave = getSuspiciousEmptyCharacterDefinitionSave(editedCharacter, getCharacterDefinitionFormValues(formData));
+
+            if (suspiciousEmptyDefinitionSave) {
+                const fieldList = suspiciousEmptyDefinitionSave.emptiedFieldLabels.join(', ');
+                const confirmation = await callGenericPopup(
+                    t`SillyBunny is about to save this character with previously populated definition fields empty: ${fieldList}. This can happen after a stale frontend load. Reload the page unless you intentionally cleared these fields. Continue saving?`,
+                    POPUP_TYPE.CONFIRM,
+                );
+
+                if (confirmation !== POPUP_RESULT.AFFIRMATIVE) {
+                    toastr.warning(t`Character save cancelled to protect existing definitions. Reload the page before editing this character again.`, t`Character save blocked`);
+                    return;
+                }
+
+                formData.set('allow_empty_definition_save', 'true');
+            }
+
             const fetchResult = await fetch(url, {
                 method: 'POST',
                 headers: headers,
@@ -14318,7 +14338,7 @@ export async function createOrEditCharacter(e) {
             });
 
             if (!fetchResult.ok) {
-                throw new Error('Fetch result is not ok');
+                throw new Error(await fetchResult.text() || 'Fetch result is not ok');
             }
 
             await getOneCharacter(formData.get('avatar_url'));
@@ -14351,7 +14371,10 @@ export async function createOrEditCharacter(e) {
             }
         } catch (error) {
             console.log(error);
-            toastr.error(t`Something went wrong while saving the character, or the image file provided was in an invalid format. Double check that the image is not a webp.`);
+            const message = error instanceof Error && error.message
+                ? error.message
+                : t`Something went wrong while saving the character, or the image file provided was in an invalid format. Double check that the image is not a webp.`;
+            toastr.error(message);
         }
     }
 }

--- a/public/scripts/character-save-guard.js
+++ b/public/scripts/character-save-guard.js
@@ -1,0 +1,37 @@
+export const CHARACTER_DEFINITION_SAVE_FIELDS = [
+    { formName: 'description', characterKey: 'description', label: 'Description' },
+    { formName: 'personality', characterKey: 'personality', label: 'Personality' },
+    { formName: 'scenario', characterKey: 'scenario', label: 'Scenario' },
+    { formName: 'first_mes', characterKey: 'first_mes', label: 'First message' },
+    { formName: 'mes_example', characterKey: 'mes_example', label: 'Example messages' },
+];
+
+function hasMeaningfulText(value) {
+    return String(value ?? '').trim().length > 0;
+}
+
+export function getCharacterDefinitionFormValues(formData) {
+    return Object.fromEntries(CHARACTER_DEFINITION_SAVE_FIELDS.map(field => [field.formName, formData.get(field.formName)]));
+}
+
+export function getSuspiciousEmptyCharacterDefinitionSave(character, submittedValues) {
+    if (!character || typeof character !== 'object' || !submittedValues || typeof submittedValues !== 'object') {
+        return null;
+    }
+
+    const populatedFields = CHARACTER_DEFINITION_SAVE_FIELDS.filter(field => hasMeaningfulText(character[field.characterKey]));
+    const emptiedFields = populatedFields.filter(field => !hasMeaningfulText(submittedValues[field.formName]));
+
+    if (populatedFields.length < 2 || emptiedFields.length < 2) {
+        return null;
+    }
+
+    if (emptiedFields.length !== populatedFields.length && emptiedFields.length < 3) {
+        return null;
+    }
+
+    return {
+        emptiedFieldNames: emptiedFields.map(field => field.formName),
+        emptiedFieldLabels: emptiedFields.map(field => field.label),
+    };
+}

--- a/src/character-save-guard.js
+++ b/src/character-save-guard.js
@@ -1,0 +1,34 @@
+export const CHARACTER_DEFINITION_SAVE_FIELDS = [
+    { name: 'description', label: 'Description' },
+    { name: 'personality', label: 'Personality' },
+    { name: 'scenario', label: 'Scenario' },
+    { name: 'first_mes', label: 'First message' },
+    { name: 'mes_example', label: 'Example messages' },
+];
+
+function hasMeaningfulDefinitionText(value) {
+    return String(value ?? '').trim().length > 0;
+}
+
+function getStoredDefinitionValue(character, fieldName) {
+    return character?.[fieldName] ?? character?.data?.[fieldName];
+}
+
+export function getSuspiciousEmptyCharacterDefinitionFields(currentCharacter, submittedData) {
+    if (!currentCharacter || typeof currentCharacter !== 'object' || !submittedData || typeof submittedData !== 'object') {
+        return [];
+    }
+
+    const populatedFields = CHARACTER_DEFINITION_SAVE_FIELDS.filter(field => hasMeaningfulDefinitionText(getStoredDefinitionValue(currentCharacter, field.name)));
+    const emptiedFields = populatedFields.filter(field => !hasMeaningfulDefinitionText(submittedData[field.name]));
+
+    if (populatedFields.length < 2 || emptiedFields.length < 2) {
+        return [];
+    }
+
+    if (emptiedFields.length !== populatedFields.length && emptiedFields.length < 3) {
+        return [];
+    }
+
+    return emptiedFields;
+}

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -24,6 +24,7 @@ import { getUserDirectories } from '../users.js';
 import { getChatInfo } from './chats.js';
 import { ByafParser } from '../byaf.js';
 import { CharXParser, persistCharXAssets } from '../charx.js';
+import { getSuspiciousEmptyCharacterDefinitionFields } from '../character-save-guard.js';
 
 // With 100 MB limit it would take roughly 3000 characters to reach this limit
 const memoryCacheCapacity = getConfigValue('performance.memoryCacheCapacity', '100mb');
@@ -36,6 +37,7 @@ const useDiskCache = !!getConfigValue('performance.useDiskCache', true, 'boolean
 const BULK_MERGE_CONCURRENCY = 8;
 const EXTENSION_UNSET_VALUE = '__@@UNSET@@__';
 const forbiddenAvatarRegExp = path.sep === '/' ? /[/\x00]/ : /[/\x00\\]/;
+const CHARACTER_EMPTY_DEFINITION_SAVE_OVERRIDE = 'allow_empty_definition_save';
 
 class DiskCache {
     /**
@@ -1169,6 +1171,30 @@ router.post('/edit', validateAvatarUrlMiddleware, async function (request, respo
         return;
     }
 
+    const avatarPath = path.join(request.user.directories.characters, request.body.avatar_url);
+
+    if (request.body[CHARACTER_EMPTY_DEFINITION_SAVE_OVERRIDE] !== 'true') {
+        try {
+            const currentCharacter = tryParse(await readCharacterData(avatarPath));
+            const suspiciousEmptyFields = getSuspiciousEmptyCharacterDefinitionFields(currentCharacter, request.body);
+
+            if (suspiciousEmptyFields.length > 0) {
+                const fieldList = suspiciousEmptyFields.map(field => field.label).join(', ');
+                const message = [
+                    'SillyBunny blocked this character save because previously populated definition fields were submitted empty:',
+                    `${fieldList}.`,
+                    'Reload the page before editing this character again, or confirm the save if you intentionally cleared those fields.',
+                ].join(' ');
+
+                console.warn(`Blocked suspicious empty character definition save for ${request.body.avatar_url}: ${fieldList}`);
+                response.status(409).send(message);
+                return;
+            }
+        } catch (err) {
+            console.warn('Could not inspect existing character data before edit save.', err);
+        }
+    }
+
     let char = charaFormatData(request.body, request.user.directories);
     char.chat = request.body.chat;
     char.create_date = request.body.create_date;
@@ -1177,7 +1203,6 @@ router.post('/edit', validateAvatarUrlMiddleware, async function (request, respo
 
     try {
         if (!request.file) {
-            const avatarPath = path.join(request.user.directories.characters, request.body.avatar_url);
             await writeCharacterData(avatarPath, char, targetFile, request);
         } else {
             const crop = tryParse(request.query.crop);

--- a/src/middleware/frontend-assets.js
+++ b/src/middleware/frontend-assets.js
@@ -7,39 +7,10 @@ import {
     loadFrontendManifest,
 } from '../frontend-assets.js';
 
-export function isIosWebKitUserAgent(userAgent) {
-    const normalizedUserAgent = String(userAgent || '');
-
-    return /\bAppleWebKit\//i.test(normalizedUserAgent)
-        && (
-            /\b(?:iPad|iPhone|iPod)\b/i.test(normalizedUserAgent)
-            || (/\bMacintosh\b/i.test(normalizedUserAgent) && /\bMobile\//i.test(normalizedUserAgent))
-        );
-}
-
-function getRequestUserAgent(res) {
-    return res?.req?.headers?.['user-agent']
-        ?? res?.req?.headers?.['User-Agent']
-        ?? (typeof res?.req?.get === 'function' ? res.req.get('user-agent') : '');
-}
-
-function appendVaryHeader(res, value) {
-    const currentHeader = typeof res.getHeader === 'function' ? res.getHeader('Vary') : '';
-    const values = String(currentHeader || '').split(',').map(header => header.trim()).filter(Boolean);
-    const normalizedValue = value.toLowerCase();
-
-    if (!values.some(header => header === '*' || header.toLowerCase() === normalizedValue)) {
-        values.push(value);
-    }
-
-    res.setHeader('Vary', values.join(', '));
-}
-
 export function setPublicAssetHeaders(res, requestPath) {
     if (/\.(?:m?js)$/i.test(requestPath)) {
-        // SillyBunny: iOS WebKit needs revalidation for unversioned modules; other browsers should avoid reload storms.
-        appendVaryHeader(res, 'User-Agent');
-        res.setHeader('Cache-Control', isIosWebKitUserAgent(getRequestUserAgent(res)) ? 'no-cache' : 'public, max-age=3600');
+        // SillyBunny: revalidate unversioned JS modules to avoid stale mixed frontend graphs.
+        res.setHeader('Cache-Control', 'no-cache');
         return;
     }
 

--- a/tests/character-save-guard.test.js
+++ b/tests/character-save-guard.test.js
@@ -1,0 +1,101 @@
+import { describe, expect, test } from '@jest/globals';
+
+import {
+    getCharacterDefinitionFormValues,
+    getSuspiciousEmptyCharacterDefinitionSave,
+} from '../public/scripts/character-save-guard.js';
+import { getSuspiciousEmptyCharacterDefinitionFields } from '../src/character-save-guard.js';
+
+describe('character save guard', () => {
+    test('does not warn for ordinary edits or single-field clears', () => {
+        const character = {
+            description: 'Existing description',
+            personality: 'Existing personality',
+            scenario: 'Existing scenario',
+        };
+
+        expect(getSuspiciousEmptyCharacterDefinitionSave(character, {
+            description: 'Updated description',
+            personality: 'Existing personality',
+            scenario: 'Existing scenario',
+        })).toBeNull();
+
+        expect(getSuspiciousEmptyCharacterDefinitionSave(character, {
+            description: '',
+            personality: 'Existing personality',
+            scenario: 'Existing scenario',
+        })).toBeNull();
+    });
+
+    test('warns when previously populated definition fields are submitted empty', () => {
+        const character = {
+            description: 'Existing description',
+            personality: 'Existing personality',
+            scenario: 'Existing scenario',
+            first_mes: 'Hello',
+            mes_example: '<START>',
+        };
+
+        const warning = getSuspiciousEmptyCharacterDefinitionSave(character, {
+            description: '',
+            personality: '',
+            scenario: '',
+            first_mes: '',
+            mes_example: '',
+        });
+
+        expect(warning).toEqual({
+            emptiedFieldNames: ['description', 'personality', 'scenario', 'first_mes', 'mes_example'],
+            emptiedFieldLabels: ['Description', 'Personality', 'Scenario', 'First message', 'Example messages'],
+        });
+    });
+
+    test('warns when three or more populated definition fields are cleared together', () => {
+        const warning = getSuspiciousEmptyCharacterDefinitionSave({
+            description: 'Existing description',
+            personality: 'Existing personality',
+            scenario: 'Existing scenario',
+            first_mes: 'Hello',
+        }, {
+            description: '',
+            personality: '',
+            scenario: '',
+            first_mes: 'Hello',
+        });
+
+        expect(warning?.emptiedFieldNames).toEqual(['description', 'personality', 'scenario']);
+    });
+
+    test('extracts watched fields from submitted form data', () => {
+        const formData = new FormData();
+        formData.set('description', 'Description');
+        formData.set('personality', 'Personality');
+        formData.set('scenario', 'Scenario');
+        formData.set('first_mes', 'Hello');
+        formData.set('mes_example', '<START>');
+
+        expect(getCharacterDefinitionFormValues(formData)).toEqual({
+            description: 'Description',
+            personality: 'Personality',
+            scenario: 'Scenario',
+            first_mes: 'Hello',
+            mes_example: '<START>',
+        });
+    });
+
+    test('server guard reads current character card fields before overwrite', () => {
+        const fields = getSuspiciousEmptyCharacterDefinitionFields({
+            data: {
+                description: 'Existing description',
+                personality: 'Existing personality',
+                scenario: 'Existing scenario',
+            },
+        }, {
+            description: '',
+            personality: '',
+            scenario: '',
+        });
+
+        expect(fields.map(field => field.name)).toEqual(['description', 'personality', 'scenario']);
+    });
+});

--- a/tests/frontend-asset-middleware.test.js
+++ b/tests/frontend-asset-middleware.test.js
@@ -1,24 +1,19 @@
 import { describe, expect, test } from '@jest/globals';
 
-import { isIosWebKitUserAgent, setPublicAssetHeaders } from '../src/middleware/frontend-assets.js';
+import { setPublicAssetHeaders } from '../src/middleware/frontend-assets.js';
 
-function getHeadersFor(requestPath, { userAgent = '', vary = '' } = {}) {
-    const headers = new Map(vary ? [['Vary', vary]] : []);
+function getHeadersFor(requestPath) {
+    const headers = new Map();
 
     setPublicAssetHeaders({
-        req: {
-            headers: { 'user-agent': userAgent },
-            get: name => (name.toLowerCase() === 'user-agent' ? userAgent : undefined),
-        },
-        getHeader: name => headers.get(name),
         setHeader: (name, value) => headers.set(name, value),
     }, requestPath);
 
     return headers;
 }
 
-function getCacheControlFor(requestPath, options) {
-    return getHeadersFor(requestPath, options).get('Cache-Control');
+function getCacheControlFor(requestPath) {
+    return getHeadersFor(requestPath).get('Cache-Control');
 }
 
 describe('frontend asset fallback headers', () => {
@@ -29,39 +24,14 @@ describe('frontend asset fallback headers', () => {
         expect(getCacheControlFor('/script.js.map')).toBe('no-cache');
     });
 
-    test('keeps non-iOS public JavaScript modules short-lived', () => {
-        expect(getCacheControlFor('/script.js')).toBe('public, max-age=3600');
-        expect(getCacheControlFor('/script.js', {
-            userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/125.0 Safari/537.36',
-        })).toBe('public, max-age=3600');
-        expect(getCacheControlFor('/scripts/bootstrap.mjs', {
-            userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Firefox/126.0',
-        })).toBe('public, max-age=3600');
-    });
-
-    test('revalidates public JavaScript modules only for iOS WebKit', () => {
-        expect(getCacheControlFor('/script.js', {
-            userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
-        })).toBe('no-cache');
-        expect(getCacheControlFor('/scripts/chat-render-lifecycle/render-window.js', {
-            userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
-        })).toBe('no-cache');
-    });
-
-    test('marks JavaScript cache headers as user-agent variant', () => {
-        expect(getHeadersFor('/script.js', { vary: 'Accept-Encoding' }).get('Vary')).toBe('Accept-Encoding, User-Agent');
-        expect(getHeadersFor('/script.js', { vary: 'user-agent' }).get('Vary')).toBe('user-agent');
-        expect(getHeadersFor('/script.js', { vary: '*' }).get('Vary')).toBe('*');
+    test('revalidates public JavaScript modules for every browser', () => {
+        expect(getCacheControlFor('/script.js')).toBe('no-cache');
+        expect(getCacheControlFor('/scripts/chat-render-lifecycle/render-window.js')).toBe('no-cache');
+        expect(getCacheControlFor('/scripts/bootstrap.mjs')).toBe('no-cache');
     });
 
     test('keeps static non-code fallback assets short-lived', () => {
         expect(getCacheControlFor('/img/logo.png')).toBe('public, max-age=3600');
     });
 
-    test('detects iOS WebKit user agents', () => {
-        expect(isIosWebKitUserAgent('Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148')).toBe(true);
-        expect(isIosWebKitUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 Version/17.5 Mobile/15E148 Safari/604.1')).toBe(true);
-        expect(isIosWebKitUserAgent('Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 Chrome/125.0 Mobile Safari/537.36')).toBe(false);
-        expect(isIosWebKitUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/125.0 Safari/537.36')).toBe(false);
-    });
 });

--- a/tests/frontend-assets.test.js
+++ b/tests/frontend-assets.test.js
@@ -76,8 +76,8 @@ describe('frontend asset manifest rewriting', () => {
     test('loads the main app module through a versioned URL', () => {
         const indexHtml = fs.readFileSync(path.join(process.cwd(), '..', 'public', 'index.html'), 'utf8');
 
-        expect(indexHtml).toContain('<link rel="modulepreload" href="script.js?v=20260611a">');
-        expect(indexHtml).toContain('<script type="module" src="script.js?v=20260611a"></script>');
+        expect(indexHtml).toContain('<link rel="modulepreload" href="script.js?v=20260611b">');
+        expect(indexHtml).toContain('<script type="module" src="script.js?v=20260611b"></script>');
     });
 
     test('only treats fingerprinted frontend asset names as immutable', () => {


### PR DESCRIPTION
## Summary
- restore universal no-cache revalidation for unversioned public JS modules to avoid stale mixed frontend graphs
- add client and server guards for suspicious character edit saves where previously populated definition fields are submitted empty
- bump the main script cache-bust token and update focused tests

## Verification
- npm run test:unit --prefix tests -- frontend-asset-middleware.test.js character-save-guard.test.js
- npm run test:unit --prefix tests
- npm run lint