### PR TITLE
fix: detect frontend restart by boot marker

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
     </style>
     <link rel="preload" as="style" href="style.css?v=20260610a">
     <link rel="modulepreload" href="script.js?v=20260611a">
-    <link rel="modulepreload" href="scripts/sillybunny-tabs.js?v=20260609a">
+    <link rel="modulepreload" href="scripts/sillybunny-tabs.js?v=20260611a">
     <link rel="preload" as="font" type="font/woff2" href="webfonts/Figtree/Figtree-Regular.woff2?v=20260422b" crossorigin>
     <link rel="manifest" crossorigin="use-credentials" href="manifest.json">
     <link href="webfonts/Figtree/stylesheet.css?v=20260422b" rel="stylesheet">
@@ -8868,7 +8868,7 @@
     <script type="module" src="scripts/i18n.js"></script>
     <script type="module" src="scripts/performance-loader.js"></script>
     <script type="module" src="script.js?v=20260611a"></script>
-    <script type="module" src="scripts/sillybunny-tabs.js?v=20260609a"></script>
+    <script type="module" src="scripts/sillybunny-tabs.js?v=20260611a"></script>
     <script>
         window.addEventListener('load', (event) => {
             const documentHeight = () => {

--- a/public/scripts/server-restart-monitor.js
+++ b/public/scripts/server-restart-monitor.js
@@ -1,0 +1,29 @@
+function getTrimmedVersionValue(version, key) {
+    return String(version?.[key] ?? '').trim();
+}
+
+export function hasServerReturnedAfterRestart(version, {
+    expectedRevision = '',
+    expectedVersion = '',
+    previousServerBootId = '',
+    sawOffline = false,
+} = {}) {
+    const revision = getTrimmedVersionValue(version, 'gitRevision');
+    const pkgVersion = getTrimmedVersionValue(version, 'pkgVersion');
+    const serverBootId = getTrimmedVersionValue(version, 'serverBootId');
+    const previousBootId = String(previousServerBootId ?? '').trim();
+
+    if (expectedRevision && revision === expectedRevision) {
+        return true;
+    }
+
+    if (expectedVersion && pkgVersion === expectedVersion) {
+        return true;
+    }
+
+    if (previousBootId && serverBootId && serverBootId !== previousBootId) {
+        return true;
+    }
+
+    return Boolean(sawOffline);
+}

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -4,6 +4,7 @@ import {
     MOBILE_SHELL_NAV_TOGGLE_ACTION,
 } from './mobile-shell-lifecycle/index.js';
 import { createPresetApiSyncLifecycle } from './preset-api-sync-lifecycle/index.js';
+import { hasServerReturnedAfterRestart } from './server-restart-monitor.js';
 import { flashHighlight, showFontAwesomePicker } from './utils.js';
 import { flushCharacterSaveDebounced, getOneCharacter, saveSettingsDebounced } from '../script.js';
 
@@ -9401,7 +9402,7 @@ function renderServerThumbnailSettings(data) {
     setServerAdminMessage(refs.thumbnailNote, 'Thumbnail settings loaded. Saving applies to new thumbnails immediately.', 'neutral');
 }
 
-async function waitForServerReturn(expectedRevision = '', { clearCacheBeforeReload = false, expectedVersion = '' } = {}) {
+async function waitForServerReturn(expectedRevision = '', { clearCacheBeforeReload = false, expectedVersion = '', previousServerBootId = '' } = {}) {
     let sawOffline = false;
 
     async function reloadAfterOptionalCacheClear() {
@@ -9421,20 +9422,7 @@ async function waitForServerReturn(expectedRevision = '', { clearCacheBeforeRelo
             }
 
             const version = await response.json().catch(() => ({}));
-            const revision = String(version?.gitRevision ?? '').trim();
-            const pkgVersion = String(version?.pkgVersion ?? '').trim();
-
-            if (expectedRevision && revision === expectedRevision) {
-                await reloadAfterOptionalCacheClear();
-                return true;
-            }
-
-            if (expectedVersion && pkgVersion === expectedVersion) {
-                await reloadAfterOptionalCacheClear();
-                return true;
-            }
-
-            if (sawOffline) {
+            if (hasServerReturnedAfterRestart(version, { expectedRevision, expectedVersion, previousServerBootId, sawOffline })) {
                 await reloadAfterOptionalCacheClear();
                 return true;
             }
@@ -9734,7 +9722,7 @@ async function handleServerAdminRestart() {
         setServerAdminMessage(refs.updateNote, result?.message || 'Restarting SillyBunny…', 'warn');
         toastr.info(result?.message || 'Restarting SillyBunny…', 'Server');
 
-        const restarted = await waitForServerReturn();
+        const restarted = await waitForServerReturn('', { previousServerBootId: result?.serverBootId });
         if (!restarted) {
             state.restarting = false;
             setServerAdminMessage(refs.updateNote, 'Restart is taking longer than expected. Refresh the page once the server is back.', 'warn');

--- a/src/endpoints/server-admin.js
+++ b/src/endpoints/server-admin.js
@@ -27,6 +27,7 @@ import { getConfigValue, getVersion, isPathUnderParent, tryWriteFileSync } from 
 import { getThumbnailDimensions, setThumbnailDimensions } from './image-metadata.js';
 import { getThumbnailRuntimeSettings, setThumbnailRuntimeSettings } from './thumbnails.js';
 import { requestGracefulExit } from '../shutdown.js';
+import { getServerBootId } from '../server-boot-marker.js';
 
 const GIT_OPTIONS = Object.freeze({ timeout: { block: 10 * 60 * 1000 } });
 const RESTART_RESPONSE_DELAY_MS = 200;
@@ -783,6 +784,7 @@ router.post('/restart', requireAdminMiddleware, async (_request, response) => {
         response.status(202).json({
             ok: true,
             restarting: true,
+            serverBootId: getServerBootId(),
             message: `${APP_NAME} is restarting.`,
         });
     } catch (error) {

--- a/src/server-boot-marker.js
+++ b/src/server-boot-marker.js
@@ -1,0 +1,5 @@
+const SERVER_BOOT_ID = `${Date.now().toString(36)}-${process.pid.toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+
+export function getServerBootId() {
+    return SERVER_BOOT_ID;
+}

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -22,6 +22,7 @@ import helmet from 'helmet';
 import './fetch-patch.js';
 import { APP_NAME, isBunRuntime } from './runtime.js';
 import { serverDirectory } from './server-directory.js';
+import { getServerBootId } from './server-boot-marker.js';
 
 import { serverEvents, EVENT_NAMES } from './server-events.js';
 import { loadPlugins } from './plugin-loader.js';
@@ -448,7 +449,10 @@ app.use(multerMonkeyPatch);
 
 app.get('/version', async function (_, response) {
     const data = await getVersion();
-    response.send(data);
+    response.send({
+        ...data,
+        serverBootId: getServerBootId(),
+    });
 });
 
 setupPrivateEndpoints(app);

--- a/tests/server-restart-monitor.test.js
+++ b/tests/server-restart-monitor.test.js
@@ -1,0 +1,44 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, test } from '@jest/globals';
+
+import { getServerBootId } from '../src/server-boot-marker.js';
+import { hasServerReturnedAfterRestart } from '../public/scripts/server-restart-monitor.js';
+
+const repoRoot = path.resolve(process.cwd(), '..');
+
+describe('server restart monitor', () => {
+    test('recognizes restart completion from a changed server boot marker', () => {
+        expect(hasServerReturnedAfterRestart({ serverBootId: 'next' }, { previousServerBootId: 'previous' })).toBe(true);
+        expect(hasServerReturnedAfterRestart({ serverBootId: 'same' }, { previousServerBootId: 'same' })).toBe(false);
+    });
+
+    test('keeps existing revision, version, and offline fallback checks', () => {
+        expect(hasServerReturnedAfterRestart({ gitRevision: 'abc' }, { expectedRevision: 'abc' })).toBe(true);
+        expect(hasServerReturnedAfterRestart({ pkgVersion: '1.2.3' }, { expectedVersion: '1.2.3' })).toBe(true);
+        expect(hasServerReturnedAfterRestart({}, { sawOffline: true })).toBe(true);
+        expect(hasServerReturnedAfterRestart({ gitRevision: 'old', pkgVersion: '1.2.2' }, {
+            expectedRevision: 'new',
+            expectedVersion: '1.2.3',
+        })).toBe(false);
+    });
+
+    test('exposes a stable non-empty boot marker for the current process', () => {
+        const bootId = getServerBootId();
+
+        expect(bootId).toEqual(expect.any(String));
+        expect(bootId.length).toBeGreaterThan(8);
+        expect(getServerBootId()).toBe(bootId);
+    });
+
+    test('wires the boot marker through version and restart responses', () => {
+        const serverMainSource = fs.readFileSync(path.join(repoRoot, 'src', 'server-main.js'), 'utf8');
+        const serverAdminSource = fs.readFileSync(path.join(repoRoot, 'src', 'endpoints', 'server-admin.js'), 'utf8');
+        const tabsSource = fs.readFileSync(path.join(repoRoot, 'public', 'scripts', 'sillybunny-tabs.js'), 'utf8');
+
+        expect(serverMainSource).toContain('serverBootId: getServerBootId()');
+        expect(serverAdminSource).toContain('serverBootId: getServerBootId()');
+        expect(tabsSource).toContain("waitForServerReturn('', { previousServerBootId: result?.serverBootId })");
+    });
+});


### PR DESCRIPTION
## Summary
- add a per-process server boot marker to /version
- return the current boot marker from the frontend restart endpoint
- let the frontend restart poller succeed when the marker changes, while preserving revision/version/offline fallback checks
- bump the sillybunny-tabs.js cache token for the changed restart polling module

## Verification
- npm run test:unit --prefix tests -- server-restart-monitor.test.js
- npm run test:unit --prefix tests
- npm run lint