### PR TITLE
fix: stabilize MovingUI panels on desktop

### DIFF
--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -573,8 +573,12 @@ export function dragElement($elmnt) {
         else if (maxX >= winWidth) setMovingUIStyle($elmnt, 'left', winWidth - maxX + left - 1, 'important');
     }
 
+    let isObserving = false;
+
     // Observer for style changes (position/size)
     const observer = new MutationObserver((mutations) => {
+        if (isObserving) return;
+
         const $target = $(mutations[0].target);
         if (
             !$target.is(':visible') ||
@@ -588,6 +592,8 @@ export function dragElement($elmnt) {
             observer.disconnect();
             return;
         }
+
+        isObserving = true;
 
         const element = /** @type {HTMLElement} */ ($target[0]);
         const style = getComputedStyle(element);
@@ -633,20 +639,13 @@ export function dragElement($elmnt) {
             //    $elmnt.css('width', width - 1 + 'px');
             // }
             setMovingUIStyles($elmnt, { left, top }, 'important');
-            $elmnt.off('mouseup').on('mouseup', () => {
-                if (
-                    power_user.movingUIState[stateKey].width === $elmnt.width() &&
-                    power_user.movingUIState[stateKey].height === $elmnt.height()
-                ) return;
-                savePositionAndSize();
-                observer.disconnect();
-            });
         } else if (actionType === 'drag') {
             clampToViewport();
         }
 
         // Always update position in state
         savePositionAndSize();
+        isObserving = false;
     });
 
     // Mouse event handlers
@@ -713,10 +712,19 @@ export function dragElement($elmnt) {
         }
     });
 
-    $elmnt.off('mouseup').on('mouseup', () => {
+    $(document).on('mouseup', () => {
+        if (isMouseDown && actionType === 'resize') {
+            if (
+                power_user.movingUIState[stateKey].width !== $elmnt.width() ||
+                power_user.movingUIState[stateKey].height !== $elmnt.height()
+            ) {
+                savePositionAndSize();
+            }
+            observer.disconnect();
+        }
         isMouseDown = false;
         actionType = null;
-        observer.disconnect();
+        isObserving = false;
     });
 }
 


### PR DESCRIPTION
## Bug

On desktop with MovingUI enabled, panels (especially `#sheld`) jump around constantly, particularly when pressing copy buttons on markdown text or code blocks.

## Root Cause

In `dragElement()`, the resize `mouseup` handler was registered on the panel element (``) instead of `document`. When a copy-button `mousedown` bubbled up into the resize detection zone (bottom-right corner), releasing the mouse outside the panel boundary left `isMouseDown` stuck at `true` and the `MutationObserver` permanently active. From that point on, every style change (re-layouts from toastr notifications, window resizes, etc.) triggered the observer callback, which wrote new `left`/`top` styles with `!important` — retriggering itself in a feedback loop.

Additionally, the observer callback registered a duplicate `mouseup` handler on `` on every fire, stacking hundreds of handlers.

## Fix

- **Register resize `mouseup` on `document`** so it always fires regardless of pointer position — matching how the drag path already works
- **Add `isObserving` re-entry guard** to prevent the observer from retriggering itself when writing styles
- **Remove the duplicate `mouseup` handler** that was stacked inside the observer callback; its logic is consolidated into the outer document-level handler

## Files Changed

- `public/scripts/RossAscends-mods.js` — `dragElement()` function