### PR TITLE
fix: mobile keyboard hides composer

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -1,6 +1,14 @@
 /* SillyBunny mobile shell foundation: final sheet contract for modal drawers.
  * Keep this at the end of the shell sheet so it beats older mobile drawer rules. */
 @media screen and (max-width: 768px) {
+    /* SillyBunny: visualViewport-backed height so the shell contracts with
+       the software keyboard instead of relying on dvh, which is unreliable
+       with body { position: fixed } on Android Chrome. */
+    body:not(.movingUI) #sheld {
+        height: calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-topbar-layout-offset, var(--topBarBlockSize)) - 1px) !important;
+        max-height: calc(var(--sb-shell-viewport-height, 100dvh) - var(--sb-topbar-layout-offset, var(--topBarBlockSize)) - 1px) !important;
+    }
+
     #form_sheld {
         width: 100%;
         max-width: 100%;
@@ -824,13 +832,10 @@
     @media screen and (max-width: 768px) {
         /* SillyBunny: iOS 17 WebKit can misresolve dvh for the main shell. */
         body:not(.movingUI) #sheld {
-            --sb-sheld-ios-available-height: calc(100vh - var(--sb-topbar-layout-offset));
             // SillyBunny: add visual-viewport top so that when iOS Safari shifts the
             // viewport up (keyboard open) the shell moves with it instead of floating
             // mid-screen above the composer.
             top: calc(var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) + var(--sb-shell-viewport-top, 0px)) !important;
-            height: calc(var(--sb-shell-available-height, var(--sb-sheld-ios-available-height)) - 1px) !important;
-            max-height: calc(var(--sb-shell-available-height, var(--sb-sheld-ios-available-height)) - 1px) !important;
             min-height: 100px !important;
             min-width: 0 !important;
             width: 100vw !important;


### PR DESCRIPTION
## Problem

On mobile (Android), when the keyboard shows up, it hides the rest of the page — making it impossible to type properly in the textbox.

## Root Cause

The main shell `#sheld` uses `100dvh` for its height, which doesn't reliably account for the software keyboard on Android when `body` has `position: fixed` (set by mobile-styles.css). Even with `interactive-widget=resizes-content` in the viewport meta tag, `dvh` remains unreliable in this context because the fixed-position body doesn't participate in the dynamic viewport recalculation that `dvh` depends on.

An iOS-specific fix already existed in `sillybunny-mobile-shell.css` that used `--sb-shell-available-height` (driven by `visualViewport.height` via `syncShellViewportBounds()`), but it was gated behind `@supports (-webkit-touch-callout: none)` — so Android got no equivalent fix.

## Fix

- **Add a general mobile `#sheld` height rule** in the `@media (max-width: 768px)` block that uses `--sb-shell-viewport-height` (sourced from `visualViewport.height` via `sillybunny-tabs.js`) instead of `dvh`
- **Remove redundant `height`/`max-height` from the iOS-specific block** — the general rule now covers both iOS and Android equally
- **Keep the iOS-specific `top` offset** with `--sb-shell-viewport-top` since WebKit pans the visual viewport up when the keyboard opens (a behavior unique to iOS)

### Files changed
- `public/css/sillybunny-mobile-shell.css`

## Testing

- **Android:** Open a chat, tap the text input, and verify the composer/textarea remains visible and usable above the keyboard.
- **iOS:** Verify existing keyboard behavior is preserved (shell should follow the panned viewport up).
- **Desktop (MovingUI):** No regression — rule is scoped to `body:not(.movingUI)`.
