### PR TITLE
chore: consolidate composer and bottom-bar mobile styles

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -10,14 +10,35 @@
         transform: none;
         box-sizing: border-box;
         margin: var(--sb-chat-composer-gap) auto 0;
+        padding-block-end: max(var(--sb-chat-composer-edge-gap), env(safe-area-inset-bottom, 0px));
     }
 
     #send_form {
         margin-bottom: 0;
+        padding: 4px 6px 6px;
         border-width: 1px 0 0;
         border-radius: 10px 10px 0 0;
         border-color: color-mix(in srgb, var(--SmartThemeBodyColor) 18%, transparent);
         box-shadow: 0 -10px 28px color-mix(in srgb, var(--SmartThemeShadowColor) 16%, transparent);
+    }
+
+    /* Keep phone-width composer surface overrides in the mobile shell sheet. */
+    :root:not([data-sb-theme]) #send_form,
+    :root[data-sb-theme='clean-minimal'] #send_form {
+        background: var(--sb-composer-surface-bg);
+        border-color: color-mix(in srgb, var(--SmartThemeBorderColor) 86%, transparent);
+        backdrop-filter: blur(12px) saturate(110%);
+        -webkit-backdrop-filter: blur(12px) saturate(110%);
+    }
+
+    :root:not([data-sb-theme]) #send_textarea,
+    :root[data-sb-theme='clean-minimal'] #send_textarea {
+        background: var(--sb-mobile-default-input-solid);
+    }
+
+    :root:not([data-sb-theme]) #send_form::before,
+    :root[data-sb-theme='clean-minimal'] #send_form::before {
+        opacity: var(--sb-shell-surface-opacity);
     }
 
     #send_form:focus-within {
@@ -2620,8 +2641,8 @@
         top: calc(var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) + var(--sb-mobile-shell-gap, 0px)) !important;
         bottom: auto !important;
         box-sizing: border-box !important;
-        height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset))) - var(--sb-mobile-shell-gap, 0px) - env(safe-area-inset-bottom, 0px)) !important;
-        max-height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset))) - var(--sb-mobile-shell-gap, 0px) - env(safe-area-inset-bottom, 0px)) !important;
+        height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset))) - var(--sb-mobile-shell-gap, 0px) - env(safe-area-inset-bottom, 0px))) !important;
+        max-height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset))) - var(--sb-mobile-shell-gap, 0px) - env(safe-area-inset-bottom, 0px))) !important;
     }
 }
 
@@ -2679,6 +2700,7 @@
 
     #sb-bottom-chat-bar {
         --sb-bottom-chat-mobile-gutter: max(6px, env(safe-area-inset-left, 0px), env(safe-area-inset-right, 0px));
+        --sb-bottom-chat-mobile-width: calc(100% - (var(--sb-bottom-chat-mobile-gutter) * 2));
         --sb-bottom-chat-mobile-gap: clamp(1px, calc(1.5px * var(--sb-bottom-bar-scale)), 3px);
         --sb-bottom-chat-mobile-padding-block: clamp(1px, calc(1.5px * var(--sb-bottom-bar-scale)), 2px);
         --sb-bottom-chat-mobile-padding-inline: clamp(3px, calc(4px * var(--sb-bottom-bar-scale)), 6px);
@@ -2686,6 +2708,137 @@
         --sb-bottom-chat-mobile-select-height: clamp(26px, calc(28px * var(--sb-bottom-bar-scale)), 32px);
         --sb-bottom-chat-mobile-persona-size: clamp(26px, calc(28px * var(--sb-bottom-bar-scale)), 32px);
         --sb-bottom-chat-mobile-radius: clamp(8px, calc(10px * var(--sb-bottom-bar-scale)), 13px);
+        width: min(var(--sb-bottom-chat-mobile-width), calc(100% - (var(--sb-bottom-chat-mobile-gutter) * 2)));
+        max-width: calc(100% - (var(--sb-bottom-chat-mobile-gutter) * 2));
+        display: grid;
+        grid-template-columns: var(--sb-bottom-chat-mobile-persona-size) minmax(0, 1fr) repeat(3, var(--sb-bottom-chat-mobile-button-size));
+        align-items: center;
+        justify-content: stretch;
+        gap: var(--sb-bottom-chat-mobile-gap);
+        margin: 0 auto;
+        padding: var(--sb-bottom-chat-mobile-padding-block) var(--sb-bottom-chat-mobile-padding-inline);
+        min-height: calc(var(--sb-bottom-chat-mobile-persona-size) + var(--sb-bottom-chat-mobile-padding-block) + var(--sb-bottom-chat-mobile-padding-block));
+        border-radius: var(--sb-bottom-chat-mobile-radius);
+    }
+
+    #sb-bottom-chat-select {
+        grid-column: 2;
+        grid-row: 1;
+        width: 100%;
+        min-width: 0;
+        height: var(--sb-bottom-chat-mobile-select-height);
+        min-height: var(--sb-bottom-chat-mobile-select-height);
+        max-height: var(--sb-bottom-chat-mobile-select-height);
+        padding: 0 clamp(6px, calc(8px * var(--sb-bottom-bar-scale)), 10px);
+        font-size: clamp(calc(var(--mainFontSize) * 0.68), calc(var(--mainFontSize) * 0.76 * var(--sb-bottom-bar-scale)), calc(var(--mainFontSize) * 0.86));
+        line-height: var(--sb-bottom-chat-mobile-select-height);
+        border-radius: clamp(10px, calc(11px * var(--sb-bottom-bar-scale)), 14px);
+    }
+
+    .sb-bottom-chat-collapse-toggle {
+        grid-column: 5;
+        grid-row: 1;
+        display: inline-flex;
+        justify-self: stretch;
+    }
+
+    .sb-bottom-chat-nav-actions {
+        grid-column: 3 / span 2;
+        grid-row: 1;
+        display: grid;
+        grid-template-columns: repeat(2, var(--sb-bottom-chat-mobile-button-size));
+        justify-self: stretch;
+        width: calc((var(--sb-bottom-chat-mobile-button-size) * 2) + var(--sb-bottom-chat-mobile-gap));
+    }
+
+    .sb-bottom-chat-search-toggle {
+        display: inline-flex;
+    }
+
+    .sb-bottom-chat-secondary-row {
+        grid-column: 1 / -1;
+        grid-row: 2;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        min-width: 0;
+        gap: var(--sb-bottom-chat-mobile-gap);
+        overflow-x: auto;
+        overflow-y: hidden;
+        scrollbar-width: none;
+        -webkit-overflow-scrolling: touch;
+        overscroll-behavior-x: contain;
+    }
+
+    .sb-bottom-chat-secondary-row::-webkit-scrollbar {
+        display: none;
+    }
+
+    #sb-bottom-chat-bar.sb-bottom-chat-secondary-collapsed .sb-bottom-chat-secondary-row {
+        display: none;
+    }
+
+    .sb-bottom-chat-search-field {
+        grid-column: 1 / -1;
+        grid-row: 3;
+        min-width: 100%;
+        height: var(--sb-bottom-chat-mobile-select-height);
+        min-height: var(--sb-bottom-chat-mobile-select-height);
+        max-height: var(--sb-bottom-chat-mobile-select-height);
+        padding: 0 clamp(8px, calc(9px * var(--sb-bottom-bar-scale)), 11px);
+        border-radius: clamp(10px, calc(11px * var(--sb-bottom-bar-scale)), 14px);
+    }
+
+    #sb-bottom-chat-bar:not(.sb-bottom-chat-search-open) .sb-bottom-chat-search-field {
+        display: none;
+    }
+
+    .sb-bottom-chat-search-field input {
+        height: calc(var(--sb-bottom-chat-mobile-select-height) - 14px);
+        font-size: clamp(calc(var(--mainFontSize) * 0.68), calc(var(--mainFontSize) * 0.74 * var(--sb-bottom-bar-scale)), calc(var(--mainFontSize) * 0.84));
+    }
+
+    .sb-bottom-chat-search-status {
+        max-width: 92px;
+        font-size: clamp(calc(var(--mainFontSize) * 0.58), calc(var(--mainFontSize) * 0.64 * var(--sb-bottom-bar-scale)), calc(var(--mainFontSize) * 0.72));
+    }
+
+    .sb-bottom-chat-nav-actions,
+    .sb-bottom-chat-management-actions {
+        flex: 0 0 auto;
+        flex-wrap: nowrap;
+        justify-content: center;
+        gap: var(--sb-bottom-chat-mobile-gap);
+    }
+
+    .sb-bottom-chat-management-actions {
+        width: max-content;
+    }
+
+    .sb-bottom-chat-nav-actions {
+        padding-inline-end: 0;
+        border-inline-end: 0;
+    }
+
+    #sb-persona-bubble {
+        grid-column: 1;
+        grid-row: 1;
+    }
+
+    .sb-bottom-chat-btn {
+        position: relative;
+        flex: 0 0 var(--sb-bottom-chat-mobile-button-size);
+        width: var(--sb-bottom-chat-mobile-button-size);
+        min-width: var(--sb-bottom-chat-mobile-button-size);
+        max-width: var(--sb-bottom-chat-mobile-button-size);
+        height: var(--sb-bottom-chat-mobile-button-size);
+        min-height: var(--sb-bottom-chat-mobile-button-size);
+        max-height: var(--sb-bottom-chat-mobile-button-size);
+        padding: 0;
+        border-radius: clamp(8px, calc(9px * var(--sb-bottom-bar-scale)), 12px);
+        font-size: clamp(calc(var(--mainFontSize) * 0.68), calc(var(--mainFontSize) * 0.78 * var(--sb-bottom-bar-scale)), calc(var(--mainFontSize) * 0.88));
+        line-height: 1;
     }
 
     #nonQRFormItems {
@@ -2779,6 +2932,18 @@
 
     body.ripplestyle #chat .mes:not(.smallSysMes) .mes_block {
         padding: 8px 16px 28px 12px !important;
+    }
+}
+
+@media screen and (max-width: 420px) {
+    #sb-bottom-chat-select {
+        flex-basis: 48px;
+        padding-inline: clamp(5px, calc(6px * var(--sb-bottom-bar-scale)), 8px);
+        font-size: clamp(calc(var(--mainFontSize) * 0.64), calc(var(--mainFontSize) * 0.72 * var(--sb-bottom-bar-scale)), calc(var(--mainFontSize) * 0.82));
+    }
+
+    .sb-bottom-chat-search-status {
+        max-width: 74px;
     }
 }
 

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -4293,7 +4293,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     flex: 1 1 auto;
     min-width: 0;
     width: 100%;
-    height: calc(17px * var(--sb-bottom-bar-scale)) !important;
+    height: calc(17px * var(--sb-bottom-bar-scale));
     min-height: 0 !important;
     margin: 0;
     padding: 0 !important;
@@ -4422,7 +4422,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     pointer-events: none;
 }
 
-@media screen and (max-width: 1000px) {
+@media screen and (min-width: 769px) and (max-width: 1000px) {
     #sb-bottom-chat-bar {
         --sb-bottom-chat-mobile-gutter: max(14px, env(safe-area-inset-left, 0px), env(safe-area-inset-right, 0px));
         --sb-bottom-chat-mobile-width: calc(100% - (var(--sb-bottom-chat-mobile-gutter) * 2));
@@ -4520,7 +4520,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     }
 
     .sb-bottom-chat-search-field input {
-        height: calc(var(--sb-bottom-chat-mobile-select-height) - 14px) !important;
+        height: calc(var(--sb-bottom-chat-mobile-select-height) - 14px);
         font-size: clamp(calc(var(--mainFontSize) * 0.68), calc(var(--mainFontSize) * 0.74 * var(--sb-bottom-bar-scale)), calc(var(--mainFontSize) * 0.84));
     }
 
@@ -4565,31 +4565,6 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
         font-size: clamp(calc(var(--mainFontSize) * 0.68), calc(var(--mainFontSize) * 0.78 * var(--sb-bottom-bar-scale)), calc(var(--mainFontSize) * 0.88));
         line-height: 1;
     }
-}
-
-@media screen and (max-width: 420px) {
-    #sb-bottom-chat-bar {
-        --sb-bottom-chat-mobile-gutter: max(4px, env(safe-area-inset-left, 0px), env(safe-area-inset-right, 0px));
-        --sb-bottom-chat-mobile-width: calc(100% - (var(--sb-bottom-chat-mobile-gutter) * 2));
-        --sb-bottom-chat-mobile-gap: clamp(1px, calc(1.5px * var(--sb-bottom-bar-scale)), 3px);
-        --sb-bottom-chat-mobile-padding-block: clamp(1px, calc(1.5px * var(--sb-bottom-bar-scale)), 2px);
-        --sb-bottom-chat-mobile-padding-inline: clamp(3px, calc(4px * var(--sb-bottom-bar-scale)), 6px);
-        --sb-bottom-chat-mobile-button-size: clamp(26px, calc(28px * var(--sb-bottom-bar-scale)), 32px);
-        --sb-bottom-chat-mobile-select-height: clamp(26px, calc(28px * var(--sb-bottom-bar-scale)), 32px);
-        --sb-bottom-chat-mobile-persona-size: clamp(26px, calc(28px * var(--sb-bottom-bar-scale)), 32px);
-        --sb-bottom-chat-mobile-radius: clamp(8px, calc(10px * var(--sb-bottom-bar-scale)), 13px);
-    }
-
-    #sb-bottom-chat-select {
-        flex-basis: 48px;
-        padding-inline: clamp(5px, calc(6px * var(--sb-bottom-bar-scale)), 8px);
-        font-size: clamp(calc(var(--mainFontSize) * 0.64), calc(var(--mainFontSize) * 0.72 * var(--sb-bottom-bar-scale)), calc(var(--mainFontSize) * 0.82));
-    }
-
-    .sb-bottom-chat-search-status {
-        max-width: 74px;
-    }
-
 }
 
 .sb-chat-delete-overlay {

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -1315,62 +1315,6 @@ select.text_pole:where(:not([multiple]):not([size]):not(.select2-hidden-accessib
     }
 }
 
-@media screen and (max-width: 768px) {
-    #send_form {
-        padding: 4px 6px 6px;
-    }
-
-    #nonQRFormItems {
-        align-items: flex-end;
-        gap: 6px;
-        padding: 3px 5px 2px;
-    }
-
-    #leftSendForm,
-    #rightSendForm {
-        width: auto !important;
-        min-width: max-content;
-        flex-wrap: nowrap !important;
-    }
-
-    #leftSendForm > div,
-    #rightSendForm > div:not(.mes_stop),
-    #options_button {
-        width: var(--sb-composer-action-size) !important;
-        min-width: var(--sb-composer-action-size) !important;
-        height: var(--sb-composer-action-size) !important;
-        min-height: var(--sb-composer-action-size) !important;
-        max-width: var(--sb-composer-action-size) !important;
-        max-height: var(--sb-composer-action-size) !important;
-    }
-
-    /* Override any optional theme-specific sizing. */
-    #leftSendForm > *,
-    #rightSendForm > *:not(.mes_stop),
-    #form_sheld #options_button {
-        width: var(--sb-composer-action-size) !important;
-        min-width: var(--sb-composer-action-size) !important;
-        height: var(--sb-composer-action-size) !important;
-        min-height: var(--sb-composer-action-size) !important;
-        max-width: var(--sb-composer-action-size) !important;
-        max-height: var(--sb-composer-action-size) !important;
-    }
-
-    #send_form .mes_stop {
-        width: var(--sb-composer-action-size);
-        min-width: var(--sb-composer-action-size);
-        max-width: var(--sb-composer-action-size);
-        height: var(--sb-composer-action-size);
-        min-height: var(--sb-composer-action-size);
-        max-height: var(--sb-composer-action-size);
-    }
-
-    #send_textarea {
-        min-height: 46px;
-        padding: 8px 10px;
-        font-size: var(--mainFontSize);
-    }
-}
 .popup {
     box-shadow: 0 26px 60px color-mix(in srgb, var(--SmartThemeShadowColor) 28%, transparent);
 }
@@ -1719,10 +1663,6 @@ body.bubblechat .mes[is_user='true'] .mes_block {
         --sb-message-icon-size: clamp(24px, calc(var(--bottomFormBlockSize, 36px) * 0.62), 30px);
     }
 
-    #form_sheld {
-        padding-block-end: max(var(--sb-chat-composer-edge-gap), env(safe-area-inset-bottom, 0px));
-    }
-
     :root:not([data-sb-theme]),
     :root[data-sb-theme='clean-minimal'] {
         --sb-mobile-default-surface-solid: color-mix(in srgb, var(--SmartThemeBlurTintColor) 92%, black 8%);
@@ -1754,24 +1694,8 @@ body.bubblechat .mes[is_user='true'] .mes_block {
         }
     }
 
-
-    :root:not([data-sb-theme]) #send_form,
-    :root[data-sb-theme='clean-minimal'] #send_form {
-        background: var(--sb-composer-surface-bg) !important;
-        border-color: color-mix(in srgb, var(--SmartThemeBorderColor) 86%, transparent) !important;
-        backdrop-filter: blur(12px) saturate(110%);
-        -webkit-backdrop-filter: blur(12px) saturate(110%);
-    }
-
-    :root:not([data-sb-theme]) #send_textarea,
-    :root[data-sb-theme='clean-minimal'] #send_textarea {
-        background: var(--sb-mobile-default-input-solid);
-    }
-
-    :root:not([data-sb-theme]) #send_form::before,
     :root:not([data-sb-theme]) #sb-chatbar::before,
     :root:not([data-sb-theme]) #sb-mobile-chat-tools-panel::before,
-    :root[data-sb-theme='clean-minimal'] #send_form::before,
     :root[data-sb-theme='clean-minimal'] #sb-chatbar::before,
     :root[data-sb-theme='clean-minimal'] #sb-mobile-chat-tools-panel::before {
         opacity: var(--sb-shell-surface-opacity) !important;
@@ -5489,26 +5413,6 @@ input[type='range']::-moz-range-thumb {
         border-radius: 999px;
     }
 
-    #leftSendForm > div,
-    #rightSendForm > div:not(.mes_stop),
-    #send_form .mes_stop,
-    #options_button {
-        width: var(--sb-composer-action-size);
-        min-width: var(--sb-composer-action-size);
-        height: var(--sb-composer-action-size);
-        min-height: var(--sb-composer-action-size);
-        max-height: var(--sb-composer-action-size);
-    }
-
-    #send_textarea {
-        min-height: 46px;
-        padding: 6px 8px;
-    }
-
-    :root[data-sb-compact-mode='true'] #send_textarea {
-        min-height: 38px;
-        padding: 5px 7px;
-    }
 }
 
 @media screen and (max-width: 480px) {

--- a/tests/mobile-css-budgets.test.js
+++ b/tests/mobile-css-budgets.test.js
@@ -44,9 +44,9 @@ function getMediaQueryPxValues(cssSource) {
 // review note explaining the regression.
 const FORK_SHEET_IMPORTANT_BUDGETS = Object.freeze({
     'sillybunny-mobile-shell.css': 661,
-    'sillybunny-tabs.css': 386,
+    'sillybunny-tabs.css': 384,
     'sillybunny-chat-styles.css': 225,
-    'sillybunny-theme.css': 157,
+    'sillybunny-theme.css': 141,
 });
 
 const FORK_SHEET_LAYERS = Object.freeze({
@@ -126,6 +126,22 @@ describe('mobile css ratchet budgets', () => {
         expect(forkSheetSources['sillybunny-mobile-shell.css']).toContain(":root[data-sb-theme='clean-minimal'] #top-bar::before");
         expect(forkSheetSources['sillybunny-mobile-shell.css']).toContain('background: var(--sb-topbar-surface-bg) !important;');
         expect(forkSheetSources['sillybunny-mobile-shell.css']).toContain('opacity: var(--sb-shell-surface-opacity);');
+    });
+
+    test('mobile shell owns mobile composer and bottom-chat responsive overrides', () => {
+        const normalizedThemeSource = forkSheetSources['sillybunny-theme.css'].replace(/\r\n/g, '\n');
+        const normalizedTabsSource = forkSheetSources['sillybunny-tabs.css'].replace(/\r\n/g, '\n');
+        const normalizedShellSource = forkSheetSources['sillybunny-mobile-shell.css'].replace(/\r\n/g, '\n');
+
+        expect(normalizedThemeSource).not.toContain('/* Override any optional theme-specific sizing. */');
+        expect(normalizedThemeSource).not.toContain(":root:not([data-sb-theme]) #send_form,\n    :root[data-sb-theme='clean-minimal'] #send_form");
+        expect(normalizedTabsSource).not.toContain('@media screen and (max-width: 1000px) {\n    #sb-bottom-chat-bar');
+        expect(normalizedTabsSource).not.toContain('@media screen and (max-width: 420px) {\n    #sb-bottom-chat-bar');
+
+        expect(normalizedTabsSource).toContain('@media screen and (min-width: 769px) and (max-width: 1000px) {\n    #sb-bottom-chat-bar');
+        expect(normalizedShellSource).toContain('/* Keep phone-width composer surface overrides in the mobile shell sheet. */');
+        expect(normalizedShellSource).toContain('padding-block-end: max(var(--sb-chat-composer-edge-gap), env(safe-area-inset-bottom, 0px));');
+        expect(normalizedShellSource).toContain('#sb-bottom-chat-bar:not(.sb-bottom-chat-search-open) .sb-bottom-chat-search-field');
     });
 
     test('fork sheets keep verified upstream collision guards outside layers', () => {


### PR DESCRIPTION
## What?
Consolidates phone-width composer and bottom-chat responsive styling into `sillybunny-mobile-shell.css`, leaving `sillybunny-tabs.css` responsible for the 769-1000px compact-desktop bottom-chat layout.

## Why?
Phase 2 is reducing mobile CSS ownership overlap so the shell sheet owns phone chrome behavior while the shared/theme sheets stop carrying duplicate mobile composer rules.

## How?
Moves the mobile composer surface overrides out of the theme sheet, moves the phone bottom-chat grid/layout overrides into the shell sheet, and narrows the tabs bottom-chat media query to compact desktop. Also fixes an unbalanced shell `calc()` declaration so later shell media blocks continue parsing, and lowers the CSS `!important` ratchets for tabs and theme.

## Testing?
- `git diff --check`
- `node --check public/scripts/sillybunny-tabs.js`
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.json mobile-css-budgets.test.js`
- `npm run lint`
- `npm run check:frontend-budgets`
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.json`
- `SILLYBUNNY_TEST_BASE_URL=http://127.0.0.1:4567 npm run test:e2e -- mobile-shell-smoke.e2e.js`

## Screenshots (optional)
Rendered checks were refreshed at 390x844, 768x1024, and 820x1180. The 390/768 views compute the bottom chat bar from the shell-owned mobile grid, the 820 view remains in the compact-desktop band, and all three reported zero horizontal overflow.

## Anything Else?
Merge after PR 2.3 on `staging`.