### PR TITLE
fix: load script.js under its bare URL to restore single module identity

### DIFF
--- a/docs/upstream-touch-ledger.md
+++ b/docs/upstream-touch-ledger.md
@@ -197,13 +197,13 @@ This ledger tracks intentional SillyBunny divergence in upstream-origin files. I
 | Field | Value |
 | --- | --- |
 | Area | Settings and frontend boot. |
-| Divergence reason | SillyBunny keeps `script.js` loaded through its canonical URL, keeps OOC/HTML retention settings copy synchronized with active-turn depth behavior, and exposes core background transparency sliders without requiring Moonlit Echoes. |
+| Divergence reason | SillyBunny keeps `script.js` loaded through its canonical URL, keeps OOC/HTML retention settings copy synchronized with active-turn depth behavior, and exposes core background transparency sliders without requiring Moonlit Echoes. `script.js` must NEVER carry a `?v=` query: every module imports `../script.js` bare, and a versioned tag URL splits ES-module identity so `script.js` evaluates twice and registers every delegated handler twice (all inline-drawer toggles break). Stale-cache protection comes from `src/middleware/frontend-assets.js` serving JS with `Cache-Control: no-cache`, not from URL versioning. |
 | Target seam | `public/scripts/ooc-blocks.js` for retention behavior; `public/css/sillybunny-chat-styles.css` and `public/scripts/power-user.js` for core transparency behavior. |
 | Adapter shape | Keep HTML changes limited to static boot references and settings labels/tooltips. |
-| Protecting tests | `tests/frontend-assets.test.js`, `tests/ooc-blocks.test.js`, `tests/core-message-transparency.test.js`. |
-| Validation | `npm run test:unit --prefix tests -- frontend-assets.test.js ooc-blocks.test.js`, `npm run test:unit --prefix tests -- core-message-transparency.test.js`, `npm run build:frontend`, browser smoke check. |
+| Protecting tests | `tests/script-module-identity.test.js`, `tests/frontend-assets.test.js`, `tests/ooc-blocks.test.js`, `tests/core-message-transparency.test.js`. |
+| Validation | `npm run test:unit --prefix tests -- script-module-identity.test.js frontend-assets.test.js ooc-blocks.test.js`, `npm run test:unit --prefix tests -- core-message-transparency.test.js`, `npm run build:frontend`, browser smoke check. |
 | Rollback path | Restore versioned `script.js` references, previous settings copy, and remove core transparency slider markup if cache behavior or settings semantics regress. Chat transparency CSS loading rolls back through `public/scripts/power-user.js`. |
-| Last reviewed | 2026-06-06 Bug 1 transparency migration. |
+| Last reviewed | 2026-06-11 script.js module-identity regression fix (double-evaluated frontend after #413 re-versioned the tag; inline drawers dead). |
 | Owner | Refactor integrator. |
 
 ### `public/index.html` - mobile stylesheet media gates

--- a/public/index.html
+++ b/public/index.html
@@ -18,7 +18,7 @@
         }
     </style>
     <link rel="preload" as="style" href="style.css?v=20260610a">
-    <link rel="modulepreload" href="script.js?v=20260611b">
+    <link rel="modulepreload" href="script.js">
     <link rel="modulepreload" href="scripts/sillybunny-tabs.js?v=20260611a">
     <link rel="preload" as="font" type="font/woff2" href="webfonts/Figtree/Figtree-Regular.woff2?v=20260422b" crossorigin>
     <link rel="manifest" crossorigin="use-credentials" href="manifest.json">
@@ -8867,7 +8867,7 @@
     <script type="module" src="lib/eventemitter.js"></script>
     <script type="module" src="scripts/i18n.js"></script>
     <script type="module" src="scripts/performance-loader.js"></script>
-    <script type="module" src="script.js?v=20260611b"></script>
+    <script type="module" src="script.js"></script>
     <script type="module" src="scripts/sillybunny-tabs.js?v=20260611a"></script>
     <script>
         window.addEventListener('load', (event) => {

--- a/tests/frontend-assets.test.js
+++ b/tests/frontend-assets.test.js
@@ -73,13 +73,10 @@ describe('frontend asset manifest rewriting', () => {
         expect(FRONTEND_ASSET_PREFIX).toBe('/frontend-assets/');
     });
 
-    test('loads the main app module through a versioned URL', () => {
-        const indexHtml = fs.readFileSync(path.join(process.cwd(), '..', 'public', 'index.html'), 'utf8');
-
-        expect(indexHtml).toContain('<link rel="modulepreload" href="script.js?v=20260611b">');
-        expect(indexHtml).toContain('<script type="module" src="script.js?v=20260611b"></script>');
-    });
-
+    // The 'loads the main app module through a versioned URL' test was removed:
+    // it pinned the regression that double-evaluated script.js (module identity
+    // splits when the tag URL carries ?v= but bare '../script.js' imports do not).
+    // tests/script-module-identity.test.js owns the corrected invariant.
     test('only treats fingerprinted frontend asset names as immutable', () => {
         expect(HASHED_FRONTEND_ASSET_RE.test('script-0123456789ab.js')).toBe(true);
         expect(HASHED_FRONTEND_ASSET_RE.test('scripts/extensions-abcdef123456.js')).toBe(true);

--- a/tests/script-module-identity.test.js
+++ b/tests/script-module-identity.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, test } from '@jest/globals';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const indexHtml = readFileSync(path.join(repoRoot, 'public', 'index.html'), 'utf8');
+
+function collectJsFiles(dir, out = []) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const fullPath = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+            collectJsFiles(fullPath, out);
+        } else if (entry.name.endsWith('.js')) {
+            out.push(fullPath);
+        }
+    }
+
+    return out;
+}
+
+describe('frontend module identity', () => {
+    // Browsers key ES module identity by full URL, query string included. Every
+    // module imports '../script.js' bare, so a cache-busting query on the
+    // index.html script.js tag makes the browser evaluate script.js twice and
+    // register every delegated event handler twice (toggles then no-op because
+    // each click fires both copies). Stale-cache protection comes from the
+    // frontend-assets middleware serving JS with Cache-Control: no-cache.
+    test('script.js loads under its bare URL so module identity matches bare imports', () => {
+        expect(indexHtml).toContain('<link rel="modulepreload" href="script.js">');
+        expect(indexHtml).toContain('<script type="module" src="script.js"></script>');
+        expect(indexHtml).not.toMatch(/(?:src|href)="script\.js\?/);
+    });
+
+    test('cache-busted module tags are never bare-imported elsewhere', () => {
+        const versionedModuleSrcs = [...indexHtml.matchAll(/<script type="module" src="([^"]+)\?[^"]*">/g)]
+            .map(match => match[1]);
+        const jsFiles = collectJsFiles(path.join(repoRoot, 'public'));
+
+        for (const src of versionedModuleSrcs) {
+            const basename = path.posix.basename(src).replace(/\./g, '\\.');
+            const importPattern = new RegExp(`(?:from\\s*|import\\s*\\(\\s*)['"][^'"]*${basename}['"]`);
+            const offenders = jsFiles.filter(file => importPattern.test(readFileSync(file, 'utf8')));
+
+            expect(offenders).toEqual([]);
+        }
+    });
+});


### PR DESCRIPTION
## What

Removes the `?v=20260611b` query from the two `script.js` references in `public/index.html` (modulepreload + module tag), replaces the test that pinned the versioned URL with a module-identity regression test, and updates the upstream-touch ledger entry that documents this invariant.

## Why

#413 versioned the `script.js` tag URL. Browsers key ES-module identity by **full URL**, and every frontend module imports `../script.js` **bare** — so the browser evaluated `script.js` twice (once as `script.js?v=20260611b` via the tag, once as `script.js` via the import graph). Both evaluations ran init and registered every delegated click handler **twice**: each click on an inline-drawer toggle fired two `slideToggle`s, so all settings dropdowns (Token Budget / Output / Advanced & Reasoning, and every other inline drawer) opened-and-instantly-closed — visually dead. Reported live after today's staging pull.

The ledger (`public/index.html — boot assets and settings copy`) has documented "script.js loaded through its canonical URL" as a fork invariant since 2026-06-06; #413 regressed it without a protecting test. Stale-cache protection (the reason for the `?v=`) is already provided by the frontend-assets middleware serving every JS file with `Cache-Control: no-cache`.

## How

- `public/index.html`: `script.js?v=20260611b` → `script.js` in the modulepreload link and the module script tag. `sillybunny-tabs.js?v=` is untouched — nothing imports it, so its identity cannot split.
- `tests/script-module-identity.test.js` (new): pins the bare references, and generically asserts that **no** cache-busted `type="module"` tag is bare-imported anywhere under `public/` (fails on the exact #413 mistake for any module).
- `tests/frontend-assets.test.js`: removed the `loads the main app module through a versioned URL` test — it pinned the regression itself.
- `docs/upstream-touch-ledger.md`: index.html entry now spells out the module-identity mechanism, names the new protecting test, and bumps last-reviewed.

## Testing

- New test fails on the unfixed tree (2/2 red on `fead27e22`), passes after the fix.
- Full unit suite: **116/116 suites, 1054/1054 tests green** (only delta vs staging: removed regression-pinning test, added 2 identity tests).
- Root `npm run lint` clean. The 25 tests-dir lint problems are pre-existing on staging (today's #413/#418/#420/#421 test files), untouched here.
- Live-browser verification on port 4567 (msedge headless probe, junction-linked profile):
  - Before: `script.js` fetched under **two** URLs; `.inline-drawer-toggle` delegated handler registered **2×** (243 total delegated click handlers); clicking the Token Budget header left content `display:none`, chevron stuck `down`.
  - After: single `script.js` fetch; handler registered **1×** (138 total); click opens the drawer (`display:block`, chevron `up`).

Single clean revert; no behavior beyond restoring the documented boot reference shape.