### PR TITLE
chore: add docker instructions to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,7 @@ Include a Discord-friendly update summary for non-hotfix releases so the changes
 **How to update**
 - Built-in updater: open Customize > Server and update from there.
 - Git clone: run git pull.
+- Docker: run git pull, then sudo docker compose up -d --build (the --build is required to rebuild the local image).
 - Launcher users: close and reopen Start.bat, Start.command, or start.sh.
 - ZIP users: grab the new release directly.
 ```


### PR DESCRIPTION
Places Docker update instructions in the CONTRIBUTING.md How to Update Discord-friendly post section.