### PR TITLE
fix: agent enable/disable toggle not responding on mobile

### DIFF
--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -1726,6 +1726,16 @@ function renderAgentList() {
 
             card.find('.ica--card-drag-handle').on('click', stopEvent);
 
+            // Prevent touch-punch (jQuery UI mouse widget polyfill) from
+            // capturing touchstart on these buttons. Inside a .sortable()
+            // container, touch-punch's _touchStart consults _mouseCapture
+            // which only checks `handle` (not `cancel`), so it swallows
+            // the touchstart and may never synthesize a click on mobile.
+            // Stopping propagation on touch events keeps them local.
+            const touchPassthrough = function (event) { event.stopPropagation(); };
+            card.find('.ica--card-toggle').on('touchstart touchend', touchPassthrough);
+            card.find('.ica--card-favorite').on('touchstart touchend', touchPassthrough);
+
             card.find('.ica--card-toggle').on('click', async function (event) {
                 stopEvent(event);
                 await toggleAgentEnabled(agent);

--- a/public/scripts/extensions/in-chat-agents/style.css
+++ b/public/scripts/extensions/in-chat-agents/style.css
@@ -1586,4 +1586,20 @@ button.ica--card-pill--version-update {
         display: inline-flex;
         touch-action: none;
     }
+
+    .ica--card-toggle::before {
+        content: '';
+        position: absolute;
+        inset: -14px -10px;
+    }
+
+    .ica--card-favorite {
+        position: relative;
+    }
+
+    .ica--card-favorite::before {
+        content: '';
+        position: absolute;
+        inset: -14px -10px;
+    }
 }


### PR DESCRIPTION
## Bug

On mobile, tapping the agent enable/disable toggle (the small pill switch on each agent card) sometimes does nothing. The same toggle works fine on desktop. Select mode checkbox and edit button work normally on mobile.

## Root Cause

The toggle is an empty `<button>` rendered inside a jQuery UI `.sortable()` container. The globally-loaded **jQuery UI touch-punch** polyfill (jquery.ui.touch-punch.min.js) binds `touchstart`/`touchend` on every sortable element. On the touch path, `_touchStart` calls `_mouseCapture` which only checks the `handle` option — it does **not** check `cancel` (which lists `.ica--card-toggle`). When the capture succeeds, touch-punch calls `event.preventDefault()` on the raw touch event, killing the browser's native click synthesis. The synthetic click it produces instead is only dispatched conditionally (e.g. skipped for slow ≥500 ms presses, or presses with any touch movement on the tiny 22×11 px mobile target). The result is the toggle `click` handler never fires.

This is corroborated by the fact that the `.ica--card-select` checkbox (a native `<input>`) works fine — touch-punch explicitly skips `input`/`textarea` targets.

## Fix

1. **`index.js`** — Bind a `touchstart touchend` handler on `.ica--card-toggle` and `.ica--card-favorite` that calls `event.stopPropagation()`. This prevents the touch events from bubbling up to the sortable container where touch-punch listens, preserving the browser's native tap → click path.

2. **`style.css`** — Add invisible `::before` hit-area extensions (`inset: -14px -10px`) on `.ica--card-toggle` and `.ica--card-favorite` inside the existing `(pointer: coarse)` media block, bringing the effective tap target closer to the 44 px floor enforced elsewhere — with zero visual change.

Desktop behavior is unaffected (no touch events fire; CSS changes are inside a coarse-pointer media query).

## Testing

- ESLint clean on both touched files.
- Verified: toggle responds to tap on mobile, card still opens the editor, favorite toggles, drag-reorder via handle still works.