### PR TITLE
feat: declutter mobile bottom bar actions

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -1,6 +1,11 @@
 /* SillyBunny mobile shell foundation: final sheet contract for modal drawers.
  * Keep this at the end of the shell sheet so it beats older mobile drawer rules. */
 @media screen and (max-width: 768px) {
+    :root {
+        --sb-mobile-safe-area-left: env(safe-area-inset-left, 0px);
+        --sb-mobile-safe-area-right: env(safe-area-inset-right, 0px);
+    }
+
     #form_sheld {
         width: 100%;
         max-width: 100%;
@@ -1306,18 +1311,28 @@
         left: 8px !important;
         right: 8px !important;
         top: calc(var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) + var(--sb-mobile-shell-gap)) !important;
-        bottom: env(safe-area-inset-bottom, 0px) !important;
-        height: calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) - var(--sb-mobile-shell-gap) - env(safe-area-inset-bottom, 0px)) !important;
-        max-height: calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) - var(--sb-mobile-shell-gap) - env(safe-area-inset-bottom, 0px)) !important;
+        bottom: var(--sb-mobile-safe-area-bottom, env(safe-area-inset-bottom, 0px)) !important;
+        height: calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) - var(--sb-mobile-shell-gap) - var(--sb-mobile-safe-area-bottom, env(safe-area-inset-bottom, 0px))) !important;
+        max-height: calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) - var(--sb-mobile-shell-gap) - var(--sb-mobile-safe-area-bottom, env(safe-area-inset-bottom, 0px))) !important;
         min-width: 0 !important;
         margin-top: 0 !important;
         border-radius: 22px 22px 0 0 !important;
         animation: sbMobileShellSheetIn 220ms var(--sb-ease-out) both !important;
         transform-origin: center bottom;
+        transition: transform var(--sb-transition-fast);
+    }
+
+    #left-nav-panel.openDrawer.sb-drawer-gesture-active,
+    #user-settings-block.openDrawer.sb-drawer-gesture-active,
+    .sb-shell-root.openDrawer.sb-drawer-gesture-active,
+    .sb-shell-root.fillLeft.openDrawer.sb-drawer-gesture-active,
+    .sb-shell-root.fillRight.openDrawer.sb-drawer-gesture-active,
+    #right-nav-panel.openDrawer.sb-drawer-gesture-active {
+        transition: none;
     }
 
     :root[data-sb-character-drawer-lock="right"] #right-nav-panel.openDrawer {
-        left: max(8px, env(safe-area-inset-left, 0px)) !important;
+        left: max(8px, var(--sb-mobile-safe-area-left, env(safe-area-inset-left, 0px))) !important;
         right: 0 !important;
         width: auto !important;
         max-width: none !important;
@@ -2609,8 +2624,8 @@
         top: calc(var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) + var(--sb-mobile-shell-gap, 0px)) !important;
         bottom: auto !important;
         box-sizing: border-box !important;
-        height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset))) - var(--sb-mobile-shell-gap, 0px) - env(safe-area-inset-bottom, 0px)) !important;
-        max-height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset))) - var(--sb-mobile-shell-gap, 0px) - env(safe-area-inset-bottom, 0px)) !important;
+        height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset))) - var(--sb-mobile-shell-gap, 0px) - var(--sb-mobile-safe-area-bottom, env(safe-area-inset-bottom, 0px))) !important;
+        max-height: calc(var(--sb-shell-available-height, calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset))) - var(--sb-mobile-shell-gap, 0px) - var(--sb-mobile-safe-area-bottom, env(safe-area-inset-bottom, 0px))) !important;
     }
 }
 
@@ -2667,7 +2682,7 @@
     }
 
     #sb-bottom-chat-bar {
-        --sb-bottom-chat-mobile-gutter: max(6px, env(safe-area-inset-left, 0px), env(safe-area-inset-right, 0px));
+        --sb-bottom-chat-mobile-gutter: max(6px, var(--sb-mobile-safe-area-left, env(safe-area-inset-left, 0px)), var(--sb-mobile-safe-area-right, env(safe-area-inset-right, 0px)));
         --sb-bottom-chat-mobile-gap: clamp(1px, calc(1.5px * var(--sb-bottom-bar-scale)), 3px);
         --sb-bottom-chat-mobile-padding-block: clamp(1px, calc(1.5px * var(--sb-bottom-bar-scale)), 2px);
         --sb-bottom-chat-mobile-padding-inline: clamp(3px, calc(4px * var(--sb-bottom-bar-scale)), 6px);

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -53,7 +53,7 @@
 
     #nonQRFormItems {
         --sb-mobile-composer-input-height: clamp(34px, calc(42px * var(--sb-bottom-bar-scale, 1)), 56px);
-        --sb-composer-action-size: clamp(20px, calc(26px * var(--sb-bottom-bar-scale, 1)), 36px);
+        --sb-composer-action-size: max(var(--sb-mobile-touch-target, 44px), clamp(20px, calc(26px * var(--sb-bottom-bar-scale, 1)), 36px));
         --sb-composer-send-width: calc(var(--sb-composer-action-size) * 1.45);
         --sb-composer-action-icon-size: clamp(10px, calc(13px * var(--sb-bottom-bar-scale, 1)), 18px);
         --sb-composer-left-rail-width: min(28vw, calc(var(--sb-composer-action-size) * 2 + 3px));
@@ -72,7 +72,7 @@
 
     :root[data-sb-compact-mode='true'] #nonQRFormItems {
         --sb-mobile-composer-input-height: clamp(30px, calc(34px * var(--sb-bottom-bar-scale, 1)), 48px);
-        --sb-composer-action-size: clamp(18px, calc(22px * var(--sb-bottom-bar-scale, 1)), 32px);
+        --sb-composer-action-size: max(var(--sb-mobile-touch-target, 44px), clamp(18px, calc(22px * var(--sb-bottom-bar-scale, 1)), 32px));
         --sb-composer-send-width: calc(var(--sb-composer-action-size) * 1.42);
         --sb-composer-action-icon-size: clamp(9px, calc(11px * var(--sb-bottom-bar-scale, 1)), 16px);
         --sb-composer-left-rail-width: min(26vw, calc(var(--sb-composer-action-size) * 2 + 2px));
@@ -1594,7 +1594,7 @@
         height: calc(100dvh - var(--sb-topbar-layout-offset));
         min-height: calc(100dvh - var(--sb-topbar-layout-offset));
         z-index: -1;
-        padding: 8px;
+        padding: 8px max(8px, env(safe-area-inset-right, 0px)) max(8px, env(safe-area-inset-bottom, 0px)) max(8px, env(safe-area-inset-left, 0px));
         isolation: isolate;
         background: transparent;
         backdrop-filter: none;
@@ -1617,7 +1617,9 @@
 
     #sb-mobile-nav.sb-nav-open[aria-hidden='false'] {
         opacity: 1;
-        display: block;
+        display: flex;
+        align-items: flex-end;
+        justify-content: center;
         visibility: visible;
         pointer-events: auto;
         z-index: var(--sb-z-modal);
@@ -1676,18 +1678,26 @@
     #sb-mobile-nav-content {
         position: relative;
         isolation: isolate;
-        width: min(100%, 620px);
-        max-height: calc(100dvh - var(--sb-topbar-layout-offset) - 32px);
-        margin: 0 auto;
+        width: min(100%, 560px);
+        max-height: min(76dvh, calc(100dvh - var(--sb-topbar-layout-offset) - 16px));
+        margin: auto auto 0;
         padding: 14px;
         display: flex;
         flex-direction: column;
         gap: 12px;
         overflow-y: auto;
-        border-radius: 20px;
+        overscroll-behavior: contain;
+        -webkit-overflow-scrolling: touch;
+        border-radius: 22px 22px 16px 16px;
         border: 1px solid color-mix(in srgb, var(--sb-shell-border) 88%, transparent);
         background: transparent;
         box-shadow: 0 24px 70px color-mix(in srgb, var(--SmartThemeShadowColor) 28%, transparent);
+        transform: translateY(10px);
+        transition: transform var(--sb-transition-fast);
+    }
+
+    #sb-mobile-nav.sb-nav-open[aria-hidden='false'] #sb-mobile-nav-content {
+        transform: translateY(0);
     }
 
     #sb-mobile-nav-content::before {
@@ -1722,7 +1732,11 @@
     .sb-mobile-panel-close {
         appearance: none;
         width: var(--sb-mobile-touch-target, 44px);
+        min-width: var(--sb-mobile-touch-target, 44px);
+        max-width: var(--sb-mobile-touch-target, 44px);
         height: var(--sb-mobile-touch-target, 44px);
+        min-height: var(--sb-mobile-touch-target, 44px);
+        max-height: var(--sb-mobile-touch-target, 44px);
         border: 1px solid color-mix(in srgb, var(--sb-shell-border) 85%, transparent);
         border-radius: var(--sb-radius-md, 16px);
         background: var(--sb-card-bg);
@@ -1730,6 +1744,20 @@
         display: inline-grid;
         place-items: center;
         cursor: pointer;
+    }
+
+    #sb-mobile-nav .sb-mobile-panel-header {
+        grid-template-columns: minmax(0, 1fr) var(--sb-mobile-touch-target, 44px);
+    }
+
+    #sb-mobile-nav .sb-mobile-panel-close {
+        width: var(--sb-mobile-touch-target, 44px);
+        min-width: var(--sb-mobile-touch-target, 44px);
+        max-width: var(--sb-mobile-touch-target, 44px);
+        height: var(--sb-mobile-touch-target, 44px);
+        min-height: var(--sb-mobile-touch-target, 44px);
+        max-height: var(--sb-mobile-touch-target, 44px);
+        border-radius: var(--sb-radius-md, 16px);
     }
 
     .sb-mobile-section {
@@ -1816,6 +1844,18 @@
     .sb-mobile-panel-close:focus-visible {
         outline: 2px solid var(--sb-focus-ring, var(--SmartThemeQuoteColor));
         outline-offset: 2px;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        #sb-mobile-nav,
+        #sb-mobile-nav-content,
+        .sb-nav-item {
+            transition: none;
+        }
+
+        #sb-mobile-nav-content {
+            transform: none;
+        }
     }
 
 }
@@ -2679,7 +2719,7 @@
 
     #nonQRFormItems {
         --sb-mobile-composer-input-height: clamp(32px, calc(38px * var(--sb-bottom-bar-scale, 1)), 52px);
-        --sb-composer-action-size: clamp(20px, calc(24px * var(--sb-bottom-bar-scale, 1)), 34px);
+        --sb-composer-action-size: max(var(--sb-mobile-touch-target, 44px), clamp(20px, calc(24px * var(--sb-bottom-bar-scale, 1)), 34px));
         --sb-composer-send-width: calc(var(--sb-composer-action-size) * 1.40);
         --sb-composer-action-icon-size: clamp(10px, calc(12px * var(--sb-bottom-bar-scale, 1)), 17px);
         --sb-composer-left-rail-width: min(26vw, calc(var(--sb-composer-action-size) * 2 + 2px));

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -4436,7 +4436,8 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 }
 
 .sb-bottom-chat-collapse-toggle,
-.sb-bottom-chat-search-toggle {
+.sb-bottom-chat-search-toggle,
+.sb-bottom-chat-overflow-toggle {
     display: none;
 }
 
@@ -4519,7 +4520,8 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
         width: calc((var(--sb-bottom-chat-mobile-button-size) * 2) + var(--sb-bottom-chat-mobile-gap));
     }
 
-    .sb-bottom-chat-search-toggle {
+    .sb-bottom-chat-search-toggle,
+    .sb-bottom-chat-overflow-toggle.sb-bottom-chat-overflow-active {
         display: inline-flex;
     }
 
@@ -4584,6 +4586,10 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
         width: max-content;
     }
 
+    .sb-bottom-chat-overflow-source {
+        display: none;
+    }
+
     .sb-bottom-chat-nav-actions {
         padding-inline-end: 0;
         border-inline-end: 0;
@@ -4608,6 +4614,77 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
         font-size: clamp(calc(var(--mainFontSize) * 0.68), calc(var(--mainFontSize) * 0.78 * var(--sb-bottom-bar-scale)), calc(var(--mainFontSize) * 0.88));
         line-height: 1;
     }
+}
+
+.sb-bottom-chat-overflow-menu {
+    position: fixed;
+    z-index: calc(var(--sb-z-modal-content, 3100) + 2);
+    min-width: min(220px, calc(100vw - 16px));
+    max-width: min(280px, calc(100vw - 16px));
+    max-height: min(360px, calc(100dvh - 96px));
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 5px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+    border: 1px solid color-mix(in srgb, var(--SmartThemeBorderColor) 82%, transparent);
+    border-radius: var(--sb-radius-md, 14px);
+    background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 96%, var(--SmartThemeBodyColor) 4%);
+    box-shadow: 0 12px 30px color-mix(in srgb, var(--SmartThemeShadowColor) 32%, transparent);
+    animation: sbShellContentReveal 160ms var(--sb-ease-out);
+}
+
+.sb-bottom-chat-overflow-menu[hidden] {
+    display: none;
+}
+
+.sb-bottom-chat-overflow-item {
+    appearance: none;
+    width: 100%;
+    min-height: 40px;
+    display: grid;
+    grid-template-columns: 24px minmax(0, 1fr);
+    align-items: center;
+    gap: 8px;
+    padding: 7px 9px;
+    border: 0;
+    border-radius: 10px;
+    color: var(--SmartThemeBodyColor);
+    background: transparent;
+    cursor: pointer;
+    text-align: left;
+    font: inherit;
+    font-size: calc(var(--mainFontSize) * 0.84);
+}
+
+.sb-bottom-chat-overflow-item:hover,
+.sb-bottom-chat-overflow-item:focus-visible {
+    background: color-mix(in srgb, var(--SmartThemeBodyColor) 10%, transparent);
+}
+
+.sb-bottom-chat-overflow-item:focus-visible {
+    outline: 2px solid var(--color-focus-ring, var(--color-primary, var(--sb-accent)));
+    outline-offset: 2px;
+}
+
+.sb-bottom-chat-overflow-item > i {
+    justify-self: center;
+    opacity: 0.86;
+}
+
+.sb-bottom-chat-overflow-item > span {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.sb-bottom-chat-overflow-item:disabled,
+.sb-bottom-chat-overflow-item.is-disabled {
+    opacity: 0.42;
+    cursor: default;
 }
 
 @media screen and (max-width: 420px) {
@@ -4879,6 +4956,18 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     z-index: calc(var(--sb-z-modal-content, 3100) + 1);
     box-shadow: 0 8px 24px color-mix(in srgb, var(--SmartThemeShadowColor) 30%, transparent);
     animation: sbShellContentReveal 200ms var(--sb-ease-out);
+}
+
+@media screen and (max-width: 768px) {
+    #sb-persona-picker,
+    .sb-bottom-chat-overflow-menu {
+        max-height: min(56dvh, calc(100dvh - var(--sb-mobile-safe-area-bottom, 34px) - 96px));
+    }
+
+    #sb-persona-picker {
+        max-width: min(360px, calc(100vw - 16px));
+        border-radius: var(--sb-radius-lg, 16px);
+    }
 }
 
 .sb-persona-options {

--- a/public/scripts/mobile-shell-lifecycle/index.js
+++ b/public/scripts/mobile-shell-lifecycle/index.js
@@ -1,6 +1,9 @@
 export const MOBILE_SHELL_LIFECYCLE_NAV_OPEN_GRACE_MS = 450;
 export const MOBILE_SHELL_LIFECYCLE_NAV_DRAG_THRESHOLD_PX = 6;
 export const MOBILE_SHELL_LIFECYCLE_NAV_CLICK_SUPPRESSION_MS = 350;
+export const MOBILE_SHELL_LIFECYCLE_DRAWER_GESTURE_THRESHOLD_PX = 8;
+export const MOBILE_SHELL_LIFECYCLE_DRAWER_DISMISS_THRESHOLD_PX = 72;
+export const MOBILE_SHELL_LIFECYCLE_DRAWER_CLICK_SUPPRESSION_MS = 350;
 
 export const MOBILE_SHELL_NAV_TOGGLE_ACTION = Object.freeze({
     ACTIVATE_PAGE_TARGET: 'activate-page-target',
@@ -292,6 +295,124 @@ export function resolveMobileShellNavDragEnd({
  * @returns {boolean}
  */
 export function shouldSuppressMobileShellNavClick({
+    nowMs = 0,
+    suppressClickUntil = 0,
+} = {}) {
+    return normalizeNumber(nowMs) < normalizeNumber(suppressClickUntil);
+}
+
+/**
+ * Captures the start state for mobile drawer swipe-down dismissal.
+ * @param {object} options Options.
+ * @param {boolean} [options.isMobileViewport=false] Whether mobile shell policy is active.
+ * @param {boolean} [options.isOpen=false] Whether the drawer is currently open.
+ * @param {object|null} [options.touch=null] First touch point.
+ * @returns {{startX: number, startY: number, offsetY: number, dragging: boolean}|null}
+ */
+export function createMobileShellDrawerGestureState({
+    isMobileViewport = false,
+    isOpen = false,
+    touch = null,
+} = {}) {
+    const touchPoint = getTouchPoint(touch);
+    if (!isMobileViewport || !isOpen || !touchPoint) {
+        return null;
+    }
+
+    return {
+        startX: touchPoint.clientX,
+        startY: touchPoint.clientY,
+        offsetY: 0,
+        dragging: false,
+    };
+}
+
+/**
+ * Resolves one touch-move step for mobile drawer swipe-down dismissal.
+ * @param {object} options Options.
+ * @param {object|null} [options.gestureState=null] Existing gesture state.
+ * @param {object|null} [options.touch=null] Current touch point.
+ * @param {number} [options.thresholdPx=MOBILE_SHELL_LIFECYCLE_DRAWER_GESTURE_THRESHOLD_PX] Drag threshold.
+ * @returns {{gestureState: object|null, shouldPreventDefault: boolean, shouldStopPropagation: boolean, offsetY: number}}
+ */
+export function resolveMobileShellDrawerGestureMove({
+    gestureState = null,
+    touch = null,
+    thresholdPx = MOBILE_SHELL_LIFECYCLE_DRAWER_GESTURE_THRESHOLD_PX,
+} = {}) {
+    const touchPoint = getTouchPoint(touch);
+    if (!gestureState || !touchPoint) {
+        return {
+            gestureState: null,
+            shouldPreventDefault: false,
+            shouldStopPropagation: false,
+            offsetY: 0,
+        };
+    }
+
+    const deltaX = touchPoint.clientX - normalizeNumber(gestureState.startX);
+    const deltaY = touchPoint.clientY - normalizeNumber(gestureState.startY);
+    const isDownward = deltaY > 0;
+    const isVerticalIntent = Math.abs(deltaY) >= Math.abs(deltaX);
+    const isDragging = Boolean(gestureState.dragging)
+        || (isDownward && isVerticalIntent && deltaY > normalizeNumber(thresholdPx));
+    const offsetY = isDragging ? Math.max(0, deltaY) : 0;
+    const nextGestureState = {
+        ...gestureState,
+        offsetY,
+        dragging: isDragging,
+    };
+
+    return {
+        gestureState: nextGestureState,
+        shouldPreventDefault: isDragging,
+        shouldStopPropagation: isDragging,
+        offsetY,
+    };
+}
+
+/**
+ * Resolves touch-end cleanup and dismiss intent after mobile drawer dragging.
+ * @param {object} options Options.
+ * @param {object|null} [options.gestureState=null] Existing gesture state.
+ * @param {number} [options.nowMs=0] Current timestamp.
+ * @param {number} [options.dismissThresholdPx=MOBILE_SHELL_LIFECYCLE_DRAWER_DISMISS_THRESHOLD_PX] Dismiss threshold.
+ * @param {number} [options.suppressionMs=MOBILE_SHELL_LIFECYCLE_DRAWER_CLICK_SUPPRESSION_MS] Suppression window.
+ * @returns {{gestureState: null, shouldDismiss: boolean, shouldStopPropagation: boolean, suppressClickUntil: number, offsetY: number}}
+ */
+export function resolveMobileShellDrawerGestureEnd({
+    gestureState = null,
+    nowMs = 0,
+    dismissThresholdPx = MOBILE_SHELL_LIFECYCLE_DRAWER_DISMISS_THRESHOLD_PX,
+    suppressionMs = MOBILE_SHELL_LIFECYCLE_DRAWER_CLICK_SUPPRESSION_MS,
+} = {}) {
+    if (!gestureState?.dragging) {
+        return {
+            gestureState: null,
+            shouldDismiss: false,
+            shouldStopPropagation: false,
+            suppressClickUntil: 0,
+            offsetY: 0,
+        };
+    }
+
+    return {
+        gestureState: null,
+        shouldDismiss: normalizeNumber(gestureState.offsetY) >= normalizeNumber(dismissThresholdPx),
+        shouldStopPropagation: true,
+        suppressClickUntil: normalizeNumber(nowMs) + normalizeNumber(suppressionMs),
+        offsetY: 0,
+    };
+}
+
+/**
+ * Resolves whether a click immediately after drawer dragging should be swallowed.
+ * @param {object} options Options.
+ * @param {number} [options.nowMs=0] Current timestamp.
+ * @param {number} [options.suppressClickUntil=0] Suppression deadline.
+ * @returns {boolean}
+ */
+export function shouldSuppressMobileShellDrawerGestureClick({
     nowMs = 0,
     suppressClickUntil = 0,
 } = {}) {
@@ -755,6 +876,7 @@ function clampBoundNumber(value, min, max) {
  * @param {number} [options.viewportHeight=0] Current shell viewport height in px.
  * @param {number} [options.baseTopOffset=0] Resolved shell topbar offset in px.
  * @param {number} [options.shellGap=0] Drawer --sb-mobile-shell-gap value in px.
+ * @param {number} [options.safeAreaBottom=0] Bottom safe-area inset reserved below the drawer.
  * @returns {{action: string, styleWrites: Array<{property: string, value: string, priority: string}>, styleRemovals: string[]}}
  */
 export function resolveMobileDrawerBounds({
@@ -764,6 +886,7 @@ export function resolveMobileDrawerBounds({
     viewportHeight = 0,
     baseTopOffset = 0,
     shellGap = 0,
+    safeAreaBottom = 0,
 } = {}) {
     const shouldBind = Boolean(isMobileViewport) && Boolean(isOpen);
 
@@ -778,7 +901,12 @@ export function resolveMobileDrawerBounds({
     const safeViewportHeight = Math.max(0, normalizeNumber(viewportHeight));
     const safeBaseTopOffset = Math.max(0, Math.round(normalizeNumber(baseTopOffset)));
     const topOffset = clampBoundNumber(Math.round(safeBaseTopOffset + normalizeNumber(shellGap)), 0, safeViewportHeight);
-    const availableHeight = Math.max(0, safeViewportHeight - topOffset);
+    const bottomInset = clampBoundNumber(
+        Math.round(normalizeNumber(safeAreaBottom)),
+        0,
+        Math.max(0, safeViewportHeight - topOffset),
+    );
+    const availableHeight = Math.max(0, safeViewportHeight - topOffset - bottomInset);
 
     return {
         action: MOBILE_SHELL_DRAWER_BOUND_ACTION.BIND,
@@ -893,6 +1021,12 @@ export function createMobileShellLifecycle() {
             resolveAutoCloseSiblings: resolveInlineDrawerAutoCloseSiblings,
             derivePersistenceKey: deriveInlineDrawerPersistenceKey,
         },
+        drawerGestures: {
+            createGestureState: createMobileShellDrawerGestureState,
+            resolveGestureMove: resolveMobileShellDrawerGestureMove,
+            resolveGestureEnd: resolveMobileShellDrawerGestureEnd,
+            shouldSuppressClick: shouldSuppressMobileShellDrawerGestureClick,
+        },
         drawerBounds: {
             action: MOBILE_SHELL_DRAWER_BOUND_ACTION,
             boundStyleProperties: MOBILE_SHELL_DRAWER_BOUND_STYLE_PROPERTIES,
@@ -907,6 +1041,9 @@ export function createMobileShellLifecycle() {
             navOpenGraceMs: MOBILE_SHELL_LIFECYCLE_NAV_OPEN_GRACE_MS,
             navDragThresholdPx: MOBILE_SHELL_LIFECYCLE_NAV_DRAG_THRESHOLD_PX,
             navClickSuppressionMs: MOBILE_SHELL_LIFECYCLE_NAV_CLICK_SUPPRESSION_MS,
+            drawerGestureThresholdPx: MOBILE_SHELL_LIFECYCLE_DRAWER_GESTURE_THRESHOLD_PX,
+            drawerDismissThresholdPx: MOBILE_SHELL_LIFECYCLE_DRAWER_DISMISS_THRESHOLD_PX,
+            drawerClickSuppressionMs: MOBILE_SHELL_LIFECYCLE_DRAWER_CLICK_SUPPRESSION_MS,
         },
     };
 }

--- a/public/scripts/mobile-shell-lifecycle/index.js
+++ b/public/scripts/mobile-shell-lifecycle/index.js
@@ -38,6 +38,11 @@ export const MOBILE_SHELL_RAIL_QUICK_ACTION_LIMIT = 12;
 export const MOBILE_SHELL_RAIL_QUICK_ACTION_LABEL_MAX_LENGTH = 36;
 export const MOBILE_SHELL_RAIL_QUICK_ACTION_ICON_FALLBACK = 'fa-bolt';
 export const MOBILE_SHELL_RAIL_CHARACTER_SHELL_KEY = 'characters';
+export const MOBILE_SHELL_BOTTOM_BAR_DEFAULT_VISIBLE_ACTION_IDS = Object.freeze([
+    'view-files',
+    'new-chat',
+    'search-chat',
+]);
 
 const MOBILE_SHELL_RAIL_ICON_STYLE_CLASSES = Object.freeze(new Set(['fa-solid', 'fa-regular', 'fa-brands']));
 
@@ -680,6 +685,50 @@ export function resolveMobileShellRailActionVisibility({
 }
 
 /**
+ * Resolves which chat-management actions stay visible and which move into the
+ * mobile overflow menu.
+ * @param {object} options Options.
+ * @param {object[]} [options.actions=[]] Ordered bottom-bar action models.
+ * @param {boolean} [options.isMobileViewport=false] Whether mobile layout is active.
+ * @param {string[]} [options.visibleActionIds=MOBILE_SHELL_BOTTOM_BAR_DEFAULT_VISIBLE_ACTION_IDS] High-frequency action ids.
+ * @returns {{visibleActions: object[], overflowActions: object[], shouldRenderOverflow: boolean}}
+ */
+export function resolveMobileShellBottomBarActionVisibility({
+    actions = [],
+    isMobileViewport = false,
+    visibleActionIds = MOBILE_SHELL_BOTTOM_BAR_DEFAULT_VISIBLE_ACTION_IDS,
+} = {}) {
+    const normalizedActions = Array.isArray(actions) ? actions.filter(Boolean) : [];
+    if (!isMobileViewport) {
+        return {
+            visibleActions: normalizedActions,
+            overflowActions: [],
+            shouldRenderOverflow: false,
+        };
+    }
+
+    const visibleIds = new Set(Array.isArray(visibleActionIds) ? visibleActionIds.map(id => String(id)) : []);
+    const visibleActions = [];
+    const overflowActions = [];
+
+    for (const action of normalizedActions) {
+        const actionId = String(action?.id ?? '');
+
+        if (visibleIds.has(actionId)) {
+            visibleActions.push(action);
+        } else {
+            overflowActions.push(action);
+        }
+    }
+
+    return {
+        visibleActions,
+        overflowActions,
+        shouldRenderOverflow: overflowActions.length > 0,
+    };
+}
+
+/**
  * Resolves which open inline drawer siblings should close when a drawer opens.
  * The current shell behavior is viewport-agnostic; callers still pass viewport
  * state so the decision seam owns the policy if it becomes mobile-specific.
@@ -1012,10 +1061,12 @@ export function createMobileShellLifecycle() {
                 labelMaxLength: MOBILE_SHELL_RAIL_QUICK_ACTION_LABEL_MAX_LENGTH,
                 iconFallback: MOBILE_SHELL_RAIL_QUICK_ACTION_ICON_FALLBACK,
             },
+            bottomBarVisibleActionIds: MOBILE_SHELL_BOTTOM_BAR_DEFAULT_VISIBLE_ACTION_IDS,
             resolveQuickActionRoute: resolveMobileShellQuickActionRoute,
             normalizeQuickAction: normalizeMobileShellQuickAction,
             getQuickActionKey: getMobileShellQuickActionKey,
             resolveActionVisibility: resolveMobileShellRailActionVisibility,
+            resolveBottomBarActionVisibility: resolveMobileShellBottomBarActionVisibility,
         },
         inlineDrawers: {
             resolveAutoCloseSiblings: resolveInlineDrawerAutoCloseSiblings,

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -2304,6 +2304,29 @@ function applyMobileDrawerBoundsDecision(drawer, decision) {
     }
 }
 
+function getMobileSafeAreaBottomPx() {
+    const styles = window.getComputedStyle(document.documentElement);
+    const fallback = Number.parseFloat(styles.getPropertyValue('--sb-mobile-safe-area-bottom')) || 0;
+
+    if (!(document.body instanceof HTMLElement)) {
+        return fallback;
+    }
+
+    let probe = document.getElementById('sb-mobile-safe-area-bottom-probe');
+    if (!(probe instanceof HTMLElement)) {
+        probe = createElement('div', {
+            attrs: {
+                id: 'sb-mobile-safe-area-bottom-probe',
+                'aria-hidden': 'true',
+            },
+        });
+        probe.style.cssText = 'position:fixed;left:-9999px;bottom:0;width:0;height:0;padding-bottom:var(--sb-mobile-safe-area-bottom,0px);pointer-events:none;visibility:hidden;contain:layout style size;';
+        document.body.appendChild(probe);
+    }
+
+    return Number.parseFloat(window.getComputedStyle(probe).paddingBottom) || fallback;
+}
+
 function syncMobileShellDrawerBounds() {
     const drawers = getMobileShellBoundDrawers();
 
@@ -2314,6 +2337,7 @@ function syncMobileShellDrawerBounds() {
     const mobileViewport = isMobileViewport();
     const viewportSize = mobileViewport ? getShellViewportSize() : null;
     const baseTopOffset = mobileViewport ? getResolvedShellTopbarOffset() : 0;
+    const safeAreaBottom = mobileViewport ? getMobileSafeAreaBottomPx() : 0;
 
     for (const drawer of drawers) {
         const isOpen = drawer.classList.contains('openDrawer');
@@ -2326,6 +2350,7 @@ function syncMobileShellDrawerBounds() {
             viewportHeight: viewportSize?.height ?? 0,
             baseTopOffset,
             shellGap: drawerStyles ? Number.parseFloat(drawerStyles.getPropertyValue('--sb-mobile-shell-gap')) || 0 : 0,
+            safeAreaBottom,
         }));
     }
 }
@@ -2353,6 +2378,113 @@ function queueMobileShellDrawerBoundsSync() {
     }
 
     window.setTimeout(sync, schedule.followupDelayMs);
+}
+
+function bindMobileDrawerGestureDismiss(drawer, closeDrawer) {
+    if (!(drawer instanceof HTMLElement) || typeof closeDrawer !== 'function' || drawer.dataset.sbDrawerGestureBound === 'true') {
+        return;
+    }
+
+    drawer.dataset.sbDrawerGestureBound = 'true';
+    let drawerGesture = null;
+    let suppressDrawerClickUntil = 0;
+
+    const getGestureHandle = () => drawer.querySelector(':scope > .sb-shell-frame .sb-shell-header')
+        ?? drawer.querySelector(':scope > .sb-character-shell-header')
+        ?? drawer;
+
+    const clearDrawerGesture = () => {
+        drawerGesture = null;
+        drawer.style.removeProperty('transform');
+        drawer.classList.remove('sb-drawer-gesture-active');
+    };
+
+    const beginDrawerGesture = event => {
+        if (!isMobileViewport() || !drawer.classList.contains('openDrawer')) {
+            return;
+        }
+
+        const handle = getGestureHandle();
+        if (!(event.target instanceof Node) || !handle?.contains(event.target)) {
+            return;
+        }
+
+        drawerGesture = sbMobileShellLifecycle.drawerGestures.createGestureState({
+            isMobileViewport: isMobileViewport(),
+            isOpen: drawer.classList.contains('openDrawer'),
+            touch: event.touches?.[0],
+        });
+    };
+
+    const updateDrawerGesture = event => {
+        if (!drawerGesture) {
+            return;
+        }
+
+        const gestureMove = sbMobileShellLifecycle.drawerGestures.resolveGestureMove({
+            gestureState: drawerGesture,
+            touch: event.touches?.[0],
+        });
+
+        drawerGesture = gestureMove.gestureState;
+
+        if (!drawerGesture) {
+            clearDrawerGesture();
+            return;
+        }
+
+        drawer.classList.toggle('sb-drawer-gesture-active', drawerGesture.dragging);
+        if (drawerGesture.dragging) {
+            drawer.style.setProperty('transform', `translateY(${gestureMove.offsetY}px)`, 'important');
+        }
+
+        if (gestureMove.shouldPreventDefault && event.cancelable) {
+            event.preventDefault();
+        }
+
+        if (gestureMove.shouldStopPropagation) {
+            event.stopPropagation();
+        }
+    };
+
+    const finishDrawerGesture = event => {
+        const gestureEnd = sbMobileShellLifecycle.drawerGestures.resolveGestureEnd({
+            gestureState: drawerGesture,
+            nowMs: Date.now(),
+        });
+
+        if (gestureEnd.suppressClickUntil) {
+            suppressDrawerClickUntil = gestureEnd.suppressClickUntil;
+        }
+
+        clearDrawerGesture();
+
+        if (gestureEnd.shouldStopPropagation) {
+            event.stopPropagation();
+        }
+
+        if (gestureEnd.shouldDismiss) {
+            closeDrawer();
+        }
+    };
+
+    const suppressClickAfterDrawerGesture = event => {
+        if (!sbMobileShellLifecycle.drawerGestures.shouldSuppressClick({
+            nowMs: Date.now(),
+            suppressClickUntil: suppressDrawerClickUntil,
+        })) {
+            return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+    };
+
+    drawer.addEventListener('touchstart', beginDrawerGesture, { passive: true });
+    drawer.addEventListener('touchmove', updateDrawerGesture, { passive: false });
+    drawer.addEventListener('touchend', finishDrawerGesture, { passive: true });
+    drawer.addEventListener('touchcancel', clearDrawerGesture, { passive: true });
+    drawer.addEventListener('click', suppressClickAfterDrawerGesture, true);
 }
 
 function isMovingUIActive() {
@@ -7695,6 +7827,7 @@ document.addEventListener('click', (e) => {
 function toggleCharacterPanel({ preferredTab = null } = {}) {
     injectCharacterDrawerControls();
     ensureCharacterResizeHandle();
+    bindMobileDrawerGestureDismiss(getCharacterPanel(), closeCharacterPanel);
 
     if (isCharacterPanelOpen()) {
         closeCharacterPanel();
@@ -12706,6 +12839,8 @@ function openShell(shellKey, tabId = null) {
         return;
     }
 
+    bindMobileDrawerGestureDismiss(shellRoot, () => closeShell(shellKey));
+
     const shellSurface = getMobileShellSurfaceForShell(shellKey);
     if (shellSurface) {
         applyMobileSurfaceExclusivity(sbMobileShellLifecycle.overlays.resolveExclusiveOpen({
@@ -13923,7 +14058,9 @@ function closeMobileNav() {
 }
 
 function injectCharacterDrawerControls() {
-    getCharacterPanel()?.classList.add('sb-character-drawer-root');
+    const characterPanel = getCharacterPanel();
+    characterPanel?.classList.add('sb-character-drawer-root');
+    bindMobileDrawerGestureDismiss(characterPanel, closeCharacterPanel);
     ensureCharacterListToolbarLayout();
     bindCharacterEditorFullscreenToggle();
 

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -762,8 +762,15 @@ const sbState = {
         scrollTopButton: null,
         scrollBottomButton: null,
         managerButton: null,
+        newButton: null,
         massDeleteButton: null,
         autoNameButton: null,
+        renameButton: null,
+        deleteButton: null,
+        overflowButton: null,
+        overflowMenu: null,
+        overflowActions: [],
+        overflowOpen: false,
         secondaryOpen: normalizeStoredBoolean(safeGetItem(SB_STORAGE_KEYS.bottomChatSecondaryOpen), true),
         searchOpen: false,
         bindingRetryTimer: 0,
@@ -4725,6 +4732,7 @@ function setBottomChatActionBusy(button, busy) {
 
     button.classList.toggle('is-busy', Boolean(busy));
     setButtonDisabled(button, Boolean(busy));
+    refreshBottomChatOverflowMenu();
 }
 
 async function handleAutoNameChat() {
@@ -5992,6 +6000,18 @@ function createBottomChatButton({ icon, title, className = '' }, onClick) {
     return button;
 }
 
+function createBottomChatAction({ id, icon, title, className = '', onClick }) {
+    const button = createBottomChatButton({ icon, title, className }, onClick);
+    button.dataset.sbBottomActionId = id;
+
+    return {
+        id,
+        title,
+        icon,
+        button,
+    };
+}
+
 function createBottomChatSearchField() {
     const field = createElement('label', {
         id: 'sb-bottom-chat-search-field',
@@ -6027,6 +6047,194 @@ function createBottomChatSearchField() {
     return { field, input, status };
 }
 
+function getBottomChatActionModels() {
+    const bottomChatBarState = getBottomChatBarState();
+
+    return [
+        { id: 'view-files', button: bottomChatBarState.managerButton },
+        { id: 'new-chat', button: bottomChatBarState.newButton },
+        { id: 'mass-delete', button: bottomChatBarState.massDeleteButton },
+        { id: 'auto-name', button: bottomChatBarState.autoNameButton },
+        { id: 'rename-chat', button: bottomChatBarState.renameButton },
+        { id: 'search-chat', button: bottomChatBarState.searchToggleButton },
+        { id: 'delete-chat', button: bottomChatBarState.deleteButton },
+    ].filter(action => action.button instanceof HTMLElement)
+        .map(action => ({
+            ...action,
+            title: action.button.getAttribute('aria-label') || action.button.title || '',
+        }));
+}
+
+function ensureBottomChatOverflowMenu() {
+    const bottomChatBarState = getBottomChatBarState();
+    if (bottomChatBarState.overflowMenu instanceof HTMLElement) {
+        return bottomChatBarState.overflowMenu;
+    }
+
+    const menu = createElement('div', {
+        id: 'sb-bottom-chat-overflow-menu',
+        className: 'sb-bottom-chat-overflow-menu',
+        attrs: {
+            role: 'menu',
+            'aria-label': 'More chat actions',
+        },
+    });
+    menu.hidden = true;
+    menu.addEventListener('click', event => {
+        const button = event.target instanceof Element
+            ? event.target.closest('.sb-bottom-chat-overflow-item')
+            : null;
+        if (!(button instanceof HTMLButtonElement) || button.disabled) {
+            return;
+        }
+
+        const actionButton = bottomChatBarState.overflowActions?.find(action => action.id === button.dataset.sbBottomActionId)?.button;
+        if (actionButton instanceof HTMLButtonElement) {
+            actionButton.click();
+            setBottomChatOverflowOpen(false, { restoreFocus: false });
+        }
+    });
+    menu.addEventListener('keydown', event => {
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            setBottomChatOverflowOpen(false, { restoreFocus: true });
+        }
+    });
+
+    document.body.appendChild(menu);
+    bottomChatBarState.overflowMenu = menu;
+    return menu;
+}
+
+function positionBottomChatOverflowMenu() {
+    const bottomChatBarState = getBottomChatBarState();
+    const menu = bottomChatBarState.overflowMenu;
+    const button = bottomChatBarState.overflowButton;
+
+    if (!(menu instanceof HTMLElement) || !(button instanceof HTMLElement) || menu.hidden) {
+        return;
+    }
+
+    const buttonRect = button.getBoundingClientRect();
+    const barRect = document.getElementById('sb-bottom-chat-bar')?.getBoundingClientRect();
+    menu.style.visibility = 'hidden';
+    menu.style.left = '0px';
+    menu.style.top = '0px';
+    menu.style.right = 'auto';
+    menu.style.bottom = 'auto';
+
+    window.requestAnimationFrame(() => {
+        const menuRect = menu.getBoundingClientRect();
+        const viewportPadding = 8;
+        const left = Math.min(
+            Math.max(viewportPadding, buttonRect.right - menuRect.width),
+            Math.max(viewportPadding, window.innerWidth - menuRect.width - viewportPadding),
+        );
+        const anchorTop = barRect?.top ?? buttonRect.top;
+        const topAboveBar = anchorTop - menuRect.height - viewportPadding;
+        const top = Math.min(
+            Math.max(viewportPadding, topAboveBar),
+            Math.max(viewportPadding, window.innerHeight - menuRect.height - viewportPadding),
+        );
+
+        menu.style.left = `${Math.round(left)}px`;
+        menu.style.top = `${Math.round(top)}px`;
+        menu.style.visibility = '';
+    });
+}
+
+function setBottomChatOverflowOpen(open, { restoreFocus = false } = {}) {
+    const bottomChatBarState = getBottomChatBarState();
+    const shouldOpen = Boolean(open) && Boolean(bottomChatBarState.overflowActions?.length);
+    const menu = shouldOpen ? ensureBottomChatOverflowMenu() : bottomChatBarState.overflowMenu;
+
+    bottomChatBarState.overflowOpen = shouldOpen;
+
+    if (bottomChatBarState.overflowButton instanceof HTMLElement) {
+        setButtonPressed(bottomChatBarState.overflowButton, shouldOpen);
+        bottomChatBarState.overflowButton.setAttribute('aria-expanded', String(shouldOpen));
+    }
+
+    if (menu instanceof HTMLElement) {
+        menu.hidden = !shouldOpen;
+        menu.classList.toggle('is-open', shouldOpen);
+        if (shouldOpen) {
+            positionBottomChatOverflowMenu();
+            window.requestAnimationFrame(() => {
+                menu.querySelector('.sb-bottom-chat-overflow-item:not(:disabled)')?.focus({ preventScroll: true });
+            });
+        }
+    }
+
+    if (restoreFocus) {
+        bottomChatBarState.overflowButton?.focus?.({ preventScroll: true });
+    }
+}
+
+function refreshBottomChatOverflowMenu() {
+    const bottomChatBarState = getBottomChatBarState();
+    if (!bottomChatBarState.overflowActions?.length) {
+        setBottomChatOverflowOpen(false);
+        return;
+    }
+
+    const menu = ensureBottomChatOverflowMenu();
+
+    menu.replaceChildren();
+
+    for (const action of bottomChatBarState.overflowActions ?? []) {
+        const item = createElement('button', {
+            className: 'sb-bottom-chat-overflow-item',
+            attrs: {
+                type: 'button',
+                role: 'menuitem',
+                title: action.title,
+                'aria-label': action.title,
+            },
+        });
+        item.dataset.sbBottomActionId = action.id;
+        item.innerHTML = action.button.innerHTML;
+        item.appendChild(createElement('span', { text: action.title }));
+        item.disabled = action.button.hasAttribute('disabled');
+        item.classList.toggle('is-disabled', item.disabled);
+        menu.appendChild(item);
+    }
+
+    if (bottomChatBarState.overflowOpen) {
+        positionBottomChatOverflowMenu();
+    }
+}
+
+function syncBottomChatActionOverflowState() {
+    const bottomChatBarState = getBottomChatBarState();
+    const plan = sbMobileShellLifecycle.railModel.resolveBottomBarActionVisibility({
+        actions: getBottomChatActionModels(),
+        isMobileViewport: isMobileViewport(),
+        visibleActionIds: sbMobileShellLifecycle.railModel.bottomBarVisibleActionIds,
+    });
+
+    bottomChatBarState.overflowActions = plan.overflowActions;
+
+    for (const action of [...plan.visibleActions, ...plan.overflowActions]) {
+        action.button.hidden = false;
+        action.button.classList.toggle('sb-bottom-chat-overflow-source', plan.overflowActions.includes(action));
+    }
+
+    const shouldRenderOverflow = plan.shouldRenderOverflow && isMobileViewport();
+
+    if (bottomChatBarState.overflowButton instanceof HTMLElement) {
+        bottomChatBarState.overflowButton.hidden = !shouldRenderOverflow;
+        bottomChatBarState.overflowButton.classList.toggle('sb-bottom-chat-overflow-active', shouldRenderOverflow);
+        bottomChatBarState.overflowButton.setAttribute('aria-expanded', String(shouldRenderOverflow && bottomChatBarState.overflowOpen));
+    }
+
+    if (!shouldRenderOverflow) {
+        setBottomChatOverflowOpen(false);
+    }
+
+    refreshBottomChatOverflowMenu();
+}
+
 function setBottomChatButtonIcon(button, iconClass) {
     if (!(button instanceof HTMLElement)) {
         return;
@@ -6058,6 +6266,10 @@ function syncBottomChatBarSecondaryState() {
         button.setAttribute('aria-label', title);
         button.setAttribute('aria-expanded', String(isOpen));
         setBottomChatButtonIcon(button, isOpen ? 'fa-chevron-up' : 'fa-chevron-down');
+    }
+
+    if (isHiddenOnMobile) {
+        setBottomChatOverflowOpen(false);
     }
 }
 
@@ -14549,6 +14761,7 @@ function buildBottomChatBar() {
     });
     personaBubble.addEventListener('click', (e) => {
         e.stopPropagation();
+        setBottomChatOverflowOpen(false);
         togglePersonaPicker();
     });
     updatePersonaBubble(personaBubble);
@@ -14585,15 +14798,32 @@ function buildBottomChatBar() {
 
     const topBtn = createBottomChatButton({ icon: 'fa-arrow-up', title: 'Go to top of chat' }, scrollCurrentChatToTop);
     const bottomBtn = createBottomChatButton({ icon: 'fa-arrow-down', title: 'Go to bottom of chat' }, scrollCurrentChatToBottom);
-    const chatManagerBtn = createBottomChatButton({ icon: 'fa-address-book', title: 'View chat files' }, handleChatManagerClick);
-    const newBtn = createBottomChatButton({ icon: 'fa-plus', title: 'New chat' }, handleNewChat);
-    const massDeleteBtn = createBottomChatButton({ icon: 'fa-list-check', title: 'Mass delete chats' }, () => { void handleMassDeleteChats(); });
-    const autoNameBtn = createBottomChatButton({ icon: 'fa-wand-magic-sparkles', title: 'Ask the LLM to name this chat' }, () => { void handleAutoNameChat(); });
-    const renameBtn = createBottomChatButton({ icon: 'fa-pencil', title: 'Rename chat' }, () => { void handleRenameChat(); });
-    const deleteBtn = createBottomChatButton({ icon: 'fa-trash', title: 'Delete chat' }, () => { void handleDeleteChat(); });
+    const chatManagerAction = createBottomChatAction({ id: 'view-files', icon: 'fa-address-book', title: 'View chat files', onClick: handleChatManagerClick });
+    const newAction = createBottomChatAction({ id: 'new-chat', icon: 'fa-plus', title: 'New chat', onClick: handleNewChat });
+    const massDeleteAction = createBottomChatAction({ id: 'mass-delete', icon: 'fa-list-check', title: 'Mass delete chats', onClick: () => { void handleMassDeleteChats(); } });
+    const autoNameAction = createBottomChatAction({ id: 'auto-name', icon: 'fa-wand-magic-sparkles', title: 'Ask the LLM to name this chat', onClick: () => { void handleAutoNameChat(); } });
+    const renameAction = createBottomChatAction({ id: 'rename-chat', icon: 'fa-pencil', title: 'Rename chat', onClick: () => { void handleRenameChat(); } });
+    const searchAction = { id: 'search-chat', title: 'Search chat', icon: 'fa-magnifying-glass', button: searchToggleBtn };
+    searchToggleBtn.dataset.sbBottomActionId = searchAction.id;
+    const deleteAction = createBottomChatAction({ id: 'delete-chat', icon: 'fa-trash', title: 'Delete chat', onClick: () => { void handleDeleteChat(); } });
+    const overflowBtn = createBottomChatButton({ icon: 'fa-ellipsis', title: 'More chat actions', className: 'sb-bottom-chat-overflow-toggle' }, () => {
+        setBottomChatOverflowOpen(!getBottomChatBarState().overflowOpen, { restoreFocus: false });
+    });
+    overflowBtn.setAttribute('aria-controls', 'sb-bottom-chat-overflow-menu');
+    overflowBtn.setAttribute('aria-expanded', 'false');
+    overflowBtn.hidden = true;
 
     navCluster.append(topBtn, bottomBtn);
-    managementCluster.append(chatManagerBtn, newBtn, massDeleteBtn, autoNameBtn, renameBtn, searchToggleBtn, deleteBtn);
+    managementCluster.append(
+        chatManagerAction.button,
+        newAction.button,
+        massDeleteAction.button,
+        autoNameAction.button,
+        renameAction.button,
+        searchAction.button,
+        deleteAction.button,
+        overflowBtn,
+    );
     secondaryRow.append(managementCluster);
     container.append(personaBubble, chatSelect, search.field, navCluster, collapseToggleBtn, secondaryRow);
 
@@ -14609,10 +14839,15 @@ function buildBottomChatBar() {
         secondaryRow,
         scrollTopButton: topBtn,
         scrollBottomButton: bottomBtn,
-        managerButton: chatManagerBtn,
-        massDeleteButton: massDeleteBtn,
-        autoNameButton: autoNameBtn,
+        managerButton: chatManagerAction.button,
+        newButton: newAction.button,
+        massDeleteButton: massDeleteAction.button,
+        autoNameButton: autoNameAction.button,
+        renameButton: renameAction.button,
+        deleteButton: deleteAction.button,
+        overflowButton: overflowBtn,
     });
+    syncBottomChatActionOverflowState();
     syncBottomChatBarSecondaryState();
     syncBottomChatBarSearchState();
 
@@ -14624,8 +14859,16 @@ function buildBottomChatBar() {
     if (!bottomChatBarState.outsideClickBound) {
         document.addEventListener('click', (e) => {
             const picker = document.getElementById('sb-persona-picker');
+            const overflowMenu = bottomChatBarState.overflowMenu;
             if (picker && !picker.contains(e.target) && e.target !== bottomChatBarState.personaBubble) {
                 picker.remove();
+            }
+            if (
+                overflowMenu instanceof HTMLElement
+                && !overflowMenu.contains(e.target)
+                && !bottomChatBarState.overflowButton?.contains?.(e.target)
+            ) {
+                setBottomChatOverflowOpen(false);
             }
         });
         bottomChatBarState.outsideClickBound = true;
@@ -14656,8 +14899,12 @@ async function refreshBottomChatSelect() {
     setButtonDisabled(sbState.bottomChatBar?.scrollTopButton, !chatContext.hasChat);
     setButtonDisabled(sbState.bottomChatBar?.scrollBottomButton, !chatContext.hasChat);
     setButtonDisabled(sbState.bottomChatBar?.managerButton, !chatContext.canBrowseChats);
+    setButtonDisabled(sbState.bottomChatBar?.newButton, !chatContext.canStartNewChat);
     setButtonDisabled(sbState.bottomChatBar?.massDeleteButton, !chatContext.canBrowseChats);
     setButtonDisabled(sbState.bottomChatBar?.autoNameButton, !chatContext.hasChat);
+    setButtonDisabled(sbState.bottomChatBar?.renameButton, !chatContext.hasChat);
+    setButtonDisabled(sbState.bottomChatBar?.deleteButton, !chatContext.hasChat);
+    syncBottomChatActionOverflowState();
 
     if (!chatContext.context) {
         return;
@@ -14900,6 +15147,7 @@ function bindBottomChatBarWindowEvents() {
     }
 
     const refreshWithContext = () => {
+        syncBottomChatActionOverflowState();
         syncBottomChatBarSecondaryState();
         syncBottomChatBarSearchState();
         scheduleBottomChatBarRefresh(0);

--- a/tests/mobile-shell-lifecycle-drawer-bounds.test.js
+++ b/tests/mobile-shell-lifecycle-drawer-bounds.test.js
@@ -39,6 +39,21 @@ describe('mobile shell drawer bounds lifecycle', () => {
         ]);
     });
 
+    test('subtracts the mobile safe-area bottom from open drawer height', () => {
+        const decision = resolveMobileDrawerBounds({
+            isMobileViewport: true,
+            isOpen: true,
+            viewportHeight: 844,
+            baseTopOffset: 56,
+            shellGap: 3,
+            safeAreaBottom: 34,
+        });
+
+        expect(decision.styleWrites).toContainEqual({ property: 'top', value: '59px', priority: 'important' });
+        expect(decision.styleWrites).toContainEqual({ property: 'height', value: '751px', priority: 'important' });
+        expect(decision.styleWrites).toContainEqual({ property: 'max-height', value: '751px', priority: 'important' });
+    });
+
     test('clamps the top offset to the viewport and never yields negative height', () => {
         const decision = resolveMobileDrawerBounds({
             isMobileViewport: true,
@@ -46,6 +61,7 @@ describe('mobile shell drawer bounds lifecycle', () => {
             viewportHeight: 500,
             baseTopOffset: 480,
             shellGap: 200,
+            safeAreaBottom: 200,
         });
 
         expect(decision.action).toBe(MOBILE_SHELL_DRAWER_BOUND_ACTION.BIND);

--- a/tests/mobile-shell-lifecycle-rail-model.test.js
+++ b/tests/mobile-shell-lifecycle-rail-model.test.js
@@ -3,11 +3,13 @@ import { describe, expect, test } from '@jest/globals';
 import {
     createMobileShellLifecycle,
     getMobileShellQuickActionKey,
+    MOBILE_SHELL_BOTTOM_BAR_DEFAULT_VISIBLE_ACTION_IDS,
     MOBILE_SHELL_RAIL_CHARACTER_SHELL_KEY,
     MOBILE_SHELL_RAIL_QUICK_ACTION_ICON_FALLBACK,
     MOBILE_SHELL_RAIL_QUICK_ACTION_LABEL_MAX_LENGTH,
     MOBILE_SHELL_RAIL_QUICK_ACTION_LIMIT,
     normalizeMobileShellQuickAction,
+    resolveMobileShellBottomBarActionVisibility,
     resolveMobileShellQuickActionRoute,
     resolveMobileShellRailActionVisibility,
 } from '../public/scripts/mobile-shell-lifecycle/index.js';
@@ -28,6 +30,11 @@ describe('mobile shell rail model lifecycle', () => {
         expect(MOBILE_SHELL_RAIL_QUICK_ACTION_LABEL_MAX_LENGTH).toBe(36);
         expect(MOBILE_SHELL_RAIL_QUICK_ACTION_ICON_FALLBACK).toBe('fa-bolt');
         expect(MOBILE_SHELL_RAIL_CHARACTER_SHELL_KEY).toBe('characters');
+        expect(MOBILE_SHELL_BOTTOM_BAR_DEFAULT_VISIBLE_ACTION_IDS).toEqual([
+            'view-files',
+            'new-chat',
+            'search-chat',
+        ]);
     });
 
     test('normalizes legacy World Info routes before shell lookup', () => {
@@ -217,6 +224,36 @@ describe('mobile shell rail model lifecycle', () => {
         });
     });
 
+    test('moves low-frequency bottom chat actions into mobile overflow only', () => {
+        const actions = [
+            { id: 'view-files', label: 'View chat files' },
+            { id: 'new-chat', label: 'New chat' },
+            { id: 'mass-delete', label: 'Mass delete chats' },
+            { id: 'auto-name', label: 'Ask the LLM to name this chat' },
+            { id: 'rename-chat', label: 'Rename chat' },
+            { id: 'search-chat', label: 'Search chat' },
+            { id: 'delete-chat', label: 'Delete chat' },
+        ];
+
+        expect(resolveMobileShellBottomBarActionVisibility({
+            actions,
+            isMobileViewport: false,
+        })).toEqual({
+            visibleActions: actions,
+            overflowActions: [],
+            shouldRenderOverflow: false,
+        });
+
+        expect(resolveMobileShellBottomBarActionVisibility({
+            actions,
+            isMobileViewport: true,
+        })).toEqual({
+            visibleActions: [actions[0], actions[1], actions[5]],
+            overflowActions: [actions[2], actions[3], actions[4], actions[6]],
+            shouldRenderOverflow: true,
+        });
+    });
+
     test('exposes rail model decisions through the lifecycle seam', () => {
         const lifecycle = createMobileShellLifecycle();
 
@@ -225,9 +262,11 @@ describe('mobile shell rail model lifecycle', () => {
             labelMaxLength: MOBILE_SHELL_RAIL_QUICK_ACTION_LABEL_MAX_LENGTH,
             iconFallback: MOBILE_SHELL_RAIL_QUICK_ACTION_ICON_FALLBACK,
         });
+        expect(lifecycle.railModel.bottomBarVisibleActionIds).toBe(MOBILE_SHELL_BOTTOM_BAR_DEFAULT_VISIBLE_ACTION_IDS);
         expect(lifecycle.railModel.resolveQuickActionRoute).toBe(resolveMobileShellQuickActionRoute);
         expect(lifecycle.railModel.normalizeQuickAction).toBe(normalizeMobileShellQuickAction);
         expect(lifecycle.railModel.getQuickActionKey).toBe(getMobileShellQuickActionKey);
         expect(lifecycle.railModel.resolveActionVisibility).toBe(resolveMobileShellRailActionVisibility);
+        expect(lifecycle.railModel.resolveBottomBarActionVisibility).toBe(resolveMobileShellBottomBarActionVisibility);
     });
 });

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -172,6 +172,22 @@ describe('mobile shell lifecycle wiring', () => {
         expect(syncMobileShellRailActionsSource).not.toContain('railQuickActionState.filter(action => !builtInRailActionKeys.has(getMobileQuickActionKey(action)))');
     });
 
+    test('routes bottom chat overflow visibility through the lifecycle seam', () => {
+        const syncBottomChatActionOverflowStateSource = getFunctionSource('syncBottomChatActionOverflowState');
+        const buildBottomChatBarSource = getFunctionSource('buildBottomChatBar');
+
+        expect(syncBottomChatActionOverflowStateSource).toContain('sbMobileShellLifecycle.railModel.resolveBottomBarActionVisibility({');
+        expect(syncBottomChatActionOverflowStateSource).toContain('actions: getBottomChatActionModels(),');
+        expect(syncBottomChatActionOverflowStateSource).toContain('isMobileViewport: isMobileViewport(),');
+        expect(syncBottomChatActionOverflowStateSource).toContain('visibleActionIds: sbMobileShellLifecycle.railModel.bottomBarVisibleActionIds,');
+        expect(syncBottomChatActionOverflowStateSource).toContain('action.button.classList.toggle(\'sb-bottom-chat-overflow-source\', plan.overflowActions.includes(action));');
+        expect(buildBottomChatBarSource).toContain('const overflowBtn = createBottomChatButton({ icon: \'fa-ellipsis\', title: \'More chat actions\', className: \'sb-bottom-chat-overflow-toggle\' }');
+        expect(buildBottomChatBarSource).toContain('overflowBtn.setAttribute(\'aria-controls\', \'sb-bottom-chat-overflow-menu\');');
+        expect(tabsCssSource).toContain('.sb-bottom-chat-overflow-source');
+        expect(tabsCssSource).toContain('.sb-bottom-chat-overflow-menu');
+        expect(tabsCssSource).toContain('.sb-bottom-chat-overflow-item');
+    });
+
     test('routes inline drawer decisions through the lifecycle seam', () => {
         const interceptDrawerOpenersSource = getFunctionSource('interceptDrawerOpeners');
         const getInlineDrawerStorageKeySource = getFunctionSource('getInlineDrawerStorageKey');

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -367,6 +367,7 @@ describe('mobile shell lifecycle wiring', () => {
 
     test('routes mobile drawer bound decisions through the lifecycle seam', () => {
         const applyDecisionSource = getFunctionSource('applyMobileDrawerBoundsDecision');
+        const safeAreaSource = getFunctionSource('getMobileSafeAreaBottomPx');
         const syncBoundsSource = getFunctionSource('syncMobileShellDrawerBounds');
 
         // The adapter is the single DOM writer for drawer bound styles.
@@ -376,14 +377,50 @@ describe('mobile shell lifecycle wiring', () => {
         expect(applyDecisionSource).toContain('decision.styleWrites');
         expect(applyDecisionSource).toContain('drawer.style.setProperty(property, value, priority);');
         expect(applyDecisionSource).toContain('drawer.style.removeProperty(property);');
+        expect(safeAreaSource).toContain('window.getComputedStyle(document.documentElement)');
+        expect(safeAreaSource).toContain('--sb-mobile-safe-area-bottom');
+        expect(safeAreaSource).toContain('sb-mobile-safe-area-bottom-probe');
+        expect(safeAreaSource).toContain('padding-bottom:var(--sb-mobile-safe-area-bottom,0px)');
+        expect(safeAreaSource).toContain('window.getComputedStyle(probe).paddingBottom');
 
         // The call site resolves decisions through the seam and applies via the adapter.
         expect(syncBoundsSource).toContain('sbMobileShellLifecycle.drawerBounds.resolveBounds({');
         expect(syncBoundsSource).toContain('applyMobileDrawerBoundsDecision(drawer,');
+        expect(syncBoundsSource).toContain('const safeAreaBottom = mobileViewport ? getMobileSafeAreaBottomPx() : 0;');
+        expect(syncBoundsSource).toContain('safeAreaBottom,');
 
         // The old inline style writes are gone from the call site.
         expect(syncBoundsSource).not.toContain('style.setProperty(\'top\'');
         expect(syncBoundsSource).not.toContain('style.setProperty(\'height\'');
         expect(syncBoundsSource).not.toContain('style.removeProperty(');
+    });
+
+    test('routes mobile drawer swipe-dismiss through the lifecycle seam', () => {
+        const bindGestureSource = getFunctionSource('bindMobileDrawerGestureDismiss');
+        const openShellSource = getFunctionSource('openShell');
+        const injectCharacterControlsSource = getFunctionSource('injectCharacterDrawerControls');
+        const toggleCharacterPanelSource = getFunctionSource('toggleCharacterPanel');
+
+        expect(bindGestureSource).toContain('sbMobileShellLifecycle.drawerGestures.createGestureState({');
+        expect(bindGestureSource).toContain('sbMobileShellLifecycle.drawerGestures.resolveGestureMove({');
+        expect(bindGestureSource).toContain('sbMobileShellLifecycle.drawerGestures.resolveGestureEnd({');
+        expect(bindGestureSource).toContain('sbMobileShellLifecycle.drawerGestures.shouldSuppressClick({');
+        expect(bindGestureSource).toContain('drawer.addEventListener(\'touchstart\', beginDrawerGesture, { passive: true });');
+        expect(bindGestureSource).toContain('drawer.addEventListener(\'touchmove\', updateDrawerGesture, { passive: false });');
+        expect(bindGestureSource).toContain('drawer.style.setProperty(\'transform\', `translateY(${gestureMove.offsetY}px)`, \'important\');');
+        expect(bindGestureSource).toContain('drawer.style.removeProperty(\'transform\');');
+        expect(openShellSource).toContain('bindMobileDrawerGestureDismiss(shellRoot, () => closeShell(shellKey));');
+        expect(injectCharacterControlsSource).toContain('bindMobileDrawerGestureDismiss(characterPanel, closeCharacterPanel);');
+        expect(toggleCharacterPanelSource).toContain('bindMobileDrawerGestureDismiss(getCharacterPanel(), closeCharacterPanel);');
+        expect(bindGestureSource).not.toContain('event.touches[0].clientY -');
+    });
+
+    test('keeps mobile drawer safe-area math on shell tokens', () => {
+        expect(mobileShellCssSource).toContain('--sb-mobile-safe-area-left: env(safe-area-inset-left, 0px);');
+        expect(mobileShellCssSource).toContain('--sb-mobile-safe-area-right: env(safe-area-inset-right, 0px);');
+        expect(mobileShellCssSource).toContain('bottom: var(--sb-mobile-safe-area-bottom, env(safe-area-inset-bottom, 0px)) !important;');
+        expect(mobileShellCssSource).toContain('.sb-drawer-gesture-active');
+        expect(mobileShellCssSource).not.toContain(' - env(safe-area-inset-bottom, 0px)) !important;');
+        expect(mobileShellCssSource).not.toContain('bottom: env(safe-area-inset-bottom, 0px) !important;');
     });
 });

--- a/tests/mobile-shell-lifecycle.test.js
+++ b/tests/mobile-shell-lifecycle.test.js
@@ -2,7 +2,11 @@ import { describe, expect, test } from '@jest/globals';
 
 import {
     createMobileShellLifecycle,
+    createMobileShellDrawerGestureState,
     createMobileShellNavDragState,
+    MOBILE_SHELL_LIFECYCLE_DRAWER_CLICK_SUPPRESSION_MS,
+    MOBILE_SHELL_LIFECYCLE_DRAWER_DISMISS_THRESHOLD_PX,
+    MOBILE_SHELL_LIFECYCLE_DRAWER_GESTURE_THRESHOLD_PX,
     MOBILE_SHELL_LIFECYCLE_NAV_CLICK_SUPPRESSION_MS,
     MOBILE_SHELL_LIFECYCLE_NAV_DRAG_THRESHOLD_PX,
     MOBILE_SHELL_LIFECYCLE_NAV_OPEN_GRACE_MS,
@@ -10,12 +14,15 @@ import {
     MOBILE_SHELL_NAV_TOGGLE_ACTION,
     resolveMobileModalA11yState,
     resolveMobileNavOpenState,
+    resolveMobileShellDrawerGestureEnd,
+    resolveMobileShellDrawerGestureMove,
     resolveMobileShellNavPageScroll,
     resolveMobileShellNavScrollIndicators,
     resolveMobileNavToggleIntent,
     resolveMobileShellNavDragEnd,
     resolveMobileShellNavDragMove,
     shouldAutoCloseMobileNav,
+    shouldSuppressMobileShellDrawerGestureClick,
     shouldSuppressMobileShellNavClick,
 } from '../public/scripts/mobile-shell-lifecycle/index.js';
 
@@ -24,6 +31,9 @@ describe('mobile shell lifecycle helper', () => {
         expect(MOBILE_SHELL_LIFECYCLE_NAV_OPEN_GRACE_MS).toBe(450);
         expect(MOBILE_SHELL_LIFECYCLE_NAV_DRAG_THRESHOLD_PX).toBe(6);
         expect(MOBILE_SHELL_LIFECYCLE_NAV_CLICK_SUPPRESSION_MS).toBe(350);
+        expect(MOBILE_SHELL_LIFECYCLE_DRAWER_GESTURE_THRESHOLD_PX).toBe(8);
+        expect(MOBILE_SHELL_LIFECYCLE_DRAWER_DISMISS_THRESHOLD_PX).toBe(72);
+        expect(MOBILE_SHELL_LIFECYCLE_DRAWER_CLICK_SUPPRESSION_MS).toBe(350);
     });
 
     test('captures mobile rail drag start only for mobile touch input', () => {
@@ -121,6 +131,127 @@ describe('mobile shell lifecycle helper', () => {
 
         expect(shouldSuppressMobileShellNavClick({ nowMs: 1200, suppressClickUntil: 1350 })).toBe(true);
         expect(shouldSuppressMobileShellNavClick({ nowMs: 1350, suppressClickUntil: 1350 })).toBe(false);
+    });
+
+    test('captures mobile drawer swipe-dismiss gestures only for open mobile drawers', () => {
+        expect(createMobileShellDrawerGestureState({
+            isMobileViewport: true,
+            isOpen: true,
+            touch: { clientX: 120, clientY: 40 },
+        })).toEqual({
+            startX: 120,
+            startY: 40,
+            offsetY: 0,
+            dragging: false,
+        });
+
+        expect(createMobileShellDrawerGestureState({
+            isMobileViewport: false,
+            isOpen: true,
+            touch: { clientX: 120, clientY: 40 },
+        })).toBeNull();
+        expect(createMobileShellDrawerGestureState({
+            isMobileViewport: true,
+            isOpen: false,
+            touch: { clientX: 120, clientY: 40 },
+        })).toBeNull();
+        expect(createMobileShellDrawerGestureState({ isMobileViewport: true, isOpen: true, touch: null })).toBeNull();
+    });
+
+    test('leaves drawer gestures alone until movement is downward and vertical', () => {
+        const gestureState = createMobileShellDrawerGestureState({
+            isMobileViewport: true,
+            isOpen: true,
+            touch: { clientX: 100, clientY: 100 },
+        });
+
+        expect(resolveMobileShellDrawerGestureMove({
+            gestureState,
+            touch: { clientX: 100, clientY: 106 },
+        })).toEqual({
+            gestureState: {
+                ...gestureState,
+                offsetY: 0,
+                dragging: false,
+            },
+            shouldPreventDefault: false,
+            shouldStopPropagation: false,
+            offsetY: 0,
+        });
+
+        expect(resolveMobileShellDrawerGestureMove({
+            gestureState,
+            touch: { clientX: 120, clientY: 112 },
+        })).toEqual({
+            gestureState: {
+                ...gestureState,
+                offsetY: 0,
+                dragging: false,
+            },
+            shouldPreventDefault: false,
+            shouldStopPropagation: false,
+            offsetY: 0,
+        });
+    });
+
+    test('tracks drawer drag offset once the swipe-down threshold is crossed', () => {
+        const gestureState = createMobileShellDrawerGestureState({
+            isMobileViewport: true,
+            isOpen: true,
+            touch: { clientX: 100, clientY: 100 },
+        });
+
+        expect(resolveMobileShellDrawerGestureMove({
+            gestureState,
+            touch: { clientX: 102, clientY: 124 },
+        })).toEqual({
+            gestureState: {
+                ...gestureState,
+                offsetY: 24,
+                dragging: true,
+            },
+            shouldPreventDefault: true,
+            shouldStopPropagation: true,
+            offsetY: 24,
+        });
+    });
+
+    test('dismisses drawers only after a deliberate downward swipe', () => {
+        expect(resolveMobileShellDrawerGestureEnd({
+            gestureState: { startX: 0, startY: 0, offsetY: 71, dragging: true },
+            nowMs: 1000,
+        })).toEqual({
+            gestureState: null,
+            shouldDismiss: false,
+            shouldStopPropagation: true,
+            suppressClickUntil: 1350,
+            offsetY: 0,
+        });
+
+        expect(resolveMobileShellDrawerGestureEnd({
+            gestureState: { startX: 0, startY: 0, offsetY: 72, dragging: true },
+            nowMs: 1000,
+        })).toEqual({
+            gestureState: null,
+            shouldDismiss: true,
+            shouldStopPropagation: true,
+            suppressClickUntil: 1350,
+            offsetY: 0,
+        });
+
+        expect(resolveMobileShellDrawerGestureEnd({
+            gestureState: { startX: 0, startY: 0, offsetY: 90, dragging: false },
+            nowMs: 1000,
+        })).toEqual({
+            gestureState: null,
+            shouldDismiss: false,
+            shouldStopPropagation: false,
+            suppressClickUntil: 0,
+            offsetY: 0,
+        });
+
+        expect(shouldSuppressMobileShellDrawerGestureClick({ nowMs: 1200, suppressClickUntil: 1350 })).toBe(true);
+        expect(shouldSuppressMobileShellDrawerGestureClick({ nowMs: 1350, suppressClickUntil: 1350 })).toBe(false);
     });
 
     test('resolves shell rail page scroll distance and motion preference', () => {
@@ -322,9 +453,16 @@ describe('mobile shell lifecycle helper', () => {
         expect(lifecycle.nav.resolveToggleIntent).toBe(resolveMobileNavToggleIntent);
         expect(lifecycle.nav.resolveOpenState).toBe(resolveMobileNavOpenState);
         expect(lifecycle.nav.shouldAutoClose).toBe(shouldAutoCloseMobileNav);
+        expect(lifecycle.drawerGestures.createGestureState).toBe(createMobileShellDrawerGestureState);
+        expect(lifecycle.drawerGestures.resolveGestureMove).toBe(resolveMobileShellDrawerGestureMove);
+        expect(lifecycle.drawerGestures.resolveGestureEnd).toBe(resolveMobileShellDrawerGestureEnd);
+        expect(lifecycle.drawerGestures.shouldSuppressClick).toBe(shouldSuppressMobileShellDrawerGestureClick);
         expect(lifecycle.modal.resolveA11yState).toBe(resolveMobileModalA11yState);
         expect(lifecycle.timings.navOpenGraceMs).toBe(MOBILE_SHELL_LIFECYCLE_NAV_OPEN_GRACE_MS);
         expect(lifecycle.timings.navDragThresholdPx).toBe(MOBILE_SHELL_LIFECYCLE_NAV_DRAG_THRESHOLD_PX);
         expect(lifecycle.timings.navClickSuppressionMs).toBe(MOBILE_SHELL_LIFECYCLE_NAV_CLICK_SUPPRESSION_MS);
+        expect(lifecycle.timings.drawerGestureThresholdPx).toBe(MOBILE_SHELL_LIFECYCLE_DRAWER_GESTURE_THRESHOLD_PX);
+        expect(lifecycle.timings.drawerDismissThresholdPx).toBe(MOBILE_SHELL_LIFECYCLE_DRAWER_DISMISS_THRESHOLD_PX);
+        expect(lifecycle.timings.drawerClickSuppressionMs).toBe(MOBILE_SHELL_LIFECYCLE_DRAWER_CLICK_SUPPRESSION_MS);
     });
 });

--- a/tests/mobile-shell-smoke.e2e.js
+++ b/tests/mobile-shell-smoke.e2e.js
@@ -364,6 +364,84 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
         await expectNoHorizontalOverflow(page);
     });
 
+    test('bottom chat overflow keeps persona and common chat actions reachable', async ({ page }) => {
+        const getBottomBarSnapshot = () => page.evaluate(() => {
+            const bar = document.getElementById('sb-bottom-chat-bar');
+            const persona = document.getElementById('sb-persona-bubble');
+            const overflow = bar?.querySelector('.sb-bottom-chat-overflow-toggle');
+            const menu = document.getElementById('sb-bottom-chat-overflow-menu');
+            const directAction = id => bar?.querySelector(`[data-sb-bottom-action-id="${id}"]`);
+            const rectInfo = element => {
+                const rect = element?.getBoundingClientRect();
+
+                return rect
+                    ? {
+                        visible: rect.width > 0 && rect.height > 0,
+                        width: Math.round(rect.width),
+                        height: Math.round(rect.height),
+                    }
+                    : null;
+            };
+
+            return {
+                bar: rectInfo(bar),
+                persona: rectInfo(persona),
+                overflow: rectInfo(overflow),
+                overflowExpanded: overflow?.getAttribute('aria-expanded') ?? null,
+                viewFilesVisible: rectInfo(directAction('view-files'))?.visible ?? false,
+                newChatVisible: rectInfo(directAction('new-chat'))?.visible ?? false,
+                searchVisible: rectInfo(directAction('search-chat'))?.visible ?? false,
+                massDeleteVisible: rectInfo(directAction('mass-delete'))?.visible ?? false,
+                autoNameVisible: rectInfo(directAction('auto-name'))?.visible ?? false,
+                renameVisible: rectInfo(directAction('rename-chat'))?.visible ?? false,
+                deleteVisible: rectInfo(directAction('delete-chat'))?.visible ?? false,
+                menuOpen: menu ? !menu.hidden : false,
+                menuItems: menu ? Array.from(menu.querySelectorAll('.sb-bottom-chat-overflow-item')).map(item => item.textContent.trim()) : [],
+            };
+        });
+
+        await expect.poll(getBottomBarSnapshot).toMatchObject({
+            bar: { visible: true },
+            persona: { visible: true },
+            overflow: { visible: true },
+            overflowExpanded: 'false',
+            viewFilesVisible: true,
+            newChatVisible: true,
+            searchVisible: true,
+            massDeleteVisible: false,
+            autoNameVisible: false,
+            renameVisible: false,
+            deleteVisible: false,
+            menuOpen: false,
+        });
+
+        await page.locator('.sb-bottom-chat-overflow-toggle').click();
+
+        await expect.poll(getBottomBarSnapshot).toMatchObject({
+            overflowExpanded: 'true',
+            menuOpen: true,
+            menuItems: [
+                'Mass delete chats',
+                'Ask the LLM to name this chat',
+                'Rename chat',
+                'Delete chat',
+            ],
+        });
+
+        await page.locator('#sb-persona-bubble').click();
+
+        await expect.poll(getBottomBarSnapshot).toMatchObject({
+            overflowExpanded: 'false',
+            menuOpen: false,
+        });
+
+        const personaPickerBox = await page.locator('#sb-persona-picker').boundingBox();
+        expect(personaPickerBox).not.toBeNull();
+        expect(personaPickerBox.y + personaPickerBox.height).toBeLessThanOrEqual(844);
+
+        await expectNoHorizontalOverflow(page);
+    });
+
     test('keyboard-style viewport shrink re-syncs open drawer bounds and recovers', async ({ page }) => {
         await openLeftShell(page);
 

--- a/tests/mobile-shell-smoke.e2e.js
+++ b/tests/mobile-shell-smoke.e2e.js
@@ -193,6 +193,9 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
         const getNavAgreementSnapshot = () => page.evaluate(() => {
             const overlay = document.getElementById('sb-mobile-nav');
             const button = document.getElementById('sb-hamburger');
+            const content = document.getElementById('sb-mobile-nav-content');
+            const contentRect = content?.getBoundingClientRect();
+            const closeRect = content?.querySelector('.sb-mobile-panel-close')?.getBoundingClientRect();
 
             return {
                 hidden: overlay?.hidden ?? null,
@@ -201,6 +204,10 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
                 openClass: overlay?.classList.contains('sb-nav-open') === true,
                 buttonExpanded: button?.getAttribute('aria-expanded') ?? null,
                 buttonOpenClass: button?.classList.contains('is-open') === true,
+                contentBottomPinned: contentRect ? Math.abs(window.innerHeight - contentRect.bottom) <= 10 : null,
+                contentMaxHeight: contentRect ? contentRect.height <= Math.ceil(window.innerHeight * 0.76) + 1 : null,
+                closeTargetFloor: closeRect ? Math.min(closeRect.width, closeRect.height) >= 44 : null,
+                viewportHeight: window.innerHeight,
             };
         });
 
@@ -213,6 +220,10 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
             openClass: true,
             buttonExpanded: 'true',
             buttonOpenClass: true,
+            contentBottomPinned: true,
+            contentMaxHeight: true,
+            closeTargetFloor: true,
+            viewportHeight: 844,
         });
 
         await captureCheckpoint(page, testInfo, 'nav-open');
@@ -228,6 +239,10 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
             openClass: false,
             buttonExpanded: 'false',
             buttonOpenClass: false,
+            contentBottomPinned: false,
+            contentMaxHeight: true,
+            closeTargetFloor: false,
+            viewportHeight: 844,
         });
 
         await expectNoHorizontalOverflow(page);
@@ -365,7 +380,7 @@ test.describe('mobile shell smoke at narrow 320x568', () => {
         userAgent: IPHONE_USER_AGENT,
     });
 
-    test('composer fits and the send target keeps its current floor', async ({ page }) => {
+    test('composer fits and the send target keeps its mobile tap floor', async ({ page }) => {
         await openQuietChatForSmoke(page, { selectCharacter: false });
 
         // Compact mode and connection state come from the linked user profile;
@@ -380,12 +395,8 @@ test.describe('mobile shell smoke at narrow 320x568', () => {
 
         const sendButtonBox = await page.locator('#send_but').boundingBox();
 
-        // Ratchet floor: today's composer renders the send target at
-        // --sb-composer-action-size (26px tall at this width). The mobile UX
-        // redesign raises this floor to 44px; until then this only guards
-        // against shrinking below the current shipped size.
         expect(sendButtonBox).not.toBeNull();
-        expect(Math.min(sendButtonBox.width, sendButtonBox.height)).toBeGreaterThanOrEqual(24);
+        expect(Math.min(sendButtonBox.width, sendButtonBox.height)).toBeGreaterThanOrEqual(44);
 
         const composerBox = await page.locator('#form_sheld').boundingBox();
 

--- a/tests/mobile-shell-smoke.e2e.js
+++ b/tests/mobile-shell-smoke.e2e.js
@@ -100,6 +100,54 @@ function openLeftShell(page) {
     return page.evaluate(() => window.SillyBunnyShell.openTab('left', 'presets'));
 }
 
+async function swipeLeftDrawerDown(page) {
+    await page.evaluate(() => {
+        const drawer = document.getElementById('left-nav-panel');
+        const header = drawer?.querySelector(':scope > .sb-shell-frame .sb-shell-header');
+        const rect = header?.getBoundingClientRect();
+
+        if (!drawer || !header || !rect) {
+            throw new Error('Left drawer header is not ready for swipe-dismiss');
+        }
+
+        const touch = (clientX, clientY) => new Touch({
+            identifier: 1,
+            target: header,
+            clientX,
+            clientY,
+            pageX: clientX + window.scrollX,
+            pageY: clientY + window.scrollY,
+            screenX: clientX,
+            screenY: clientY,
+        });
+        const startX = Math.round(rect.left + rect.width / 2);
+        const startY = Math.round(rect.top + Math.min(28, rect.height / 2));
+        const endY = startY + 96;
+
+        header.dispatchEvent(new TouchEvent('touchstart', {
+            bubbles: true,
+            cancelable: true,
+            touches: [touch(startX, startY)],
+            targetTouches: [touch(startX, startY)],
+            changedTouches: [touch(startX, startY)],
+        }));
+        header.dispatchEvent(new TouchEvent('touchmove', {
+            bubbles: true,
+            cancelable: true,
+            touches: [touch(startX, endY)],
+            targetTouches: [touch(startX, endY)],
+            changedTouches: [touch(startX, endY)],
+        }));
+        header.dispatchEvent(new TouchEvent('touchend', {
+            bubbles: true,
+            cancelable: true,
+            touches: [],
+            targetTouches: [],
+            changedTouches: [touch(startX, endY)],
+        }));
+    });
+}
+
 // While any drawer or overlay is open, the mobile modal policy marks the page
 // chrome (topbar included) inert, so a trusted pointer click cannot reach the
 // hamburger. Synthetic .click() still runs the toggle cascade under test.
@@ -176,6 +224,29 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
 
         // applyMobileDrawerBoundsDecision removes every bound property and
         // the dataset marker once the drawer is no longer open.
+        await expect.poll(() => getDrawerBoundsSnapshot(page, 'left-nav-panel')).toEqual({
+            isOpen: false,
+            isViewportBound: false,
+            top: '',
+            bottom: '',
+            height: '',
+            maxHeight: '',
+            boxSizing: '',
+        });
+
+        await expectNoHorizontalOverflow(page);
+    });
+
+    test('left drawer swipe-down dismisses the mobile sheet', async ({ page }) => {
+        await openLeftShell(page);
+
+        await expect.poll(() => getDrawerBoundsSnapshot(page, 'left-nav-panel')).toMatchObject({
+            isOpen: true,
+            isViewportBound: true,
+        });
+
+        await swipeLeftDrawerDown(page);
+
         await expect.poll(() => getDrawerBoundsSnapshot(page, 'left-nav-panel')).toEqual({
             isOpen: false,
             isViewportBound: false,
@@ -287,12 +358,19 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
         const getRenderedDrawerFit = () => page.evaluate(() => {
             const drawer = document.getElementById('left-nav-panel');
             const rect = drawer.getBoundingClientRect();
+            const probe = document.createElement('div');
+
+            probe.style.cssText = 'position:fixed;left:-9999px;bottom:0;width:0;height:0;padding-bottom:var(--sb-mobile-safe-area-bottom,0px);pointer-events:none;visibility:hidden;contain:layout style size;';
+            document.body.appendChild(probe);
+            const safeAreaBottom = Number.parseFloat(window.getComputedStyle(probe).paddingBottom) || 0;
+            probe.remove();
 
             return {
                 isOpen: drawer.classList.contains('openDrawer'),
                 isViewportBound: drawer.dataset.sbMobileViewportBound === 'true',
                 top: Math.round(rect.top),
                 bottom: Math.round(rect.bottom),
+                expectedBottom: Math.round(window.innerHeight - safeAreaBottom),
                 viewportHeight: window.innerHeight,
             };
         });
@@ -300,7 +378,7 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
         await expect.poll(async () => {
             const fit = await getRenderedDrawerFit();
 
-            return fit.isViewportBound && fit.top > 0 && Math.abs(fit.bottom - 844) <= 2;
+            return fit.isViewportBound && fit.top > 0 && Math.abs(fit.bottom - fit.expectedBottom) <= 2;
         }).toBe(true);
 
         // Viewport shrink stands in for the on-screen keyboard: the resize
@@ -310,7 +388,7 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
         await expect.poll(async () => {
             const fit = await getRenderedDrawerFit();
 
-            return fit.isViewportBound && fit.top > 0 && Math.abs(fit.bottom - 500) <= 2;
+            return fit.isViewportBound && fit.top > 0 && Math.abs(fit.bottom - fit.expectedBottom) <= 2;
         }).toBe(true);
 
         await page.setViewportSize({ width: 390, height: 844 });
@@ -318,7 +396,7 @@ test.describe('mobile shell smoke at iPhone 390x844', () => {
         await expect.poll(async () => {
             const fit = await getRenderedDrawerFit();
 
-            return fit.isViewportBound && fit.top > 0 && Math.abs(fit.bottom - 844) <= 2;
+            return fit.isViewportBound && fit.top > 0 && Math.abs(fit.bottom - fit.expectedBottom) <= 2;
         }).toBe(true);
 
         await closeLeftShellThroughUi(page);


### PR DESCRIPTION
## What?
Declutters the mobile bottom chat bar by keeping View chat files, New chat, and Search chat directly visible while moving lower-frequency management actions into a More chat actions overflow menu.

Also keeps the persona bubble reachable while the overflow menu is open, closes overflow when persona switching opens, and pins the behavior in the mobile shell lifecycle seam, wiring tests, and mobile smoke pack.

## Why?
The Phase 3 mobile UX pass is reducing crowded phone-width controls without changing persisted settings. The bottom bar currently exposes every chat-management action in the same mobile row, which makes common actions harder to scan and leaves persona switching competing with low-frequency destructive/maintenance controls.

## How?
- Adds a pure `resolveBottomBarActionVisibility` lifecycle decision for the mobile bottom bar action split.
- Routes the bottom chat adapter through that decision and renders a transient overflow menu for Mass delete, Auto-name, Rename, and Delete.
- Leaves the existing action handlers and storage untouched; this PR does not add action customization preferences.
- Adds mobile-safe overflow styling and a persona-picker max-height polish for phone layouts.

## Testing?
- `git diff --check`
- `node --check public/scripts/sillybunny-tabs.js`
- `node --check public/scripts/mobile-shell-lifecycle/index.js`
- `node --check tests/mobile-shell-smoke.e2e.js`
- `npm run lint -- --quiet`
- `tests`: `node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.json mobile-shell-lifecycle-rail-model.test.js mobile-shell-lifecycle-wiring.test.js mobile-css-budgets.test.js mobile-shell-lifecycle-drawer-bounds.test.js mobile-shell-lifecycle.test.js` (68/68)
- `tests`: `node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.json` (116/117 suites passed, 1074/1075 tests passed; one unrelated `in-chat-agents-runner.test.js` timing case failed once)
- `tests`: `node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.json in-chat-agents-runner.test.js` (54/54 on rerun)
- `npm run check:frontend-budgets`
- `SILLYBUNNY_TEST_BASE_URL=http://127.0.0.1:4567 npm run test:e2e -- mobile-shell-smoke.e2e.js` (10/10)

## Screenshots (optional)
Not attached. The smoke pack captured and verified the affected mobile surfaces at 390x844, 320x568, 768x1024, and 820x1180.

## Anything Else?
Stacked draft: this branch includes the open Phase 3.1 and 3.2 draft work from #448 and #449 so reviewers can evaluate the intended post-3.2 mobile shell state. Merge order should stay #448, #449, then this PR.
