### PR TITLE
fix: avoid direct writes after Windows temp rename failures

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -2076,29 +2076,35 @@ export function flattenSchema(schema, api) {
 export function tryWriteFileSync(filePath, data, options = typeof data === 'string' ? 'utf8' : undefined) {
     const isRetryableWindowsWriteError = (error) => process.platform === 'win32' && ['EACCES', 'EBUSY', 'EPERM'].includes(error?.code);
     const sleepSync = (delayMs) => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
+    const retryDelaysMs = [50, 125, 250];
+    let lastError;
+    const runWithWindowsRetries = (operation) => {
+        for (let attempt = 0; attempt <= retryDelaysMs.length; attempt++) {
+            try {
+                operation();
+                return true;
+            } catch (error) {
+                if (!isRetryableWindowsWriteError(error)) {
+                    throw error;
+                }
+
+                lastError = error;
+                if (attempt < retryDelaysMs.length) {
+                    sleepSync(retryDelaysMs[attempt]);
+                }
+            }
+        }
+
+        return false;
+    };
     const directory = path.dirname(filePath);
     //Ensure the directory exists.
     if (!fs.existsSync(directory)) {
         fs.mkdirSync(directory, { recursive: true });
     }
 
-    const retryDelaysMs = [50, 125, 250];
-    let lastError;
-
-    for (let attempt = 0; attempt <= retryDelaysMs.length; attempt++) {
-        try {
-            writeFileAtomicSync(filePath, data, options);
-            return;
-        } catch (error) {
-            if (!isRetryableWindowsWriteError(error)) {
-                throw error;
-            }
-
-            lastError = error;
-            if (attempt < retryDelaysMs.length) {
-                sleepSync(retryDelaysMs[attempt]);
-            }
-        }
+    if (runWithWindowsRetries(() => writeFileAtomicSync(filePath, data, options))) {
+        return;
     }
 
     if (lastError) {
@@ -2107,26 +2113,39 @@ export function tryWriteFileSync(filePath, data, options = typeof data === 'stri
 
     // SillyBunny: keep the existing file intact while retrying a Windows-safe replacement.
     const tempFilePath = `${filePath}.tmp`;
-    fs.writeFileSync(tempFilePath, data, options);
-
-    for (let attempt = 0; attempt <= retryDelaysMs.length; attempt++) {
+    const cleanupTempFile = () => {
         try {
-            fs.renameSync(tempFilePath, filePath);
-            return;
+            if (fs.existsSync(tempFilePath)) {
+                fs.unlinkSync(tempFilePath);
+            }
         } catch (error) {
-            if (!isRetryableWindowsWriteError(error)) {
-                throw error;
-            }
-
-            lastError = error;
-            if (attempt < retryDelaysMs.length) {
-                sleepSync(retryDelaysMs[attempt]);
-            }
+            console.warn(`Failed to clean up temp write file for ${filePath}.`, error?.code);
         }
-    }
+    };
 
-    console.warn(`Temp file rename failed for ${filePath}. Falling back to a direct write.`, lastError?.code);
-    fs.writeFileSync(filePath, data, options);
+    try {
+        if (!runWithWindowsRetries(() => fs.writeFileSync(tempFilePath, data, options))) {
+            throw lastError;
+        }
+
+        if (runWithWindowsRetries(() => fs.renameSync(tempFilePath, filePath))) {
+            return;
+        }
+
+        console.warn(`Temp file rename failed for ${filePath}. Falling back to a copy replacement.`, lastError?.code);
+        if (runWithWindowsRetries(() => fs.copyFileSync(tempFilePath, filePath))) {
+            return;
+        }
+
+        console.warn(`Temp file copy failed for ${filePath}. Falling back to a direct write.`, lastError?.code);
+        if (runWithWindowsRetries(() => fs.writeFileSync(filePath, data, options))) {
+            return;
+        }
+
+        throw lastError;
+    } finally {
+        cleanupTempFile();
+    }
 }
 
 /**

--- a/tests/util-write-atomic-fallback.test.js
+++ b/tests/util-write-atomic-fallback.test.js
@@ -56,10 +56,11 @@ describe('tryWriteFileSync atomic fallback', () => {
         expect(renameSpy.mock.calls.at(-1)).toEqual([`${filePath}.tmp`, filePath]);
     });
 
-    test('uses direct write only after the temp-file rename retries are exhausted', () => {
+    test('copies the temp file when temp-file rename retries are exhausted', () => {
         const filePath = createTargetPath();
         mockWritableTarget();
         const writeFileSpy = jest.spyOn(fs, 'writeFileSync');
+        const copyFileSpy = jest.spyOn(fs, 'copyFileSync');
         jest.spyOn(fs, 'renameSync').mockImplementation(() => {
             throw createWindowsFileLockError('EBUSY');
         });
@@ -67,7 +68,30 @@ describe('tryWriteFileSync atomic fallback', () => {
 
         tryWriteFileSync(filePath, 'payload', 'utf8');
 
+        expect(writeFileSpy.mock.calls.map(call => call[0])).toEqual([`${filePath}.tmp`]);
+        expect(copyFileSpy).toHaveBeenCalledWith(`${filePath}.tmp`, filePath);
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Temp file rename failed'), 'EBUSY');
+        expect(fs.existsSync(`${filePath}.tmp`)).toBe(false);
+        expect(fs.readFileSync(filePath, 'utf8')).toBe('payload');
+    });
+
+    test('uses direct write only after temp-file rename and copy retries are exhausted', () => {
+        const filePath = createTargetPath();
+        mockWritableTarget();
+        const writeFileSpy = jest.spyOn(fs, 'writeFileSync');
+        jest.spyOn(fs, 'renameSync').mockImplementation(() => {
+            throw createWindowsFileLockError('EBUSY');
+        });
+        jest.spyOn(fs, 'copyFileSync').mockImplementation(() => {
+            throw createWindowsFileLockError('EPERM');
+        });
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        tryWriteFileSync(filePath, 'payload', 'utf8');
+
         expect(writeFileSpy.mock.calls.map(call => call[0])).toEqual([`${filePath}.tmp`, filePath]);
         expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Temp file rename failed'), 'EBUSY');
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Temp file copy failed'), 'EPERM');
+        expect(fs.existsSync(`${filePath}.tmp`)).toBe(false);
     });
 });


### PR DESCRIPTION
## Summary
- retry all Windows write fallback steps, including temp writes and the final direct-write fallback
- use a temp-file copy replacement after Windows rename retries fail, before falling back to direct writes
- clean up leftover temp write files after fallback attempts

## Tests
- npx eslint src/util.js tests/util-write-atomic-fallback.test.js
- node --experimental-vm-modules $(npm exec --package jest@29.7.0 -- which jest) --config jest.config.json util-write-atomic-fallback.test.js --runInBand
- node --experimental-vm-modules $(npm exec --package jest@29.7.0 -- which jest) --config jest.config.json group-chat-info.test.js --runInBand