### PR TITLE
fix: retry group chat loads after CSRF refresh

### DIFF
--- a/public/scripts/group-chats.js
+++ b/public/scripts/group-chats.js
@@ -1107,11 +1107,11 @@ async function regenerateGroup() {
  * @returns {Promise<ChatFile>} Array of chat messages
  */
 async function loadGroupChat(chatId) {
-    const response = await fetch('/api/chats/group/get', {
+    const response = await fetchWithCsrfRetry('/api/chats/group/get', () => ({
         method: 'POST',
         headers: getRequestHeaders(),
         body: JSON.stringify({ id: chatId }),
-    });
+    }), { refreshCsrfToken });
 
     if (response.ok) {
         const data = await response.json();
@@ -1135,11 +1135,11 @@ async function groupChatExists(chatId) {
     }
 
     try {
-        const response = await fetch('/api/chats/group/info', {
+        const response = await fetchWithCsrfRetry('/api/chats/group/info', () => ({
             method: 'POST',
             headers: getRequestHeaders(),
             body: JSON.stringify({ id: chatId }),
-        });
+        }), { refreshCsrfToken });
 
         if (response.ok) {
             return 'present';

--- a/tests/chat-integrity-rotation.test.js
+++ b/tests/chat-integrity-rotation.test.js
@@ -463,4 +463,21 @@ describe('chat integrity rotation', () => {
         expect(groupChatSource).toContain('const isActiveGroupChatSave = selected_group === groupId && group.chat_id === chatId;');
         expect(groupChatSource).toContain('if (isActiveGroupChatSave && typeof responseData?.integrity === \'string\' && responseData.integrity)');
     });
+
+    test('retries group chat load requests after stale CSRF before integrity metadata is initialized', async () => {
+        const groupChatSource = await fs.readFile(fileURLToPath(new URL('../public/scripts/group-chats.js', import.meta.url)), 'utf8');
+        const loadGroupChatBody = groupChatSource.slice(
+            groupChatSource.indexOf('async function loadGroupChat(chatId)'),
+            groupChatSource.indexOf('/**\n * Checks whether a group chat file currently exists on the server.'),
+        );
+        const groupChatExistsBody = groupChatSource.slice(
+            groupChatSource.indexOf('async function groupChatExists(chatId)'),
+            groupChatSource.indexOf('/**\n * Validates a group by checking if all members exist'),
+        );
+
+        expect(loadGroupChatBody).toContain('fetchWithCsrfRetry(\'/api/chats/group/get\'');
+        expect(loadGroupChatBody).toContain('{ refreshCsrfToken }');
+        expect(groupChatExistsBody).toContain('fetchWithCsrfRetry(\'/api/chats/group/info\'');
+        expect(groupChatExistsBody).toContain('{ refreshCsrfToken }');
+    });
 });


### PR DESCRIPTION
## Summary
- retry stale-CSRF responses for group chat load requests before chat metadata is initialized
- retry stale-CSRF responses for group chat existence checks used during group validation
- add a regression assertion so group load paths stay covered by the CSRF retry helper

## Root cause
After the CSRF refresh PR, group saves retried stale tokens, but /api/chats/group/get still used a one-shot fetch. If the server rotated the CSRF secret, loading a group chat could silently return an empty chat, causing the client to generate a fresh in-memory integrity slug. The next save then correctly failed because that generated slug did not match the existing file on disk.

## Verification
- node --check public/scripts/group-chats.js
- node --check tests/chat-integrity-rotation.test.js
- cd tests && npm run test:unit -- chat-integrity-rotation.test.js csrf-token-refresh.test.js
- ./node_modules/.bin/eslint public/scripts/group-chats.js tests/chat-integrity-rotation.test.js