### PR TITLE
fix: improve extension load diagnostics

### DIFF
--- a/public/scripts/extension-load-errors.js
+++ b/public/scripts/extension-load-errors.js
@@ -1,0 +1,100 @@
+const UNKNOWN_EXTENSION_LOAD_ERROR = 'Unknown extension load error';
+
+function isNonEmptyString(value) {
+    return typeof value === 'string' && value.trim().length > 0;
+}
+
+function getErrorTargetUrl(error) {
+    const target = error?.target ?? error?.currentTarget;
+    const url = target?.src ?? target?.href;
+
+    return isNonEmptyString(url) ? url.trim() : '';
+}
+
+function stringifyObjectError(error) {
+    if (!error || typeof error !== 'object') {
+        return '';
+    }
+
+    try {
+        const seen = new WeakSet();
+        const json = JSON.stringify(error, (_, value) => {
+            if (typeof value === 'object' && value !== null) {
+                if (seen.has(value)) {
+                    return '[Circular]';
+                }
+
+                seen.add(value);
+            }
+
+            if (typeof value === 'function') {
+                return `[Function ${value.name || 'anonymous'}]`;
+            }
+
+            return value;
+        });
+
+        return json && json !== '{}' ? json : '';
+    } catch {
+        return '';
+    }
+}
+
+export function formatExtensionLoadError(error) {
+    if (error instanceof Error && isNonEmptyString(error.message)) {
+        return error.message.trim();
+    }
+
+    if (isNonEmptyString(error)) {
+        return error.trim();
+    }
+
+    if (isNonEmptyString(error?.message)) {
+        return error.message.trim();
+    }
+
+    if (error?.reason !== undefined && error.reason !== error) {
+        const reason = formatExtensionLoadError(error.reason);
+
+        if (reason !== UNKNOWN_EXTENSION_LOAD_ERROR) {
+            return reason;
+        }
+    }
+
+    const targetUrl = getErrorTargetUrl(error);
+
+    if (targetUrl) {
+        return `Load failed for ${targetUrl}`;
+    }
+
+    if (isNonEmptyString(error?.type)) {
+        return `Load failed (${error.type.trim()})`;
+    }
+
+    const jsonError = stringifyObjectError(error);
+
+    if (jsonError) {
+        return jsonError;
+    }
+
+    const stringified = String(error ?? '').trim();
+
+    if (stringified && stringified !== '[object Object]') {
+        return stringified;
+    }
+
+    return UNKNOWN_EXTENSION_LOAD_ERROR;
+}
+
+export function createExtensionScriptLoadError(name, url, event) {
+    const targetUrl = getErrorTargetUrl(event) || (isNonEmptyString(url) ? url.trim() : '');
+    const extensionName = isNonEmptyString(name) ? ` for "${name.trim()}"` : '';
+    const source = targetUrl ? `: ${targetUrl}` : '';
+    const error = new Error(`Could not load extension script${extensionName}${source}`);
+
+    error.cause = event;
+    error.extensionName = name;
+    error.extensionScriptUrl = targetUrl;
+
+    return error;
+}

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -10,6 +10,7 @@ import { debounce_timeout } from './constants.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { SimpleMutex } from './util/SimpleMutex.js';
 import { loadStylesheetAsync, prefetchAsset } from './dynamic-styles.js';
+import { createExtensionScriptLoadError, formatExtensionLoadError } from './extension-load-errors.js';
 import {
     EXTENSION_BOOT_ACTIVATION_ACTION,
     normalizeExtensionBootId,
@@ -1040,8 +1041,9 @@ async function activateExtensions() {
                         return callExtensionHook(name, 'activate');
                     })
                     .catch(err => {
-                        console.log('Could not activate extension', name, err);
-                        extensionLoadErrors.add(t`Extension "${displayName}" failed to load: ${err}`);
+                        const loadError = formatExtensionLoadError(err);
+                        console.log('Could not activate extension', name, loadError, err);
+                        extensionLoadErrors.add(t`Extension "${displayName}" failed to load: ${loadError}`);
                     })
                     .finally(() => {
                         activatingExtensionDedupKeys.delete(extensionKey);
@@ -1231,7 +1233,7 @@ function addExtensionScript(name, manifest) {
             script.src = url;
             script.async = true;
             script.onerror = function (err) {
-                reject(err);
+                reject(createExtensionScriptLoadError(name, url, err));
             };
             script.onload = function () {
                 if (!ready) {

--- a/tests/extension-load-errors.test.js
+++ b/tests/extension-load-errors.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createExtensionScriptLoadError, formatExtensionLoadError } from '../public/scripts/extension-load-errors.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+describe('extension load error diagnostics', () => {
+    test('wraps script load events with extension and script details', () => {
+        const event = { type: 'error', target: { src: 'https://example.test/scripts/extensions/third-party/Extension-WebSearch/index.js?v=1' } };
+        const error = createExtensionScriptLoadError('third-party/Extension-WebSearch', '/fallback.js', event);
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toBe('Could not load extension script for "third-party/Extension-WebSearch": https://example.test/scripts/extensions/third-party/Extension-WebSearch/index.js?v=1');
+        expect(error.cause).toBe(event);
+        expect(error.extensionName).toBe('third-party/Extension-WebSearch');
+        expect(error.extensionScriptUrl).toBe('https://example.test/scripts/extensions/third-party/Extension-WebSearch/index.js?v=1');
+    });
+
+    test('formats raw browser events without object Object output', () => {
+        expect(formatExtensionLoadError({ type: 'error', target: { src: '/scripts/extensions/third-party/Extension-WebSearch/index.js?v=1' } }))
+            .toBe('Load failed for /scripts/extensions/third-party/Extension-WebSearch/index.js?v=1');
+
+        expect(formatExtensionLoadError({ type: 'error' })).toBe('Load failed (error)');
+    });
+
+    test('preserves useful error and object messages', () => {
+        expect(formatExtensionLoadError(new Error('Extension context is not available yet.'))).toBe('Extension context is not available yet.');
+        expect(formatExtensionLoadError({ message: 'WebSearch failed during module evaluation' })).toBe('WebSearch failed during module evaluation');
+        expect(formatExtensionLoadError({ reason: new Error('SillyTavern.getContext is not ready') })).toBe('SillyTavern.getContext is not ready');
+        expect(formatExtensionLoadError({ code: 'ERR_WEBSEARCH', extension: 'WebSearch' })).toBe('{"code":"ERR_WEBSEARCH","extension":"WebSearch"}');
+        expect(formatExtensionLoadError({})).toBe('Unknown extension load error');
+    });
+
+    test('wires diagnostics into extension activation and script loading', () => {
+        const extensionsSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'extensions.js'), 'utf8');
+
+        expect(extensionsSource).toContain("import { createExtensionScriptLoadError, formatExtensionLoadError } from './extension-load-errors.js';");
+        expect(extensionsSource).toContain('const loadError = formatExtensionLoadError(err);');
+        expect(extensionsSource).toContain('extensionLoadErrors.add(t`Extension "${displayName}" failed to load: ${loadError}`);');
+        expect(extensionsSource).toContain('reject(createExtensionScriptLoadError(name, url, err));');
+    });
+});


### PR DESCRIPTION
## Summary
- wrap extension script load failures in real Error objects that include the extension name and script URL
- format raw Events, Error-like objects, nested reasons, and JSON-ish objects before showing extension load failures
- avoid `[object Object]` in extension details while keeping the original error object in console logs

## Verification
- npm run test:unit --prefix tests -- extension-load-errors.test.js
- npm run test:unit --prefix tests
- npm run lint