### PR TITLE
fix(ui): preserve sampling profile button text width

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -216,10 +216,10 @@
                                             </div>
                                             <div class="flex-container gap3px">
                                                 <button id="model_sampling_profile_save" class="menu_button" title="Save current sampling for this model" data-i18n="[title]Save current sampling for this model">
-                                                    <i class="fa-fw fa-solid fa-floppy-disk"></i> Save Profile
+                                                    <i class="fa-fw fa-solid fa-floppy-disk"></i> <span data-i18n="Save Profile">Save Profile</span>
                                                 </button>
                                                 <button id="model_sampling_profile_clear" class="menu_button" title="Clear saved profile for this model" data-i18n="[title]Clear saved profile for this model">
-                                                    <i class="fa-fw fa-solid fa-trash"></i> Clear Profile
+                                                    <i class="fa-fw fa-solid fa-trash"></i> <span data-i18n="Clear Profile">Clear Profile</span>
                                                 </button>
                                             </div>
                                         </div>


### PR DESCRIPTION
## Summary
- Wrap sampling profile button labels in spans so mobile icon-only styles no longer match
- Keep Save/Clear Profile actions as text buttons with translatable labels

## Tests
- bun test tests/openai-sampling-profiles-wiring.test.js