### PR TITLE
fix(guided-generations): honor impersonation perspective prompts

### DIFF
--- a/docs/upstream-touch-ledger.md
+++ b/docs/upstream-touch-ledger.md
@@ -262,13 +262,13 @@ This ledger tracks intentional SillyBunny divergence in upstream-origin files. I
 | Field | Value |
 | --- | --- |
 | Area | Generation lifecycle and settings. |
-| Divergence reason | SillyBunny impersonate generations on chat-completion backends need a first-person user-voice control prompt even when the editable impersonation fields are empty. |
+| Divergence reason | SillyBunny impersonate generations on chat-completion backends need a first-person user-voice control prompt even when the editable impersonation fields are empty. Guided Generations must also let custom impersonation prompts control first-, second-, or third-person perspective without a conflicting first-person-only frame. |
 | Target seam | Core chat-completion prompt preparation in `public/scripts/openai.js`; Guided Generations adds its own fork-side system frame. |
-| Adapter shape | Keep fallback selection in tiny helpers, use the default impersonation prompt for empty system directives, use a default Claude user-speaker prefill, and respect prompt-manager disabling when adding the impersonate control prompt. |
+| Adapter shape | Keep fallback selection in tiny helpers, use the default impersonation prompt for empty system directives, use a default Claude user-speaker prefill, and respect prompt-manager disabling when adding the impersonate control prompt. Keep Guided Generations' impersonate frame person-neutral and make the user-configured guide authoritative for perspective and narration style. |
 | Protecting tests | `tests/openai-impersonate-defaults.test.js`, `tests/guided-generations-steering.test.js`. |
 | Validation | `npm run test:unit --prefix tests -- openai-impersonate-defaults.test.js guided-generations-steering.test.js`, `node --check public/scripts/openai.js`, live chat-completion impersonate smoke when API access is available. |
 | Rollback path | Restore empty-string behavior for impersonation prompt/prefill and remove the prompt-manager guard if provider behavior regresses. |
-| Last reviewed | 2026-06-06 Bug 6 impersonate first-person defaults. |
+| Last reviewed | 2026-06-13 Guided Impersonate person-neutral steering. |
 | Owner | Refactor integrator and settings owner. |
 
 ### `public/css/sillybunny-tabs.css`, `public/css/sillybunny-mobile-shell.css`, `public/css/select2-overrides.css`, `public/css/welcome.css`, `public/style.css`, `public/script.js`, `public/sw.js`, and `public/index.html` - menu polish assets

--- a/public/scripts/extensions/guided-generations/index.js
+++ b/public/scripts/extensions/guided-generations/index.js
@@ -27,7 +27,7 @@ const defaultSettings = {
     promptGuidedResponse: '[Take the following into special consideration for your next message: {{input}}]',
     promptGuidedSwipe: '[Take the following into special consideration for your next message: {{input}}]',
     promptGuidedCorrection: '[Apply the following correction to your previous message: {{input}}]',
-    promptImpersonate1st: 'Write the next message in first person as {{user}}, not {{char}}. Keep the response in {{user}}\'s own words and actions. {{input}}',
+    promptImpersonate1st: 'Write the next message as {{user}}, not {{char}}. Follow the requested perspective, narration style, and constraints exactly. {{input}}',
     helperPrefillMessages: '',
     depthPromptGuidedResponse: 0,
     depthPromptGuidedSwipe: 0,
@@ -339,7 +339,7 @@ function updateExtensionButtons() {
 
     const buttons = [
         settings.showSimpleSendButton && createActionButton('gg_simple_send_button', 'Simple Send', 'fa-solid fa-paper-plane', simpleSend),
-        settings.showImpersonate1stPerson && createActionButton('gg_impersonate_button', 'Guided Impersonate', 'fa-solid fa-user', guidedImpersonate),
+        settings.showImpersonate1stPerson && createActionButton('gg_impersonate_button', 'Guided Impersonate', 'fa-solid fa-user-pen', guidedImpersonate),
         settings.showGuidedSwipe && createActionButton('gg_swipe_button', 'Guided Swipe', 'fa-solid fa-forward', guidedSwipe),
         settings.showGuidedCorrection && createActionButton('gg_correction_button', 'Guided Correction', 'fa-solid fa-pen-to-square', guidedCorrection),
         settings.showGuidedResponse && createActionButton('gg_response_button', 'Guided Response', 'fa-solid fa-compass', guidedResponse),

--- a/public/scripts/extensions/guided-generations/scripts/guidedImpersonate.js
+++ b/public/scripts/extensions/guided-generations/scripts/guidedImpersonate.js
@@ -21,7 +21,31 @@ function escapeSlashCommandDelimiters(value) {
 }
 
 function getImpersonateSystemFrame() {
-    return 'Guided Impersonate: write only as {{user}} in first person. Do not answer as {{char}}, narrator, or system. Treat helper prefill text as context, not as a speaker override.';
+    return [
+        'Guided Impersonate: generate only the next text-box message for {{user}}.',
+        'The guided impersonation prompt is authoritative for grammatical person, narration style, length, and exclusions.',
+        'If it asks for first, second, or third person, follow that requested perspective exactly.',
+        'Do not answer as {{char}}, explain the task, mention these instructions, or continue beyond the requested {{user}} message.',
+        'Treat helper prefill text as context, not as a speaker override.',
+    ].join(' ');
+}
+
+function buildGuidedImpersonatePrompt(filledPrompt, helperPrefillPrompt) {
+    const prompt = String(filledPrompt ?? '').trim();
+    const helper = String(helperPrefillPrompt ?? '').trim();
+    const sections = [
+        'Follow the guided impersonation prompt exactly when generating {{user}}\'s next text-box message. It is instruction text, not story text. Obey any requested first-, second-, or third-person perspective, narration style, dialogue requirements, length limits, and exclusions.',
+    ];
+
+    if (prompt) {
+        sections.push(`<guided_impersonation_prompt>\n${prompt}\n</guided_impersonation_prompt>`);
+    }
+
+    if (helper) {
+        sections.push(`<helper_prefill_context>\n${helper}\n</helper_prefill_context>`);
+    }
+
+    return sections.join('\n\n');
 }
 
 async function guidedImpersonate() {
@@ -50,10 +74,7 @@ async function guidedImpersonate() {
     const promptTemplate = settings.promptImpersonate1st ?? '';
     const filledPrompt = applyPromptTemplate(promptTemplate, currentInputText);
     const helperPrefillPrompt = serializeHelperPrefillForPrompt(parseHelperPrefillMessages(settings.helperPrefillMessages));
-    const impersonatePrompt = [filledPrompt, helperPrefillPrompt]
-        .map(value => String(value ?? '').trim())
-        .filter(Boolean)
-        .join('\n\n');
+    const impersonatePrompt = buildGuidedImpersonatePrompt(filledPrompt, helperPrefillPrompt);
     const fullScript = `// Impersonate guide|
 /inject id=gg-impersonate-voice position=chat ephemeral=true scan=true depth=0 role=system ${escapeSlashCommandDelimiters(getImpersonateSystemFrame())} |
 /impersonate await=true ${escapeSlashCommandDelimiters(impersonatePrompt)} |
@@ -63,7 +84,7 @@ async function guidedImpersonate() {
         await switching.switch();
         await getContext().executeSlashCommandsWithOptions(fullScript);
         setLastImpersonateResult(textarea.value);
-        debugLog('[Impersonate-1st] STScript executed, new input stored in shared state.');
+        debugLog('[Impersonate] STScript executed, new input stored in shared state.');
     } catch (error) {
         console.error('[GuidedGenerations][Impersonate] Error executing Guided Impersonate stscript:', error);
         setLastImpersonateResult('');

--- a/public/scripts/extensions/guided-generations/settings.html
+++ b/public/scripts/extensions/guided-generations/settings.html
@@ -85,7 +85,7 @@
 
             <div class="setting_item">
                 <div class="gg-profile-row">
-                    <label for="gg_profileImpersonate1st">Impersonate profile</label>
+                    <label for="gg_profileImpersonate1st">Guided Impersonate profile</label>
                     <select id="gg_profileImpersonate1st" name="profileImpersonate1st" class="gg-setting-input text_pole"></select>
                     <label for="gg_presetImpersonate1st">Preset</label>
                     <select id="gg_presetImpersonate1st" name="presetImpersonate1st" class="gg-setting-input text_pole"></select>

--- a/tests/guided-generations-steering.test.js
+++ b/tests/guided-generations-steering.test.js
@@ -137,8 +137,12 @@ describe('Guided Generations steering commands', () => {
         expect(textarea.dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'input' }));
     });
 
-    test('guided impersonate frames first-person voice and appends helper prefill blocks', async () => {
-        extensionSettings['guided-generations'].promptImpersonate1st = 'FIRST PERSON: {{input}}';
+    test.each([
+        ['first', 'FIRST PERSON: {{input}}'],
+        ['second', 'SECOND PERSON: {{input}}'],
+        ['third', 'THIRD PERSON: {{input}}'],
+    ])('guided impersonate lets the prompt control %s-person perspective', async (_, promptTemplate) => {
+        extensionSettings['guided-generations'].promptImpersonate1st = promptTemplate;
         extensionSettings['guided-generations'].helperPrefillMessages = `[system]
 Stay terse.
 
@@ -151,10 +155,18 @@ I | begin`;
 
         expect(context.executeSlashCommandsWithOptions).toHaveBeenCalledTimes(1);
         const command = context.executeSlashCommandsWithOptions.mock.calls[0][0];
-        expect(command).toContain('/inject id=gg-impersonate-voice position=chat ephemeral=true scan=true depth=0 role=system Guided Impersonate: write only as {{user}} in first person.');
-        expect(command).toContain('/impersonate await=true FIRST PERSON: aim for a colder, suspicious reply');
+        expect(command).toContain('/inject id=gg-impersonate-voice position=chat ephemeral=true scan=true depth=0 role=system Guided Impersonate: generate only the next text-box message for {{user}}.');
+        expect(command).toContain('The guided impersonation prompt is authoritative for grammatical person, narration style, length, and exclusions.');
+        expect(command).toContain('If it asks for first, second, or third person, follow that requested perspective exactly.');
+        expect(command).not.toContain('write only as {{user}} in first person');
+        expect(command).toContain('/impersonate await=true Follow the guided impersonation prompt exactly when generating {{user}}\'s next text-box message.');
+        expect(command).toContain('<guided_impersonation_prompt>');
+        expect(command).toContain(promptTemplate.replace('{{input}}', 'aim for a colder, suspicious reply'));
+        expect(command).toContain('</guided_impersonation_prompt>');
+        expect(command).toContain('<helper_prefill_context>');
         expect(command).toContain('SYSTEM:\nStay terse.');
         expect(command).toContain('ASSISTANT:\nI \\| begin');
+        expect(command).toContain('</helper_prefill_context>');
         expect(command).toContain('/flushinject gg-impersonate-voice |');
     });
 });


### PR DESCRIPTION
## What?
Guided Impersonate now treats the configured impersonation prompt as the authority for perspective and narration style instead of forcing a first-person system frame.

The default Guided Impersonate prompt and settings label were updated to describe general impersonation. The existing setting keys stay unchanged so saved settings continue to load.

## Why?
Custom Guided Impersonate prompts that requested second- or third-person output could be weakened or contradicted by the hard-coded first-person frame, especially prompts that requested narration such as third-person extradiegetic writing.

## How?
The Guided Impersonate STScript now injects a person-neutral system frame and wraps the configured prompt in a labeled guided impersonation section. The wrapper explicitly tells the model to obey requested first-, second-, or third-person perspective, narration style, dialogue requirements, length limits, and exclusions.

The steering regression test now covers first-, second-, and third-person Guided Impersonate prompts.

## Testing?
- `npm run test:unit --prefix tests -- guided-generations-steering.test.js guided-generations-settings.test.js openai-impersonate-defaults.test.js`
- `node --check public\scripts\extensions\guided-generations\scripts\guidedImpersonate.js`
- `node --check public\scripts\extensions\guided-generations\index.js`
- `git diff --check`
- Focused ESLint on the changed test and frontend JS files.

## Screenshots (optional)
Not applicable; prompt construction and one settings label changed, with no layout change.

## Anything Else?
The upstream touch ledger was updated so future sync work preserves the person-neutral Guided Impersonate frame.