### PR TITLE
chore: layer fork stylesheets and consolidate top-bar mobile rules

### DIFF
--- a/public/css/sillybunny-chat-styles.css
+++ b/public/css/sillybunny-chat-styles.css
@@ -1,3 +1,4 @@
+@layer sb-chat {
 /* Built-in SillyBunny ports of Moonlit Echoes chat layouts.
    Extracted from SillyBunny-MoonlitEchoesTheme/style.css and kept scoped to
    the native Echo, Whisper, Hush, Ripple, and Tide body classes. */
@@ -1576,5 +1577,29 @@ body:is(.echostyle, .whisperstyle, .hushstyle, .ripplestyle, .tidestyle) #chat .
     body.ripplestyle #chat .mes:not(.smallSysMes) .mes_text {
         margin-top: 0 !important;
         padding-top: 0 !important;
+    }
+}
+}
+
+/* Unlayered fork cascade guards for upstream rules that beat layered chat-style rules. */
+/* Must beat upstream public/style.css:1315 .mes. */
+body:is(.echostyle, .whisperstyle, .hushstyle, .tidestyle) #chat .mes {
+    display: block;
+}
+
+/* Must beat upstream public/style.css:1662 .mes_text. */
+body.tidestyle #chat .mes .mes_text {
+    max-width: 74%;
+}
+
+/* Must beat upstream public/style.css:1378 .swipe_left, .swipe_right. */
+body:is(.echostyle, .whisperstyle, .hushstyle, .tidestyle) #chat .last_mes :is(.swipe_right, .swipe_left) {
+    opacity: 0.6;
+}
+
+@media screen and (min-width: 1001px) {
+    /* Must beat upstream public/style.css:3521 .mes_block .ch_name. */
+    body:is(.echostyle, .whisperstyle, .hushstyle, .tidestyle) #chat .mes:not(.smallSysMes) .mes_block .ch_name {
+        align-items: center;
     }
 }

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -1,3 +1,4 @@
+@layer sb-shell {
 /* SillyBunny mobile shell foundation: final sheet contract for modal drawers.
  * Keep this at the end of the shell sheet so it beats older mobile drawer rules. */
 @media screen and (max-width: 768px) {
@@ -1060,12 +1061,12 @@
 
     #sb-topbar-primary .sb-proxy-button i,
     #sb-topbar-primary .sb-chatbar-button > i {
-        width: 1em !important;
-        height: 1em !important;
-        flex: 0 0 auto !important;
+        width: 1em;
+        height: 1em;
+        flex: 0 0 auto;
         display: inline-flex !important;
-        align-items: center !important;
-        justify-content: center !important;
+        align-items: center;
+        justify-content: center;
         font-size: calc(var(--sb-mobile-toggle-size) * 0.48) !important;
         line-height: 1 !important;
         margin: 0 !important;
@@ -1106,6 +1107,19 @@
         padding: 0 var(--sb-topbar-padding-x);
     }
 
+    /* Keep phone-width top-bar surface overrides in the mobile shell sheet. */
+    :root:not([data-sb-theme]) #top-bar,
+    :root[data-sb-theme='clean-minimal'] #top-bar {
+        background: var(--sb-topbar-surface-bg) !important;
+        backdrop-filter: blur(12px) saturate(110%) !important;
+        -webkit-backdrop-filter: blur(12px) saturate(110%) !important;
+    }
+
+    :root:not([data-sb-theme]) #top-bar::before,
+    :root[data-sb-theme='clean-minimal'] #top-bar::before {
+        opacity: var(--sb-shell-surface-opacity);
+    }
+
     #sb-topbar-stack {
         grid-template-rows:
             var(--sb-topbar-primary-height)
@@ -1115,7 +1129,7 @@
     }
 
     #sb-connection-strip {
-        display: none !important;
+        display: none;
     }
 
     #sb-chatbar {
@@ -2823,5 +2837,67 @@
     .streaming-display button {
         font-size: 0.82em;
         padding: 6px 10px;
+    }
+}
+}
+
+/* Unlayered fork cascade guards for upstream rules that beat layered mobile shell rules. */
+@media screen and (max-width: 768px) {
+    /* Must beat upstream public/style.css:971 #form_sheld. */
+    #form_sheld {
+        margin: var(--sb-chat-composer-gap) auto 0;
+    }
+
+    /* Must beat upstream public/css/mobile-styles.css:1096 #send_form. */
+    #send_form {
+        border-width: 1px 0 0;
+        border-color: color-mix(in srgb, var(--SmartThemeBodyColor) 18%, transparent);
+    }
+
+    /* Must beat the unlayered theme focus guard after upstream public/css/mobile-styles.css:1096 #send_form. */
+    #send_form:focus-within {
+        border-top-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 56%, transparent);
+        box-shadow:
+            0 -10px 28px color-mix(in srgb, var(--SmartThemeShadowColor) 16%, transparent),
+            0 0 0 1px color-mix(in srgb, var(--color-primary, var(--sb-accent)) 24%, transparent),
+            inset 0 1px 0 color-mix(in srgb, var(--color-primary, var(--sb-accent)) 34%, transparent),
+            inset 0 0 0 1px color-mix(in srgb, var(--sb-focus-ring) 24%, transparent);
+    }
+
+    /* Must beat the unlayered base/focus #send_form guards while generating. */
+    #send_form.sb-generating-controls {
+        border-top-color: color-mix(in srgb, var(--sb-generating-glow-color, var(--SmartThemeQuoteColor)) 78%, transparent);
+        box-shadow:
+            0 -10px 28px color-mix(in srgb, var(--SmartThemeShadowColor) 16%, transparent),
+            0 -6px 24px color-mix(in srgb, var(--sb-generating-glow-color, var(--SmartThemeQuoteColor)) 28%, transparent),
+            0 0 0 1px color-mix(in srgb, var(--sb-generating-glow-color, var(--SmartThemeQuoteColor)) 52%, transparent),
+            inset 0 1px 0 color-mix(in srgb, var(--sb-generating-glow-color, var(--SmartThemeQuoteColor)) 52%, transparent);
+    }
+
+    /* Must beat upstream public/style.css:862 #top-bar. */
+    #top-bar {
+        height: var(--sb-topbar-layout-offset);
+    }
+
+    /* Must beat upstream public/css/mobile-styles.css:165 #right-nav-panel #CharListButtonAndHotSwaps. */
+    #right-nav-panel.openDrawer > #CharListButtonAndHotSwaps {
+        display: flex;
+    }
+
+    /* Must beat upstream public/style.css:2875 #right-nav-panel-tabs. */
+    #right-nav-panel.openDrawer:is([data-menu-type="character_edit"], [data-menu-type="create"]) #right-nav-panel-tabs {
+        display: grid;
+    }
+
+    /* Must beat upstream public/css/tags.css:162 .rm_tag_controls. */
+    #right-nav-panel.openDrawer .rm_tag_controls {
+        flex-wrap: nowrap;
+    }
+
+    /* Must beat upstream public/style.css:3489 .character_name_block_sub_line. */
+    #right-nav-panel.openDrawer #rm_print_characters_block .character_name_block_sub_line {
+        position: static;
+        right: auto;
+        top: auto;
     }
 }

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -1,3 +1,4 @@
+@layer sb-tabs {
 /* =============================================================================
    SillyBunny Navigation Shell
    ============================================================================= */
@@ -7685,4 +7686,47 @@ body.charListGrid #right-nav-panel.openDrawer #rm_print_characters_block:not(.gr
         animation: none !important;
         transition-duration: 0.01ms !important;
     }
+}
+}
+
+/* Unlayered fork cascade guards for upstream rules that beat layered shell layout rules. */
+/* Must beat upstream public/style.css:862/869 #top-bar. */
+#top-bar {
+    z-index: var(--sb-z-shell);
+    align-items: flex-start;
+    height: var(--sb-topbar-layout-offset);
+}
+
+/* Must beat upstream public/style.css:878/879/882 #sheld. */
+#sheld {
+    top: var(--sb-topbar-layout-offset);
+    height: calc(100dvh - var(--sb-topbar-layout-offset) - 1px);
+    max-height: calc(100dvh - var(--sb-topbar-layout-offset) - 1px);
+}
+
+/* Must beat upstream public/style.css:5142/5143 #select_chat_popup. */
+#select_chat_popup {
+    max-height: calc(100vh - var(--sb-topbar-layout-offset));
+    max-height: calc(100dvh - var(--sb-topbar-layout-offset));
+}
+
+/* Must beat upstream public/style.css:6042/6043 #top-settings-holder. */
+#top-settings-holder {
+    position: fixed;
+    z-index: var(--sb-z-shell-panel);
+}
+
+/* Must beat upstream public/style.css:6051 .drawer. */
+#top-settings-holder > .sb-drawer-host:not(.sb-embedded-drawer) {
+    width: 0;
+    min-width: 0;
+    flex: 0 0 auto;
+    overflow: hidden;
+}
+
+/* Must beat upstream public/style.css:6267 .fillRight. */
+.sb-shell-root.fillLeft.openDrawer,
+.sb-shell-root.fillRight.openDrawer,
+#right-nav-panel.openDrawer {
+    z-index: var(--sb-z-shell-panel);
 }

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -1,3 +1,6 @@
+@layer sb-theme, sb-tabs, sb-chat, sb-shell;
+
+@layer sb-theme {
 /* =============================================================================
    SillyBunny Theme Overhaul
    ============================================================================= */
@@ -1751,12 +1754,6 @@ body.bubblechat .mes[is_user='true'] .mes_block {
         }
     }
 
-    :root:not([data-sb-theme]) #top-bar,
-    :root[data-sb-theme='clean-minimal'] #top-bar {
-        background: var(--sb-topbar-surface-bg) !important;
-        backdrop-filter: blur(12px) saturate(110%);
-        -webkit-backdrop-filter: blur(12px) saturate(110%);
-    }
 
     :root:not([data-sb-theme]) #send_form,
     :root[data-sb-theme='clean-minimal'] #send_form {
@@ -1771,11 +1768,9 @@ body.bubblechat .mes[is_user='true'] .mes_block {
         background: var(--sb-mobile-default-input-solid);
     }
 
-    :root:not([data-sb-theme]) #top-bar::before,
     :root:not([data-sb-theme]) #send_form::before,
     :root:not([data-sb-theme]) #sb-chatbar::before,
     :root:not([data-sb-theme]) #sb-mobile-chat-tools-panel::before,
-    :root[data-sb-theme='clean-minimal'] #top-bar::before,
     :root[data-sb-theme='clean-minimal'] #send_form::before,
     :root[data-sb-theme='clean-minimal'] #sb-chatbar::before,
     :root[data-sb-theme='clean-minimal'] #sb-mobile-chat-tools-panel::before {
@@ -5816,4 +5811,89 @@ input[type='range']::-moz-range-thumb {
         padding-inline: 4px;
         text-align: center;
     }
+}
+}
+
+/* Unlayered fork cascade guards for upstream rules that beat layered theme rules. */
+/* Must beat upstream public/style.css:91 :root. */
+:root {
+    --color-surface: color-mix(in srgb, var(--SmartThemeBlurTintColor) 96%, var(--SmartThemeBodyColor) 4%);
+}
+
+/* Must beat upstream public/style.css:957 #chat. */
+#chat {
+    bottom: 0;
+}
+
+/* Must beat upstream public/style.css:864/865/866/867/868 #top-bar. */
+#top-bar {
+    background:
+        linear-gradient(180deg, color-mix(in srgb, var(--sb-shell-header-glow) 80%, transparent), transparent 110%),
+        var(--sb-topbar-surface-bg);
+    border-bottom: 1px solid color-mix(in srgb, var(--sb-shell-border) 90%, transparent);
+    box-shadow: 0 12px 28px color-mix(in srgb, var(--SmartThemeShadowColor) 16%, transparent);
+    backdrop-filter: blur(24px);
+    -webkit-backdrop-filter: blur(24px);
+}
+
+/* Must keep the Safari workaround above the unlayered public/style.css:852 #top-bar guard. */
+body.safari-macos #top-bar {
+    border-bottom-color: transparent;
+    box-shadow:
+        0 1px 0 color-mix(in srgb, var(--sb-shell-border) 90%, transparent),
+        0 12px 28px color-mix(in srgb, var(--SmartThemeShadowColor) 16%, transparent);
+}
+
+/* Must beat upstream public/style.css:6130 .inline-drawer-header. */
+.inline-drawer-header {
+    background: var(--color-surface-strong, color-mix(in srgb, var(--SmartThemeBlurTintColor) 90%, var(--SmartThemeBodyColor) 10%));
+}
+
+/* Must beat upstream public/style.css:971/978 #form_sheld. */
+#form_sheld {
+    margin: var(--sb-chat-composer-gap) auto 0;
+}
+
+/* Must beat upstream public/style.css:995 #nonQRFormItems. */
+#nonQRFormItems {
+    padding: 4px 6px;
+}
+
+/* Must beat upstream public/style.css:1027/1031 send-form action controls. */
+#leftSendForm > div,
+#rightSendForm > div:not(.mes_stop),
+#send_form .mes_stop,
+#options_button {
+    width: var(--sb-composer-action-size);
+    border: 1px solid color-mix(in srgb, var(--sb-shell-border) 82%, transparent);
+}
+
+/* Must beat upstream public/css/mobile-styles.css:1096 #send_form. */
+#send_form:focus-within {
+    border-color: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 56%, var(--sb-shell-border));
+}
+
+/* Must beat upstream public/style.css:4909/4914 .mes_buttons, .extraMesButtons. */
+#chat .mes .mes_buttons,
+#chat .mes .extraMesButtons {
+    gap: 3px;
+    padding: 0;
+}
+
+/* Must beat upstream public/style.css:5074/5077/5078 .edit_textarea, .reasoning_edit_textarea. */
+#chat .edit_textarea,
+#chat .reasoning_edit_textarea {
+    padding: 12px 14px;
+    background: color-mix(in srgb, var(--color-primary, var(--sb-accent)) 8%, var(--sb-input-bg));
+    line-height: calc(var(--mainFontSize) + 0.35rem);
+}
+
+/* Must beat upstream public/style.css:5996 #CustomCSS-textAreaBlock. */
+#CustomCSS-textAreaBlock {
+    display: flex;
+}
+
+/* Must beat upstream public/style.css:3103 #rm_extensions_block. */
+#rm_extensions_block {
+    overflow: visible;
 }

--- a/tests/mobile-css-budgets.test.js
+++ b/tests/mobile-css-budgets.test.js
@@ -13,6 +13,20 @@ function countImportant(cssSource) {
     return (cssSource.match(/!important/g) ?? []).length;
 }
 
+function countBraceDepthBefore(cssSource, index) {
+    let depth = 0;
+
+    for (const char of cssSource.slice(0, index)) {
+        if (char === '{') {
+            depth += 1;
+        } else if (char === '}') {
+            depth -= 1;
+        }
+    }
+
+    return depth;
+}
+
 function getMediaQueryPxValues(cssSource) {
     const pxValues = new Set();
 
@@ -29,12 +43,43 @@ function getMediaQueryPxValues(cssSource) {
 // test landed. Lower them as cleanup PRs land; never raise them without a
 // review note explaining the regression.
 const FORK_SHEET_IMPORTANT_BUDGETS = Object.freeze({
-    'sillybunny-mobile-shell.css': 664,
+    'sillybunny-mobile-shell.css': 661,
     'sillybunny-tabs.css': 386,
     'sillybunny-chat-styles.css': 225,
-    'sillybunny-theme.css': 158,
+    'sillybunny-theme.css': 157,
 });
 
+const FORK_SHEET_LAYERS = Object.freeze({
+    'sillybunny-theme.css': 'sb-theme',
+    'sillybunny-tabs.css': 'sb-tabs',
+    'sillybunny-chat-styles.css': 'sb-chat',
+    'sillybunny-mobile-shell.css': 'sb-shell',
+});
+
+const FORK_LAYER_ORDER = 'sb-theme, sb-tabs, sb-chat, sb-shell';
+const FORK_UNLAYERED_GUARD_PINS = Object.freeze({
+    'sillybunny-theme.css': [
+        '/* Must beat upstream public/style.css:91 :root. */',
+        '/* Must beat upstream public/style.css:864/865/866/867/868 #top-bar. */',
+        '/* Must beat upstream public/style.css:5996 #CustomCSS-textAreaBlock. */',
+    ],
+    'sillybunny-tabs.css': [
+        '/* Must beat upstream public/style.css:862/869 #top-bar. */',
+        '/* Must beat upstream public/style.css:6051 .drawer. */',
+        '/* Must beat upstream public/style.css:6267 .fillRight. */',
+    ],
+    'sillybunny-chat-styles.css': [
+        '/* Must beat upstream public/style.css:1315 .mes. */',
+        '/* Must beat upstream public/style.css:1662 .mes_text. */',
+        '/* Must beat upstream public/style.css:1378 .swipe_left, .swipe_right. */',
+    ],
+    'sillybunny-mobile-shell.css': [
+        '/* Must beat upstream public/style.css:971 #form_sheld. */',
+        '/* Must beat upstream public/css/mobile-styles.css:1096 #send_form. */',
+        '/* Must beat the unlayered base/focus #send_form guards while generating. */',
+        '/* Must beat upstream public/css/tags.css:162 .rm_tag_controls. */',
+    ],
+});
 const FORK_DISTINCT_BREAKPOINT_BUDGET = 18;
 
 const forkSheetSources = Object.fromEntries(
@@ -62,6 +107,39 @@ describe('mobile css ratchet budgets', () => {
         const sortedPxValues = [...pxValues].sort((left, right) => Number(left) - Number(right));
 
         expect(sortedPxValues.length).toBeLessThanOrEqual(FORK_DISTINCT_BREAKPOINT_BUDGET);
+    });
+
+    test('fork sheets declare the canonical layer order and wrappers', () => {
+        const normalizedThemeSource = forkSheetSources['sillybunny-theme.css'].replace(/\r\n/g, '\n');
+
+        expect(normalizedThemeSource.startsWith(`@layer ${FORK_LAYER_ORDER};\n\n@layer ${FORK_SHEET_LAYERS['sillybunny-theme.css']} {`)).toBe(true);
+
+        for (const [sheetName, layerName] of Object.entries(FORK_SHEET_LAYERS)) {
+            expect(forkSheetSources[sheetName]).toContain(`@layer ${layerName} {`);
+        }
+    });
+
+    test('mobile shell owns mobile top-bar surface overrides', () => {
+        expect(forkSheetSources['sillybunny-theme.css']).not.toContain(':root:not([data-sb-theme]) #top-bar,');
+        expect(forkSheetSources['sillybunny-theme.css']).not.toContain(":root[data-sb-theme='clean-minimal'] #top-bar::before,");
+        expect(forkSheetSources['sillybunny-mobile-shell.css']).toContain(':root:not([data-sb-theme]) #top-bar,');
+        expect(forkSheetSources['sillybunny-mobile-shell.css']).toContain(":root[data-sb-theme='clean-minimal'] #top-bar::before");
+        expect(forkSheetSources['sillybunny-mobile-shell.css']).toContain('background: var(--sb-topbar-surface-bg) !important;');
+        expect(forkSheetSources['sillybunny-mobile-shell.css']).toContain('opacity: var(--sb-shell-surface-opacity);');
+    });
+
+    test('fork sheets keep verified upstream collision guards outside layers', () => {
+        for (const [sheetName, pins] of Object.entries(FORK_UNLAYERED_GUARD_PINS)) {
+            const cssSource = forkSheetSources[sheetName];
+            const guardIndex = cssSource.indexOf('/* Unlayered fork cascade guards');
+
+            expect(guardIndex).toBeGreaterThan(-1);
+            expect(countBraceDepthBefore(cssSource, guardIndex)).toBe(0);
+
+            for (const pin of pins) {
+                expect(cssSource).toContain(pin);
+            }
+        }
     });
 });
 


### PR DESCRIPTION
## What?
Wrap the four fork-owned stylesheets in canonical cascade layers: `sb-theme`, `sb-tabs`, `sb-chat`, and `sb-shell`.

Move the phone-width default/clean-minimal `#top-bar` surface override into `sillybunny-mobile-shell.css`, then add trailing unlayered cascade guards for the verified upstream collisions introduced by layering.

Drop six redundant mobile-shell `!important` declarations and lower the mobile-shell/theme ratchet budgets to the new measured counts.

## Why?
Layering the fork stylesheets gives the fork a predictable intra-fork cascade order, but unlayered upstream styles beat normal declarations inside layers. The unlayered guard sections preserve the current fork winners for the verified collision set while still allowing the fork sheets to move into layers.

## How?
The theme sheet declares the layer order at the top, and each fork stylesheet wraps its existing rules in its assigned layer.

Each guard section sits outside the layer wrapper and includes comments naming the upstream rule it must beat. The guard set covers top-bar/shell geometry, the hidden top-settings drawer host, composer and edit-box chrome, character panel mobile layout, and custom chat-style layout rules.

The mobile-shell top-bar surface override keeps `!important` on the surface/filter declarations so it still wins over upstream/unlayered important background rules in the phone-width shell path.

`tests/mobile-css-budgets.test.js` now pins the layer wrappers, mobile top-bar ownership, guard sections at brace depth zero, and the lowered important-count ceilings.

## Testing?
- `git diff --check`
- `npm run lint`
- `npm run check:frontend-budgets`
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.json` — 117 suites / 1066 tests passed
- `SILLYBUNNY_TEST_BASE_URL=http://127.0.0.1:4567 npm run test:e2e -- mobile-shell-smoke.e2e.js` — 8/8 passed

## Screenshots (optional)
Before/after screenshots were captured during validation at 390x844, 768x1024, and 820x1180.

## Anything Else?
Draft PR for PR 2.3 of the mobile CSS consolidation sequence. No upstream-origin files are touched.
