### PR TITLE
fix(chat): await deferred mobile repaint before MESSAGE_UPDATED

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -631,6 +631,8 @@ let pendingMobileMessageUpdateFrame = 0;
 let pendingMobileMessageUpdateTimer = 0;
 let messageUpdateQueue = null;
 let mobileMessageUpdateQueue = null;
+/** @type {Array<() => void>} Resolvers for Promises waiting on the next mobile-queue flush. */
+let mobileMessageUpdateFlushResolvers = [];
 let streamingVisibleWriteBuffer = null;
 let chatMessageResizeObserver = null;
 let mobileChatViewportObserver = null;
@@ -2710,19 +2712,33 @@ function flushPendingMobileMessageUpdates() {
     pendingMobileMessageUpdateFrame = 0;
     pendingMobileMessageUpdateTimer = 0;
     getMobileMessageUpdateQueue().flush();
+    // Notify all callers awaiting this flush that the DOM is now repainted.
+    const resolvers = mobileMessageUpdateFlushResolvers.splice(0);
+    for (const resolve of resolvers) resolve();
 }
 
+/**
+ * Queues a mobile message-block update and returns a Promise that resolves after the
+ * deferred rAF flush actually repaints the DOM.  This lets async callers await the
+ * real paint completion rather than just the data write.
+ * @param {number|string} messageId
+ * @param {object} message
+ * @param {{rerenderMessage: boolean}} options
+ * @returns {Promise<void>}
+ */
 function queueMobileMessageBlockUpdate(messageId, message, { rerenderMessage }) {
     getMobileMessageUpdateQueue().queue(messageId, message, { rerenderMessage });
 
-    if (pendingMobileMessageUpdateFrame || pendingMobileMessageUpdateTimer) {
-        return;
+    const flushPromise = new Promise(resolve => mobileMessageUpdateFlushResolvers.push(resolve));
+
+    if (!pendingMobileMessageUpdateFrame && !pendingMobileMessageUpdateTimer) {
+        pendingMobileMessageUpdateTimer = window.setTimeout(() => {
+            pendingMobileMessageUpdateTimer = 0;
+            pendingMobileMessageUpdateFrame = requestAnimationFrame(flushPendingMobileMessageUpdates);
+        }, MOBILE_MESSAGE_UPDATE_DELAY_MS);
     }
 
-    pendingMobileMessageUpdateTimer = window.setTimeout(() => {
-        pendingMobileMessageUpdateTimer = 0;
-        pendingMobileMessageUpdateFrame = requestAnimationFrame(flushPendingMobileMessageUpdates);
-    }, MOBILE_MESSAGE_UPDATE_DELAY_MS);
+    return flushPromise;
 }
 
 function insertShowMoreFragment(referenceNode, fragment) {
@@ -3888,10 +3904,11 @@ function applyMessageBlockUpdate(messageId, message, { rerenderMessage = true } 
  * @param {object} message Message object
  * @param {object} [options={}] Optional arguments
  * @param {boolean} [options.rerenderMessage=true] Whether to re-render the message content (inside <c>.mes_text</c>)
+ * @returns {Promise<void>} Resolves once the message block DOM has been repainted (including the deferred mobile flush).
  */
-export function updateMessageBlock(messageId, message, { rerenderMessage = true } = {}) {
+export async function updateMessageBlock(messageId, message, { rerenderMessage = true } = {}) {
     if (shouldDeferMobileMessageUpdates()) {
-        queueMobileMessageBlockUpdate(messageId, message, { rerenderMessage });
+        await queueMobileMessageBlockUpdate(messageId, message, { rerenderMessage });
         return;
     }
 

--- a/public/script.js
+++ b/public/script.js
@@ -2731,12 +2731,14 @@ function queueMobileMessageBlockUpdate(messageId, message, { rerenderMessage }) 
 
     const flushPromise = new Promise(resolve => mobileMessageUpdateFlushResolvers.push(resolve));
 
-    if (!pendingMobileMessageUpdateFrame && !pendingMobileMessageUpdateTimer) {
-        pendingMobileMessageUpdateTimer = window.setTimeout(() => {
-            pendingMobileMessageUpdateTimer = 0;
-            pendingMobileMessageUpdateFrame = requestAnimationFrame(flushPendingMobileMessageUpdates);
-        }, MOBILE_MESSAGE_UPDATE_DELAY_MS);
+    if (pendingMobileMessageUpdateFrame || pendingMobileMessageUpdateTimer) {
+        return flushPromise;
     }
+
+    pendingMobileMessageUpdateTimer = window.setTimeout(() => {
+        pendingMobileMessageUpdateTimer = 0;
+        pendingMobileMessageUpdateFrame = requestAnimationFrame(flushPendingMobileMessageUpdates);
+    }, MOBILE_MESSAGE_UPDATE_DELAY_MS);
 
     return flushPromise;
 }

--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -3281,7 +3281,12 @@ async function refreshMessageAfterMutation(messageIndex, message, { deferBackup 
     const messageElement = document.querySelector(`.mes[mesid="${messageIndex}"]`);
 
     if (messageElement && typeof context?.updateMessageBlock === 'function') {
-        context.updateMessageBlock(messageIndex, message);
+        // Await the repaint so MESSAGE_UPDATED fires only after the DOM is actually
+        // re-rendered. On the deferred mobile path updateMessageBlock resolves after the
+        // rAF flush; otherwise it resolves synchronously. This lets DOM-mutating
+        // listeners (e.g. Dialogue Colors) re-decorate against the final DOM instead of
+        // racing the deferred render.
+        await context.updateMessageBlock(messageIndex, message);
 
         if (typeof eventSource?.emit === 'function' && event_types?.MESSAGE_UPDATED) {
             await eventSource.emit(event_types.MESSAGE_UPDATED, messageIndex);


### PR DESCRIPTION
## Summary

`updateMessageBlock()` defers the actual `.mes_text` DOM render on the mobile-batched path (`queueMobileMessageBlockUpdate` → `setTimeout(24ms)` → `requestAnimationFrame` → queue `flush()`), but the function returned **synchronously**. Callers that emit `MESSAGE_UPDATED` immediately after calling it therefore signalled "message updated" *before* the DOM was actually repainted.

The in-chat-agent runner's `refreshMessageAfterMutation()` (used by post-gen agents like Prose Polisher) does exactly this. As a result, DOM-mutating `MESSAGE_UPDATED` listeners — e.g. the **Dialogue Colors** extension's DOM coloring engine — ran against stale DOM, and the subsequent deferred render wiped their changes. This surfaced as intermittent, viewport/timing-dependent failures ("works sometimes, then it doesn't").

## Fix

- `queueMobileMessageBlockUpdate` now returns a `Promise` that resolves after the rAF flush actually repaints the DOM. Pending resolvers are tracked in a module-level list drained inside `flushPendingMobileMessageUpdates`.
- `updateMessageBlock` is now `async` and `await`s that flush on the mobile path. The desktop/lifecycle paths remain synchronous in practice, since an async function runs synchronously up to its first `await` (no mobile defer = no `await` hit).
- `refreshMessageAfterMutation` `await`s `updateMessageBlock` so `MESSAGE_UPDATED` fires only after the repaint.

This makes `MESSAGE_UPDATED` a reliable "DOM is repainted" signal for **all** extensions, not just Dialogue Colors.

## Compatibility

- `updateMessageBlock` is exported and consumed via `context.updateMessageBlock`. Non-awaiting callers keep working unchanged (fire-and-forget) — the return value was previously `undefined` and is now an ignorable Promise.
- No behavioral change on desktop / non-deferred paths.

## Testing

- `npm run lint` clean on all three touched files.
- `node --check` passes on `public/script.js`, `agent-runner.js`, and `update-queue.js`.
- Manual smoke test recommended: run a post-gen agent (e.g. Prose Polisher) on a narrow/mobile viewport with the Dialogue Colors DOM engine active and confirm decorations survive the post-edit re-render.