### PR TITLE
feat: prevent stale settings overwrites

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -912,6 +912,12 @@ let this_edit_mes_id = undefined;
 
 //settings
 export let settings;
+// SillyBunny: version-tokened settings saves avoid stale overwrites across open devices/tabs.
+let lastServerSettingsVersion = 0;
+let settingsSaveQueue = Promise.resolve();
+let settingsConflictReloadRequired = false;
+let settingsConflictPromptOpen = false;
+let settingsConflictPromptDismissed = false;
 export let amount_gen = 80; //default max length of AI generated responses
 export let max_context = 2048;
 
@@ -10909,6 +10915,45 @@ function reloadLoop() {
     }
 }
 
+function normalizeSettingsVersion(version) {
+    version = Number(version);
+    return Number.isSafeInteger(version) && version >= 0 ? version : 0;
+}
+
+async function promptSettingsConflictReload() {
+    if (settingsConflictPromptOpen) {
+        return;
+    }
+
+    if (settingsConflictPromptDismissed) {
+        toastr.warning(t`Settings saves are blocked until you reload SillyBunny.`, t`Settings save blocked`, { preventDuplicates: true });
+        return;
+    }
+
+    settingsConflictPromptOpen = true;
+
+    try {
+        const confirmation = await Popup.show.confirm(
+            t`Settings changed on another device`,
+            t`Another device or browser tab saved newer settings. Reload SillyBunny before saving again to prevent overwriting those changes.`,
+            {
+                okButton: t`Reload now`,
+                cancelButton: t`Keep editing`,
+            },
+        );
+
+        if (confirmation === POPUP_RESULT.AFFIRMATIVE) {
+            window.location.reload();
+            return;
+        }
+
+        settingsConflictPromptDismissed = true;
+        toastr.warning(t`Settings saves are blocked until you reload SillyBunny.`, t`Settings save blocked`, { preventDuplicates: true });
+    } finally {
+        settingsConflictPromptOpen = false;
+    }
+}
+
 //MARK: getSettings()
 ///////////////////////////////////////////
 export async function getSettings(initLoaderHandle = null) {
@@ -10928,6 +10973,9 @@ export async function getSettings(initLoaderHandle = null) {
     const data = await response.json();
     if (data.result != 'file not find' && data.settings) {
         settings = JSON.parse(data.settings);
+        lastServerSettingsVersion = normalizeSettingsVersion(settings._version);
+        settingsConflictReloadRequired = false;
+        settingsConflictPromptDismissed = false;
         if (settings.username !== undefined && settings.username !== '') {
             name1 = settings.username;
             $('#your_name').text(name1);
@@ -11058,9 +11106,20 @@ export async function getSettings(initLoaderHandle = null) {
 
 //MARK: saveSettings()
 export async function saveSettings(loopCounter = 0) {
+    const saveTask = settingsSaveQueue.then(() => saveSettingsInner(loopCounter));
+    settingsSaveQueue = saveTask.catch(() => {});
+    return saveTask;
+}
+
+async function saveSettingsInner(loopCounter = 0) {
     if (!settingsReady) {
         console.warn('Settings not ready, scheduling another save');
         saveSettingsDebounced();
+        return;
+    }
+
+    if (settingsConflictReloadRequired) {
+        await promptSettingsConflictReload();
         return;
     }
 
@@ -11076,6 +11135,7 @@ export async function saveSettings(loopCounter = 0) {
     }
 
     const payload = {
+        _version: lastServerSettingsVersion,
         firstRun: firstRun,
         accountStorage: accountStorage.getState(),
         currentVersion: currentVersion,
@@ -11111,9 +11171,27 @@ export async function saveSettings(loopCounter = 0) {
         });
         const result = await fetch('/api/settings/save', saveSettingsRequest);
 
+        if (result.status === 409) {
+            const conflict = await result.json().catch(() => ({}));
+            lastServerSettingsVersion = normalizeSettingsVersion(conflict?.version);
+            settingsConflictReloadRequired = true;
+            settingsConflictPromptDismissed = false;
+            await promptSettingsConflictReload();
+            return;
+        }
+
         if (!result.ok) {
             throw new Error(`Failed to save settings: ${result.statusText}`);
         }
+
+        const saveResult = await result.json().catch(() => ({}));
+        const savedSettingsVersion = normalizeSettingsVersion(saveResult?.version);
+        if (savedSettingsVersion <= payload._version) {
+            throw new Error('Settings save returned an invalid version token');
+        }
+
+        lastServerSettingsVersion = savedSettingsVersion;
+        payload._version = lastServerSettingsVersion;
 
         settings = payload;
         await eventSource.emit(event_types.SETTINGS_UPDATED);

--- a/src/endpoints/settings.js
+++ b/src/endpoints/settings.js
@@ -6,6 +6,7 @@ import _ from 'lodash';
 import bytes from 'bytes';
 
 import { SETTINGS_FILE } from '../constants.js';
+import { prepareSettingsSave } from '../settings-version.js';
 import {
     getConfigValue,
     generateTimestamp,
@@ -257,12 +258,30 @@ export const router = express.Router();
 router.post('/save', function (request, response) {
     try {
         const pathToSettings = path.join(request.user.directories.root, SETTINGS_FILE);
-        tryWriteFileSync(pathToSettings, JSON.stringify(request.body, null, 4));
+
+        if (!request.body || typeof request.body !== 'object' || Array.isArray(request.body)) {
+            return response.status(400).send({ error: 'invalid_settings' });
+        }
+
+        const currentSettings = fs.existsSync(pathToSettings)
+            ? JSON.parse(fs.readFileSync(pathToSettings, 'utf8'))
+            : {};
+
+        // SillyBunny: prevent one open device or tab from overwriting newer settings from another.
+        const preparedSave = prepareSettingsSave(request.body, currentSettings);
+        if (!preparedSave.ok) {
+            return response.status(409).send({
+                error: 'settings_conflict',
+                version: preparedSave.currentVersion,
+            });
+        }
+
+        tryWriteFileSync(pathToSettings, JSON.stringify(preparedSave.settings, null, 4));
         triggerAutoSave(request.user.profile.handle);
-        response.send({ result: 'ok' });
+        response.send({ result: 'ok', version: preparedSave.version });
     } catch (err) {
         console.error(err);
-        response.send(err);
+        response.status(500).send({ error: 'settings_save_failed' });
     }
 });
 

--- a/src/settings-version.js
+++ b/src/settings-version.js
@@ -1,0 +1,26 @@
+export function getSettingsVersion(settings) {
+    const version = Number(settings?._version);
+    return Number.isSafeInteger(version) && version >= 0 ? version : 0;
+}
+
+export function prepareSettingsSave(incomingSettings, currentSettings = {}) {
+    const incomingVersion = getSettingsVersion(incomingSettings);
+    const currentVersion = getSettingsVersion(currentSettings);
+
+    if (incomingVersion !== currentVersion) {
+        return {
+            ok: false,
+            currentVersion,
+        };
+    }
+
+    const version = currentVersion + 1;
+    return {
+        ok: true,
+        version,
+        settings: {
+            ...incomingSettings,
+            _version: version,
+        },
+    };
+}

--- a/tests/settings-version-guard.test.js
+++ b/tests/settings-version-guard.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { getSettingsVersion, prepareSettingsSave } from '../src/settings-version.js';
+
+describe('settings version guard', () => {
+    test('initializes unversioned settings on first guarded save', () => {
+        const result = prepareSettingsSave({ username: 'User' }, { username: 'Old User' });
+
+        expect(result).toMatchObject({ ok: true, version: 1 });
+        expect(result.settings).toMatchObject({ username: 'User', _version: 1 });
+    });
+
+    test('increments when the incoming version matches disk', () => {
+        const result = prepareSettingsSave({ _version: 3, username: 'User' }, { _version: 3, username: 'Old User' });
+
+        expect(result).toMatchObject({ ok: true, version: 4 });
+        expect(result.settings).toMatchObject({ username: 'User', _version: 4 });
+    });
+
+    test('rejects stale settings from another open device or tab', () => {
+        const result = prepareSettingsSave({ _version: 2, username: 'Stale User' }, { _version: 3, username: 'Current User' });
+
+        expect(result).toEqual({ ok: false, currentVersion: 3 });
+    });
+
+    test('rejects mismatched versions after restores or manual file changes', () => {
+        const result = prepareSettingsSave({ _version: 5, username: 'Open Tab User' }, { _version: 3, username: 'Restored User' });
+
+        expect(result).toEqual({ ok: false, currentVersion: 3 });
+    });
+
+    test('normalizes invalid settings versions to zero', () => {
+        expect(getSettingsVersion({ _version: -1 })).toBe(0);
+        expect(getSettingsVersion({ _version: 'not-a-number' })).toBe(0);
+        expect(getSettingsVersion({ _version: '7' })).toBe(7);
+    });
+});


### PR DESCRIPTION
## Summary
- Add a `_version` token to settings saves so stale clients cannot overwrite newer settings.
- Return `409` on version conflicts and prompt the frontend to reload before saving again.
- Serialize frontend settings saves to avoid local save races and add focused unit coverage.

## Tests
- `npx eslint src/settings-version.js src/endpoints/settings.js public/script.js tests/settings-version-guard.test.js`
- `npm run test:unit -- settings-version-guard.test.js script-export-surface.test.js`