### PR TITLE
feat: decouple sampling settings from chat completion presets

### DIFF
--- a/public/css/toggle-dependent.css
+++ b/public/css/toggle-dependent.css
@@ -533,6 +533,18 @@ label[for="bind_preset_to_connection"]:has(input:checked) {
     color: var(--active);
 }
 
+#bind_preset_to_sampling:checked~.toggleOff {
+    display: none;
+}
+
+#bind_preset_to_sampling:not(:checked)~.toggleOn {
+    display: none;
+}
+
+label[for="bind_preset_to_sampling"]:has(input:checked) {
+    color: var(--active);
+}
+
 #openai_settings input[type="checkbox"]:not(:checked)~[data-cc-toggle],
 #openai_settings input[type="checkbox"]:not(:checked)~*:has([data-cc-toggle]) {
     display: none;

--- a/public/css/toggle-dependent.css
+++ b/public/css/toggle-dependent.css
@@ -545,6 +545,19 @@ label[for="bind_preset_to_sampling"]:has(input:checked) {
     color: var(--active);
 }
 
+#model_sampling_profiles_container {
+    display: none;
+    margin-top: 5px;
+}
+
+label[for="model_sampling_profiles_enabled"]:has(input:checked) {
+    color: var(--active);
+}
+
+label[for="model_sampling_profiles_enabled"]:has(input:checked)~#model_sampling_profiles_container {
+    display: block;
+}
+
 #openai_settings input[type="checkbox"]:not(:checked)~[data-cc-toggle],
 #openai_settings input[type="checkbox"]:not(:checked)~*:has([data-cc-toggle]) {
     display: none;

--- a/public/index.html
+++ b/public/index.html
@@ -210,7 +210,7 @@
                                             <input id="model_sampling_profiles_enabled" type="checkbox" />
                                             <span data-i18n="Remember sampling settings per model">Remember sampling settings per model</span>
                                         </label>
-                                        <div id="model_sampling_profiles_container" style="display: none; margin-top: 5px;">
+                                        <div id="model_sampling_profiles_container">
                                             <div class="toggle-description justifyLeft marginBot5">
                                                 When enabled, sampling settings are automatically saved and restored for each model. Use the buttons below to manage profiles for the current model.
                                             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -193,6 +193,37 @@
                                             Recommended for most setups and especially for shared preset libraries.
                                         </strong>
                                     </div>
+                                    <div class="marginTop10 sb-setting-inline-copy sb-setting-inline-copy-center">
+                                        <label for="bind_preset_to_sampling" title="Bind presets to Sampling settings" data-i18n="[title]Bind presets to Sampling settings" class="checkbox_label widthFreeExpand">
+                                            <input id="bind_preset_to_sampling" type="checkbox" checked />
+                                            <span data-i18n="Keep sampling settings linked to preset">Keep sampling settings linked to preset</span>
+                                        </label>
+                                        <div id="bind_preset_to_sampling_copy" class="toggle-description justifyLeft marginBot5">
+                                            Linked mode updates temperature, penalties, and other sampling sliders when switching presets.
+                                        </div>
+                                        <strong id="bind_preset_to_sampling_tip" class="toggle-description justifyLeft">
+                                            Use this when each preset stores its own sampling values.
+                                        </strong>
+                                    </div>
+                                    <div class="marginTop10 sb-setting-inline-copy sb-setting-inline-copy-center">
+                                        <label for="model_sampling_profiles_enabled" title="Enable per-model sampling profiles" data-i18n="[title]Enable per-model sampling profiles" class="checkbox_label widthFreeExpand">
+                                            <input id="model_sampling_profiles_enabled" type="checkbox" />
+                                            <span data-i18n="Remember sampling settings per model">Remember sampling settings per model</span>
+                                        </label>
+                                        <div id="model_sampling_profiles_container" style="display: none; margin-top: 5px;">
+                                            <div class="toggle-description justifyLeft marginBot5">
+                                                When enabled, sampling settings are automatically saved and restored for each model. Use the buttons below to manage profiles for the current model.
+                                            </div>
+                                            <div class="flex-container gap3px">
+                                                <button id="model_sampling_profile_save" class="menu_button menu_button_icon" title="Save current sampling for this model" data-i18n="[title]Save current sampling for this model">
+                                                    <i class="fa-fw fa-solid fa-floppy-disk"></i> Save Profile
+                                                </button>
+                                                <button id="model_sampling_profile_clear" class="menu_button menu_button_icon" title="Clear saved profile for this model" data-i18n="[title]Clear saved profile for this model">
+                                                    <i class="fa-fw fa-solid fa-trash"></i> Clear Profile
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                             <div id="textgenerationwebui_api-presets">

--- a/public/scripts/openai-preset-utils.js
+++ b/public/scripts/openai-preset-utils.js
@@ -3,7 +3,7 @@
  * The default preserves legacy behavior by including connection fields.
  *
  * @param {Record<string, any>} settings Live OpenAI settings
- * @param {Record<string, [string, string, boolean, boolean, boolean]>} settingsMap OpenAI preset setting map
+ * @param {Record<string, [string, string, boolean, boolean, boolean?]>} settingsMap OpenAI preset setting map
  * @param {object} [options] Build options
  * @param {boolean} [options.includeConnection=true] Whether to include provider/model/API fields
  * @param {boolean} [options.includeSampling=true] Whether to include sampling/temperature/penalty fields
@@ -30,7 +30,7 @@ export function buildChatCompletionPreset(settings, settingsMap, { includeConnec
 /**
  * Lists preset keys that represent provider/model/API connection state.
  *
- * @param {Record<string, [string, string, boolean, boolean]>} settingsMap OpenAI preset setting map
+ * @param {Record<string, [string, string, boolean, boolean, boolean?]>} settingsMap OpenAI preset setting map
  * @returns {string[]} Preset keys that should be treated as connection fields
  */
 export function getChatCompletionConnectionPresetKeys(settingsMap) {
@@ -42,13 +42,42 @@ export function getChatCompletionConnectionPresetKeys(settingsMap) {
 /**
  * Lists preset keys that represent sampling/temperature/penalty settings.
  *
- * @param {Record<string, [string, string, boolean, boolean, boolean]>} settingsMap OpenAI preset setting map
+ * @param {Record<string, [string, string, boolean, boolean, boolean?]>} settingsMap OpenAI preset setting map
  * @returns {string[]} Preset keys that should be treated as sampling fields
  */
 export function getChatCompletionSamplingPresetKeys(settingsMap) {
     return Object.entries(settingsMap ?? {})
         .filter(([, [, , , , isSampling]]) => isSampling)
         .map(([presetKey]) => presetKey);
+}
+
+/**
+ * Lists settings keys that represent sampling/temperature/penalty settings.
+ *
+ * @param {Record<string, [string, string, boolean, boolean, boolean?]>} settingsMap OpenAI preset setting map
+ * @returns {string[]} Settings keys that should be stored in model sampling profiles
+ */
+export function getChatCompletionSamplingSettingsKeys(settingsMap) {
+    return Object.entries(settingsMap ?? {})
+        .filter(([, [, , , , isSampling]]) => isSampling)
+        .map(([, [, settingsKey]]) => settingsKey);
+}
+
+/**
+ * Builds a model sampling profile snapshot from live settings.
+ *
+ * @param {Record<string, any>} settings Live OpenAI settings
+ * @param {Record<string, [string, string, boolean, boolean, boolean?]>} settingsMap OpenAI preset setting map
+ * @returns {Record<string, any>} Sampling settings snapshot
+ */
+export function buildChatCompletionSamplingSettingsSnapshot(settings, settingsMap) {
+    const snapshot = {};
+
+    for (const settingsKey of getChatCompletionSamplingSettingsKeys(settingsMap)) {
+        snapshot[settingsKey] = settings?.[settingsKey];
+    }
+
+    return structuredClone(snapshot);
 }
 
 /**
@@ -68,6 +97,7 @@ export function shouldIncludeConnectionFieldsInPreset(settings) {
  * @returns {boolean} True when sampling fields should be included in presets
  */
 export function shouldIncludeSamplingFieldsInPreset(settings) {
+    // Legacy settings that predate this toggle should keep saving sampling fields.
     return settings?.bind_preset_to_sampling !== false;
 }
 
@@ -75,7 +105,7 @@ export function shouldIncludeSamplingFieldsInPreset(settings) {
  * Builds a Chat Completion preset body using the current linked-preset mode.
  *
  * @param {Record<string, any>} settings Live OpenAI settings
- * @param {Record<string, [string, string, boolean, boolean, boolean]>} settingsMap OpenAI preset setting map
+ * @param {Record<string, [string, string, boolean, boolean, boolean?]>} settingsMap OpenAI preset setting map
  * @returns {Record<string, any>} Preset body
  */
 export function buildChatCompletionPresetForSave(settings, settingsMap) {

--- a/public/scripts/openai-preset-utils.js
+++ b/public/scripts/openai-preset-utils.js
@@ -3,16 +3,21 @@
  * The default preserves legacy behavior by including connection fields.
  *
  * @param {Record<string, any>} settings Live OpenAI settings
- * @param {Record<string, [string, string, boolean, boolean]>} settingsMap OpenAI preset setting map
+ * @param {Record<string, [string, string, boolean, boolean, boolean]>} settingsMap OpenAI preset setting map
  * @param {object} [options] Build options
  * @param {boolean} [options.includeConnection=true] Whether to include provider/model/API fields
+ * @param {boolean} [options.includeSampling=true] Whether to include sampling/temperature/penalty fields
  * @returns {Record<string, any>} Preset body
  */
-export function buildChatCompletionPreset(settings, settingsMap, { includeConnection = true } = {}) {
+export function buildChatCompletionPreset(settings, settingsMap, { includeConnection = true, includeSampling = true } = {}) {
     const presetBody = {};
 
-    for (const [presetKey, [, settingsKey, , isConnection]] of Object.entries(settingsMap ?? {})) {
+    for (const [presetKey, [, settingsKey, , isConnection, isSampling]] of Object.entries(settingsMap ?? {})) {
         if (isConnection && !includeConnection) {
+            continue;
+        }
+
+        if (isSampling && !includeSampling) {
             continue;
         }
 
@@ -35,6 +40,18 @@ export function getChatCompletionConnectionPresetKeys(settingsMap) {
 }
 
 /**
+ * Lists preset keys that represent sampling/temperature/penalty settings.
+ *
+ * @param {Record<string, [string, string, boolean, boolean, boolean]>} settingsMap OpenAI preset setting map
+ * @returns {string[]} Preset keys that should be treated as sampling fields
+ */
+export function getChatCompletionSamplingPresetKeys(settingsMap) {
+    return Object.entries(settingsMap ?? {})
+        .filter(([, [, , , , isSampling]]) => isSampling)
+        .map(([presetKey]) => presetKey);
+}
+
+/**
  * Returns whether OpenAI preset saves should include provider/model/API fields.
  *
  * @param {Record<string, any>} settings Live OpenAI settings
@@ -45,15 +62,26 @@ export function shouldIncludeConnectionFieldsInPreset(settings) {
 }
 
 /**
+ * Returns whether OpenAI preset saves should include sampling/temperature/penalty fields.
+ *
+ * @param {Record<string, any>} settings Live OpenAI settings
+ * @returns {boolean} True when sampling fields should be included in presets
+ */
+export function shouldIncludeSamplingFieldsInPreset(settings) {
+    return settings?.bind_preset_to_sampling !== false;
+}
+
+/**
  * Builds a Chat Completion preset body using the current linked-preset mode.
  *
  * @param {Record<string, any>} settings Live OpenAI settings
- * @param {Record<string, [string, string, boolean, boolean]>} settingsMap OpenAI preset setting map
+ * @param {Record<string, [string, string, boolean, boolean, boolean]>} settingsMap OpenAI preset setting map
  * @returns {Record<string, any>} Preset body
  */
 export function buildChatCompletionPresetForSave(settings, settingsMap) {
     return buildChatCompletionPreset(settings, settingsMap, {
         includeConnection: shouldIncludeConnectionFieldsInPreset(settings),
+        includeSampling: shouldIncludeSamplingFieldsInPreset(settings),
     });
 }
 

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -412,18 +412,18 @@ const sensitiveFields = [
  * @type {Record<string, [string, string, boolean, boolean]>}
  */
 export const settingsToUpdate = {
-    chat_completion_source: ['#chat_completion_source', 'chat_completion_source', false, true],
-    temperature: ['#temp_openai', 'temp_openai', false, false],
-    frequency_penalty: ['#freq_pen_openai', 'freq_pen_openai', false, false],
-    presence_penalty: ['#pres_pen_openai', 'pres_pen_openai', false, false],
-    top_p: ['#top_p_openai', 'top_p_openai', false, false],
-    claude_disable_temperature: ['#claude_disable_temperature', 'claude_disable_temperature', true, false],
-    claude_disable_top_p: ['#claude_disable_top_p', 'claude_disable_top_p', true, false],
-    top_k: ['#top_k_openai', 'top_k_openai', false, false],
-    top_a: ['#top_a_openai', 'top_a_openai', false, false],
-    min_p: ['#min_p_openai', 'min_p_openai', false, false],
-    repetition_penalty: ['#repetition_penalty_openai', 'repetition_penalty_openai', false, false],
-    max_context_unlocked: ['#oai_max_context_unlocked', 'max_context_unlocked', true, false],
+    chat_completion_source: ['#chat_completion_source', 'chat_completion_source', false, true, false],
+    temperature: ['#temp_openai', 'temp_openai', false, false, true],
+    frequency_penalty: ['#freq_pen_openai', 'freq_pen_openai', false, false, true],
+    presence_penalty: ['#pres_pen_openai', 'pres_pen_openai', false, false, true],
+    top_p: ['#top_p_openai', 'top_p_openai', false, false, true],
+    claude_disable_temperature: ['#claude_disable_temperature', 'claude_disable_temperature', true, false, true],
+    claude_disable_top_p: ['#claude_disable_top_p', 'claude_disable_top_p', true, false, true],
+    top_k: ['#top_k_openai', 'top_k_openai', false, false, true],
+    top_a: ['#top_a_openai', 'top_a_openai', false, false, true],
+    min_p: ['#min_p_openai', 'min_p_openai', false, false, true],
+    repetition_penalty: ['#repetition_penalty_openai', 'repetition_penalty_openai', false, false, true],
+    max_context_unlocked: ['#oai_max_context_unlocked', 'max_context_unlocked', true, false, false],
     openai_model: ['#model_openai_select', 'openai_model', false, true],
     claude_model: ['#model_claude_select', 'claude_model', false, true],
     openrouter_model: ['#model_openrouter_select', 'openrouter_model', false, true],
@@ -639,6 +639,9 @@ const default_settings = {
     seed: -1,
     n: 1,
     bind_preset_to_connection: false,
+    bind_preset_to_sampling: true,
+    model_sampling_profiles: {},
+    model_sampling_profiles_enabled: false,
     extensions: {},
     model_favorites: {},
 };
@@ -6593,7 +6596,10 @@ function loadOpenAISettings(data, settings) {
 
     $(`#settings_preset_openai option[value="${openai_setting_names[oai_settings.preset_settings_openai]}"]`).prop('selected', true);
     $('#bind_preset_to_connection').prop('checked', oai_settings.bind_preset_to_connection);
+    $('#bind_preset_to_sampling').prop('checked', oai_settings.bind_preset_to_sampling !== false);
     updateBindPresetToConnectionHelp();
+    updateBindPresetToSamplingHelp();
+    updateModelSamplingProfilesHelp();
     $('#openai_external_category').toggle(oai_settings.show_external_models);
     $('.reverse_proxy_warning').toggle(oai_settings.reverse_proxy !== '');
 
@@ -6636,6 +6642,126 @@ function updateBindPresetToConnectionHelp() {
 
     copy.textContent = t`Independent mode: choosing a preset keeps your current provider and model, so one preset can be reused across multiple connections.`;
     tip.textContent = t`Recommended for most setups and especially for shared preset libraries.`;
+}
+
+function updateBindPresetToSamplingHelp() {
+    const copy = document.getElementById('bind_preset_to_sampling_copy');
+    const tip = document.getElementById('bind_preset_to_sampling_tip');
+
+    if (!(copy instanceof HTMLElement) || !(tip instanceof HTMLElement)) {
+        return;
+    }
+
+    if (oai_settings.bind_preset_to_sampling !== false) {
+        copy.textContent = t`Linked mode: choosing a preset also updates temperature, penalties, and other sampling sliders to values saved inside that preset.`;
+        tip.textContent = t`Use this when each preset stores its own sampling values.`;
+        return;
+    }
+
+    copy.textContent = t`Independent mode: choosing a preset leaves your current sampling sliders unchanged, so one set of sampling values can be reused across multiple presets.`;
+    tip.textContent = t`Recommended when different models need different sampling settings.`;
+}
+
+function updateModelSamplingProfilesHelp() {
+    const $toggle = $('#model_sampling_profiles_enabled');
+    const $container = $('#model_sampling_profiles_container');
+
+    if (!$toggle.length || !$container.length) {
+        return;
+    }
+
+    const enabled = oai_settings.model_sampling_profiles_enabled;
+    $toggle.prop('checked', enabled);
+    $container.toggle(enabled);
+}
+
+function getModelSamplingProfileKey() {
+    const source = oai_settings.chat_completion_source;
+    const model = getChatCompletionModel();
+    if (!source || !model) {
+        return null;
+    }
+    return `${source}:${model}`;
+}
+
+function getSamplingSettingsSnapshot() {
+    return {
+        temp_openai: oai_settings.temp_openai,
+        freq_pen_openai: oai_settings.freq_pen_openai,
+        pres_pen_openai: oai_settings.pres_pen_openai,
+        top_p_openai: oai_settings.top_p_openai,
+        top_k_openai: oai_settings.top_k_openai,
+        min_p_openai: oai_settings.min_p_openai,
+        top_a_openai: oai_settings.top_a_openai,
+        repetition_penalty_openai: oai_settings.repetition_penalty_openai,
+        claude_disable_temperature: oai_settings.claude_disable_temperature,
+        claude_disable_top_p: oai_settings.claude_disable_top_p,
+    };
+}
+
+function applySamplingSettings(profile) {
+    if (!profile) {
+        return false;
+    }
+    const keys = Object.keys(getSamplingSettingsSnapshot());
+    let changed = false;
+    for (const key of keys) {
+        if (profile[key] !== undefined && profile[key] !== oai_settings[key]) {
+            const $input = $(`#${key}`);
+            if ($input.length > 0) {
+                $input.val(profile[key]).trigger('input');
+            }
+            oai_settings[key] = profile[key];
+            changed = true;
+        }
+    }
+    return changed;
+}
+
+function saveSamplingProfileForCurrentModel() {
+    const profileKey = getModelSamplingProfileKey();
+    if (!profileKey) {
+        toastr.warning(t`No model is currently selected.`, t`Cannot save sampling profile`);
+        return;
+    }
+    if (!oai_settings.model_sampling_profiles) {
+        oai_settings.model_sampling_profiles = {};
+    }
+    oai_settings.model_sampling_profiles[profileKey] = getSamplingSettingsSnapshot();
+    saveSettingsDebounced();
+    const modelLabel = getChatCompletionModel();
+    toastr.success(t`Saved sampling settings for ${modelLabel}.`, t`Model sampling profile saved`);
+}
+
+function clearSamplingProfileForCurrentModel() {
+    const profileKey = getModelSamplingProfileKey();
+    if (!profileKey) {
+        toastr.warning(t`No model is currently selected.`, t`Cannot clear sampling profile`);
+        return;
+    }
+    if (oai_settings.model_sampling_profiles && oai_settings.model_sampling_profiles[profileKey]) {
+        delete oai_settings.model_sampling_profiles[profileKey];
+        saveSettingsDebounced();
+        const modelLabel = getChatCompletionModel();
+        toastr.info(t`Cleared sampling profile for ${modelLabel}.`, t`Model sampling profile removed`);
+    }
+}
+
+function maybeApplyModelSamplingProfile() {
+    if (!oai_settings.model_sampling_profiles_enabled) {
+        return;
+    }
+    const profileKey = getModelSamplingProfileKey();
+    if (!profileKey) {
+        return;
+    }
+    const profile = oai_settings.model_sampling_profiles?.[profileKey];
+    if (!profile) {
+        return;
+    }
+    applySamplingSettings(profile);
+    const modelLabel = getChatCompletionModel();
+    toastr.info(t`Applied sampling profile for ${modelLabel}.`, t`Model sampling profile loaded`, { timeOut: 3000 });
 }
 
 function maybeShowPresetConnectionBindingReminder(previousPresetName, nextPresetName) {
@@ -7344,8 +7470,12 @@ function onSettingsPresetChange() {
             $('.model_custom_select').empty();
         }
 
-        for (const [key, [selector, setting, isCheckbox, isConnection]] of Object.entries(settingsToUpdate)) {
+        for (const [key, [selector, setting, isCheckbox, isConnection, isSampling]] of Object.entries(settingsToUpdate)) {
             if (isConnection && !oai_settings.bind_preset_to_connection) {
+                continue;
+            }
+
+            if (isSampling && oai_settings.bind_preset_to_sampling === false) {
                 continue;
             }
 
@@ -8353,6 +8483,7 @@ async function onModelChange() {
     updateOpenAIModelFavoriteButton();
     refreshModelIdSearchControlsForSource(oai_settings.chat_completion_source);
     updateModelIdSearchFavoriteButtons();
+    maybeApplyModelSamplingProfile();
     eventSource.emit(event_types.CHATCOMPLETION_MODEL_CHANGED, value);
 }
 
@@ -10139,6 +10270,29 @@ export function initOpenAI() {
         oai_settings.bind_preset_to_connection = !!$(this).prop('checked');
         updateBindPresetToConnectionHelp();
         saveSettingsDebounced();
+    });
+
+    $('#bind_preset_to_sampling').on('input', function () {
+        oai_settings.bind_preset_to_sampling = !!$(this).prop('checked');
+        updateBindPresetToSamplingHelp();
+        saveSettingsDebounced();
+    });
+
+    $('#model_sampling_profiles_enabled').on('input', function () {
+        oai_settings.model_sampling_profiles_enabled = !!$(this).prop('checked');
+        updateModelSamplingProfilesHelp();
+        if (oai_settings.model_sampling_profiles_enabled) {
+            maybeApplyModelSamplingProfile();
+        }
+        saveSettingsDebounced();
+    });
+
+    $('#model_sampling_profile_save').on('click', function () {
+        saveSamplingProfileForCurrentModel();
+    });
+
+    $('#model_sampling_profile_clear').on('click', function () {
+        clearSamplingProfileForCurrentModel();
     });
 
     groupOpenAISettingsIntoDrawers();

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -86,7 +86,13 @@ import { COMETAPI_IGNORE_PATTERNS, IGNORE_SYMBOL, MEDIA_DISPLAY, MEDIA_TYPE } fr
 import { syncOpenRouterProvidersForModel, updateOpenRouterProvidersWarning } from './textgen-models.js';
 import { hasTextOrArrayPayload, shouldRetainContextAtDepth, stripHtmlTagsFromContext, stripOocBlocksFromContext } from './ooc-blocks.js';
 import { checkPostInterceptChatBudget, shouldCheckPostInterceptChatBudget } from './openai-prompt-budget.js';
-import { buildChatCompletionPresetForSave, buildReverseProxyPresetForSave, normalizeReverseProxyPreset } from './openai-preset-utils.js';
+import {
+    buildChatCompletionPresetForSave,
+    buildChatCompletionSamplingSettingsSnapshot,
+    buildReverseProxyPresetForSave,
+    normalizeReverseProxyPreset,
+    shouldIncludeSamplingFieldsInPreset,
+} from './openai-preset-utils.js';
 import { TOOL_CALL_RECURSE_LIMIT_DEFAULT, normalizeToolCallRecurseLimit } from './tool-call-recurse-limit.js';
 
 export {
@@ -408,8 +414,9 @@ const sensitiveFields = [
 ];
 
 /**
- * preset_name -> [selector, setting_name, is_checkbox, is_connection]
- * @type {Record<string, [string, string, boolean, boolean]>}
+ * preset_name -> [selector, setting_name, is_checkbox, is_connection, is_sampling]
+ * The optional is_sampling flag marks fields for preset sampling binding and model sampling profiles.
+ * @type {Record<string, [string, string, boolean, boolean, boolean?]>}
  */
 export const settingsToUpdate = {
     chat_completion_source: ['#chat_completion_source', 'chat_completion_source', false, true, false],
@@ -639,6 +646,7 @@ const default_settings = {
     seed: -1,
     n: 1,
     bind_preset_to_connection: false,
+    // Undefined keeps legacy saved settings linked; use shouldIncludeSamplingFieldsInPreset when reading it.
     bind_preset_to_sampling: true,
     model_sampling_profiles: {},
     model_sampling_profiles_enabled: false,
@@ -6596,10 +6604,10 @@ function loadOpenAISettings(data, settings) {
 
     $(`#settings_preset_openai option[value="${openai_setting_names[oai_settings.preset_settings_openai]}"]`).prop('selected', true);
     $('#bind_preset_to_connection').prop('checked', oai_settings.bind_preset_to_connection);
-    $('#bind_preset_to_sampling').prop('checked', oai_settings.bind_preset_to_sampling !== false);
+    $('#bind_preset_to_sampling').prop('checked', shouldIncludeSamplingFieldsInPreset(oai_settings));
     updateBindPresetToConnectionHelp();
     updateBindPresetToSamplingHelp();
-    updateModelSamplingProfilesHelp();
+    syncModelSamplingProfilesUI();
     $('#openai_external_category').toggle(oai_settings.show_external_models);
     $('.reverse_proxy_warning').toggle(oai_settings.reverse_proxy !== '');
 
@@ -6652,7 +6660,7 @@ function updateBindPresetToSamplingHelp() {
         return;
     }
 
-    if (oai_settings.bind_preset_to_sampling !== false) {
+    if (shouldIncludeSamplingFieldsInPreset(oai_settings)) {
         copy.textContent = t`Linked mode: choosing a preset also updates temperature, penalties, and other sampling sliders to values saved inside that preset.`;
         tip.textContent = t`Use this when each preset stores its own sampling values.`;
         return;
@@ -6662,17 +6670,15 @@ function updateBindPresetToSamplingHelp() {
     tip.textContent = t`Recommended when different models need different sampling settings.`;
 }
 
-function updateModelSamplingProfilesHelp() {
+function syncModelSamplingProfilesUI() {
     const $toggle = $('#model_sampling_profiles_enabled');
-    const $container = $('#model_sampling_profiles_container');
 
-    if (!$toggle.length || !$container.length) {
+    if (!$toggle.length) {
         return;
     }
 
-    const enabled = oai_settings.model_sampling_profiles_enabled;
+    const enabled = Boolean(oai_settings.model_sampling_profiles_enabled);
     $toggle.prop('checked', enabled);
-    $container.toggle(enabled);
 }
 
 function getModelSamplingProfileKey() {
@@ -6685,36 +6691,36 @@ function getModelSamplingProfileKey() {
 }
 
 function getSamplingSettingsSnapshot() {
-    return {
-        temp_openai: oai_settings.temp_openai,
-        freq_pen_openai: oai_settings.freq_pen_openai,
-        pres_pen_openai: oai_settings.pres_pen_openai,
-        top_p_openai: oai_settings.top_p_openai,
-        top_k_openai: oai_settings.top_k_openai,
-        min_p_openai: oai_settings.min_p_openai,
-        top_a_openai: oai_settings.top_a_openai,
-        repetition_penalty_openai: oai_settings.repetition_penalty_openai,
-        claude_disable_temperature: oai_settings.claude_disable_temperature,
-        claude_disable_top_p: oai_settings.claude_disable_top_p,
-    };
+    return buildChatCompletionSamplingSettingsSnapshot(oai_settings, settingsToUpdate);
 }
 
 function applySamplingSettings(profile) {
     if (!profile) {
         return false;
     }
-    const keys = Object.keys(getSamplingSettingsSnapshot());
+
+    const updateInput = (selector, value) => $(selector).val(value).trigger('input');
+    const updateCheckbox = (selector, value) => $(selector).prop('checked', value).trigger('input');
     let changed = false;
-    for (const key of keys) {
-        if (profile[key] !== undefined && profile[key] !== oai_settings[key]) {
-            const $input = $(`#${key}`);
-            if ($input.length > 0) {
-                $input.val(profile[key]).trigger('input');
-            }
-            oai_settings[key] = profile[key];
-            changed = true;
+
+    for (const [selector, setting, isCheckbox, , isSampling] of Object.values(settingsToUpdate)) {
+        if (!isSampling || profile[setting] === undefined || profile[setting] === oai_settings[setting]) {
+            continue;
         }
+
+        const value = profile[setting];
+        if (selector) {
+            if (isCheckbox) {
+                updateCheckbox(selector, value);
+            } else {
+                updateInput(selector, value);
+            }
+        }
+
+        oai_settings[setting] = value;
+        changed = true;
     }
+
     return changed;
 }
 
@@ -6723,9 +6729,6 @@ function saveSamplingProfileForCurrentModel() {
     if (!profileKey) {
         toastr.warning(t`No model is currently selected.`, t`Cannot save sampling profile`);
         return;
-    }
-    if (!oai_settings.model_sampling_profiles) {
-        oai_settings.model_sampling_profiles = {};
     }
     oai_settings.model_sampling_profiles[profileKey] = getSamplingSettingsSnapshot();
     saveSettingsDebounced();
@@ -6739,11 +6742,14 @@ function clearSamplingProfileForCurrentModel() {
         toastr.warning(t`No model is currently selected.`, t`Cannot clear sampling profile`);
         return;
     }
-    if (oai_settings.model_sampling_profiles && oai_settings.model_sampling_profiles[profileKey]) {
+    if (oai_settings.model_sampling_profiles?.[profileKey]) {
         delete oai_settings.model_sampling_profiles[profileKey];
         saveSettingsDebounced();
         const modelLabel = getChatCompletionModel();
         toastr.info(t`Cleared sampling profile for ${modelLabel}.`, t`Model sampling profile removed`);
+    } else {
+        const modelLabel = getChatCompletionModel();
+        toastr.info(t`No saved sampling profile exists for ${modelLabel}.`, t`No sampling profile to clear`);
     }
 }
 
@@ -7475,7 +7481,7 @@ function onSettingsPresetChange() {
                 continue;
             }
 
-            if (isSampling && oai_settings.bind_preset_to_sampling === false) {
+            if (isSampling && !shouldIncludeSamplingFieldsInPreset(oai_settings)) {
                 continue;
             }
 
@@ -10280,7 +10286,7 @@ export function initOpenAI() {
 
     $('#model_sampling_profiles_enabled').on('input', function () {
         oai_settings.model_sampling_profiles_enabled = !!$(this).prop('checked');
-        updateModelSamplingProfilesHelp();
+        syncModelSamplingProfilesUI();
         if (oai_settings.model_sampling_profiles_enabled) {
             maybeApplyModelSamplingProfile();
         }

--- a/tests/openai-preset-utils.test.js
+++ b/tests/openai-preset-utils.test.js
@@ -4,8 +4,10 @@ import {
     buildChatCompletionPresetForSave,
     buildReverseProxyPresetForSave,
     getChatCompletionConnectionPresetKeys,
+    getChatCompletionSamplingPresetKeys,
     normalizeReverseProxyPreset,
     shouldIncludeConnectionFieldsInPreset,
+    shouldIncludeSamplingFieldsInPreset,
 } from '../public/scripts/openai-preset-utils.js';
 
 const settingsMap = {
@@ -17,9 +19,20 @@ const settingsMap = {
     prompts: ['', 'prompts', false, false],
 };
 
+const settingsMapWithSampling = {
+    chat_completion_source: ['#chat_completion_source', 'chat_completion_source', false, true, false],
+    temperature: ['#temp_openai', 'temp_openai', false, false, true],
+    frequency_penalty: ['#freq_pen_openai', 'freq_pen_openai', false, false, true],
+    openai_model: ['#model_openai_select', 'openai_model', false, true, false],
+    assistant_prefill: ['#claude_assistant_prefill', 'assistant_prefill', false, false, false],
+    custom_url: ['#custom_api_url_text', 'custom_url', false, true, false],
+    prompts: ['', 'prompts', false, false, false],
+};
+
 const settings = {
     chat_completion_source: 'custom',
     temp_openai: 0.72,
+    freq_pen_openai: 0.1,
     openai_model: 'mimo-model',
     assistant_prefill: '',
     custom_url: 'http://127.0.0.1:8080/v1',
@@ -165,6 +178,66 @@ describe('Chat Completion preset utilities', () => {
             url: '',
             password: '',
             source: '',
+        });
+    });
+
+    test('can build a preset without sampling fields', () => {
+        expect(buildChatCompletionPreset(settings, settingsMapWithSampling, { includeSampling: false })).toEqual({
+            chat_completion_source: 'custom',
+            openai_model: 'mimo-model',
+            assistant_prefill: '',
+            custom_url: 'http://127.0.0.1:8080/v1',
+            prompts: [{ identifier: 'main', content: 'Prompt after edit' }],
+        });
+    });
+
+    test('can build a preset without both connection and sampling fields', () => {
+        expect(buildChatCompletionPreset(settings, settingsMapWithSampling, { includeConnection: false, includeSampling: false })).toEqual({
+            assistant_prefill: '',
+            prompts: [{ identifier: 'main', content: 'Prompt after edit' }],
+        });
+    });
+
+    test('lists sampling preset keys using preset field names', () => {
+        expect(getChatCompletionSamplingPresetKeys(settingsMapWithSampling)).toEqual([
+            'temperature',
+            'frequency_penalty',
+        ]);
+    });
+
+    test('returns empty sampling keys for maps without sampling flags', () => {
+        expect(getChatCompletionSamplingPresetKeys(settingsMap)).toEqual([]);
+    });
+
+    test('includes sampling fields by default when bind_preset_to_sampling is not set', () => {
+        expect(shouldIncludeSamplingFieldsInPreset({})).toBe(true);
+        expect(shouldIncludeSamplingFieldsInPreset({ bind_preset_to_sampling: undefined })).toBe(true);
+        expect(shouldIncludeSamplingFieldsInPreset({ bind_preset_to_sampling: true })).toBe(true);
+    });
+
+    test('excludes sampling fields when bind_preset_to_sampling is false', () => {
+        expect(shouldIncludeSamplingFieldsInPreset({ bind_preset_to_sampling: false })).toBe(false);
+    });
+
+    test('builds preset manager save snapshots respecting sampling binding', () => {
+        expect(buildChatCompletionPresetForSave({
+            ...settings,
+            bind_preset_to_connection: false,
+            bind_preset_to_sampling: false,
+        }, settingsMapWithSampling)).toEqual({
+            assistant_prefill: '',
+            prompts: [{ identifier: 'main', content: 'Prompt after edit' }],
+        });
+
+        expect(buildChatCompletionPresetForSave({
+            ...settings,
+            bind_preset_to_connection: false,
+            bind_preset_to_sampling: true,
+        }, settingsMapWithSampling)).toEqual({
+            temperature: 0.72,
+            frequency_penalty: 0.1,
+            assistant_prefill: '',
+            prompts: [{ identifier: 'main', content: 'Prompt after edit' }],
         });
     });
 });

--- a/tests/openai-preset-utils.test.js
+++ b/tests/openai-preset-utils.test.js
@@ -2,9 +2,11 @@ import { describe, expect, test } from '@jest/globals';
 import {
     buildChatCompletionPreset,
     buildChatCompletionPresetForSave,
+    buildChatCompletionSamplingSettingsSnapshot,
     buildReverseProxyPresetForSave,
     getChatCompletionConnectionPresetKeys,
     getChatCompletionSamplingPresetKeys,
+    getChatCompletionSamplingSettingsKeys,
     normalizeReverseProxyPreset,
     shouldIncludeConnectionFieldsInPreset,
     shouldIncludeSamplingFieldsInPreset,
@@ -205,8 +207,24 @@ describe('Chat Completion preset utilities', () => {
         ]);
     });
 
+    test('lists sampling settings keys using live setting names', () => {
+        expect(getChatCompletionSamplingSettingsKeys(settingsMapWithSampling)).toEqual([
+            'temp_openai',
+            'freq_pen_openai',
+        ]);
+    });
+
+    test('builds model sampling snapshots from sampling flags', () => {
+        expect(buildChatCompletionSamplingSettingsSnapshot(settings, settingsMapWithSampling)).toEqual({
+            temp_openai: 0.72,
+            freq_pen_openai: 0.1,
+        });
+    });
+
     test('returns empty sampling keys for maps without sampling flags', () => {
         expect(getChatCompletionSamplingPresetKeys(settingsMap)).toEqual([]);
+        expect(getChatCompletionSamplingSettingsKeys(settingsMap)).toEqual([]);
+        expect(buildChatCompletionSamplingSettingsSnapshot(settings, settingsMap)).toEqual({});
     });
 
     test('includes sampling fields by default when bind_preset_to_sampling is not set', () => {

--- a/tests/openai-sampling-profiles-wiring.test.js
+++ b/tests/openai-sampling-profiles-wiring.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const openAiSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'openai.js'), 'utf8');
+const indexHtml = readFileSync(path.join(repoRoot, 'public', 'index.html'), 'utf8');
+const toggleDependentCss = readFileSync(path.join(repoRoot, 'public', 'css', 'toggle-dependent.css'), 'utf8');
+
+function getFunctionSource(name) {
+    const marker = `function ${name}(`;
+    const start = openAiSource.indexOf(marker);
+
+    expect(start).toBeGreaterThanOrEqual(0);
+
+    const bodyStart = openAiSource.indexOf(') {', start) + 2;
+    let depth = 0;
+
+    for (let index = bodyStart; index < openAiSource.length; index++) {
+        const char = openAiSource[index];
+        if (char === '{') {
+            depth++;
+        } else if (char === '}') {
+            depth--;
+            if (depth === 0) {
+                return openAiSource.slice(start, index + 1);
+            }
+        }
+    }
+
+    throw new Error(`Unable to find function source for ${name}`);
+}
+
+describe('OpenAI sampling profile wiring', () => {
+    test('restores checkbox-backed sampling settings as checked state', () => {
+        const applySamplingSettingsSource = getFunctionSource('applySamplingSettings');
+
+        expect(applySamplingSettingsSource).toContain('for (const [selector, setting, isCheckbox, , isSampling] of Object.values(settingsToUpdate))');
+        expect(applySamplingSettingsSource).toContain('$(selector).prop(\'checked\', value).trigger(\'input\')');
+        expect(applySamplingSettingsSource).not.toContain('$(`#${key}`)');
+    });
+
+    test('keeps sampling snapshots derived from settingsToUpdate', () => {
+        const getSamplingSettingsSnapshotSource = getFunctionSource('getSamplingSettingsSnapshot');
+
+        expect(getSamplingSettingsSnapshotSource).toContain('buildChatCompletionSamplingSettingsSnapshot(oai_settings, settingsToUpdate)');
+        expect(getSamplingSettingsSnapshotSource).not.toContain('temp_openai: oai_settings.temp_openai');
+    });
+
+    test('uses CSS-driven visibility for the model sampling profile controls', () => {
+        expect(indexHtml).toContain('id="model_sampling_profiles_container"');
+        expect(indexHtml).not.toContain('id="model_sampling_profiles_container" style=');
+        expect(toggleDependentCss).toContain('label[for="model_sampling_profiles_enabled"]:has(input:checked)~#model_sampling_profiles_container');
+        expect(openAiSource).toContain('function syncModelSamplingProfilesUI()');
+        expect(openAiSource).not.toContain('function updateModelSamplingProfilesHelp()');
+    });
+});


### PR DESCRIPTION
## Summary

Implements #464 — Decouple Sampling from Chat Completion Preset.

Many LLMs have specific sampling settings defined in their documentation (e.g. Mistral 3.5 recommends temp=0.7, others work better with lower or higher values). Using incorrect sampling settings for a model can make it unstable or uncreative. Currently, sampling settings are tied to chat completion presets, which makes it difficult to mix and match presets with model-specific sampling values.

## Changes

### Tier 1: Sampling Preset Decoupling
- Added a new `bind_preset_to_sampling` toggle (default `true` for backwards compatibility)
- When enabled (default): existing behavior — presets save and restore sampling fields
- When disabled: chat completion presets ignore all sampling fields; sampling sliders persist globally and are no longer overwritten when switching presets

### Tier 2: Per-Model Sampling Profiles
- Added a new `model_sampling_profiles_enabled` toggle
- Added a map `model_sampling_profiles` keyed by `source:model` that stores per-model sampling settings
- When enabled, sampling settings are automatically restored for the current model on model change
- Provides UI buttons to save or clear the sampling profile for the currently selected model

### Fields Affected
All Chat Completion sampling fields: `temp_openai`, `top_p_openai`, `top_k_openai`, `min_p_openai`, `top_a_openai`, `freq_pen_openai`, `pres_pen_openai`, `repetition_penalty_openai`, `claude_disable_temperature`, `claude_disable_top_p`.

### Testing
- Added 7 new unit tests in `tests/openai-preset-utils.test.js` — all pass
- All existing related tests continue to pass (32/32)
- No ESLint errors

### PR Conventions
- Uses `feat:` prefix per Conventional Commits
- Targets `staging` branch per CONTRIBUTING.md
- Self-contained: no upstream sync or other feature changes mixed in

Closes #464