### PR TITLE
fix: refresh stale CSRF tokens

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -938,6 +938,7 @@ var css_send_form_display = $('<div id=send_form></div>').css('display');
 var kobold_horde_model = '';
 
 export let token;
+let csrfTokenRefreshPromise = null;
 
 
 /** The tag of the active character. (NOT the id) */
@@ -958,6 +959,38 @@ export function getRequestHeaders({ omitContentType = false } = {}) {
     }
 
     return headers;
+}
+
+/**
+ * Refreshes the CSRF token used by fetch and jQuery requests.
+ * @returns {Promise<string>} The refreshed CSRF token.
+ */
+export async function refreshCsrfToken() {
+    if (!csrfTokenRefreshPromise) {
+        // SillyBunny: recover from server restarts that rotate the CSRF secret without a full page reload.
+        csrfTokenRefreshPromise = (async () => {
+            const tokenResponse = await fetch('/csrf-token', {
+                cache: 'no-store',
+                credentials: 'same-origin',
+                headers: {
+                    'Cache-Control': 'no-cache',
+                    'Pragma': 'no-cache',
+                },
+            });
+
+            if (!tokenResponse.ok) {
+                throw new Error(`Failed to refresh CSRF token: ${tokenResponse.status}`);
+            }
+
+            const tokenData = await tokenResponse.json();
+            token = tokenData.token;
+            return token;
+        })().finally(() => {
+            csrfTokenRefreshPromise = null;
+        });
+    }
+
+    return csrfTokenRefreshPromise;
 }
 
 export function getSlideToggleOptions() {
@@ -1079,16 +1112,7 @@ async function firstLoadInit() {
     };
 
     try {
-        const tokenResponse = await fetch('/csrf-token', {
-            cache: 'no-store',
-            credentials: 'same-origin',
-            headers: {
-                'Cache-Control': 'no-cache',
-                'Pragma': 'no-cache',
-            },
-        });
-        const tokenData = await tokenResponse.json();
-        token = tokenData.token;
+        await refreshCsrfToken();
 
         registerPromptManagerMigration();
         initDomHandlers();

--- a/public/scripts/csrf-token-refresh.js
+++ b/public/scripts/csrf-token-refresh.js
@@ -1,0 +1,39 @@
+const INVALID_CSRF_TOKEN_TEXT = 'Invalid CSRF token';
+
+/**
+ * Checks whether a response is the server's stale-CSRF rejection.
+ * @param {Response} response Fetch response to inspect
+ * @returns {Promise<boolean>} True when the response is an invalid-CSRF 403.
+ */
+export async function isInvalidCsrfTokenResponse(response) {
+    if (response?.status !== 403 || typeof response.clone !== 'function') {
+        return false;
+    }
+
+    try {
+        const text = await response.clone().text();
+        return text.includes(INVALID_CSRF_TOKEN_TEXT);
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Fetches once, refreshes a stale CSRF token, then retries the request once.
+ * @param {string|URL|Request} resource Fetch resource
+ * @param {() => RequestInit|Promise<RequestInit>} buildInit Builds fresh request init for each attempt
+ * @param {object} options Retry options
+ * @param {() => Promise<unknown>} options.refreshCsrfToken Function that refreshes the CSRF token
+ * @param {typeof fetch} [options.fetchFn=fetch] Fetch implementation
+ * @returns {Promise<Response>} Fetch response
+ */
+export async function fetchWithCsrfRetry(resource, buildInit, { refreshCsrfToken, fetchFn = fetch } = {}) {
+    const response = await fetchFn(resource, await buildInit());
+
+    if (!await isInvalidCsrfTokenResponse(response) || typeof refreshCsrfToken !== 'function') {
+        return response;
+    }
+
+    await refreshCsrfToken();
+    return fetchFn(resource, await buildInit());
+}

--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -67,6 +67,7 @@ import {
     setCharacterSettingsOverrides,
     system_avatar,
     getRequestHeaders,
+    refreshCsrfToken,
     isChatSaving,
     setExternalAbortController,
     baseChatReplace,
@@ -92,6 +93,7 @@ import { POPUP_TYPE, Popup, callGenericPopup } from './popup.js';
 import { t } from './i18n.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { compressRequest } from './request-compression.js';
+import { fetchWithCsrfRetry } from './csrf-token-refresh.js';
 import { chat_completion_sources, oai_settings } from './openai.js';
 
 export {
@@ -1642,15 +1644,17 @@ async function saveGroupChatImmediately({ groupId, shouldSaveGroup, force = fals
         character_name: 'unused',
     };
     const chatMessages = Array.isArray(chatData) ? chatData : cloneGroupChatSavePayload(chat);
-    const saveGroupChatRequest = await compressRequest({
+    const savePayload = JSON.stringify({ id: chatId, chat: [chatHeader, ...chatMessages], force: force, deferBackup: Boolean(deferBackup) });
+    const buildSaveGroupChatRequest = () => compressRequest({
         method: 'POST',
         headers: getRequestHeaders(),
-        body: JSON.stringify({ id: chatId, chat: [chatHeader, ...chatMessages], force: force, deferBackup: Boolean(deferBackup) }),
+        body: savePayload,
     });
-    const response = await fetch('/api/chats/group/save', saveGroupChatRequest);
+    // SillyBunny: rebuild compressed save requests after refreshing a stale CSRF token.
+    const response = await fetchWithCsrfRetry('/api/chats/group/save', buildSaveGroupChatRequest, { refreshCsrfToken });
 
     if (!response.ok) {
-        const errorData = await response.json();
+        const errorData = await response.json().catch(() => ({}));
         const isIntegrityError = errorData?.error === 'integrity' && !force;
         if (!isIntegrityError) {
             toastr.error(t`Check the server connection and reload the page to prevent data loss.`, t`Group Chat could not be saved`);

--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -4,9 +4,10 @@ import {
     MOBILE_SHELL_NAV_TOGGLE_ACTION,
 } from './mobile-shell-lifecycle/index.js';
 import { createPresetApiSyncLifecycle } from './preset-api-sync-lifecycle/index.js';
+import { fetchWithCsrfRetry } from './csrf-token-refresh.js';
 import { hasServerReturnedAfterRestart } from './server-restart-monitor.js';
 import { flashHighlight, showFontAwesomePicker } from './utils.js';
-import { flushCharacterSaveDebounced, getOneCharacter, saveSettingsDebounced } from '../script.js';
+import { flushCharacterSaveDebounced, getOneCharacter, refreshCsrfToken, saveSettingsDebounced } from '../script.js';
 
 const sbMobileShellLifecycle = createMobileShellLifecycle();
 const sbPresetApiSyncLifecycle = createPresetApiSyncLifecycle();
@@ -4485,11 +4486,11 @@ async function fetchGroupChatFiles(chatContext) {
 
         const chats = await Promise.all(groupChats.map(async chatId => {
             try {
-                const response = await fetch('/api/chats/group/info', {
+                const response = await fetchWithCsrfRetry('/api/chats/group/info', () => ({
                     method: 'POST',
-                    headers,
+                    headers: getRequestHeadersFromContext(chatContext.context),
                     body: JSON.stringify({ id: chatId }),
-                });
+                }), { refreshCsrfToken });
 
                 if (!response.ok) {
                     if (response.status === 404) {
@@ -9156,20 +9157,25 @@ async function requestServerAdmin(endpoint, body = {}) {
 }
 
 async function requestUserPrivateAction(endpoint, { body = {}, useFormData = false } = {}) {
-    const requestHeaders = await waitForAuthorizedRequestHeaders();
-    const headers = useFormData
-        ? (() => {
-            const multipartHeaders = { ...requestHeaders };
-            delete multipartHeaders['Content-Type'];
-            delete multipartHeaders['content-type'];
-            return multipartHeaders;
-        })()
-        : requestHeaders;
-    const response = await fetch(endpoint, {
-        method: 'POST',
-        headers,
-        body: useFormData ? body : JSON.stringify(body),
-    });
+    const buildRequest = async () => {
+        const requestHeaders = await waitForAuthorizedRequestHeaders();
+        const headers = useFormData
+            ? (() => {
+                const multipartHeaders = { ...requestHeaders };
+                delete multipartHeaders['Content-Type'];
+                delete multipartHeaders['content-type'];
+                return multipartHeaders;
+            })()
+            : requestHeaders;
+
+        return {
+            method: 'POST',
+            headers,
+            body: useFormData ? body : JSON.stringify(body),
+        };
+    };
+
+    const response = await fetchWithCsrfRetry(endpoint, buildRequest, { refreshCsrfToken });
 
     const text = await response.text();
     let data = null;

--- a/tests/__snapshots__/script-export-surface.test.js.snap
+++ b/tests/__snapshots__/script-export-surface.test.js.snap
@@ -172,6 +172,7 @@ exports[`public/script.js named export surface matches the parser-derived export
   "recentSwipes",
   "redisplayChat",
   "refreshCharacterAvatar",
+  "refreshCsrfToken",
   "refreshMessageModelIcons",
   "refreshSwipeButtons",
   "reloadChatMutex",

--- a/tests/csrf-token-refresh.test.js
+++ b/tests/csrf-token-refresh.test.js
@@ -1,0 +1,68 @@
+import { describe, expect, jest, test } from '@jest/globals';
+
+import { fetchWithCsrfRetry, isInvalidCsrfTokenResponse } from '../public/scripts/csrf-token-refresh.js';
+
+function responseWith(status, body) {
+    return new Response(body, { status });
+}
+
+describe('CSRF token refresh retry helper', () => {
+    test('detects invalid CSRF token responses without consuming the original body', async () => {
+        const response = responseWith(403, 'ForbiddenError: Invalid CSRF token. Please refresh the page and try again.');
+
+        await expect(isInvalidCsrfTokenResponse(response)).resolves.toBe(true);
+        await expect(response.text()).resolves.toContain('Invalid CSRF token');
+    });
+
+    test('refreshes and retries once for invalid CSRF token responses', async () => {
+        let token = 'old-token';
+        const fetchFn = jest.fn()
+            .mockResolvedValueOnce(responseWith(403, 'ForbiddenError: Invalid CSRF token. Please refresh the page and try again.'))
+            .mockResolvedValueOnce(responseWith(200, '{"ok":true}'));
+        const refreshCsrfToken = jest.fn(async () => {
+            token = 'new-token';
+        });
+        const buildInit = jest.fn(() => ({
+            method: 'POST',
+            headers: { 'X-CSRF-Token': token },
+            body: '{}',
+        }));
+
+        const response = await fetchWithCsrfRetry('/api/test', buildInit, { refreshCsrfToken, fetchFn });
+
+        expect(response.status).toBe(200);
+        expect(refreshCsrfToken).toHaveBeenCalledTimes(1);
+        expect(buildInit).toHaveBeenCalledTimes(2);
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+        expect(fetchFn.mock.calls[0][1].headers['X-CSRF-Token']).toBe('old-token');
+        expect(fetchFn.mock.calls[1][1].headers['X-CSRF-Token']).toBe('new-token');
+    });
+
+    test('does not retry ordinary forbidden responses', async () => {
+        const fetchFn = jest.fn().mockResolvedValue(responseWith(403, 'Forbidden'));
+        const refreshCsrfToken = jest.fn();
+        const buildInit = jest.fn(() => ({ method: 'POST' }));
+
+        const response = await fetchWithCsrfRetry('/api/test', buildInit, { refreshCsrfToken, fetchFn });
+
+        expect(response.status).toBe(403);
+        expect(refreshCsrfToken).not.toHaveBeenCalled();
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+        expect(buildInit).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not loop after a refreshed token is still rejected', async () => {
+        const fetchFn = jest.fn()
+            .mockResolvedValueOnce(responseWith(403, 'ForbiddenError: Invalid CSRF token. Please refresh the page and try again.'))
+            .mockResolvedValueOnce(responseWith(403, 'ForbiddenError: Invalid CSRF token. Please refresh the page and try again.'));
+        const refreshCsrfToken = jest.fn(async () => {});
+        const buildInit = jest.fn(() => ({ method: 'POST' }));
+
+        const response = await fetchWithCsrfRetry('/api/test', buildInit, { refreshCsrfToken, fetchFn });
+
+        expect(response.status).toBe(403);
+        expect(refreshCsrfToken).toHaveBeenCalledTimes(1);
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+        expect(buildInit).toHaveBeenCalledTimes(2);
+    });
+});


### PR DESCRIPTION
## Summary
- add a shared stale-CSRF response detector and one-shot retry helper
- refresh the module CSRF token from /csrf-token with an in-flight guard
- retry group chat info, user-private actions, and compressed group chat saves after an invalid CSRF token response

Closes #472

## Verification
- `node --check ../public/script.js && node --check ../public/scripts/sillybunny-tabs.js && node --check ../public/scripts/group-chats.js && node --check ../public/scripts/csrf-token-refresh.js && node --check csrf-token-refresh.test.js && npm run test:unit -- csrf-token-refresh.test.js`
- `./node_modules/.bin/eslint public/script.js public/scripts/sillybunny-tabs.js public/scripts/group-chats.js public/scripts/csrf-token-refresh.js tests/csrf-token-refresh.test.js`