### PR TITLE
chore(tests): pin @playwright/test to 1.60.0 for chromium 1223

### DIFF
--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -7,7 +7,7 @@
             "name": "sillytavern-tests",
             "license": "AGPL-3.0",
             "dependencies": {
-                "@playwright/test": "^1.56.1",
+                "@playwright/test": "1.60.0",
                 "@types/jest": "^29.5.12",
                 "eslint": "^8.57.0",
                 "eslint-plugin-jest": "^27.9.0",
@@ -1024,12 +1024,12 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.56.1",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
-            "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+            "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.56.1"
+                "playwright": "1.60.0"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -3909,12 +3909,12 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.56.1",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
-            "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+            "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.56.1"
+                "playwright-core": "1.60.0"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -3927,9 +3927,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.56.1",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
-            "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+            "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
             "license": "Apache-2.0",
             "bin": {
                 "playwright-core": "cli.js"

--- a/tests/package.json
+++ b/tests/package.json
@@ -10,7 +10,7 @@
         "lint:fix": "eslint \"**/*.js\" ./*.js --fix"
     },
     "dependencies": {
-        "@playwright/test": "^1.56.1",
+        "@playwright/test": "1.60.0",
         "@types/jest": "^29.5.12",
         "eslint": "^8.57.0",
         "eslint-plugin-jest": "^27.9.0",


### PR DESCRIPTION
## What
Pins `@playwright/test` to exactly `1.60.0` (latest; was `^1.56.1` locked at 1.56.1) in `tests/`.

## Why
The dev machine''s Playwright browser cache now holds Chromium **1223** only — the rev 1194 that 1.56.1 expects is gone, and `playwright install` stalls on this machine, so the locked toolchain cannot launch a browser at all. `@playwright/test` 1.60.0 (current `latest`) expects exactly rev 1223, restoring local e2e with zero downloads. The exact pin (no caret) keeps the required browser revision from drifting ahead of the installed cache on a future `npm install`.

## Testing
- Lockfile delta is exclusively the three playwright packages 1.56.1 → 1.60.0.
- `playwright-core/browsers.json` at 1.60.0 lists chromium/headless-shell revision 1223 — matching the installed cache (markers intact).
- Full mobile-shell e2e smoke evidence on 1.60.0 lands with the next program PR (2.3), which runs the pack as its verification net.