### PR TITLE
fix: clear cookies and cache now works on iOS WebKit

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -997,7 +997,7 @@ function registerSillyBunnyServiceWorker() {
     }
 
     const register = () => {
-        navigator.serviceWorker.register('/sw.js?v=20260609d', { updateViaCache: 'none' }).then((registration) => {
+        navigator.serviceWorker.register('/sw.js?v=20260614a', { updateViaCache: 'none' }).then((registration) => {
             return registration.update().catch((error) => {
                 console.warn('Failed to update SillyBunny service worker.', error);
             });
@@ -11120,6 +11120,30 @@ export async function clearFrontendCache({ skipConfirmation = false, saveBeforeC
 
     if (globalThis.navigator?.serviceWorker && typeof globalThis.navigator.serviceWorker.getRegistrations === 'function') {
         try {
+            // SillyBunny: on iOS WebKit the controlling service worker stays attached to this
+            // page after unregister() until the page unloads. Without an explicit purge the SW
+            // re-fills its caches during the reload navigation, undoing the clear. We message
+            // the controller to delete all sillybunny-cache-* caches before unregistering.
+            const controller = globalThis.navigator.serviceWorker.controller;
+            if (controller) {
+                await new Promise((resolve) => {
+                    const channel = new MessageChannel();
+                    const timeout = globalThis.setTimeout(() => {
+                        // Best-effort: don't block the clear if the SW doesn't respond in time.
+                        console.warn('[Cache] Service worker did not acknowledge cache purge; proceeding anyway.');
+                        resolve();
+                    }, 3000);
+                    channel.port1.onmessage = (event) => {
+                        globalThis.clearTimeout(timeout);
+                        if (event.data?.type === 'SB_CLEAR_CACHES_DONE' && !event.data.ok) {
+                            console.warn('[Cache] Service worker reported a partial cache purge failure.');
+                        }
+                        resolve();
+                    };
+                    controller.postMessage({ type: 'SB_CLEAR_CACHES' }, [channel.port2]);
+                });
+            }
+
             const registrations = await globalThis.navigator.serviceWorker.getRegistrations();
             await Promise.all(registrations.map(registration => registration.unregister()));
         } catch (error) {
@@ -11134,16 +11158,18 @@ export async function clearFrontendCache({ skipConfirmation = false, saveBeforeC
 
     droppedStores.forEach((result, index) => {
         if (result.status === 'rejected') {
-            console.error(`Failed to clear IndexedDB cache store: ${FRONTEND_CACHE_INSTANCE_NAMES[index]}`, result.reason);
-            cacheErrors.push(result.reason);
+            // SillyBunny: IDB drops are best-effort. iOS WebKit with ITP or storage pressure
+            // can reject localforage.dropInstance() — log but don't abort the clear so that
+            // cookie expiry and the reload still happen.
+            console.warn(`Failed to clear IndexedDB cache store: ${FRONTEND_CACHE_INSTANCE_NAMES[index]}`, result.reason);
         }
     });
 
     try {
         sessionStorage.clear();
     } catch (error) {
-        console.error('Failed to clear session storage', error);
-        cacheErrors.push(error);
+        // SillyBunny: sessionStorage may be blocked by iOS ITP in private browsing; non-fatal.
+        console.warn('Failed to clear session storage', error);
     }
 
     if (cacheErrors.length > 0) {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const SB_SW_CACHE_VERSION = 'sillybunny-cache-v20260610a';
+const SB_SW_CACHE_VERSION = 'sillybunny-cache-v20260614a';
 const SB_STATIC_CACHE = `${SB_SW_CACHE_VERSION}-static`;
 const SB_SHELL_CACHE = `${SB_SW_CACHE_VERSION}-shell`;
 const SB_FRONTEND_ASSET_PREFIX = '/frontend-assets/';
@@ -108,6 +108,39 @@ async function networkFirst(request) {
 
 self.addEventListener('install', () => {
     self.skipWaiting();
+});
+
+// SillyBunny: iOS WebKit keeps the current page controlled by this service worker until the
+// page unloads, even after registration.unregister(). Without this the SW would re-populate
+// its caches during the pre-reload window and the reload navigation itself, undoing a cache
+// clear. The page posts { type: 'SB_CLEAR_CACHES' } and waits for the matching reply before
+// reloading.
+async function deleteSillyBunnyCaches() {
+    const cacheNames = await caches.keys();
+    await Promise.all(cacheNames
+        .filter(cacheName => cacheName.startsWith('sillybunny-cache-'))
+        .map(cacheName => caches.delete(cacheName)));
+}
+
+self.addEventListener('message', (event) => {
+    if (event.data?.type !== 'SB_CLEAR_CACHES') {
+        return;
+    }
+
+    event.waitUntil((async () => {
+        let ok = true;
+        try {
+            await deleteSillyBunnyCaches();
+        } catch (error) {
+            console.error('SillyBunny service worker failed to clear caches on request.', error);
+            ok = false;
+        }
+
+        const port = event.ports?.[0];
+        if (port) {
+            port.postMessage({ type: 'SB_CLEAR_CACHES_DONE', ok });
+        }
+    })());
 });
 
 self.addEventListener('activate', (event) => {


### PR DESCRIPTION
## What

Two bugs caused the "Clear cookies & cache" button to silently do nothing on iOS.

**Bug 1 — IDB failures aborted the entire clear**

`localforage.dropInstance()` can be rejected on iOS under ITP or storage pressure. The rejection was pushed to `cacheErrors`, causing `clearFrontendCache` to return `false`. The handler in `sillybunny-tabs.js` saw `!didClear` and returned before ever expiring cookies or reloading. IDB drops and `sessionStorage.clear()` are now best-effort (warn, don't abort), so cookie expiry and the reload always run.

**Bug 2 — Active service worker re-filled its caches during the reload**

On iOS WebKit `registration.unregister()` does not detach the controlling SW from the current page — it stays in control through the unload. The SW's `networkFirst` and `staleWhileRevalidate` fetch handlers were re-populating `SB_STATIC_CACHE` / `SB_SHELL_CACHE` during the 1 s pre-reload window and the reload navigation itself, immediately undoing the clear.

`sw.js` now handles a `{ type: 'SB_CLEAR_CACHES' }` message that deletes all `sillybunny-cache-*` entries and replies on a `MessageChannel` port. `clearFrontendCache` messages the active controller and awaits the reply (3 s timeout, best-effort) before calling `unregister()`.

Cache version bumped to `v20260614a` so the updated SW is fetched and old caches are pruned on next `activate`.

## Files changed

- `public/script.js` — IDB/sessionStorage failures non-fatal; message controller before unregister
- `public/sw.js` — `SB_CLEAR_CACHES` message handler; cache version bump

## Testing

No automated tests cover browser-side service worker messaging (existing test suite covers server-side middleware only). Manual verification on iOS Safari/Chrome recommended.