### PR TITLE
chore: allow mobile refactor PR base

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,8 +17,8 @@ jobs:
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          if [ "$BASE_REF" != "staging" ]; then
-            echo "Pull requests must target the staging branch. Current target: $BASE_REF"
+          if [ "$BASE_REF" != "staging" ] && [ "$BASE_REF" != "TLD/mobile-refactor" ]; then
+            echo "Pull requests must target staging or TLD/mobile-refactor. Current target: $BASE_REF"
             exit 1
           fi
 


### PR DESCRIPTION
## What?
Allows pull requests to target either `staging` or `TLD/mobile-refactor` in the PR metadata validation workflow.

## Why?
The mobile UI refactor stack now intentionally targets `TLD/mobile-refactor`, while ordinary contribution PRs can still target `staging`. The previous workflow rejected the refactor stack even when the base branch was correct for this program.

## How?
The target-branch shell check in `.github/workflows/pr-checks.yml` now accepts `staging` or `TLD/mobile-refactor` and reports both allowed targets in the failure message.

## Testing?
- `git diff --check`
- Inspected the workflow diff for the branch allow-list change.

A local YAML parse was not run because this fresh worktree does not have dependencies installed; GitHub Actions will parse the workflow after push.

## Screenshots (optional)
Not applicable; workflow-only change.

## Anything Else?
This should merge before relying on the metadata check for the mobile-refactor PR stack.
