### PR TITLE
fix: keep corrupted group chats listable

### DIFF
--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -4499,7 +4499,8 @@ async function fetchGroupChatFiles(chatContext) {
                     return normalizeChatInfo({ file_name: chatId });
                 }
 
-                return normalizeChatInfo(await response.json());
+                const chatInfo = normalizeChatInfo(await response.json());
+                return chatInfo.fileName ? chatInfo : normalizeChatInfo({ file_name: chatId });
             } catch {
                 return normalizeChatInfo({ file_name: chatId });
             }

--- a/src/endpoints/chats.js
+++ b/src/endpoints/chats.js
@@ -660,6 +660,26 @@ export async function getChatInfo(pathToFile, additionalData = {}, withMetadata 
     }
 }
 
+export async function getListableGroupChatInfo(chatFilePath, id) {
+    const chatInfo = await getChatInfo(chatFilePath);
+    const fileName = String(chatInfo?.file_name ?? '').trim();
+
+    if (fileName) {
+        return chatInfo;
+    }
+
+    const fallbackFileName = sanitize(`${id}.jsonl`);
+    const fallbackFileId = path.parse(fallbackFileName).name;
+    const normalizedChatInfo = chatInfo && typeof chatInfo === 'object' ? chatInfo : {};
+
+    // SillyBunny: keep corrupted group chats visible so chat selectors do not enter empty-list retry storms.
+    return {
+        ...normalizedChatInfo,
+        file_id: String(normalizedChatInfo.file_id ?? '').trim() || fallbackFileId,
+        file_name: fallbackFileName,
+    };
+}
+
 export const router = express.Router();
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
@@ -1116,7 +1136,7 @@ router.post('/group/info', async (request, response) => {
             return response.status(404).send({ error: 'not_found' });
         }
 
-        const chatInfo = await getChatInfo(chatFilePath);
+        const chatInfo = await getListableGroupChatInfo(chatFilePath, id);
         return response.send(chatInfo);
     } catch (error) {
         console.error(error);

--- a/tests/group-chat-info.test.js
+++ b/tests/group-chat-info.test.js
@@ -1,0 +1,33 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, jest, test } from '@jest/globals';
+import { setConfigFilePath } from '../src/util.js';
+
+setConfigFilePath(fileURLToPath(new URL('../default/config.yaml', import.meta.url)));
+
+describe('getListableGroupChatInfo', () => {
+    test('returns a file name fallback for corrupted group chat files', async () => {
+        const { getListableGroupChatInfo } = await import('../src/endpoints/chats.js');
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sillybunny-group-chat-info-'));
+        const chatFile = path.join(tempDir, 'Workspace.jsonl');
+
+        await fs.writeFile(chatFile, [
+            JSON.stringify({ chat_metadata: {}, user_name: 'User', character_name: 'Bot' }),
+            '{"name":"Bot","mes":"unfinished',
+        ].join('\n'));
+
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        try {
+            await expect(getListableGroupChatInfo(chatFile, 'Workspace')).resolves.toMatchObject({
+                file_id: 'Workspace',
+                file_name: 'Workspace.jsonl',
+            });
+        } finally {
+            warnSpy.mockRestore();
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- Keep corrupted group chat info responses listable by adding fallback `file_id`/`file_name` data for `/api/chats/group/info`.
- Fall back to the group chat id in the selector when a 200 response normalizes to an empty file name.
- Add a backend regression test for corrupted group chat JSONL info.

## Why
A corrupted group chat file currently returns `{}`, gets filtered out by the chat selector, and can collapse the browseable chat list to empty. That empty-list state triggers repeated selector refresh retries, which causes visible token-count flicker and amplifies stale-CSRF POST floods.

## Testing
- `npm run test:unit -- group-chat-info.test.js chat-integrity-rotation.test.js` from `tests/`
- `node --check src/endpoints/chats.js`
- `node --check public/scripts/sillybunny-tabs.js`

## Follow-ups
- #471 tracks the separate Windows atomic-write fallback corruption source.
- #472 tracks the separate stale CSRF token refresh issue.

## Changelog
Not updated yet per request.