### PR TITLE
chore: tighten phase 2 mobile css ratchets

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -820,7 +820,7 @@
     }
 }
 
-@media screen and (min-width: 769px) and (max-width: 1180px) {
+@media screen and (min-width: 769px) and (max-width: 1000px) {
     /* SillyBunny: keep tablet full-screen shells edge-to-edge without overriding MovingUI resizing. */
     body:not(.movingUI) #sheld {
         width: 100vw;

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -220,6 +220,14 @@
     height: var(--sb-topbar-layout-offset);
     padding: max(env(safe-area-inset-top), 0px) var(--sb-topbar-padding-x) 0;
     overflow: visible;
+    isolation: isolate;
+    background:
+        linear-gradient(180deg, color-mix(in srgb, var(--sb-shell-header-glow) 80%, transparent), transparent 110%),
+        var(--sb-topbar-surface-bg);
+    border-bottom: 1px solid color-mix(in srgb, var(--sb-shell-border) 90%, transparent);
+    box-shadow: 0 12px 28px color-mix(in srgb, var(--SmartThemeShadowColor) 16%, transparent);
+    backdrop-filter: blur(24px);
+    -webkit-backdrop-filter: blur(24px);
 }
 
 @media (pointer: fine) and (hover: hover) {
@@ -236,6 +244,39 @@
 
 #top-bar * {
     pointer-events: auto;
+}
+
+#top-bar::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    background:
+        linear-gradient(180deg, color-mix(in srgb, var(--sb-shell-header-glow) 80%, transparent), transparent 110%),
+        var(--sb-topbar-surface-bg);
+    opacity: var(--sb-shell-surface-opacity);
+}
+
+/* Firefox and Chrome on macOS can mispaint the fixed header surface pseudo-element. */
+body:is(.firefox-macos, .chrome-macos) #top-bar {
+    background:
+        linear-gradient(180deg, color-mix(in srgb, var(--sb-shell-header-glow) 80%, transparent), transparent 110%),
+        var(--sb-topbar-surface-bg);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+}
+
+body:is(.firefox-macos, .chrome-macos) #top-bar::before {
+    display: none;
+}
+
+/* Safari on macOS can show a sub-pixel border artifact with backdrop-filter. */
+body.safari-macos #top-bar {
+    border-bottom-color: transparent;
+    box-shadow:
+        0 1px 0 color-mix(in srgb, var(--sb-shell-border) 90%, transparent),
+        0 12px 28px color-mix(in srgb, var(--SmartThemeShadowColor) 16%, transparent);
 }
 
 body.sb-topbar-dragging {
@@ -3314,7 +3355,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     gap: var(--sb-shell-space-xs);
 }
 
-@media screen and (max-width: 900px) {
+@media screen and (max-width: 1000px) {
     .sb-admin-card-header,
     .sb-server-config-meta {
         flex-direction: column;
@@ -4619,7 +4660,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     }
 }
 
-@media screen and (max-width: 480px) {
+@media screen and (max-width: 620px) {
     .sb-chat-delete-overlay {
         inset: 0;
         align-items: center;
@@ -4996,7 +5037,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     font-weight: 700;
 }
 
-@media screen and (max-width: 520px) {
+@media screen and (max-width: 620px) {
     #sb-persona-picker {
         min-width: min(300px, calc(100vw - 16px));
     }
@@ -5223,7 +5264,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     gap: 4px;
 }
 
-@media screen and (min-width: 1100px) {
+@media screen and (min-width: 1001px) {
     #right-nav-panel .sb-character-editor-controls-row {
         grid-template-columns: var(--sb-character-editor-avatar-size) minmax(0, 1fr) minmax(240px, 28rem);
         grid-template-areas:
@@ -6123,7 +6164,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     min-width: 0;
 }
 
-@media screen and (max-width: 900px) {
+@media screen and (max-width: 1000px) {
     #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #group_tags_div {
         grid-column: 1 / -1;
         width: min(448px, 100%);
@@ -6449,7 +6490,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     margin-left: auto;
 }
 
-@media screen and (max-width: 1420px) {
+@media screen and (max-width: 1000px) {
     #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack {
         grid-template-columns: auto minmax(0, 1fr);
     }
@@ -6465,7 +6506,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     }
 }
 
-@media screen and (max-width: 1180px) {
+@media screen and (max-width: 1000px) {
     #right-nav-panel:is([data-menu-type="group_create"], [data-menu-type="group_edit"]) #GroupFavDelOkBack {
         grid-template-columns: minmax(0, 1fr);
     }
@@ -7082,7 +7123,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     }
 }
 
-@media screen and (max-width: 1100px) {
+@media screen and (max-width: 1000px) {
     #left-nav-panel.openDrawer,
     #user-settings-block.openDrawer,
     .sb-shell-root.fillLeft.openDrawer,
@@ -7142,7 +7183,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     }
 }
 
-@media screen and (max-width: 1180px), screen and (max-height: 860px) {
+@media screen and (max-width: 1000px), screen and (max-height: 768px) {
     #left-nav-panel.openDrawer,
     #user-settings-block.openDrawer,
     .sb-shell-root.fillLeft.openDrawer,
@@ -7154,7 +7195,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     }
 }
 
-@media screen and (max-height: 860px) {
+@media screen and (max-height: 768px) {
     #left-nav-panel.openDrawer,
     #user-settings-block.openDrawer,
     .sb-shell-root.fillLeft.openDrawer,
@@ -7181,7 +7222,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     }
 }
 
-@media screen and (min-width: 1001px) and (max-width: 1440px) {
+@media screen and (min-width: 1001px) {
     #left-nav-panel.openDrawer,
     #user-settings-block.openDrawer {
         width: min(100vw, clamp(680px, 60vw, 920px)) !important;
@@ -7191,7 +7232,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 }
 
 /* Expansion of PR #145: Add compact mode scaling for laptop viewport panels */
-@media screen and (min-width: 1001px) and (max-width: 1440px) {
+@media screen and (min-width: 1001px) {
     :root[data-sb-compact-mode='true'] #left-nav-panel.openDrawer,
     :root[data-sb-compact-mode='true'] #user-settings-block.openDrawer {
         width: min(100vw, clamp(600px, 58vw, 810px)) !important;
@@ -7202,7 +7243,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 
 
 
-@media screen and (max-width: 450px) {
+@media screen and (max-width: 620px) {
     .sb-mobile-section-list {
         grid-template-columns: 1fr;
     }
@@ -7665,11 +7706,26 @@ body.charListGrid #right-nav-panel.openDrawer #rm_print_characters_block:not(.gr
 }
 
 /* Unlayered fork cascade guards for upstream rules that beat layered shell layout rules. */
-/* Must beat upstream public/style.css:862/869 #top-bar. */
+/* Must beat upstream public/style.css:862/864/865/866/867/868/869 #top-bar. */
 #top-bar {
     z-index: var(--sb-z-shell);
     align-items: flex-start;
     height: var(--sb-topbar-layout-offset);
+    background:
+        linear-gradient(180deg, color-mix(in srgb, var(--sb-shell-header-glow) 80%, transparent), transparent 110%),
+        var(--sb-topbar-surface-bg);
+    border-bottom: 1px solid color-mix(in srgb, var(--sb-shell-border) 90%, transparent);
+    box-shadow: 0 12px 28px color-mix(in srgb, var(--SmartThemeShadowColor) 16%, transparent);
+    backdrop-filter: blur(24px);
+    -webkit-backdrop-filter: blur(24px);
+}
+
+/* Must keep the Safari workaround above the unlayered public/style.css:852 #top-bar guard. */
+body.safari-macos #top-bar {
+    border-bottom-color: transparent;
+    box-shadow:
+        0 1px 0 color-mix(in srgb, var(--sb-shell-border) 90%, transparent),
+        0 12px 28px color-mix(in srgb, var(--SmartThemeShadowColor) 16%, transparent);
 }
 
 /* Must beat upstream public/style.css:878/879/882 #sheld. */

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -378,43 +378,6 @@ body::before {
     scroll-padding-bottom: 8px;
 }
 
-#top-bar {
-    position: relative;
-    isolation: isolate;
-    background:
-        linear-gradient(180deg, color-mix(in srgb, var(--sb-shell-header-glow) 80%, transparent), transparent 110%),
-        var(--sb-topbar-surface-bg);
-    border-bottom: 1px solid color-mix(in srgb, var(--sb-shell-border) 90%, transparent);
-    box-shadow: 0 12px 28px color-mix(in srgb, var(--SmartThemeShadowColor) 16%, transparent);
-    backdrop-filter: blur(24px);
-    -webkit-backdrop-filter: blur(24px);
-}
-
-#top-bar::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    z-index: -1;
-    pointer-events: none;
-    background:
-        linear-gradient(180deg, color-mix(in srgb, var(--sb-shell-header-glow) 80%, transparent), transparent 110%),
-        var(--sb-topbar-surface-bg);
-    opacity: var(--sb-shell-surface-opacity);
-}
-
-/* Firefox and Chrome on macOS can mispaint the fixed header surface pseudo-element. */
-body:is(.firefox-macos, .chrome-macos) #top-bar {
-    background:
-        linear-gradient(180deg, color-mix(in srgb, var(--sb-shell-header-glow) 80%, transparent), transparent 110%),
-        var(--sb-topbar-surface-bg) !important;
-    backdrop-filter: none !important;
-    -webkit-backdrop-filter: none !important;
-}
-
-body:is(.firefox-macos, .chrome-macos) #top-bar::before {
-    display: none !important;
-}
-
 /*
  * macOS browser compositors can mispaint contained/transformed descendants in
  * the top-bar stack, which shows up as a dark block in the center header area.
@@ -427,14 +390,6 @@ body:is(.firefox-macos, .chrome-macos, .safari-macos) #sb-chatbar-layer {
 
 body:is(.firefox-macos, .chrome-macos) #sb-chatbar-layer {
     will-change: auto !important;
-}
-
-/* Safari on macOS can show a sub-pixel border artifact with backdrop-filter. */
-body.safari-macos #top-bar {
-    border-bottom-color: transparent;
-    box-shadow:
-        0 1px 0 color-mix(in srgb, var(--sb-shell-border) 90%, transparent),
-        0 12px 28px color-mix(in srgb, var(--SmartThemeShadowColor) 16%, transparent);
 }
 
 hr {
@@ -719,7 +674,7 @@ h3:not(.popup h3):not(#chat h3) {
     margin-top: 0;
 }
 
-@media screen and (min-width: 769px) and (max-width: 1280px) and (pointer: fine) {
+@media screen and (min-width: 769px) and (max-width: 1000px) and (pointer: fine) {
     .checkbox_label {
         min-height: 32px;
         gap: 8px;
@@ -2390,7 +2345,7 @@ input[type='range']::-moz-range-thumb {
     grid-column: span 2;
 }
 
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 768px) {
     .sb-sampling-priority-row {
         grid-template-columns: 1fr;
     }
@@ -3091,7 +3046,7 @@ input[type='range']::-moz-range-thumb {
     }
 }
 
-@media screen and (max-width: 520px) {
+@media screen and (max-width: 620px) {
     .sb-sampling-control-card.sb-sampling-textgen-card:not(.sb-sampling-large-card):not(.sb-sampling-multi-card) > [data-tg-samplers] {
         gap: 6px;
     }
@@ -4106,7 +4061,7 @@ input[type='range']::-moz-range-thumb {
     border-radius: var(--sb-radius-md);
 }
 
-@media screen and (max-width: 850px) {
+@media screen and (max-width: 1000px) {
     .sb-setting-inline-copy-center {
         width: 100%;
         min-width: 0;
@@ -5415,7 +5370,7 @@ input[type='range']::-moz-range-thumb {
 
 }
 
-@media screen and (max-width: 480px) {
+@media screen and (max-width: 620px) {
     #AdvancedFormatting .title_restorable.standoutHeader {
         gap: 6px;
     }
@@ -5727,25 +5682,6 @@ input[type='range']::-moz-range-thumb {
 /* Must beat upstream public/style.css:957 #chat. */
 #chat {
     bottom: 0;
-}
-
-/* Must beat upstream public/style.css:864/865/866/867/868 #top-bar. */
-#top-bar {
-    background:
-        linear-gradient(180deg, color-mix(in srgb, var(--sb-shell-header-glow) 80%, transparent), transparent 110%),
-        var(--sb-topbar-surface-bg);
-    border-bottom: 1px solid color-mix(in srgb, var(--sb-shell-border) 90%, transparent);
-    box-shadow: 0 12px 28px color-mix(in srgb, var(--SmartThemeShadowColor) 16%, transparent);
-    backdrop-filter: blur(24px);
-    -webkit-backdrop-filter: blur(24px);
-}
-
-/* Must keep the Safari workaround above the unlayered public/style.css:852 #top-bar guard. */
-body.safari-macos #top-bar {
-    border-bottom-color: transparent;
-    box-shadow:
-        0 1px 0 color-mix(in srgb, var(--sb-shell-border) 90%, transparent),
-        0 12px 28px color-mix(in srgb, var(--SmartThemeShadowColor) 16%, transparent);
 }
 
 /* Must beat upstream public/style.css:6130 .inline-drawer-header. */

--- a/tests/mobile-css-budgets.test.js
+++ b/tests/mobile-css-budgets.test.js
@@ -46,7 +46,7 @@ const FORK_SHEET_IMPORTANT_BUDGETS = Object.freeze({
     'sillybunny-mobile-shell.css': 0,
     'sillybunny-tabs.css': 384,
     'sillybunny-chat-styles.css': 225,
-    'sillybunny-theme.css': 141,
+    'sillybunny-theme.css': 137,
 });
 
 const FORK_SHEET_LAYERS = Object.freeze({
@@ -60,11 +60,10 @@ const FORK_LAYER_ORDER = 'sb-theme, sb-tabs, sb-chat, sb-shell';
 const FORK_UNLAYERED_GUARD_PINS = Object.freeze({
     'sillybunny-theme.css': [
         '/* Must beat upstream public/style.css:91 :root. */',
-        '/* Must beat upstream public/style.css:864/865/866/867/868 #top-bar. */',
         '/* Must beat upstream public/style.css:5996 #CustomCSS-textAreaBlock. */',
     ],
     'sillybunny-tabs.css': [
-        '/* Must beat upstream public/style.css:862/869 #top-bar. */',
+        '/* Must beat upstream public/style.css:862/864/865/866/867/868/869 #top-bar. */',
         '/* Must beat upstream public/style.css:6051 .drawer. */',
         '/* Must beat upstream public/style.css:6267 .fillRight. */',
     ],
@@ -80,7 +79,7 @@ const FORK_UNLAYERED_GUARD_PINS = Object.freeze({
         '/* Must beat upstream public/css/tags.css:162 .rm_tag_controls. */',
     ],
 });
-const FORK_DISTINCT_BREAKPOINT_BUDGET = 18;
+const FORK_DISTINCT_BREAKPOINT_BUDGET = 6;
 
 const forkSheetSources = Object.fromEntries(
     Object.keys(FORK_SHEET_IMPORTANT_BUDGETS).map(sheetName => [sheetName, readPublicFile('css', sheetName)]),


### PR DESCRIPTION
## What?

This PR finishes the Phase 2 mobile CSS exit gates by tightening the fork stylesheet breakpoint and top-bar ownership ratchets.

## Why?

After PR 2.5, the mobile shell `!important` target was green, but the documented Phase 2 exit checks still found too many fork media-query px values and broad `#top-bar` ownership across three fork sheets. This cleanup makes those checks enforceable before Phase 3 visual work starts.

## How?

- Moves top-bar visual surface rules from `sillybunny-theme.css` into the existing shell/top-bar section of `sillybunny-tabs.css`.
- Consolidates the unlayered top-bar cascade guard into `sillybunny-tabs.css`, leaving broad `#top-bar` ownership in two fork sheets.
- Normalizes remaining ad-hoc fork media-query px values onto the canonical `420 / 620 / 768 / 769 / 1000 / 1001` bands.
- Lowers `FORK_DISTINCT_BREAKPOINT_BUDGET` from 18 to 6 and `sillybunny-theme.css` `!important` budget from 141 to 137.

## Testing?

- `git diff --check`
- `node --check public/scripts/sillybunny-tabs.js`
- `npm run lint`
- `npm run check:frontend-budgets`
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.json mobile-css-budgets.test.js`
- `npm run test:unit` — 117 suites / 1067 tests passed
- `SILLYBUNNY_TEST_BASE_URL=http://127.0.0.1:4567 npm run test:e2e -- mobile-shell-smoke.e2e.js` — 8/8 passed
- Render probe at 390, 768, 820, 1000, 1001, and 1440 widths: zero horizontal overflow and top-bar rendered fixed with expected surface.

## Screenshots (optional)

Reviewed smoke checkpoints for left drawer, nav open, chat tools, and short-viewport composer states. Screenshots are not embedded in this PR body.

## Anything Else?

This is the Phase 2 exit cleanup between PR #434 and the Phase 3 UX redesign PRs.
