### PR TITLE
fix: preserve user backend on settings load instead of switching to reverse proxy source

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -9054,8 +9054,7 @@ export function loadProxyPresets(settings) {
         appendProxyPresetOption(preset);
     }
     $('#openai_proxy_preset').val(selected_proxy.name);
-    const shouldApplySource = Boolean(selected_proxy.source);
-    setProxyPreset(selected_proxy.name, selected_proxy.url, selected_proxy.password, selected_proxy.source, { applySource: shouldApplySource, silent: true });
+    setProxyPreset(selected_proxy.name, selected_proxy.url, selected_proxy.password, selected_proxy.source, { applySource: false, silent: true });
 }
 
 function normalizeProxyPreset(preset) {

--- a/tests/openai-proxy-preset-wiring.test.js
+++ b/tests/openai-proxy-preset-wiring.test.js
@@ -64,14 +64,12 @@ describe('OpenAI proxy preset wiring', () => {
         expect(setProxyPresetSource).toContain('reconnectOpenAi();');
     });
 
-    test('applies selected proxy backend binding when loading presets', () => {
+    test('loads selected proxy preset credentials without overriding the saved backend', () => {
         const loadProxyPresetsSource = getFunctionSource('loadProxyPresets');
-        const applySourceFlagIndex = loadProxyPresetsSource.indexOf('const shouldApplySource = Boolean(selected_proxy.source);');
-        const setProxyPresetIndex = loadProxyPresetsSource.indexOf('setProxyPreset(selected_proxy.name, selected_proxy.url, selected_proxy.password, selected_proxy.source, { applySource: shouldApplySource, silent: true });');
+        const setProxyPresetIndex = loadProxyPresetsSource.indexOf('setProxyPreset(selected_proxy.name, selected_proxy.url, selected_proxy.password, selected_proxy.source, { applySource: false, silent: true });');
 
-        expect(applySourceFlagIndex).toBeGreaterThanOrEqual(0);
-        expect(setProxyPresetIndex).toBeGreaterThan(applySourceFlagIndex);
-        expect(loadProxyPresetsSource).not.toContain('{ applySource: false }');
+        expect(setProxyPresetIndex).toBeGreaterThanOrEqual(0);
+        expect(loadProxyPresetsSource).not.toContain('{ applySource: true, silent: true }');
     });
 
     test('switches backend on silent load without triggering a reconnect', () => {


### PR DESCRIPTION
## Bug

When the page loads (refresh) or backends are switched, the reverse proxy preset's **Bind to Backend** source binding overrides the user's actual last-selected Chat Completion source (e.g. *Custom OpenAI Compatible*). The overridden value is then persisted, making the switch sticky across refreshes.

### Root cause

`loadProxyPresets()` runs *after* `loadOpenAISettings()` has already restored the user's saved `chat_completion_source`. It calls `setProxyPreset()` with `{ applySource: true, silent: true }` whenever the selected proxy preset has a non-empty `source` binding, which silently rewrites `oai_settings.chat_completion_source` and the UI dropdown to the proxy's bound backend.

### Fix

Always pass `{ applySource: false, silent: true }` from `loadProxyPresets()`. The proxy URL and password still apply correctly during load — only the source override is suppressed. Interactive source switching via the proxy preset dropdown (`onProxyPresetChange`) is unchanged.

## Changes

- `public/scripts/openai.js` — drop the source-binding switch during silent settings load.
- `tests/openai-proxy-preset-wiring.test.js` — update the corresponding test to assert the new flag.