### PR TITLE
fix(ica): include pre trackers in repair controls

### DIFF
--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -27,6 +27,7 @@ import {
     getEnabledToolAgents,
     getGlobalSettings,
     getPromptTransformMode,
+    isTrackerFixAgent,
     isPathfinderSubmoduleEnabled,
     saveAgent,
     isToolAgent,
@@ -4714,10 +4715,7 @@ export async function runTrackerFixOnMessage(messageIndex) {
 
     const generationType = 'normal';
     const enabledAgents = getEnabledAgents();
-    const trackerAgents = enabledAgents.filter(agent =>
-        agent.category === 'tracker' &&
-        (agent.phase === 'post' || agent.phase === 'both'),
-    );
+    const trackerAgents = enabledAgents.filter(isTrackerFixAgent);
 
     if (trackerAgents.length === 0) {
         toastr.info('No enabled tracker agents found.');
@@ -4725,6 +4723,7 @@ export async function runTrackerFixOnMessage(messageIndex) {
     }
 
     const trackerTransformAgents = trackerAgents.filter(agent =>
+        (agent.phase === 'post' || agent.phase === 'both') &&
         agent.postProcess?.promptTransformEnabled &&
         String(agent.prompt ?? '').trim(),
     );

--- a/public/scripts/extensions/in-chat-agents/agent-store.js
+++ b/public/scripts/extensions/in-chat-agents/agent-store.js
@@ -796,6 +796,21 @@ export function getAgentRegexScripts(rawAgent = {}) {
     return legacyScript ? [legacyScript] : [];
 }
 
+export function isTrackerFixAgent(agent = {}) {
+    if (agent?.category !== 'tracker') {
+        return false;
+    }
+
+    if (agent.phase === 'post' || agent.phase === 'both') {
+        return true;
+    }
+
+    return agent.phase === 'pre' && (
+        (agent.postProcess?.enabled && agent.postProcess.type === 'extract') ||
+        getAgentRegexScripts(agent).length > 0
+    );
+}
+
 function cacheAgentRegexScriptsForAgent(agent) {
     cacheAgentRegexScripts(agent?.id, getAgentRegexScripts(agent));
 }

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -28,6 +28,7 @@ import {
     normalizeAgentCategory,
     getAgentChatScopeLabel,
     getPromptTransformMode,
+    isTrackerFixAgent,
     isPathfinderSubmoduleEnabled,
     findTemplateForAgentSnapshot,
     getRedundantBundledAgentDuplicateIds,
@@ -188,10 +189,6 @@ function stopEvent(event) {
 
 function getLastAssistantMessageIndex() {
     return chat.findLastIndex(message => message && !message.is_user && !message.is_system);
-}
-
-function isTrackerFixAgent(agent) {
-    return agent?.category === 'tracker' && (agent.phase === 'post' || agent.phase === 'both');
 }
 
 function hasTrackerFixAgents() {

--- a/tests/in-chat-agents-pre-intercept-summary.test.js
+++ b/tests/in-chat-agents-pre-intercept-summary.test.js
@@ -100,6 +100,7 @@ beforeAll(async () => {
         normalizeAgentCategory: jest.fn(value => value),
         getAgentChatScopeLabel: jest.fn(() => 'Individual chat'),
         getPromptTransformMode: jest.fn(() => 'rewrite'),
+        isTrackerFixAgent: jest.fn(() => false),
         isPathfinderSubmoduleEnabled: jest.fn(() => false),
         findTemplateForAgentSnapshot: jest.fn(() => null),
         getRedundantBundledAgentDuplicateIds: jest.fn(() => []),

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -262,6 +262,14 @@ describe('in-chat agent post-processing runner', () => {
             getEnabledToolAgents: jest.fn(() => []),
             getGlobalSettings: jest.fn(() => globalSettings),
             getPromptTransformMode: jest.fn(agent => agent?.postProcess?.promptTransformMode === 'append' ? 'append' : 'rewrite'),
+            isTrackerFixAgent: jest.fn(agent => {
+                if (agent?.category !== 'tracker') return false;
+                if (agent.phase === 'post' || agent.phase === 'both') return true;
+                return agent.phase === 'pre' && (
+                    (agent.postProcess?.enabled && agent.postProcess.type === 'extract') ||
+                    (Array.isArray(agent.regexScripts) && agent.regexScripts.length > 0)
+                );
+            }),
             isPathfinderSubmoduleEnabled: jest.fn(() => true),
             saveAgent: jest.fn(async () => {}),
             isToolAgent: jest.fn(() => false),
@@ -486,6 +494,29 @@ describe('in-chat agent post-processing runner', () => {
                 minDepth: null,
                 maxDepth: null,
             }],
+            conditions: {
+                triggerKeywords: [],
+                triggerProbability: 100,
+                generationTypes: ['normal'],
+            },
+        }];
+    }
+
+    function usePreExtractTracker() {
+        enabledAgents = [{
+            id: 'agent-pre-extract-tracker',
+            name: 'Pre Extract Tracker',
+            category: 'tracker',
+            phase: 'pre',
+            prompt: 'Track changed statuses.',
+            injection: { order: 100 },
+            postProcess: {
+                enabled: true,
+                type: 'extract',
+                extractPattern: '\\[STATUS\\|[^\\]]*\\]',
+                extractVariable: 'status_data',
+                promptTransformEnabled: false,
+            },
             conditions: {
                 triggerKeywords: [],
                 triggerProbability: 100,
@@ -1444,6 +1475,25 @@ describe('in-chat agent post-processing runner', () => {
 
         await new Promise(resolve => setTimeout(resolve, 5));
         expect(saveChat).toHaveBeenCalledTimes(1);
+    });
+
+    test('manual tracker fix runs pre-phase extract trackers', async () => {
+        usePreExtractTracker();
+
+        const { runTrackerFixOnMessage } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        chat.push({
+            name: 'Assistant',
+            mes: 'Fresh reply\n[STATUS|Alice|Tired|Moderate]',
+            is_user: false,
+            is_system: false,
+            extra: {},
+        });
+
+        await runTrackerFixOnMessage(0);
+
+        expect(chatMetadata.agent_status_data).toBe('[STATUS|Alice|Tired|Moderate]');
+        expect(saveChatDebounced).toHaveBeenCalledTimes(1);
+        expect(globalThis.toastr.success).toHaveBeenCalledWith('1 post-process run', 'Trackers fixed');
     });
 
     test('snapshots regex-only agents on streamed tokens before final message events', async () => {

--- a/tests/in-chat-agents-store.test.js
+++ b/tests/in-chat-agents-store.test.js
@@ -488,6 +488,35 @@ describe('in-chat agent scoped enabled state', () => {
         expect(store.getEnabledAgents().map(agent => agent.id)).toEqual(['saved-status', 'saved-scene']);
     });
 
+    test('considers pre-phase extract trackers repairable', async () => {
+        const store = await importStore();
+
+        expect(store.isTrackerFixAgent({
+            category: 'tracker',
+            phase: 'pre',
+            postProcess: {
+                enabled: true,
+                type: 'extract',
+            },
+        })).toBe(true);
+        expect(store.isTrackerFixAgent({
+            category: 'tracker',
+            phase: 'pre',
+            postProcess: {
+                enabled: false,
+                type: 'extract',
+            },
+        })).toBe(false);
+        expect(store.isTrackerFixAgent({
+            category: 'tracker',
+            phase: 'pre',
+            postProcess: {
+                enabled: true,
+                type: 'append',
+            },
+        })).toBe(false);
+    });
+
     test('keeps prompt-changed custom snapshots from matching bundled templates', async () => {
         const store = await importStore();
         const templates = [{


### PR DESCRIPTION
## Summary
- share the Fix Trackers eligibility predicate between the UI and runner
- include pre-phase tracker agents when they have extract post-processing or regex repair work
- keep prompt transforms limited to post/both trackers so pre prompt-only agents are not run from message repair
- add regression coverage for pre-phase extract trackers

## Testing
- npm run lint
- cd tests && npm run test:unit -- in-chat-agents-runner.test.js in-chat-agents-pre-intercept-summary.test.js in-chat-agents-store.test.js in-chat-agents-templates.test.js