### PR TITLE
fix: preserve OpenAI preset selection on backend switch

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -215,10 +215,10 @@
                                                 When enabled, sampling settings are automatically saved and restored for each model. Use the buttons below to manage profiles for the current model.
                                             </div>
                                             <div class="flex-container gap3px">
-                                                <button id="model_sampling_profile_save" class="menu_button menu_button_icon" title="Save current sampling for this model" data-i18n="[title]Save current sampling for this model">
+                                                <button id="model_sampling_profile_save" class="menu_button" title="Save current sampling for this model" data-i18n="[title]Save current sampling for this model">
                                                     <i class="fa-fw fa-solid fa-floppy-disk"></i> Save Profile
                                                 </button>
-                                                <button id="model_sampling_profile_clear" class="menu_button menu_button_icon" title="Clear saved profile for this model" data-i18n="[title]Clear saved profile for this model">
+                                                <button id="model_sampling_profile_clear" class="menu_button" title="Clear saved profile for this model" data-i18n="[title]Clear saved profile for this model">
                                                     <i class="fa-fw fa-solid fa-trash"></i> Clear Profile
                                                 </button>
                                             </div>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -6602,7 +6602,7 @@ function loadOpenAISettings(data, settings) {
     applyToolCallRecurseLimit(oai_settings.tool_call_recurse_limit);
     syncMaxContextUnlockedControl(oai_settings);
 
-    $(`#settings_preset_openai option[value="${openai_setting_names[oai_settings.preset_settings_openai]}"]`).prop('selected', true);
+    restoreOpenAIPresetSelection();
     $('#bind_preset_to_connection').prop('checked', oai_settings.bind_preset_to_connection);
     $('#bind_preset_to_sampling').prop('checked', shouldIncludeSamplingFieldsInPreset(oai_settings));
     updateBindPresetToConnectionHelp();
@@ -7441,6 +7441,17 @@ async function onLogitBiasPresetDeleteClick() {
 
     biasCache = undefined;
     saveSettingsDebounced();
+}
+
+function restoreOpenAIPresetSelection(presetName = oai_settings.preset_settings_openai) {
+    const presetValue = openai_setting_names?.[presetName];
+
+    if (presetValue === undefined) {
+        return;
+    }
+
+    oai_settings.preset_settings_openai = presetName;
+    $('#settings_preset_openai').val(String(presetValue));
 }
 
 // Load OpenAI preset settings
@@ -9835,6 +9846,7 @@ export function initOpenAI() {
     });
 
     $('#chat_completion_source').on('change', function () {
+        const presetName = oai_settings.preset_settings_openai;
         cancelStatusCheck('Chat Completion source changed');
         model_list = [];
         oai_settings.chat_completion_source = String($(this).find(':selected').val());
@@ -9842,6 +9854,8 @@ export function initOpenAI() {
         toggleChatCompletionForms();
         applyConfigurableContextLimit();
         syncProxyPresetToBoundSource(oai_settings.chat_completion_source);
+        // SillyBunny: source switches should not reset the selected settings preset.
+        restoreOpenAIPresetSelection(presetName);
         saveSettingsDebounced();
         reconnectOpenAi();
         forceCharacterEditorTokenize();

--- a/tests/openai-proxy-preset-wiring.test.js
+++ b/tests/openai-proxy-preset-wiring.test.js
@@ -122,4 +122,24 @@ describe('OpenAI proxy preset wiring', () => {
         // Proxy preset must be applied before reconnecting so the reconnect uses the bound proxy.
         expect(reconnectIndex).toBeGreaterThan(syncCallIndex);
     });
+
+    test('preserves the selected settings preset when switching backends', () => {
+        const restoreSource = getFunctionSource('restoreOpenAIPresetSelection');
+        const initSource = getFunctionSource('initOpenAI');
+        const sourceChangeIndex = initSource.indexOf('$(\'#chat_completion_source\').on(\'change\'');
+        const capturePresetIndex = initSource.indexOf('const presetName = oai_settings.preset_settings_openai;', sourceChangeIndex);
+        const sourceUpdateIndex = initSource.indexOf('oai_settings.chat_completion_source = String($(this).find(\':selected\').val());', sourceChangeIndex);
+        const syncCallIndex = initSource.indexOf('syncProxyPresetToBoundSource(oai_settings.chat_completion_source);', sourceChangeIndex);
+        const restoreCallIndex = initSource.indexOf('restoreOpenAIPresetSelection(presetName);', sourceChangeIndex);
+        const saveIndex = initSource.indexOf('saveSettingsDebounced();', sourceChangeIndex);
+
+        expect(restoreSource).toContain('const presetValue = openai_setting_names?.[presetName];');
+        expect(restoreSource).toContain('oai_settings.preset_settings_openai = presetName;');
+        expect(restoreSource).toContain('$(\'#settings_preset_openai\').val(String(presetValue));');
+
+        expect(capturePresetIndex).toBeGreaterThan(sourceChangeIndex);
+        expect(sourceUpdateIndex).toBeGreaterThan(capturePresetIndex);
+        expect(restoreCallIndex).toBeGreaterThan(syncCallIndex);
+        expect(saveIndex).toBeGreaterThan(restoreCallIndex);
+    });
 });

--- a/tests/openai-sampling-profiles-wiring.test.js
+++ b/tests/openai-sampling-profiles-wiring.test.js
@@ -55,4 +55,11 @@ describe('OpenAI sampling profile wiring', () => {
         expect(openAiSource).toContain('function syncModelSamplingProfilesUI()');
         expect(openAiSource).not.toContain('function updateModelSamplingProfilesHelp()');
     });
+
+    test('keeps model sampling profile actions as text buttons', () => {
+        expect(indexHtml).toContain('id="model_sampling_profile_save" class="menu_button"');
+        expect(indexHtml).toContain('id="model_sampling_profile_clear" class="menu_button"');
+        expect(indexHtml).not.toContain('id="model_sampling_profile_save" class="menu_button menu_button_icon"');
+        expect(indexHtml).not.toContain('id="model_sampling_profile_clear" class="menu_button menu_button_icon"');
+    });
 });


### PR DESCRIPTION
## Summary
- Keep the selected OpenAI settings preset when switching chat completion backends, including reverse-proxy source sync.
- Restore the per-model sampling profile action buttons to normal text buttons so Save/Clear labels do not crowd under mobile/icon styling.
- Add wiring coverage for both behaviors.

## Tests
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.json openai-sampling-profiles-wiring.test.js openai-proxy-preset-wiring.test.js` (from `tests/`)
