### PR TITLE
feat: improve mobile nav reachability

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -53,7 +53,7 @@
 
     #nonQRFormItems {
         --sb-mobile-composer-input-height: clamp(34px, calc(42px * var(--sb-bottom-bar-scale, 1)), 56px);
-        --sb-composer-action-size: clamp(20px, calc(26px * var(--sb-bottom-bar-scale, 1)), 36px);
+        --sb-composer-action-size: max(var(--sb-mobile-touch-target, 44px), clamp(20px, calc(26px * var(--sb-bottom-bar-scale, 1)), 36px));
         --sb-composer-send-width: calc(var(--sb-composer-action-size) * 1.45);
         --sb-composer-action-icon-size: clamp(10px, calc(13px * var(--sb-bottom-bar-scale, 1)), 18px);
         --sb-composer-left-rail-width: min(28vw, calc(var(--sb-composer-action-size) * 2 + 3px));
@@ -72,7 +72,7 @@
 
     :root[data-sb-compact-mode='true'] #nonQRFormItems {
         --sb-mobile-composer-input-height: clamp(30px, calc(34px * var(--sb-bottom-bar-scale, 1)), 48px);
-        --sb-composer-action-size: clamp(18px, calc(22px * var(--sb-bottom-bar-scale, 1)), 32px);
+        --sb-composer-action-size: max(var(--sb-mobile-touch-target, 44px), clamp(18px, calc(22px * var(--sb-bottom-bar-scale, 1)), 32px));
         --sb-composer-send-width: calc(var(--sb-composer-action-size) * 1.42);
         --sb-composer-action-icon-size: clamp(9px, calc(11px * var(--sb-bottom-bar-scale, 1)), 16px);
         --sb-composer-left-rail-width: min(26vw, calc(var(--sb-composer-action-size) * 2 + 2px));
@@ -1594,7 +1594,7 @@
         height: calc(100dvh - var(--sb-topbar-layout-offset));
         min-height: calc(100dvh - var(--sb-topbar-layout-offset));
         z-index: -1;
-        padding: 8px;
+        padding: 8px max(8px, env(safe-area-inset-right, 0px)) max(8px, env(safe-area-inset-bottom, 0px)) max(8px, env(safe-area-inset-left, 0px));
         isolation: isolate;
         background: transparent;
         backdrop-filter: none;
@@ -1617,7 +1617,9 @@
 
     #sb-mobile-nav.sb-nav-open[aria-hidden='false'] {
         opacity: 1;
-        display: block;
+        display: flex;
+        align-items: flex-end;
+        justify-content: center;
         visibility: visible;
         pointer-events: auto;
         z-index: var(--sb-z-modal);
@@ -1676,18 +1678,26 @@
     #sb-mobile-nav-content {
         position: relative;
         isolation: isolate;
-        width: min(100%, 620px);
-        max-height: calc(100dvh - var(--sb-topbar-layout-offset) - 32px);
-        margin: 0 auto;
+        width: min(100%, 560px);
+        max-height: min(76dvh, calc(100dvh - var(--sb-topbar-layout-offset) - 16px));
+        margin: auto auto 0;
         padding: 14px;
         display: flex;
         flex-direction: column;
         gap: 12px;
         overflow-y: auto;
-        border-radius: 20px;
+        overscroll-behavior: contain;
+        -webkit-overflow-scrolling: touch;
+        border-radius: 22px 22px 16px 16px;
         border: 1px solid color-mix(in srgb, var(--sb-shell-border) 88%, transparent);
         background: transparent;
         box-shadow: 0 24px 70px color-mix(in srgb, var(--SmartThemeShadowColor) 28%, transparent);
+        transform: translateY(10px);
+        transition: transform var(--sb-transition-fast);
+    }
+
+    #sb-mobile-nav.sb-nav-open[aria-hidden='false'] #sb-mobile-nav-content {
+        transform: translateY(0);
     }
 
     #sb-mobile-nav-content::before {
@@ -1722,7 +1732,11 @@
     .sb-mobile-panel-close {
         appearance: none;
         width: var(--sb-mobile-touch-target, 44px);
+        min-width: var(--sb-mobile-touch-target, 44px);
+        max-width: var(--sb-mobile-touch-target, 44px);
         height: var(--sb-mobile-touch-target, 44px);
+        min-height: var(--sb-mobile-touch-target, 44px);
+        max-height: var(--sb-mobile-touch-target, 44px);
         border: 1px solid color-mix(in srgb, var(--sb-shell-border) 85%, transparent);
         border-radius: var(--sb-radius-md, 16px);
         background: var(--sb-card-bg);
@@ -1730,6 +1744,20 @@
         display: inline-grid;
         place-items: center;
         cursor: pointer;
+    }
+
+    #sb-mobile-nav .sb-mobile-panel-header {
+        grid-template-columns: minmax(0, 1fr) var(--sb-mobile-touch-target, 44px);
+    }
+
+    #sb-mobile-nav .sb-mobile-panel-close {
+        width: var(--sb-mobile-touch-target, 44px);
+        min-width: var(--sb-mobile-touch-target, 44px);
+        max-width: var(--sb-mobile-touch-target, 44px);
+        height: var(--sb-mobile-touch-target, 44px);
+        min-height: var(--sb-mobile-touch-target, 44px);
+        max-height: var(--sb-mobile-touch-target, 44px);
+        border-radius: var(--sb-radius-md, 16px);
     }
 
     .sb-mobile-section {
@@ -1816,6 +1844,18 @@
     .sb-mobile-panel-close:focus-visible {
         outline: 2px solid var(--sb-focus-ring, var(--SmartThemeQuoteColor));
         outline-offset: 2px;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        #sb-mobile-nav,
+        #sb-mobile-nav-content,
+        .sb-nav-item {
+            transition: none;
+        }
+
+        #sb-mobile-nav-content {
+            transform: none;
+        }
     }
 
 }
@@ -2679,7 +2719,7 @@
 
     #nonQRFormItems {
         --sb-mobile-composer-input-height: clamp(32px, calc(38px * var(--sb-bottom-bar-scale, 1)), 52px);
-        --sb-composer-action-size: clamp(20px, calc(24px * var(--sb-bottom-bar-scale, 1)), 34px);
+        --sb-composer-action-size: max(var(--sb-mobile-touch-target, 44px), clamp(20px, calc(24px * var(--sb-bottom-bar-scale, 1)), 34px));
         --sb-composer-send-width: calc(var(--sb-composer-action-size) * 1.40);
         --sb-composer-action-icon-size: clamp(10px, calc(12px * var(--sb-bottom-bar-scale, 1)), 17px);
         --sb-composer-left-rail-width: min(26vw, calc(var(--sb-composer-action-size) * 2 + 2px));

--- a/tests/mobile-shell-smoke.e2e.js
+++ b/tests/mobile-shell-smoke.e2e.js
@@ -193,6 +193,9 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
         const getNavAgreementSnapshot = () => page.evaluate(() => {
             const overlay = document.getElementById('sb-mobile-nav');
             const button = document.getElementById('sb-hamburger');
+            const content = document.getElementById('sb-mobile-nav-content');
+            const contentRect = content?.getBoundingClientRect();
+            const closeRect = content?.querySelector('.sb-mobile-panel-close')?.getBoundingClientRect();
 
             return {
                 hidden: overlay?.hidden ?? null,
@@ -201,6 +204,10 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
                 openClass: overlay?.classList.contains('sb-nav-open') === true,
                 buttonExpanded: button?.getAttribute('aria-expanded') ?? null,
                 buttonOpenClass: button?.classList.contains('is-open') === true,
+                contentBottomPinned: contentRect ? Math.abs(window.innerHeight - contentRect.bottom) <= 10 : null,
+                contentMaxHeight: contentRect ? contentRect.height <= Math.ceil(window.innerHeight * 0.76) + 1 : null,
+                closeTargetFloor: closeRect ? Math.min(closeRect.width, closeRect.height) >= 44 : null,
+                viewportHeight: window.innerHeight,
             };
         });
 
@@ -213,6 +220,10 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
             openClass: true,
             buttonExpanded: 'true',
             buttonOpenClass: true,
+            contentBottomPinned: true,
+            contentMaxHeight: true,
+            closeTargetFloor: true,
+            viewportHeight: 844,
         });
 
         await captureCheckpoint(page, testInfo, 'nav-open');
@@ -228,6 +239,10 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
             openClass: false,
             buttonExpanded: 'false',
             buttonOpenClass: false,
+            contentBottomPinned: false,
+            contentMaxHeight: true,
+            closeTargetFloor: false,
+            viewportHeight: 844,
         });
 
         await expectNoHorizontalOverflow(page);
@@ -365,7 +380,7 @@ test.describe('mobile shell smoke at narrow 320x568', () => {
         userAgent: IPHONE_USER_AGENT,
     });
 
-    test('composer fits and the send target keeps its current floor', async ({ page }) => {
+    test('composer fits and the send target keeps its mobile tap floor', async ({ page }) => {
         await openQuietChatForSmoke(page, { selectCharacter: false });
 
         // Compact mode and connection state come from the linked user profile;
@@ -380,12 +395,8 @@ test.describe('mobile shell smoke at narrow 320x568', () => {
 
         const sendButtonBox = await page.locator('#send_but').boundingBox();
 
-        // Ratchet floor: today's composer renders the send target at
-        // --sb-composer-action-size (26px tall at this width). The mobile UX
-        // redesign raises this floor to 44px; until then this only guards
-        // against shrinking below the current shipped size.
         expect(sendButtonBox).not.toBeNull();
-        expect(Math.min(sendButtonBox.width, sendButtonBox.height)).toBeGreaterThanOrEqual(24);
+        expect(Math.min(sendButtonBox.width, sendButtonBox.height)).toBeGreaterThanOrEqual(44);
 
         const composerBox = await page.locator('#form_sheld').boundingBox();
 


### PR DESCRIPTION
## What?
Make the mobile hamburger navigation easier to reach and safer to tap on phone layouts.

## Why?
Phase 3.1 of the SillyBunny UI refactor calls for a thumb-zone mobile nav sheet and a 44px mobile tap-target floor. The existing hamburger nav opened as a centered modal-style panel and the narrow composer send target could render below the desired mobile hit size.

## How?
- Anchor the mobile hamburger nav content to the bottom of the viewport with safe-area-aware padding and a capped sheet height.
- Keep the nav close button at the shared `--sb-mobile-touch-target` floor, overriding older mobile nav close sizing only within the hamburger nav surface.
- Raise the mobile composer action size floor to the same 44px token, including compact mode and the later phone density pass.
- Disable the nav sheet transition when `prefers-reduced-motion: reduce` is active.
- Extend `mobile-shell-smoke.e2e.js` to pin bottom-sheet geometry, close target floor, and the 320px send target floor.

## Testing?
- `git diff --check`
- `node --check public/scripts/sillybunny-tabs.js`
- `npm run lint -- --quiet`
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.json mobile-css-budgets.test.js` from `tests/` (7 passed)
- `npm run check:frontend-budgets`
- `SILLYBUNNY_TEST_BASE_URL=http://127.0.0.1:4567 npm run test:e2e -- mobile-shell-smoke.e2e.js` from `tests/` (8 passed)

## Screenshots (optional)
The smoke run attached the existing `nav-open` checkpoint artifact for the updated bottom nav sheet.

## Anything Else?
Draft PR. This PR intentionally avoids persisted mobile nav default changes; it is visual/tap-target work only.