### PR TITLE
feat: Add quick delete shortcut button to message actions

### DIFF
--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -1486,6 +1486,15 @@ select.text_pole:where(:not([multiple]):not([size]):not(.select2-hidden-accessib
     display: none !important;
 }
 
+#chat .mes .mes_delete {
+    color: var(--sb-color-danger);
+}
+
+#chat .mes .mes_delete:hover {
+    color: color-mix(in srgb, var(--sb-color-danger) 80%, white);
+    background: color-mix(in srgb, var(--sb-color-danger) 12%, transparent);
+}
+
 #chat .mes .mes_view_agent_changes {
     width: var(--sb-message-icon-size) !important;
     inline-size: var(--sb-message-icon-size) !important;

--- a/public/index.html
+++ b/public/index.html
@@ -8086,6 +8086,7 @@
                             </div>
                             <div data-tooltip="Click to open checkpoint chat&#10;Shift+Click to replace the existing checkpoint with a new one" class="mes_button mes_bookmark fa-solid fa-flag" data-i18n="[data-tooltip]Open checkpoint chat&#10;Shift+Click to replace the existing checkpoint with a new one"></div>
                             <div title="Edit" class="mes_button mes_edit fa-solid fa-pencil " data-i18n="[title]Edit"></div>
+                            <div title="Delete" class="mes_button mes_delete fa-solid fa-trash-can" data-i18n="[title]Delete"></div>
                         </div>
                         <div class="mes_edit_buttons">
                             <div class="mes_edit_done menu_button  fa-solid fa-check" title="Confirm" data-i18n="[title]Confirm"></div>

--- a/public/script.js
+++ b/public/script.js
@@ -16701,6 +16701,21 @@ jQuery(async function () {
         }
     });
 
+    $(document).on('click', '.mes_delete', async function () {
+        if (is_delete_mode) {
+            return;
+        }
+        const mesId = Number($(this).closest('.mes').attr('mesid'));
+        const message = chat[mesId];
+        if (!message) {
+            return;
+        }
+        const selectedSwipe = message.swipe_id ?? undefined;
+        const swipesArray = Array.isArray(message.swipes) ? message.swipes : [];
+        const canDeleteSwipe = !message.is_user && swipesArray.length > 1 && mesId === chat.length - 1 && selectedSwipe !== undefined;
+        await deleteMessage(mesId, canDeleteSwipe ? selectedSwipe : undefined, true);
+    });
+
     $(document).on('click', '.mes_edit_cancel', async function () {
         await messageEditCancel.call(this, this_edit_mes_id);
     });


### PR DESCRIPTION
Adds a trash icon shortcut next to the edit icon on messages for quick deletion without entering edit mode.

**Changes:**
- HTML: Added `.mes_delete` button with trash icon in message action bar
- JS: Click handler derives message ID from DOM and calls `deleteMessage()` with confirmation always enabled
- CSS: Red icon color using `--sb-color-danger` with hover highlight

**Behavior:**
- Clicking the trash icon immediately shows the delete confirmation popup
- If on the last message with swipes, offers both 'Delete Swipe' and 'Delete Message' options
- Works on both user and assistant messages
- Respects `is_delete_mode` check like the edit button

Closes #[issue-number-if-applicable]