### PR TITLE
fix: remove constant "Model sampling profile loaded" toast

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -6766,8 +6766,7 @@ function maybeApplyModelSamplingProfile() {
         return;
     }
     applySamplingSettings(profile);
-    const modelLabel = getChatCompletionModel();
-    toastr.info(t`Applied sampling profile for ${modelLabel}.`, t`Model sampling profile loaded`, { timeOut: 3000 });
+    // SillyBunny: Removed constant "Model sampling profile loaded" toast to reduce UI noise
 }
 
 function maybeShowPresetConnectionBindingReminder(previousPresetName, nextPresetName) {


### PR DESCRIPTION
Removes the constant "Model sampling profile loaded" toast notification entirely.

This toast fires silently every time the sampling profile is automatically applied upon model or preset changes, which introduces unnecessary UI screen clutter and clutters the screen for users. The profile still applies its settings correctly in the background, so the notification is no longer needed.