### PR TITLE
fix(mobile): prevent iOS chat overscroll blanking and keyboard composer displacement

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -825,7 +825,10 @@
         /* SillyBunny: iOS 17 WebKit can misresolve dvh for the main shell. */
         body:not(.movingUI) #sheld {
             --sb-sheld-ios-available-height: calc(100vh - var(--sb-topbar-layout-offset));
-            top: var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) !important;
+            // SillyBunny: add visual-viewport top so that when iOS Safari shifts the
+            // viewport up (keyboard open) the shell moves with it instead of floating
+            // mid-screen above the composer.
+            top: calc(var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) + var(--sb-shell-viewport-top, 0px)) !important;
             height: calc(var(--sb-shell-available-height, var(--sb-sheld-ios-available-height)) - 1px) !important;
             max-height: calc(var(--sb-shell-available-height, var(--sb-sheld-ios-available-height)) - 1px) !important;
             min-height: 100px !important;

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -2252,8 +2252,8 @@ function getShellViewportSize() {
     return {
         width,
         height,
-        left: 0,
-        top: 0,
+        left: Math.max(0, Math.round(readFiniteViewportNumber(visualViewport?.offsetLeft, 0))),
+        top: Math.max(0, Math.round(readFiniteViewportNumber(visualViewport?.offsetTop, 0))),
         right: width,
         bottom: height,
     };
@@ -2271,6 +2271,10 @@ function syncShellViewportBounds() {
     root.style.setProperty('--sb-shell-viewport-height', `${viewportSize.height}px`);
     root.style.setProperty('--sb-shell-measured-top-offset', `${topOffset}px`);
     root.style.setProperty('--sb-shell-available-height', `${Math.max(0, viewportSize.height - topOffset)}px`);
+    // SillyBunny: iOS Safari shifts the visual viewport (visualViewport.offsetTop > 0)
+    // when the keyboard opens; without this var the shell stays anchored at
+    // the layout viewport top and the composer floats mid-screen.
+    root.style.setProperty('--sb-shell-viewport-top', `${viewportSize.top}px`);
 }
 
 function getMobileShellBoundDrawers() {
@@ -2447,27 +2451,50 @@ function hydratePersistedShellSizes() {
 }
 
 function getResolvedShellTopbarOffset() {
-    const chatShell = document.getElementById('sheld');
-    if (chatShell instanceof HTMLElement && chatShell.getClientRects().length > 0) {
-        const chatRect = chatShell.getBoundingClientRect();
-        if (Number.isFinite(chatRect.top) && chatRect.top > 0) {
-            return chatRect.top;
+    const docEl = document.documentElement;
+    const docTop = (docEl instanceof HTMLElement && docEl.getClientRects().length > 0)
+        ? Math.max(0, Math.round(readFiniteViewportNumber(docEl.getBoundingClientRect().top, 0)))
+        : 0;
+
+    // SillyBunny: on mobile the shell's own rect.top is driven by the very
+    // CSS var this function feeds back into (--sb-shell-measured-top-offset),
+    // so reading it creates a feedback loop. If an overscroll momentarily
+    // displaces the shell (e.g. iOS rubber-band), the displaced value is
+    // written back, the shell is pushed further, and the chat goes blank
+    // even after the page snaps back. Stay off #sheld on mobile.
+    const isMobileViewportLike = isMobileViewport() || isTouchOnlyDesktopViewport();
+    const fallbackTopOffset = (() => {
+        const topbarOffset = Number.parseFloat(
+            window.getComputedStyle(document.documentElement).getPropertyValue('--sb-topbar-layout-offset'),
+        );
+        return Number.isFinite(topbarOffset) ? topbarOffset : 0;
+    })();
+
+    if (!isMobileViewportLike) {
+        const chatShell = document.getElementById('sheld');
+        if (chatShell instanceof HTMLElement && chatShell.getClientRects().length > 0) {
+            const chatRect = chatShell.getBoundingClientRect();
+            if (Number.isFinite(chatRect.top)) {
+                const offset = chatRect.top - docTop;
+                if (offset > 0) {
+                    return offset;
+                }
+            }
         }
     }
 
     const topBar = document.getElementById('top-bar');
     if (topBar instanceof HTMLElement && topBar.getClientRects().length > 0) {
         const topBarRect = topBar.getBoundingClientRect();
-        if (Number.isFinite(topBarRect.bottom) && topBarRect.bottom > 0) {
-            return topBarRect.bottom;
+        if (Number.isFinite(topBarRect.bottom)) {
+            const offset = topBarRect.bottom - docTop;
+            if (offset > 0) {
+                return offset;
+            }
         }
     }
 
-    const topbarOffset = Number.parseFloat(
-        window.getComputedStyle(document.documentElement).getPropertyValue('--sb-topbar-layout-offset'),
-    );
-
-    return Number.isFinite(topbarOffset) ? topbarOffset : 0;
+    return fallbackTopOffset;
 }
 
 function getShellViewportTop(root, viewportSize = getShellViewportSize()) {

--- a/public/style.css
+++ b/public/style.css
@@ -205,6 +205,11 @@ html {
        fixed-layout app and strand a black bar at the bottom. */
     overflow: hidden;
     overflow: clip;
+    /* SillyBunny: iOS Safari will otherwise rubber-band scroll the whole app
+       (black gap, blank chat) when a drag lands above #chat or touches the
+       top-bar, because the shell is positioned fixed-ish and not overflow-y
+       scrollable. `none` prevents any scroll chaining off the document. */
+    overscroll-behavior: none;
 }
 
 body {
@@ -225,6 +230,8 @@ body {
     overflow: hidden;
     overflow: clip;
     color-scheme: only light;
+    /* SillyBunny: paired with html; stops scroll chaining off the document. */
+    overscroll-behavior: none;
 }
 
 /* SillyBunny: Firefox ignores WebKit scrollbar pseudo-elements. */
@@ -963,6 +970,10 @@ body .panelControlBar {
     z-index: 30;
     flex-grow: 1;
     overflow-anchor: none;
+    /* SillyBunny: keep iOS touch rubber-band inside #chat only; paired with
+       html/body `overscroll-behavior: none` this blocks the page-level
+       overscroll that blanks the whole conversation. */
+    overscroll-behavior-y: contain;
 }
 
 #form_sheld {


### PR DESCRIPTION
## Reported bug (iOS screen recording)

Two symptoms when using the chat on iOS:

1. **Chat goes blank after scrolling near the top.** Dragging near the top of the conversation causes the entire page to rubber-band down (black gap appears above the top-bar), then snaps back — but the chat messages disappear and sometimes don't come back.
2. **Composer floats mid-screen when the keyboard opens.** Tapping the textarea to type shoots the input box to the top of the screen instead of pinning it above the keyboard.

## Root causes

**Symptom 1 — page-level overscroll scroll-chaining off the shell.**
`html`/`body` had no `overscroll-behavior`, so a touch landing above `#chat` (or `#chat` pulled to its edge) chained scroll up to the document and rubber-banded the whole app. Because `#sheld` and the drawers are sized against the visual viewport (`--sb-shell-viewport-height`), `syncShellViewportBounds()` fires *during* the overscroll and measures the visually-displaced `#sheld.getClientRects().top` — writing it back to `--sb-shell-measured-top-offset`, which is the value that *positions* the shell. The displaced value locks the shell in place even after the page snaps back → blank chat.

**Symptom 2 — `visualViewport.offsetTop` ignored.**
`getShellViewportSize()` in `sillybunny-tabs.js` returned `top: 0, left: 0` unconditionally. iOS Safari does not resize the layout viewport when the keyboard opens; it shifts the *visual* viewport up (`visualViewport.offsetTop > 0`). The shell is sized to `visualViewport.height` but anchored at the layout-viewport top, so the composer visually floats above the keyboard instead of tracking it. (The chat-delete overlay already handles this correctly via `bindChatDeleteVisualViewport` — same pattern applied here.)

## Fixes

|\u202fFile|Change|
|---|---|
|`public/style.css`|`overscroll-behavior: none` on `html`/`body`; `overscroll-behavior-y: contain` on `#chat` — blocks page-level overscroll, keeps rubber-band inside the chat area.|
|`public/scripts/sillybunny-tabs.js`|`getShellViewportSize()` now reads real `visualViewport.offsetTop/offsetLeft`; `syncShellViewportBounds()` publishes new `--sb-shell-viewport-top` CSS var.|
|`public/scripts/sillybunny-tabs.js`|`getResolvedShellTopbarOffset()` — on mobile skip self-measuring `#sheld` (its top is driven by the var being computed); subtract `document.documentElement.getBoundingClientRect().top` from readings so transient page displacement is factored out.|
|`public/css/sillybunny-mobile-shell.css`|iOS `#sheld` rule: `top` now adds `var(--sb-shell-viewport-top, 0px)` so the shell tracks the visual viewport when the keyboard opens.|

## Verification

- `npm run lint` — clean.
- Desktop: `overscroll-behavior: none` on `html`/`body` does not affect wheel routing (which targets `#chat` via `routeShellWheelToChat`). Shell sizing unchanged on desktop (`getShellViewportSize` only consumes `visualViewport` offsets when a real visual viewport exists and reports non-zero offsets — desktop without zoom reports 0).
- Touch-only / iPad desktop breakpoints use the same mobile path.

## Needs on-device iOS test

The overscroll blanking could not be reproduced without an iOS device/simulator. Confirming:
- [ ] Dragging near the top of chat no longer rubber-bands the whole page.
- [ ] Chat messages remain visible after a rapid scroll.
- [ ] Composer stays pinned above the keyboard when typing.
- [ ] Keyboard dismiss restores the shell to full height.

---

_All SillyBunny divergences from upstream SillyTavern are marked with inline `SillyBunny:` comments as per CONTRIBUTING.md. PR allows maintainer edits. No force-push after this leaves draft._