### PR TITLE
feat: polish mobile drawer safe areas

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -1,6 +1,11 @@
 /* SillyBunny mobile shell foundation: final sheet contract for modal drawers.
  * Keep this at the end of the shell sheet so it beats older mobile drawer rules. */
 @media screen and (max-width: 768px) {
+    :root {
+        --sb-mobile-safe-area-left: env(safe-area-inset-left, 0px);
+        --sb-mobile-safe-area-right: env(safe-area-inset-right, 0px);
+    }
+
     #form_sheld {
         width: 100%;
         max-width: 100%;
@@ -1306,18 +1311,28 @@
         left: 8px !important;
         right: 8px !important;
         top: calc(var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) + var(--sb-mobile-shell-gap)) !important;
-        bottom: env(safe-area-inset-bottom, 0px) !important;
-        height: calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) - var(--sb-mobile-shell-gap) - env(safe-area-inset-bottom, 0px)) !important;
-        max-height: calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) - var(--sb-mobile-shell-gap) - env(safe-area-inset-bottom, 0px)) !important;
+        bottom: var(--sb-mobile-safe-area-bottom, env(safe-area-inset-bottom, 0px)) !important;
+        height: calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) - var(--sb-mobile-shell-gap) - var(--sb-mobile-safe-area-bottom, env(safe-area-inset-bottom, 0px))) !important;
+        max-height: calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) - var(--sb-mobile-shell-gap) - var(--sb-mobile-safe-area-bottom, env(safe-area-inset-bottom, 0px))) !important;
         min-width: 0 !important;
         margin-top: 0 !important;
         border-radius: 22px 22px 0 0 !important;
         animation: sbMobileShellSheetIn 220ms var(--sb-ease-out) both !important;
         transform-origin: center bottom;
+        transition: transform var(--sb-transition-fast);
+    }
+
+    #left-nav-panel.openDrawer.sb-drawer-gesture-active,
+    #user-settings-block.openDrawer.sb-drawer-gesture-active,
+    .sb-shell-root.openDrawer.sb-drawer-gesture-active,
+    .sb-shell-root.fillLeft.openDrawer.sb-drawer-gesture-active,
+    .sb-shell-root.fillRight.openDrawer.sb-drawer-gesture-active,
+    #right-nav-panel.openDrawer.sb-drawer-gesture-active {
+        transition: none;
     }
 
     :root[data-sb-character-drawer-lock="right"] #right-nav-panel.openDrawer {
-        left: max(8px, env(safe-area-inset-left, 0px)) !important;
+        left: max(8px, var(--sb-mobile-safe-area-left, env(safe-area-inset-left, 0px))) !important;
         right: 0 !important;
         width: auto !important;
         max-width: none !important;
@@ -2609,8 +2624,8 @@
         top: calc(var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) + var(--sb-mobile-shell-gap, 0px)) !important;
         bottom: auto !important;
         box-sizing: border-box !important;
-        height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset))) - var(--sb-mobile-shell-gap, 0px) - env(safe-area-inset-bottom, 0px)) !important;
-        max-height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset))) - var(--sb-mobile-shell-gap, 0px) - env(safe-area-inset-bottom, 0px)) !important;
+        height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset))) - var(--sb-mobile-shell-gap, 0px) - var(--sb-mobile-safe-area-bottom, env(safe-area-inset-bottom, 0px))) !important;
+        max-height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset))) - var(--sb-mobile-shell-gap, 0px) - var(--sb-mobile-safe-area-bottom, env(safe-area-inset-bottom, 0px))) !important;
     }
 }
 
@@ -2667,7 +2682,7 @@
     }
 
     #sb-bottom-chat-bar {
-        --sb-bottom-chat-mobile-gutter: max(6px, env(safe-area-inset-left, 0px), env(safe-area-inset-right, 0px));
+        --sb-bottom-chat-mobile-gutter: max(6px, var(--sb-mobile-safe-area-left, env(safe-area-inset-left, 0px)), var(--sb-mobile-safe-area-right, env(safe-area-inset-right, 0px)));
         --sb-bottom-chat-mobile-gap: clamp(1px, calc(1.5px * var(--sb-bottom-bar-scale)), 3px);
         --sb-bottom-chat-mobile-padding-block: clamp(1px, calc(1.5px * var(--sb-bottom-bar-scale)), 2px);
         --sb-bottom-chat-mobile-padding-inline: clamp(3px, calc(4px * var(--sb-bottom-bar-scale)), 6px);

--- a/public/scripts/mobile-shell-lifecycle/index.js
+++ b/public/scripts/mobile-shell-lifecycle/index.js
@@ -1,6 +1,9 @@
 export const MOBILE_SHELL_LIFECYCLE_NAV_OPEN_GRACE_MS = 450;
 export const MOBILE_SHELL_LIFECYCLE_NAV_DRAG_THRESHOLD_PX = 6;
 export const MOBILE_SHELL_LIFECYCLE_NAV_CLICK_SUPPRESSION_MS = 350;
+export const MOBILE_SHELL_LIFECYCLE_DRAWER_GESTURE_THRESHOLD_PX = 8;
+export const MOBILE_SHELL_LIFECYCLE_DRAWER_DISMISS_THRESHOLD_PX = 72;
+export const MOBILE_SHELL_LIFECYCLE_DRAWER_CLICK_SUPPRESSION_MS = 350;
 
 export const MOBILE_SHELL_NAV_TOGGLE_ACTION = Object.freeze({
     ACTIVATE_PAGE_TARGET: 'activate-page-target',
@@ -292,6 +295,124 @@ export function resolveMobileShellNavDragEnd({
  * @returns {boolean}
  */
 export function shouldSuppressMobileShellNavClick({
+    nowMs = 0,
+    suppressClickUntil = 0,
+} = {}) {
+    return normalizeNumber(nowMs) < normalizeNumber(suppressClickUntil);
+}
+
+/**
+ * Captures the start state for mobile drawer swipe-down dismissal.
+ * @param {object} options Options.
+ * @param {boolean} [options.isMobileViewport=false] Whether mobile shell policy is active.
+ * @param {boolean} [options.isOpen=false] Whether the drawer is currently open.
+ * @param {object|null} [options.touch=null] First touch point.
+ * @returns {{startX: number, startY: number, offsetY: number, dragging: boolean}|null}
+ */
+export function createMobileShellDrawerGestureState({
+    isMobileViewport = false,
+    isOpen = false,
+    touch = null,
+} = {}) {
+    const touchPoint = getTouchPoint(touch);
+    if (!isMobileViewport || !isOpen || !touchPoint) {
+        return null;
+    }
+
+    return {
+        startX: touchPoint.clientX,
+        startY: touchPoint.clientY,
+        offsetY: 0,
+        dragging: false,
+    };
+}
+
+/**
+ * Resolves one touch-move step for mobile drawer swipe-down dismissal.
+ * @param {object} options Options.
+ * @param {object|null} [options.gestureState=null] Existing gesture state.
+ * @param {object|null} [options.touch=null] Current touch point.
+ * @param {number} [options.thresholdPx=MOBILE_SHELL_LIFECYCLE_DRAWER_GESTURE_THRESHOLD_PX] Drag threshold.
+ * @returns {{gestureState: object|null, shouldPreventDefault: boolean, shouldStopPropagation: boolean, offsetY: number}}
+ */
+export function resolveMobileShellDrawerGestureMove({
+    gestureState = null,
+    touch = null,
+    thresholdPx = MOBILE_SHELL_LIFECYCLE_DRAWER_GESTURE_THRESHOLD_PX,
+} = {}) {
+    const touchPoint = getTouchPoint(touch);
+    if (!gestureState || !touchPoint) {
+        return {
+            gestureState: null,
+            shouldPreventDefault: false,
+            shouldStopPropagation: false,
+            offsetY: 0,
+        };
+    }
+
+    const deltaX = touchPoint.clientX - normalizeNumber(gestureState.startX);
+    const deltaY = touchPoint.clientY - normalizeNumber(gestureState.startY);
+    const isDownward = deltaY > 0;
+    const isVerticalIntent = Math.abs(deltaY) >= Math.abs(deltaX);
+    const isDragging = Boolean(gestureState.dragging)
+        || (isDownward && isVerticalIntent && deltaY > normalizeNumber(thresholdPx));
+    const offsetY = isDragging ? Math.max(0, deltaY) : 0;
+    const nextGestureState = {
+        ...gestureState,
+        offsetY,
+        dragging: isDragging,
+    };
+
+    return {
+        gestureState: nextGestureState,
+        shouldPreventDefault: isDragging,
+        shouldStopPropagation: isDragging,
+        offsetY,
+    };
+}
+
+/**
+ * Resolves touch-end cleanup and dismiss intent after mobile drawer dragging.
+ * @param {object} options Options.
+ * @param {object|null} [options.gestureState=null] Existing gesture state.
+ * @param {number} [options.nowMs=0] Current timestamp.
+ * @param {number} [options.dismissThresholdPx=MOBILE_SHELL_LIFECYCLE_DRAWER_DISMISS_THRESHOLD_PX] Dismiss threshold.
+ * @param {number} [options.suppressionMs=MOBILE_SHELL_LIFECYCLE_DRAWER_CLICK_SUPPRESSION_MS] Suppression window.
+ * @returns {{gestureState: null, shouldDismiss: boolean, shouldStopPropagation: boolean, suppressClickUntil: number, offsetY: number}}
+ */
+export function resolveMobileShellDrawerGestureEnd({
+    gestureState = null,
+    nowMs = 0,
+    dismissThresholdPx = MOBILE_SHELL_LIFECYCLE_DRAWER_DISMISS_THRESHOLD_PX,
+    suppressionMs = MOBILE_SHELL_LIFECYCLE_DRAWER_CLICK_SUPPRESSION_MS,
+} = {}) {
+    if (!gestureState?.dragging) {
+        return {
+            gestureState: null,
+            shouldDismiss: false,
+            shouldStopPropagation: false,
+            suppressClickUntil: 0,
+            offsetY: 0,
+        };
+    }
+
+    return {
+        gestureState: null,
+        shouldDismiss: normalizeNumber(gestureState.offsetY) >= normalizeNumber(dismissThresholdPx),
+        shouldStopPropagation: true,
+        suppressClickUntil: normalizeNumber(nowMs) + normalizeNumber(suppressionMs),
+        offsetY: 0,
+    };
+}
+
+/**
+ * Resolves whether a click immediately after drawer dragging should be swallowed.
+ * @param {object} options Options.
+ * @param {number} [options.nowMs=0] Current timestamp.
+ * @param {number} [options.suppressClickUntil=0] Suppression deadline.
+ * @returns {boolean}
+ */
+export function shouldSuppressMobileShellDrawerGestureClick({
     nowMs = 0,
     suppressClickUntil = 0,
 } = {}) {
@@ -755,6 +876,7 @@ function clampBoundNumber(value, min, max) {
  * @param {number} [options.viewportHeight=0] Current shell viewport height in px.
  * @param {number} [options.baseTopOffset=0] Resolved shell topbar offset in px.
  * @param {number} [options.shellGap=0] Drawer --sb-mobile-shell-gap value in px.
+ * @param {number} [options.safeAreaBottom=0] Bottom safe-area inset reserved below the drawer.
  * @returns {{action: string, styleWrites: Array<{property: string, value: string, priority: string}>, styleRemovals: string[]}}
  */
 export function resolveMobileDrawerBounds({
@@ -764,6 +886,7 @@ export function resolveMobileDrawerBounds({
     viewportHeight = 0,
     baseTopOffset = 0,
     shellGap = 0,
+    safeAreaBottom = 0,
 } = {}) {
     const shouldBind = Boolean(isMobileViewport) && Boolean(isOpen);
 
@@ -778,7 +901,12 @@ export function resolveMobileDrawerBounds({
     const safeViewportHeight = Math.max(0, normalizeNumber(viewportHeight));
     const safeBaseTopOffset = Math.max(0, Math.round(normalizeNumber(baseTopOffset)));
     const topOffset = clampBoundNumber(Math.round(safeBaseTopOffset + normalizeNumber(shellGap)), 0, safeViewportHeight);
-    const availableHeight = Math.max(0, safeViewportHeight - topOffset);
+    const bottomInset = clampBoundNumber(
+        Math.round(normalizeNumber(safeAreaBottom)),
+        0,
+        Math.max(0, safeViewportHeight - topOffset),
+    );
+    const availableHeight = Math.max(0, safeViewportHeight - topOffset - bottomInset);
 
     return {
         action: MOBILE_SHELL_DRAWER_BOUND_ACTION.BIND,
@@ -893,6 +1021,12 @@ export function createMobileShellLifecycle() {
             resolveAutoCloseSiblings: resolveInlineDrawerAutoCloseSiblings,
             derivePersistenceKey: deriveInlineDrawerPersistenceKey,
         },
+        drawerGestures: {
+            createGestureState: createMobileShellDrawerGestureState,
+            resolveGestureMove: resolveMobileShellDrawerGestureMove,
+            resolveGestureEnd: resolveMobileShellDrawerGestureEnd,
+            shouldSuppressClick: shouldSuppressMobileShellDrawerGestureClick,
+        },
         drawerBounds: {
             action: MOBILE_SHELL_DRAWER_BOUND_ACTION,
             boundStyleProperties: MOBILE_SHELL_DRAWER_BOUND_STYLE_PROPERTIES,
@@ -907,6 +1041,9 @@ export function createMobileShellLifecycle() {
             navOpenGraceMs: MOBILE_SHELL_LIFECYCLE_NAV_OPEN_GRACE_MS,
             navDragThresholdPx: MOBILE_SHELL_LIFECYCLE_NAV_DRAG_THRESHOLD_PX,
             navClickSuppressionMs: MOBILE_SHELL_LIFECYCLE_NAV_CLICK_SUPPRESSION_MS,
+            drawerGestureThresholdPx: MOBILE_SHELL_LIFECYCLE_DRAWER_GESTURE_THRESHOLD_PX,
+            drawerDismissThresholdPx: MOBILE_SHELL_LIFECYCLE_DRAWER_DISMISS_THRESHOLD_PX,
+            drawerClickSuppressionMs: MOBILE_SHELL_LIFECYCLE_DRAWER_CLICK_SUPPRESSION_MS,
         },
     };
 }

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -2304,6 +2304,29 @@ function applyMobileDrawerBoundsDecision(drawer, decision) {
     }
 }
 
+function getMobileSafeAreaBottomPx() {
+    const styles = window.getComputedStyle(document.documentElement);
+    const fallback = Number.parseFloat(styles.getPropertyValue('--sb-mobile-safe-area-bottom')) || 0;
+
+    if (!(document.body instanceof HTMLElement)) {
+        return fallback;
+    }
+
+    let probe = document.getElementById('sb-mobile-safe-area-bottom-probe');
+    if (!(probe instanceof HTMLElement)) {
+        probe = createElement('div', {
+            attrs: {
+                id: 'sb-mobile-safe-area-bottom-probe',
+                'aria-hidden': 'true',
+            },
+        });
+        probe.style.cssText = 'position:fixed;left:-9999px;bottom:0;width:0;height:0;padding-bottom:var(--sb-mobile-safe-area-bottom,0px);pointer-events:none;visibility:hidden;contain:layout style size;';
+        document.body.appendChild(probe);
+    }
+
+    return Number.parseFloat(window.getComputedStyle(probe).paddingBottom) || fallback;
+}
+
 function syncMobileShellDrawerBounds() {
     const drawers = getMobileShellBoundDrawers();
 
@@ -2314,6 +2337,7 @@ function syncMobileShellDrawerBounds() {
     const mobileViewport = isMobileViewport();
     const viewportSize = mobileViewport ? getShellViewportSize() : null;
     const baseTopOffset = mobileViewport ? getResolvedShellTopbarOffset() : 0;
+    const safeAreaBottom = mobileViewport ? getMobileSafeAreaBottomPx() : 0;
 
     for (const drawer of drawers) {
         const isOpen = drawer.classList.contains('openDrawer');
@@ -2326,6 +2350,7 @@ function syncMobileShellDrawerBounds() {
             viewportHeight: viewportSize?.height ?? 0,
             baseTopOffset,
             shellGap: drawerStyles ? Number.parseFloat(drawerStyles.getPropertyValue('--sb-mobile-shell-gap')) || 0 : 0,
+            safeAreaBottom,
         }));
     }
 }
@@ -2353,6 +2378,113 @@ function queueMobileShellDrawerBoundsSync() {
     }
 
     window.setTimeout(sync, schedule.followupDelayMs);
+}
+
+function bindMobileDrawerGestureDismiss(drawer, closeDrawer) {
+    if (!(drawer instanceof HTMLElement) || typeof closeDrawer !== 'function' || drawer.dataset.sbDrawerGestureBound === 'true') {
+        return;
+    }
+
+    drawer.dataset.sbDrawerGestureBound = 'true';
+    let drawerGesture = null;
+    let suppressDrawerClickUntil = 0;
+
+    const getGestureHandle = () => drawer.querySelector(':scope > .sb-shell-frame .sb-shell-header')
+        ?? drawer.querySelector(':scope > .sb-character-shell-header')
+        ?? drawer;
+
+    const clearDrawerGesture = () => {
+        drawerGesture = null;
+        drawer.style.removeProperty('transform');
+        drawer.classList.remove('sb-drawer-gesture-active');
+    };
+
+    const beginDrawerGesture = event => {
+        if (!isMobileViewport() || !drawer.classList.contains('openDrawer')) {
+            return;
+        }
+
+        const handle = getGestureHandle();
+        if (!(event.target instanceof Node) || !handle?.contains(event.target)) {
+            return;
+        }
+
+        drawerGesture = sbMobileShellLifecycle.drawerGestures.createGestureState({
+            isMobileViewport: isMobileViewport(),
+            isOpen: drawer.classList.contains('openDrawer'),
+            touch: event.touches?.[0],
+        });
+    };
+
+    const updateDrawerGesture = event => {
+        if (!drawerGesture) {
+            return;
+        }
+
+        const gestureMove = sbMobileShellLifecycle.drawerGestures.resolveGestureMove({
+            gestureState: drawerGesture,
+            touch: event.touches?.[0],
+        });
+
+        drawerGesture = gestureMove.gestureState;
+
+        if (!drawerGesture) {
+            clearDrawerGesture();
+            return;
+        }
+
+        drawer.classList.toggle('sb-drawer-gesture-active', drawerGesture.dragging);
+        if (drawerGesture.dragging) {
+            drawer.style.setProperty('transform', `translateY(${gestureMove.offsetY}px)`, 'important');
+        }
+
+        if (gestureMove.shouldPreventDefault && event.cancelable) {
+            event.preventDefault();
+        }
+
+        if (gestureMove.shouldStopPropagation) {
+            event.stopPropagation();
+        }
+    };
+
+    const finishDrawerGesture = event => {
+        const gestureEnd = sbMobileShellLifecycle.drawerGestures.resolveGestureEnd({
+            gestureState: drawerGesture,
+            nowMs: Date.now(),
+        });
+
+        if (gestureEnd.suppressClickUntil) {
+            suppressDrawerClickUntil = gestureEnd.suppressClickUntil;
+        }
+
+        clearDrawerGesture();
+
+        if (gestureEnd.shouldStopPropagation) {
+            event.stopPropagation();
+        }
+
+        if (gestureEnd.shouldDismiss) {
+            closeDrawer();
+        }
+    };
+
+    const suppressClickAfterDrawerGesture = event => {
+        if (!sbMobileShellLifecycle.drawerGestures.shouldSuppressClick({
+            nowMs: Date.now(),
+            suppressClickUntil: suppressDrawerClickUntil,
+        })) {
+            return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+    };
+
+    drawer.addEventListener('touchstart', beginDrawerGesture, { passive: true });
+    drawer.addEventListener('touchmove', updateDrawerGesture, { passive: false });
+    drawer.addEventListener('touchend', finishDrawerGesture, { passive: true });
+    drawer.addEventListener('touchcancel', clearDrawerGesture, { passive: true });
+    drawer.addEventListener('click', suppressClickAfterDrawerGesture, true);
 }
 
 function isMovingUIActive() {
@@ -7695,6 +7827,7 @@ document.addEventListener('click', (e) => {
 function toggleCharacterPanel({ preferredTab = null } = {}) {
     injectCharacterDrawerControls();
     ensureCharacterResizeHandle();
+    bindMobileDrawerGestureDismiss(getCharacterPanel(), closeCharacterPanel);
 
     if (isCharacterPanelOpen()) {
         closeCharacterPanel();
@@ -12706,6 +12839,8 @@ function openShell(shellKey, tabId = null) {
         return;
     }
 
+    bindMobileDrawerGestureDismiss(shellRoot, () => closeShell(shellKey));
+
     const shellSurface = getMobileShellSurfaceForShell(shellKey);
     if (shellSurface) {
         applyMobileSurfaceExclusivity(sbMobileShellLifecycle.overlays.resolveExclusiveOpen({
@@ -13923,7 +14058,9 @@ function closeMobileNav() {
 }
 
 function injectCharacterDrawerControls() {
-    getCharacterPanel()?.classList.add('sb-character-drawer-root');
+    const characterPanel = getCharacterPanel();
+    characterPanel?.classList.add('sb-character-drawer-root');
+    bindMobileDrawerGestureDismiss(characterPanel, closeCharacterPanel);
     ensureCharacterListToolbarLayout();
     bindCharacterEditorFullscreenToggle();
 

--- a/tests/mobile-shell-lifecycle-drawer-bounds.test.js
+++ b/tests/mobile-shell-lifecycle-drawer-bounds.test.js
@@ -39,6 +39,21 @@ describe('mobile shell drawer bounds lifecycle', () => {
         ]);
     });
 
+    test('subtracts the mobile safe-area bottom from open drawer height', () => {
+        const decision = resolveMobileDrawerBounds({
+            isMobileViewport: true,
+            isOpen: true,
+            viewportHeight: 844,
+            baseTopOffset: 56,
+            shellGap: 3,
+            safeAreaBottom: 34,
+        });
+
+        expect(decision.styleWrites).toContainEqual({ property: 'top', value: '59px', priority: 'important' });
+        expect(decision.styleWrites).toContainEqual({ property: 'height', value: '751px', priority: 'important' });
+        expect(decision.styleWrites).toContainEqual({ property: 'max-height', value: '751px', priority: 'important' });
+    });
+
     test('clamps the top offset to the viewport and never yields negative height', () => {
         const decision = resolveMobileDrawerBounds({
             isMobileViewport: true,
@@ -46,6 +61,7 @@ describe('mobile shell drawer bounds lifecycle', () => {
             viewportHeight: 500,
             baseTopOffset: 480,
             shellGap: 200,
+            safeAreaBottom: 200,
         });
 
         expect(decision.action).toBe(MOBILE_SHELL_DRAWER_BOUND_ACTION.BIND);

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -367,6 +367,7 @@ describe('mobile shell lifecycle wiring', () => {
 
     test('routes mobile drawer bound decisions through the lifecycle seam', () => {
         const applyDecisionSource = getFunctionSource('applyMobileDrawerBoundsDecision');
+        const safeAreaSource = getFunctionSource('getMobileSafeAreaBottomPx');
         const syncBoundsSource = getFunctionSource('syncMobileShellDrawerBounds');
 
         // The adapter is the single DOM writer for drawer bound styles.
@@ -376,14 +377,50 @@ describe('mobile shell lifecycle wiring', () => {
         expect(applyDecisionSource).toContain('decision.styleWrites');
         expect(applyDecisionSource).toContain('drawer.style.setProperty(property, value, priority);');
         expect(applyDecisionSource).toContain('drawer.style.removeProperty(property);');
+        expect(safeAreaSource).toContain('window.getComputedStyle(document.documentElement)');
+        expect(safeAreaSource).toContain('--sb-mobile-safe-area-bottom');
+        expect(safeAreaSource).toContain('sb-mobile-safe-area-bottom-probe');
+        expect(safeAreaSource).toContain('padding-bottom:var(--sb-mobile-safe-area-bottom,0px)');
+        expect(safeAreaSource).toContain('window.getComputedStyle(probe).paddingBottom');
 
         // The call site resolves decisions through the seam and applies via the adapter.
         expect(syncBoundsSource).toContain('sbMobileShellLifecycle.drawerBounds.resolveBounds({');
         expect(syncBoundsSource).toContain('applyMobileDrawerBoundsDecision(drawer,');
+        expect(syncBoundsSource).toContain('const safeAreaBottom = mobileViewport ? getMobileSafeAreaBottomPx() : 0;');
+        expect(syncBoundsSource).toContain('safeAreaBottom,');
 
         // The old inline style writes are gone from the call site.
         expect(syncBoundsSource).not.toContain('style.setProperty(\'top\'');
         expect(syncBoundsSource).not.toContain('style.setProperty(\'height\'');
         expect(syncBoundsSource).not.toContain('style.removeProperty(');
+    });
+
+    test('routes mobile drawer swipe-dismiss through the lifecycle seam', () => {
+        const bindGestureSource = getFunctionSource('bindMobileDrawerGestureDismiss');
+        const openShellSource = getFunctionSource('openShell');
+        const injectCharacterControlsSource = getFunctionSource('injectCharacterDrawerControls');
+        const toggleCharacterPanelSource = getFunctionSource('toggleCharacterPanel');
+
+        expect(bindGestureSource).toContain('sbMobileShellLifecycle.drawerGestures.createGestureState({');
+        expect(bindGestureSource).toContain('sbMobileShellLifecycle.drawerGestures.resolveGestureMove({');
+        expect(bindGestureSource).toContain('sbMobileShellLifecycle.drawerGestures.resolveGestureEnd({');
+        expect(bindGestureSource).toContain('sbMobileShellLifecycle.drawerGestures.shouldSuppressClick({');
+        expect(bindGestureSource).toContain('drawer.addEventListener(\'touchstart\', beginDrawerGesture, { passive: true });');
+        expect(bindGestureSource).toContain('drawer.addEventListener(\'touchmove\', updateDrawerGesture, { passive: false });');
+        expect(bindGestureSource).toContain('drawer.style.setProperty(\'transform\', `translateY(${gestureMove.offsetY}px)`, \'important\');');
+        expect(bindGestureSource).toContain('drawer.style.removeProperty(\'transform\');');
+        expect(openShellSource).toContain('bindMobileDrawerGestureDismiss(shellRoot, () => closeShell(shellKey));');
+        expect(injectCharacterControlsSource).toContain('bindMobileDrawerGestureDismiss(characterPanel, closeCharacterPanel);');
+        expect(toggleCharacterPanelSource).toContain('bindMobileDrawerGestureDismiss(getCharacterPanel(), closeCharacterPanel);');
+        expect(bindGestureSource).not.toContain('event.touches[0].clientY -');
+    });
+
+    test('keeps mobile drawer safe-area math on shell tokens', () => {
+        expect(mobileShellCssSource).toContain('--sb-mobile-safe-area-left: env(safe-area-inset-left, 0px);');
+        expect(mobileShellCssSource).toContain('--sb-mobile-safe-area-right: env(safe-area-inset-right, 0px);');
+        expect(mobileShellCssSource).toContain('bottom: var(--sb-mobile-safe-area-bottom, env(safe-area-inset-bottom, 0px)) !important;');
+        expect(mobileShellCssSource).toContain('.sb-drawer-gesture-active');
+        expect(mobileShellCssSource).not.toContain(' - env(safe-area-inset-bottom, 0px)) !important;');
+        expect(mobileShellCssSource).not.toContain('bottom: env(safe-area-inset-bottom, 0px) !important;');
     });
 });

--- a/tests/mobile-shell-lifecycle.test.js
+++ b/tests/mobile-shell-lifecycle.test.js
@@ -2,7 +2,11 @@ import { describe, expect, test } from '@jest/globals';
 
 import {
     createMobileShellLifecycle,
+    createMobileShellDrawerGestureState,
     createMobileShellNavDragState,
+    MOBILE_SHELL_LIFECYCLE_DRAWER_CLICK_SUPPRESSION_MS,
+    MOBILE_SHELL_LIFECYCLE_DRAWER_DISMISS_THRESHOLD_PX,
+    MOBILE_SHELL_LIFECYCLE_DRAWER_GESTURE_THRESHOLD_PX,
     MOBILE_SHELL_LIFECYCLE_NAV_CLICK_SUPPRESSION_MS,
     MOBILE_SHELL_LIFECYCLE_NAV_DRAG_THRESHOLD_PX,
     MOBILE_SHELL_LIFECYCLE_NAV_OPEN_GRACE_MS,
@@ -10,12 +14,15 @@ import {
     MOBILE_SHELL_NAV_TOGGLE_ACTION,
     resolveMobileModalA11yState,
     resolveMobileNavOpenState,
+    resolveMobileShellDrawerGestureEnd,
+    resolveMobileShellDrawerGestureMove,
     resolveMobileShellNavPageScroll,
     resolveMobileShellNavScrollIndicators,
     resolveMobileNavToggleIntent,
     resolveMobileShellNavDragEnd,
     resolveMobileShellNavDragMove,
     shouldAutoCloseMobileNav,
+    shouldSuppressMobileShellDrawerGestureClick,
     shouldSuppressMobileShellNavClick,
 } from '../public/scripts/mobile-shell-lifecycle/index.js';
 
@@ -24,6 +31,9 @@ describe('mobile shell lifecycle helper', () => {
         expect(MOBILE_SHELL_LIFECYCLE_NAV_OPEN_GRACE_MS).toBe(450);
         expect(MOBILE_SHELL_LIFECYCLE_NAV_DRAG_THRESHOLD_PX).toBe(6);
         expect(MOBILE_SHELL_LIFECYCLE_NAV_CLICK_SUPPRESSION_MS).toBe(350);
+        expect(MOBILE_SHELL_LIFECYCLE_DRAWER_GESTURE_THRESHOLD_PX).toBe(8);
+        expect(MOBILE_SHELL_LIFECYCLE_DRAWER_DISMISS_THRESHOLD_PX).toBe(72);
+        expect(MOBILE_SHELL_LIFECYCLE_DRAWER_CLICK_SUPPRESSION_MS).toBe(350);
     });
 
     test('captures mobile rail drag start only for mobile touch input', () => {
@@ -121,6 +131,127 @@ describe('mobile shell lifecycle helper', () => {
 
         expect(shouldSuppressMobileShellNavClick({ nowMs: 1200, suppressClickUntil: 1350 })).toBe(true);
         expect(shouldSuppressMobileShellNavClick({ nowMs: 1350, suppressClickUntil: 1350 })).toBe(false);
+    });
+
+    test('captures mobile drawer swipe-dismiss gestures only for open mobile drawers', () => {
+        expect(createMobileShellDrawerGestureState({
+            isMobileViewport: true,
+            isOpen: true,
+            touch: { clientX: 120, clientY: 40 },
+        })).toEqual({
+            startX: 120,
+            startY: 40,
+            offsetY: 0,
+            dragging: false,
+        });
+
+        expect(createMobileShellDrawerGestureState({
+            isMobileViewport: false,
+            isOpen: true,
+            touch: { clientX: 120, clientY: 40 },
+        })).toBeNull();
+        expect(createMobileShellDrawerGestureState({
+            isMobileViewport: true,
+            isOpen: false,
+            touch: { clientX: 120, clientY: 40 },
+        })).toBeNull();
+        expect(createMobileShellDrawerGestureState({ isMobileViewport: true, isOpen: true, touch: null })).toBeNull();
+    });
+
+    test('leaves drawer gestures alone until movement is downward and vertical', () => {
+        const gestureState = createMobileShellDrawerGestureState({
+            isMobileViewport: true,
+            isOpen: true,
+            touch: { clientX: 100, clientY: 100 },
+        });
+
+        expect(resolveMobileShellDrawerGestureMove({
+            gestureState,
+            touch: { clientX: 100, clientY: 106 },
+        })).toEqual({
+            gestureState: {
+                ...gestureState,
+                offsetY: 0,
+                dragging: false,
+            },
+            shouldPreventDefault: false,
+            shouldStopPropagation: false,
+            offsetY: 0,
+        });
+
+        expect(resolveMobileShellDrawerGestureMove({
+            gestureState,
+            touch: { clientX: 120, clientY: 112 },
+        })).toEqual({
+            gestureState: {
+                ...gestureState,
+                offsetY: 0,
+                dragging: false,
+            },
+            shouldPreventDefault: false,
+            shouldStopPropagation: false,
+            offsetY: 0,
+        });
+    });
+
+    test('tracks drawer drag offset once the swipe-down threshold is crossed', () => {
+        const gestureState = createMobileShellDrawerGestureState({
+            isMobileViewport: true,
+            isOpen: true,
+            touch: { clientX: 100, clientY: 100 },
+        });
+
+        expect(resolveMobileShellDrawerGestureMove({
+            gestureState,
+            touch: { clientX: 102, clientY: 124 },
+        })).toEqual({
+            gestureState: {
+                ...gestureState,
+                offsetY: 24,
+                dragging: true,
+            },
+            shouldPreventDefault: true,
+            shouldStopPropagation: true,
+            offsetY: 24,
+        });
+    });
+
+    test('dismisses drawers only after a deliberate downward swipe', () => {
+        expect(resolveMobileShellDrawerGestureEnd({
+            gestureState: { startX: 0, startY: 0, offsetY: 71, dragging: true },
+            nowMs: 1000,
+        })).toEqual({
+            gestureState: null,
+            shouldDismiss: false,
+            shouldStopPropagation: true,
+            suppressClickUntil: 1350,
+            offsetY: 0,
+        });
+
+        expect(resolveMobileShellDrawerGestureEnd({
+            gestureState: { startX: 0, startY: 0, offsetY: 72, dragging: true },
+            nowMs: 1000,
+        })).toEqual({
+            gestureState: null,
+            shouldDismiss: true,
+            shouldStopPropagation: true,
+            suppressClickUntil: 1350,
+            offsetY: 0,
+        });
+
+        expect(resolveMobileShellDrawerGestureEnd({
+            gestureState: { startX: 0, startY: 0, offsetY: 90, dragging: false },
+            nowMs: 1000,
+        })).toEqual({
+            gestureState: null,
+            shouldDismiss: false,
+            shouldStopPropagation: false,
+            suppressClickUntil: 0,
+            offsetY: 0,
+        });
+
+        expect(shouldSuppressMobileShellDrawerGestureClick({ nowMs: 1200, suppressClickUntil: 1350 })).toBe(true);
+        expect(shouldSuppressMobileShellDrawerGestureClick({ nowMs: 1350, suppressClickUntil: 1350 })).toBe(false);
     });
 
     test('resolves shell rail page scroll distance and motion preference', () => {
@@ -322,9 +453,16 @@ describe('mobile shell lifecycle helper', () => {
         expect(lifecycle.nav.resolveToggleIntent).toBe(resolveMobileNavToggleIntent);
         expect(lifecycle.nav.resolveOpenState).toBe(resolveMobileNavOpenState);
         expect(lifecycle.nav.shouldAutoClose).toBe(shouldAutoCloseMobileNav);
+        expect(lifecycle.drawerGestures.createGestureState).toBe(createMobileShellDrawerGestureState);
+        expect(lifecycle.drawerGestures.resolveGestureMove).toBe(resolveMobileShellDrawerGestureMove);
+        expect(lifecycle.drawerGestures.resolveGestureEnd).toBe(resolveMobileShellDrawerGestureEnd);
+        expect(lifecycle.drawerGestures.shouldSuppressClick).toBe(shouldSuppressMobileShellDrawerGestureClick);
         expect(lifecycle.modal.resolveA11yState).toBe(resolveMobileModalA11yState);
         expect(lifecycle.timings.navOpenGraceMs).toBe(MOBILE_SHELL_LIFECYCLE_NAV_OPEN_GRACE_MS);
         expect(lifecycle.timings.navDragThresholdPx).toBe(MOBILE_SHELL_LIFECYCLE_NAV_DRAG_THRESHOLD_PX);
         expect(lifecycle.timings.navClickSuppressionMs).toBe(MOBILE_SHELL_LIFECYCLE_NAV_CLICK_SUPPRESSION_MS);
+        expect(lifecycle.timings.drawerGestureThresholdPx).toBe(MOBILE_SHELL_LIFECYCLE_DRAWER_GESTURE_THRESHOLD_PX);
+        expect(lifecycle.timings.drawerDismissThresholdPx).toBe(MOBILE_SHELL_LIFECYCLE_DRAWER_DISMISS_THRESHOLD_PX);
+        expect(lifecycle.timings.drawerClickSuppressionMs).toBe(MOBILE_SHELL_LIFECYCLE_DRAWER_CLICK_SUPPRESSION_MS);
     });
 });

--- a/tests/mobile-shell-smoke.e2e.js
+++ b/tests/mobile-shell-smoke.e2e.js
@@ -100,6 +100,54 @@ function openLeftShell(page) {
     return page.evaluate(() => window.SillyBunnyShell.openTab('left', 'presets'));
 }
 
+async function swipeLeftDrawerDown(page) {
+    await page.evaluate(() => {
+        const drawer = document.getElementById('left-nav-panel');
+        const header = drawer?.querySelector(':scope > .sb-shell-frame .sb-shell-header');
+        const rect = header?.getBoundingClientRect();
+
+        if (!drawer || !header || !rect) {
+            throw new Error('Left drawer header is not ready for swipe-dismiss');
+        }
+
+        const touch = (clientX, clientY) => new Touch({
+            identifier: 1,
+            target: header,
+            clientX,
+            clientY,
+            pageX: clientX + window.scrollX,
+            pageY: clientY + window.scrollY,
+            screenX: clientX,
+            screenY: clientY,
+        });
+        const startX = Math.round(rect.left + rect.width / 2);
+        const startY = Math.round(rect.top + Math.min(28, rect.height / 2));
+        const endY = startY + 96;
+
+        header.dispatchEvent(new TouchEvent('touchstart', {
+            bubbles: true,
+            cancelable: true,
+            touches: [touch(startX, startY)],
+            targetTouches: [touch(startX, startY)],
+            changedTouches: [touch(startX, startY)],
+        }));
+        header.dispatchEvent(new TouchEvent('touchmove', {
+            bubbles: true,
+            cancelable: true,
+            touches: [touch(startX, endY)],
+            targetTouches: [touch(startX, endY)],
+            changedTouches: [touch(startX, endY)],
+        }));
+        header.dispatchEvent(new TouchEvent('touchend', {
+            bubbles: true,
+            cancelable: true,
+            touches: [],
+            targetTouches: [],
+            changedTouches: [touch(startX, endY)],
+        }));
+    });
+}
+
 // While any drawer or overlay is open, the mobile modal policy marks the page
 // chrome (topbar included) inert, so a trusted pointer click cannot reach the
 // hamburger. Synthetic .click() still runs the toggle cascade under test.
@@ -176,6 +224,29 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
 
         // applyMobileDrawerBoundsDecision removes every bound property and
         // the dataset marker once the drawer is no longer open.
+        await expect.poll(() => getDrawerBoundsSnapshot(page, 'left-nav-panel')).toEqual({
+            isOpen: false,
+            isViewportBound: false,
+            top: '',
+            bottom: '',
+            height: '',
+            maxHeight: '',
+            boxSizing: '',
+        });
+
+        await expectNoHorizontalOverflow(page);
+    });
+
+    test('left drawer swipe-down dismisses the mobile sheet', async ({ page }) => {
+        await openLeftShell(page);
+
+        await expect.poll(() => getDrawerBoundsSnapshot(page, 'left-nav-panel')).toMatchObject({
+            isOpen: true,
+            isViewportBound: true,
+        });
+
+        await swipeLeftDrawerDown(page);
+
         await expect.poll(() => getDrawerBoundsSnapshot(page, 'left-nav-panel')).toEqual({
             isOpen: false,
             isViewportBound: false,
@@ -287,12 +358,19 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
         const getRenderedDrawerFit = () => page.evaluate(() => {
             const drawer = document.getElementById('left-nav-panel');
             const rect = drawer.getBoundingClientRect();
+            const probe = document.createElement('div');
+
+            probe.style.cssText = 'position:fixed;left:-9999px;bottom:0;width:0;height:0;padding-bottom:var(--sb-mobile-safe-area-bottom,0px);pointer-events:none;visibility:hidden;contain:layout style size;';
+            document.body.appendChild(probe);
+            const safeAreaBottom = Number.parseFloat(window.getComputedStyle(probe).paddingBottom) || 0;
+            probe.remove();
 
             return {
                 isOpen: drawer.classList.contains('openDrawer'),
                 isViewportBound: drawer.dataset.sbMobileViewportBound === 'true',
                 top: Math.round(rect.top),
                 bottom: Math.round(rect.bottom),
+                expectedBottom: Math.round(window.innerHeight - safeAreaBottom),
                 viewportHeight: window.innerHeight,
             };
         });
@@ -300,7 +378,7 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
         await expect.poll(async () => {
             const fit = await getRenderedDrawerFit();
 
-            return fit.isViewportBound && fit.top > 0 && Math.abs(fit.bottom - 844) <= 2;
+            return fit.isViewportBound && fit.top > 0 && Math.abs(fit.bottom - fit.expectedBottom) <= 2;
         }).toBe(true);
 
         // Viewport shrink stands in for the on-screen keyboard: the resize
@@ -310,7 +388,7 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
         await expect.poll(async () => {
             const fit = await getRenderedDrawerFit();
 
-            return fit.isViewportBound && fit.top > 0 && Math.abs(fit.bottom - 500) <= 2;
+            return fit.isViewportBound && fit.top > 0 && Math.abs(fit.bottom - fit.expectedBottom) <= 2;
         }).toBe(true);
 
         await page.setViewportSize({ width: 390, height: 844 });
@@ -318,7 +396,7 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
         await expect.poll(async () => {
             const fit = await getRenderedDrawerFit();
 
-            return fit.isViewportBound && fit.top > 0 && Math.abs(fit.bottom - 844) <= 2;
+            return fit.isViewportBound && fit.top > 0 && Math.abs(fit.bottom - fit.expectedBottom) <= 2;
         }).toBe(true);
 
         await closeLeftShellThroughUi(page);


### PR DESCRIPTION
## What?
Adds Phase 3.2 mobile drawer polish: drawer bounds now reserve the mobile safe-area bottom token, shell drawers support swipe-down dismissal from their headers, and the mobile smoke pack pins the new swipe-dismiss flow.

## Why?
Mobile drawers previously mixed raw safe-area env values with the SillyBunny safe-area token, and they had no touch-native dismiss gesture. This keeps drawer geometry aligned with the existing mobile safe-area contract and makes modal drawers easier to close on phones.

## How?
Adds a pure `drawerGestures` lifecycle namespace for swipe start, move, end, and click-suppression decisions. The monolith keeps DOM-only adapters for touch events, CSS pixel measurement of the safe-area token, and drawer closing. The drawer bounds seam now accepts an injected bottom safe-area inset so inline viewport-bound heights match the stylesheet token.

## Testing?
- `git diff --check`
- `node --check public/scripts/sillybunny-tabs.js`
- `node --check public/scripts/mobile-shell-lifecycle/index.js`
- `node --check tests/mobile-shell-smoke.e2e.js`
- `npm run lint -- --quiet`
- `mobile-shell-lifecycle.test.js`, `mobile-shell-lifecycle-drawer-bounds.test.js`, `mobile-shell-lifecycle-wiring.test.js`: 50/50
- `mobile-css-budgets.test.js`: 7/7
- Full Jest: 117 suites / 1073 tests
- `npm run check:frontend-budgets`
- `mobile-shell-smoke.e2e.js`: 9/9 on `http://127.0.0.1:4567`

## Screenshots (optional)
Not attached; this draft is covered by the mobile smoke pack across phone, narrow phone, tablet, and compact-desktop viewports.

## Anything Else?
Draft PR for Phase 3.2. Expected merge order is after #448 because both PRs touch mobile shell CSS and the mobile smoke pack.