### PR TITLE
fix: cancel pending character save when switching characters (#423)

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -708,6 +708,14 @@ export async function flushCharacterSaveDebounced() {
     await characterSavePromise;
 }
 
+export function cancelCharacterSaveDebounced() {
+    if (pendingCharacterSaveTimer) {
+        console.debug('Debounced character save cancelled');
+        clearTimeout(pendingCharacterSaveTimer);
+        pendingCharacterSaveTimer = null;
+    }
+}
+
 /**
  * Prints the character list in a debounced fashion without blocking, with a delay of 100 milliseconds.
  * Use this function instead of a direct `printCharacters()` whenever the reprinting of the character list is not the primary focus.
@@ -1269,6 +1277,7 @@ export async function selectCharacterById(id, { switchMenu = true } = {}) {
             return false;
         }
 
+        cancelCharacterSaveDebounced();
         setCharacterId(undefined);
         setCharacterName('');
         resetSelectedGroup();

--- a/tests/__snapshots__/script-export-surface.test.js.snap
+++ b/tests/__snapshots__/script-export-surface.test.js.snap
@@ -25,6 +25,7 @@ exports[`public/script.js named export surface matches the parser-derived export
   "baseChatReplace",
   "buildAvatarList",
   "callPopup",
+  "cancelCharacterSaveDebounced",
   "cancelDebouncedChatSave",
   "cancelStatusCheck",
   "cancelTtsPlay",


### PR DESCRIPTION
## Summary

Closes #423

A debounced character save (1000ms timeout) scheduled while editing character A can fire after the user clicks character B in the character list. At that point the editor form holds `create_save` defaults (empty strings) and the backend`'s `charaFormatData` unconditionally overwrites every definition field from the submitted form, resulting in the newly-selected character being persisted with empty definition/description fields.

`selectCharacterById` already flushes pending **chat** saves before switching via `flushPendingChatSavesForNavigation`, but the **character** save debounce timer had no equivalent cancellation point.

## Changes

- Add `cancelCharacterSaveDebounced()` to `public/script.js` (mirrors the existing `cancelDebouncedChatSave` pattern)
- Call `cancelCharacterSaveDebounced()` in `selectCharacterById` immediately after chat saves are flushed, before clearing the character id
- Update the `script-export-surface` snapshot to include the new export

## Testing

- `npm run test:unit` — all 115 suites / 1053 tests pass
- `npm run lint` — clean

## Root Cause Detail

1. User edits character A; `saveCharacterDebounced()` schedules a save for 1000ms later
2. Within that 1s window the user clicks character B in the character list
3. `selectCharacterById(B)` calls `flushPendingChatSavesForNavigation()` (chat only) — the pending **character** save timer is not cancelled
4. `select_selected_character(B)` is called, which first clears all form fields via `select_rm_create` (empty `create_save` defaults), then repopulates synchronously
5. The debounced character save fires, reads the partially-populated form — `charaFormatData` writes empty strings for description/personality/scenario/etc.
6. On next load, character B has empty definitions

This fix breaks the chain at step 3 by cancelling the pending timer before the switch.