### PR TITLE
fix(ui): fix mobile cache utility layout

### DIFF
--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -5477,7 +5477,12 @@ input[type='range']::-moz-range-thumb {
         align-items: stretch;
     }
 
+    #user-settings-utility-actions .sb-settings-utility-note {
+        flex: 0 0 auto;
+    }
+
     #user-settings-utility-actions .sb-settings-utility-action {
+        flex: 0 0 auto;
         width: 100%;
     }
 

--- a/public/scripts/sillybunny-settings-tabs.js
+++ b/public/scripts/sillybunny-settings-tabs.js
@@ -104,7 +104,12 @@
         }
 
         #sb-cache-settings-drawer #user-settings-utility-actions .sb-settings-utility-note {
+            flex: 0 0 auto !important;
             margin-bottom: 12px !important;
+        }
+
+        #sb-cache-settings-drawer #user-settings-utility-actions .sb-settings-utility-action {
+            flex: 0 0 auto !important;
         }
     `;
 


### PR DESCRIPTION
## Summary
- prevent mobile cache utility note and action flex-basis values from becoming large vertical heights
- keep the cache and cookies buttons full-width on mobile without stretching them tall
- reduce the oversized gap after the auto-clear cache setting in the drawer

## Verification
- bun run lint
- npm --prefix tests run test:unit
- git diff --check

E2E tests were not run because the Playwright app server was not available at http://127.0.0.1:4444.