### PR TITLE
fix(ica): recognize legacy tracker agents

### DIFF
--- a/public/scripts/extensions/in-chat-agents/agent-store.js
+++ b/public/scripts/extensions/in-chat-agents/agent-store.js
@@ -670,13 +670,35 @@ export function normalizePreProcessMaxTokens(value) {
 }
 
 const TRACKER_CATEGORY_TEMPLATE_IDS = new Set([
+    'tpl-achievements-tracker',
     'tpl-cyoa-choices',
     'tpl-direction-menu',
+    'tpl-event-tracker',
+    'tpl-item-tracker',
+    'tpl-parallel-tracker',
+    'tpl-relationship-tracker',
+    'tpl-reputation-tracker',
+    'tpl-scene-tracker',
+    'tpl-secrets-tracker',
+    'tpl-status-tracker',
+    'tpl-time-tracker',
+    'tpl-world-detail',
 ]);
 
 const TRACKER_CATEGORY_NAMES = new Set([
+    'achievements tracker',
     'cyoa choices',
     'direction menu',
+    'event tracker',
+    'item tracker',
+    'parallel off-screen',
+    'relationship tracker',
+    'reputation tracker',
+    'scene tracker',
+    'secrets tracker',
+    'status tracker',
+    'time tracker',
+    'world detail',
 ]);
 
 export function normalizeAgentCategory(category = '', sourceTemplateId = '', name = '') {

--- a/tests/in-chat-agents-store.test.js
+++ b/tests/in-chat-agents-store.test.js
@@ -465,6 +465,29 @@ describe('in-chat agent scoped enabled state', () => {
         expect(store.findTemplateForAgentSnapshot(agent, templates)?.id).toBe('tpl-achievements-tracker');
     });
 
+    test('normalizes legacy bundled tracker copies with stale categories', async () => {
+        const store = await importStore();
+        store.loadAgents([
+            {
+                id: 'saved-status',
+                name: 'Saved Status',
+                category: 'custom',
+                sourceTemplateId: 'tpl-status-tracker',
+                enabled: true,
+            },
+            {
+                id: 'saved-scene',
+                name: 'Scene Tracker',
+                category: 'custom',
+                enabled: true,
+            },
+        ]);
+
+        expect(store.getAgentById('saved-status').category).toBe('tracker');
+        expect(store.getAgentById('saved-scene').category).toBe('tracker');
+        expect(store.getEnabledAgents().map(agent => agent.id)).toEqual(['saved-status', 'saved-scene']);
+    });
+
     test('keeps prompt-changed custom snapshots from matching bundled templates', async () => {
         const store = await importStore();
         const templates = [{


### PR DESCRIPTION
## Summary
- recognize saved copies of bundled tracker templates even when their stored category is stale or custom
- cover both source template IDs and legacy tracker display names so existing installs are detected by the Fix Trackers controls
- add a store regression test for legacy tracker normalization

## Testing
- npm run lint
- cd tests && npm run test:unit -- in-chat-agents-runner.test.js in-chat-agents-pre-intercept-summary.test.js in-chat-agents-store.test.js in-chat-agents-templates.test.js