### PR TITLE
fix: compact world info entry controls

### DIFF
--- a/public/css/world-info.css
+++ b/public/css/world-info.css
@@ -971,7 +971,8 @@ select.keyselect+span.select2-container .select2-selection--multiple {
         min-height: 0;
         height: 100%;
         max-height: clamp(360px, 58vh, 820px);
-        padding-right: 4px;
+        gap: 4px;
+        padding-right: 3px;
     }
 
     #world_popup_editor_pane {
@@ -1044,20 +1045,46 @@ select.keyselect+span.select2-container .select2-selection--multiple {
         display: none !important;
     }
 
+    #world_popup_entries_list .wi-card-entry {
+        border-radius: 9px;
+        padding: 3px 5px;
+        box-shadow: 0 4px 8px color-mix(in srgb, var(--SmartThemeShadowColor) 6%, transparent);
+    }
+
+    #world_popup_entries_list .world_entry_selected .wi-card-entry {
+        box-shadow: 0 10px 22px color-mix(in srgb, var(--SmartThemeShadowColor) 14%, transparent);
+    }
+
     #world_popup_entries_list .world_entry .inline-drawer-header,
     #world_popup_entries_list .world_entry .inline-drawer-header:hover {
-        grid-template-columns: auto minmax(0, 1fr);
-        gap: 8px;
+        grid-template-columns: auto minmax(0, 1fr) auto;
+        gap: 5px;
     }
 
     #world_popup_entries_list .WIEntryHeaderMain {
         display: grid;
-        grid-column: 1 / -1;
+        grid-column: 1 / 3;
         grid-row: 1;
         grid-template-columns: auto auto minmax(0, 1fr);
         align-items: center;
         width: 100%;
-        gap: 8px;
+        gap: 4px;
+    }
+
+    #world_popup_entries_list .world_entry .killSwitch {
+        min-height: 24px;
+        height: 24px;
+        gap: 4px;
+        padding: 0 6px;
+    }
+
+    #world_popup_entries_list .world_entry .killSwitch i {
+        font-size: calc(var(--mainFontSize) * 0.84);
+    }
+
+    #world_popup_entries_list .killSwitchLabel {
+        font-size: calc(var(--mainFontSize) * 0.64);
+        letter-spacing: 0.035em;
     }
 
     #world_popup_entries_list .WIEntryHeaderMain > .inline-drawer-icon,
@@ -1066,53 +1093,82 @@ select.keyselect+span.select2-container .select2-selection--multiple {
     }
 
     #world_popup_entries_list .world_entry .inline-drawer-header:has(> .drag-handle) .WIEntryHeaderMain {
-        grid-column: 2 / -1;
+        grid-column: 2 / 3;
     }
 
     #world_popup_entries_list .WIEntryHeaderBody {
-        grid-column: 1 / -1;
-        grid-row: 2;
-        grid-template-columns: 1fr;
-        gap: 8px;
+        grid-column: 3;
+        grid-row: 1;
+        grid-template-columns: minmax(0, 0.95fr) minmax(210px, 1fr);
+        gap: 4px;
+        align-items: center;
         width: 100%;
     }
 
     #world_popup_entries_list .WIEntryTitleAndStatus {
-        grid-template-columns: minmax(0, 1fr) minmax(96px, auto);
-        gap: 6px;
+        grid-template-columns: minmax(0, 1fr) minmax(86px, auto);
+        gap: 3px;
+    }
+
+    #world_popup_entries_list .WIEntryTitleAndStatus textarea {
+        min-height: 24px;
+        max-height: 2.6rem;
+        padding: 2px 6px;
+        line-height: 1.15;
+    }
+
+    #world_popup_entries_list .WIEntryTitleAndStatus select {
+        min-height: 24px;
+        padding: 2px 5px;
     }
 
     #world_popup_entries_list .WIEntryTitleAndStatus select[name="entryStateSelector"] {
-        width: 96px;
-        min-width: 96px;
-        font-size: calc(var(--mainFontSize) * 0.72);
+        width: 86px;
+        min-width: 86px;
+        font-size: calc(var(--mainFontSize) * 0.68);
     }
 
     #world_popup_entries_list .WIEnteryHeaderControls {
-        grid-template-columns: minmax(96px, 1fr) repeat(3, minmax(62px, 0.72fr));
-        gap: 5px;
-        padding: 6px;
+        grid-template-columns: minmax(78px, 0.9fr) repeat(3, minmax(44px, 0.52fr));
+        gap: 3px;
+        padding: 2px;
+        border-radius: 7px;
     }
 
     #world_popup_entries_list .WIEnteryHeaderControls > [name="PositionBlock"] {
         grid-column: auto;
     }
 
+    #world_popup_entries_list .WIEnteryHeaderControls .world_entry_form_control {
+        gap: 1px;
+    }
+
+    #world_popup_entries_list .WIEnteryHeaderControls .world_entry_form_control input,
+    #world_popup_entries_list .WIEnteryHeaderControls .world_entry_form_control select {
+        min-height: 24px;
+        padding: 2px 5px;
+        font-size: calc(var(--mainFontSize) * 0.78);
+    }
+
     #world_popup_entries_list .WIEntryHeaderActions {
-        grid-column: 1 / -1;
-        grid-row: 2;
+        grid-column: 3;
+        grid-row: 1;
+        align-self: center;
+        flex-wrap: nowrap;
+        gap: 2px;
         justify-content: flex-end;
-        padding-top: 2px;
+        padding-top: 0;
     }
 
     #world_popup_entries_list .world_entry .inline-drawer-header:has(> .drag-handle) .WIEntryHeaderActions {
-        grid-column: 2 / -1;
+        grid-column: 3;
     }
 
     #world_popup_entries_list .WIEntryHeaderActions .menu_button {
-        width: 30px;
-        min-width: 30px;
-        height: 30px;
+        width: 24px;
+        min-width: 24px;
+        height: 24px;
+        font-size: calc(var(--mainFontSize) * 0.84);
     }
 
     #world_popup_editor_host .world_entry_edit > .flex-container.wide100p.alignitemscenter,
@@ -1202,11 +1258,11 @@ select.keyselect+span.select2-container .select2-selection--multiple {
     }
 
     #world_popup_entries_list {
-        gap: 8px;
+        gap: 4px;
     }
 
     #world_popup_entries_list .wi-card-entry {
-        padding: 10px 12px;
+        padding: 3px 5px;
     }
 }
 
@@ -1217,12 +1273,17 @@ select.keyselect+span.select2-container .select2-selection--multiple {
 }
 
 @media screen and (min-width: 961px) and (max-width: 1180px) {
+    #world_popup_entries_list .WIEntryHeaderBody {
+        grid-template-columns: 1fr;
+        gap: 3px;
+    }
+
     #world_popup_entries_list .WIEnteryHeaderControls {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
+        grid-template-columns: minmax(78px, 0.9fr) repeat(3, minmax(44px, 0.52fr));
     }
 
     #world_popup_entries_list .WIEnteryHeaderControls > [name="PositionBlock"] {
-        grid-column: 1 / -1;
+        grid-column: auto;
     }
 }
 
@@ -1266,6 +1327,19 @@ select.keyselect+span.select2-container .select2-selection--multiple {
 
     #WorldInfo.sb-shell-embedded-content .WIEnteryHeaderControls > [name="PositionBlock"] {
         grid-column: 1 / -1;
+    }
+
+    #WorldInfo.sb-shell-embedded-content #world_popup_entries_list .WIEntryHeaderBody {
+        grid-template-columns: 1fr;
+        gap: 3px;
+    }
+
+    #WorldInfo.sb-shell-embedded-content #world_popup_entries_list .WIEnteryHeaderControls {
+        grid-template-columns: minmax(78px, 0.9fr) repeat(3, minmax(44px, 0.52fr));
+    }
+
+    #WorldInfo.sb-shell-embedded-content #world_popup_entries_list .WIEnteryHeaderControls > [name="PositionBlock"] {
+        grid-column: auto;
     }
 
     #WorldInfo.sb-shell-embedded-content #wiActivationSettings {
@@ -1328,11 +1402,11 @@ select.keyselect+span.select2-container .select2-selection--multiple {
     }
 
     #WorldInfo.sb-shell-embedded-content #world_popup_entries_list {
-        gap: 8px;
+        gap: 4px;
     }
 
     #WorldInfo.sb-shell-embedded-content #world_popup_entries_list .wi-card-entry {
-        padding: 10px 12px;
+        padding: 3px 5px;
     }
 }
 


### PR DESCRIPTION
## Summary
- Compact the desktop World Info entries list cards and controls
- Keep entry actions in the main row and reduce control widths/heights
- Preserve mobile touch-target behavior by scoping the density changes to desktop/embedded list rules

## Tests
- node --input-type=module -e "import fs from 'node:fs'; import { parse } from '@adobe/css-tools'; parse(fs.readFileSync('public/css/world-info.css', 'utf8')); console.log('CSS parse OK');"
- npm run build:frontend