### PR TITLE
fix: route initial load scroll through state machine

### DIFF
--- a/docs/upstream-touch-ledger.md
+++ b/docs/upstream-touch-ledger.md
@@ -30,11 +30,11 @@ This ledger tracks intentional SillyBunny divergence in upstream-origin files. I
 | Area | Chat lifecycle. |
 | Divergence reason | SillyBunny adds mobile batching, bottom pinning, manual-scroll suppression, long-chat anchoring, streaming DOM throttles, and issue `#167` scroll stability behavior. |
 | Target seam | `public/scripts/chat-render-lifecycle/`. |
-| Adapter shape | Keep exported compatibility functions in `public/script.js`; delegate bottom-scroll decisions, scheduling, scroll intent/state, anchor preservation, replacement/media anchoring, and update batching to the lifecycle module. |
+| Adapter shape | Keep exported compatibility functions in `public/script.js`; delegate initial-load bottom landing, bottom-scroll decisions, scheduling, scroll intent/state, anchor preservation, replacement/media anchoring, and update batching to the lifecycle module. |
 | Protecting tests | `tests/chat-scroll-edges.test.js`, `tests/mobile-streaming.test.js`, `tests/chat-render-lifecycle-index.test.js`, `tests/chat-render-lifecycle-bottom-scroll.test.js`, `tests/chat-render-lifecycle-rollout-guard.test.js`, `tests/chat-render-lifecycle-anchor.test.js`, `tests/chat-render-lifecycle-scheduler.test.js`, `tests/chat-render-lifecycle-scroll-intent.test.js`, `tests/chat-render-lifecycle-scroll-state.test.js`, `tests/chat-scroll-state-machine.e2e.js`, `tests/chat-send-scroll.e2e.js`, `tests/chat-scroll-regressions.e2e.js`, future lifecycle unit tests. |
-| Validation | `node --check public/script.js tests/chat-scroll-regressions.e2e.js`, focused lifecycle Jest `chat-render-lifecycle-scroll-state.test.js chat-render-lifecycle-script-wiring.test.js`, focused media-resize e2e from `tests/chat-scroll-regressions.e2e.js`, plus prior lifecycle lint/unit/e2e packs on this stack. |
+| Validation | `node --check public/script.js`, focused lifecycle Jest `chat-render-lifecycle-scroll-state.test.js chat-render-lifecycle-script-wiring.test.js`, `npm run check:frontend-budgets`, plus prior lifecycle lint/unit/e2e packs on this stack. |
 | Rollback path | Keep legacy behavior behind temporary rollout guard until lifecycle fixtures pass. |
-| Last reviewed | 2026-06-13 media-resize scroll-state route. |
+| Last reviewed | 2026-06-13 initial-load scroll-state route. |
 | Owner | Refactor integrator. |
 
 ### `public/script.js` - generation lifecycle

--- a/public/script.js
+++ b/public/script.js
@@ -336,7 +336,6 @@ import {
     renderMessagesInBatches,
     resolveChatBottomScrollAction,
     resolveChatRenderLifecycleRollout,
-    resolveChatScrollAction,
     resolveChatScrollStateTransition,
     restoreVisibleMessageAnchor,
     settleVisibleMessageAnchor,
@@ -3110,9 +3109,12 @@ function scrollLoadedChatToBottomThroughLifecycle() {
         return;
     }
 
-    const action = resolveChatScrollAction({
+    const transition = resolveChatScrollStateTransition({
+        state: chatScrollState,
         intent: CHAT_SCROLL_INTENT.INITIAL_LOAD,
     });
+    chatScrollState = transition.state;
+    const action = transition.action;
 
     if (shouldApplyChatBottomScrollAction(action)) {
         scrollLoadedChatToBottom();

--- a/tests/chat-render-lifecycle-script-wiring.test.js
+++ b/tests/chat-render-lifecycle-script-wiring.test.js
@@ -93,10 +93,14 @@ describe('chat render lifecycle script wiring', () => {
 
         const lifecycleGateSource = getSource(lifecycleGate);
         expect(lifecycleGateSource).toContain('isChatRenderLifecycleRolloutEnabled(CHAT_RENDER_LIFECYCLE_ROUTE.INITIAL_LOAD)');
-        expect(lifecycleGateSource).toContain('resolveChatScrollAction({');
+        expect(lifecycleGateSource).toContain('const transition = resolveChatScrollStateTransition({');
+        expect(lifecycleGateSource).toContain('state: chatScrollState');
         expect(lifecycleGateSource).toContain('intent: CHAT_SCROLL_INTENT.INITIAL_LOAD');
+        expect(lifecycleGateSource).toContain('chatScrollState = transition.state;');
+        expect(lifecycleGateSource).toContain('const action = transition.action;');
         expect(lifecycleGateSource).toContain('shouldApplyChatBottomScrollAction(action)');
         expect(lifecycleGateSource).toContain('scrollLoadedChatToBottom();');
+        expect(lifecycleGateSource).not.toContain('resolveChatScrollAction({');
     });
 
     test('redisplayChat delegates selected messages to the guarded redisplay renderer', () => {

--- a/tests/chat-render-lifecycle-scroll-state.test.js
+++ b/tests/chat-render-lifecycle-scroll-state.test.js
@@ -8,11 +8,26 @@ import {
 } from '../public/scripts/chat-render-lifecycle/scroll-state.js';
 
 describe('chat render lifecycle scroll state machine', () => {
-    test('initial load enters pinned-bottom with a forced bottom action', () => {
+    test('initial load always enters pinned-bottom with a forced bottom action', () => {
         expect(resolveChatScrollStateTransition({
             state: CHAT_SCROLL_STATE.USER_READING,
             intent: CHAT_SCROLL_INTENT.INITIAL_LOAD,
             autoScrollEnabled: false,
+        })).toEqual({
+            state: CHAT_SCROLL_STATE.PINNED_BOTTOM,
+            action: {
+                action: CHAT_SCROLL_ACTION.PIN_BOTTOM,
+                force: true,
+                reason: CHAT_SCROLL_INTENT.INITIAL_LOAD,
+            },
+        });
+
+        expect(resolveChatScrollStateTransition({
+            state: CHAT_SCROLL_STATE.ANCHORED_HISTORY,
+            intent: CHAT_SCROLL_INTENT.INITIAL_LOAD,
+            autoScrollEnabled: true,
+            isNearBottom: false,
+            isManualScrollSuppressed: true,
         })).toEqual({
             state: CHAT_SCROLL_STATE.PINNED_BOTTOM,
             action: {


### PR DESCRIPTION
## What?
Routes the guarded initial-load bottom landing in `public/script.js` through the chat scroll state machine instead of resolving the scroll action directly.

## Why?
Initial chat load is the remaining scroll path called out in the mobile refactor plan after #454. Keeping it behind the existing rollout gate moves another upstream-origin scroll decision onto the shared `chat-render-lifecycle` seam while preserving the legacy fallback.

## How?
`scrollLoadedChatToBottomThroughLifecycle()` now resolves `CHAT_SCROLL_INTENT.INITIAL_LOAD` with `resolveChatScrollStateTransition()`, stores the returned `chatScrollState`, then applies the transition action with the existing bottom-scroll helper. Wiring and state-machine tests pin that the initial-load route uses the state seam and always lands in `pinned-bottom` with a forced bottom action. The upstream touch ledger records the updated adapter shape.

## Testing?
- `git diff --check`
- `node --check public/script.js`
- `npm run test:unit --prefix tests -- chat-render-lifecycle-scroll-state.test.js chat-render-lifecycle-script-wiring.test.js` (42/42)
- `npm run lint -- --quiet`
- `npm run check:frontend-budgets`
- `SILLYBUNNY_TEST_BASE_URL=http://127.0.0.1:4568 npm run test:e2e --prefix tests -- --browser=chromium chat-scroll-state-machine.e2e.js` (1/1)

The broader `chat-scroll-regressions.e2e.js -g "long chat initial render lands near the latest message"` was attempted with Chromium on `http://127.0.0.1:4568` but stopped at the existing sample-character setup blocker before exercising this change.

## Screenshots (optional)
Not applicable; this is a guarded scroll adapter change with Chromium runtime coverage rather than a visual UI change.

## Anything Else?
Targets `TLD/mobile-refactor`. The temporary test server used port 4568, and it was stopped after verification.
