### PR TITLE
feat(ica): show all enabled companions in batch selector

### DIFF
--- a/public/scripts/extensions/in-chat-agents/editor.html
+++ b/public/scripts/extensions/in-chat-agents/editor.html
@@ -211,7 +211,7 @@
         </div>
         <div class="ica--editor-row" id="ica--companion-batch-row">
             <label class="checkbox_label" title="When selected companions use the same profile, model, and context settings, they share one model request."><input type="checkbox" id="ica--editor-companion-batch" /><span>Run selected companions in one request</span></label>
-            <div class="ica--regex-note">Off by default. Turn it on to fetch currently enabled compatible companions, then pick which ones can share this agent's request.</div>
+            <div class="ica--regex-note">Off by default. Turn it on to fetch currently enabled side companions, then pick which ones can share this agent's request.</div>
         </div>
         <div class="ica--editor-row" id="ica--companion-batch-select-row" style="display:none">
             <label>Batch With Enabled Companions

--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -328,31 +328,13 @@ function normalizeCompanionBatchAgentIds(value = []) {
     return ids;
 }
 
-function getCompanionBatchCompatibilityKey(agent) {
-    const companion = getCompanionConfig(agent);
-    return JSON.stringify({
-        profile: resolveConnectionProfile(agent.connectionProfile),
-        model: String(agent.modelOverride ?? '').trim(),
-        contextMessages: companion.contextMessages,
-        includeCharacterCard: companion.includeCharacterCard,
-        includePersona: companion.includePersona,
-        includeWorldInfo: companion.includeWorldInfo,
-        includeAuthorsNote: companion.includeAuthorsNote,
-        includeSystemPrompt: companion.includeSystemPrompt,
-        includeHistory: companion.includeHistory,
-        historyDepth: companion.historyDepth,
-    });
-}
-
 function getCompanionBatchOptionsForAgent(agent) {
     if (!isCompanionAgent(agent)) return [];
 
-    const currentKey = getCompanionBatchCompatibilityKey(agent);
     return getAgents()
         .filter(candidate => candidate.id !== agent.id)
         .filter(candidate => isCompanionAgent(candidate))
         .filter(candidate => isAgentEnabledForCurrentScope(candidate))
-        .filter(candidate => getCompanionBatchCompatibilityKey(candidate) === currentKey)
         .map(candidate => ({
             id: candidate.id,
             label: String(candidate.name ?? '').trim() || candidate.id,
@@ -2706,7 +2688,7 @@ async function openEditor(agentId = null, { draft = null, autoOpenCompanionMaker
 
         select.empty();
         if (!options.length && !selectedIds.length) {
-            select.append($('<option>').val('').text('No enabled compatible companions').prop('disabled', true));
+            select.append($('<option>').val('').text('No enabled side companions').prop('disabled', true));
             return;
         }
 

--- a/tests/in-chat-agents-generation-ui-wiring.test.js
+++ b/tests/in-chat-agents-generation-ui-wiring.test.js
@@ -82,8 +82,15 @@ describe('in-chat agents generation UI wiring', () => {
         expect(extensionStyleSource).toContain('grid-template-columns: repeat(4, minmax(0, 1fr));');
         expect(editorTemplateSource).toContain('Run selected companions in one request');
         expect(editorTemplateSource).toContain('Batch With Enabled Companions');
-        expect(editorTemplateSource).toContain('Turn it on to fetch currently enabled compatible companions');
+        expect(editorTemplateSource).toContain('Turn it on to fetch currently enabled side companions');
         expect(editorTemplateSource).not.toContain('Batch with compatible companions');
+    });
+
+    test('lists all enabled side companions in batch selector regardless of compatibility', () => {
+        const source = getFunctionSource('getCompanionBatchOptionsForAgent');
+        expect(source).not.toContain('getCompanionBatchCompatibilityKey');
+        expect(source).toContain('isAgentEnabledForCurrentScope(candidate)');
+        expect(source).toContain('isCompanionAgent(candidate)');
     });
 
     test('labels companion agent cards as side execution', () => {


### PR DESCRIPTION
## Summary

Plot Compass Companion's default configuration (raw prompt, full context includes, 1-message history) rarely matches the compatibility key of other panel companions, causing it to be hidden from the "Run selected companions in one request" dropdown. This makes it impossible to include Plot Compass in a batch selection, even when a user wants to pair it with other enabled companions.

## What changes

- **`public/scripts/extensions/in-chat-agents/index.js`**  
  - Removed the `getCompanionBatchCompatibilityKey` function (no longer used).  
  - Updated `getCompanionBatchOptionsForAgent` to stop filtering batch candidates by the compatibility key. The selector now lists every enabled side companion except the current one.  
  - Changed the empty-options placeholder from "No enabled compatible companions" to "No enabled side companions".

- **`public/scripts/extensions/in-chat-agents/editor.html`**  
  - Renamed the descriptive note to say "currently enabled side companions" instead of "currently enabled compatible companions". The existing note about agents with different models, profiles, or context settings running separately is unchanged.

- **`tests/in-chat-agents-generation-ui-wiring.test.js`**  
  - Updated the editor-template substring assertion to expect the new "side companions" text.  
  - Added a test that the new `getCompanionBatchOptionsForAgent` source no longer references `getCompanionBatchCompatibilityKey` while still retaining the `isCompanionAgent` and scope-aware enabled filters.

## Runtime behavior

`partitionCompanionRuns` and `getBatchKey` in the companion runner continue to group only agents with matching connection profile, model override, and context settings into a shared request. Companions selected in the batch UI but whose keys differ are still run separately, matching the existing documentation on the editor.

## Tested

- `bun test tests/in-chat-agents-generation-ui-wiring.test.js` — 8 pass, 0 fail
- `bun run lint` — no errors