### PR TITLE
fix: keep card and hidden companions out of the tracker panel

### DIFF
--- a/public/scripts/extensions/in-chat-agents/agent-store.js
+++ b/public/scripts/extensions/in-chat-agents/agent-store.js
@@ -30,7 +30,7 @@ import {
 /**
  * @typedef {object} AgentCompanionConfig
  * @property {'auto'|'manual'} trigger
- * @property {'card'|'hidden'} displayMode
+ * @property {'card'|'panel'|'hidden'} displayMode
  * @property {'markdown'|'html'|'text'} format
  * @property {number} contextMessages
  * @property {boolean} includeCharacterCard

--- a/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
@@ -332,6 +332,20 @@ function getPanelAgents() {
     return getAgents().filter(agent => isCompanionAgent(agent) && agent.category !== 'tool');
 }
 
+// SillyBunny: the slide-out tracker panel is the home for 'panel'-mode companion state only.
+// 'card' renders inline under the reply (handled by isHiddenCompanionResult in companion-ui),
+// and 'hidden' is feedback-only and renders nowhere. When a live agent exists we trust its
+// current editor config so flipping the Display dropdown takes effect on the next render; for
+// orphaned results (deleted agent) we fall back to the mode stored on the result, defaulting to
+// the product default ('panel') when absent.
+function isPanelDisplayMode(agent, result = {}) {
+    if (agent) {
+        return getCompanionConfig(agent).displayMode === 'panel';
+    }
+
+    return (result.displayMode ?? 'panel') === 'panel';
+}
+
 function getLatestAssistantIndex() {
     return chat.findLastIndex(isAssistantMessage);
 }
@@ -357,7 +371,8 @@ export function collectPanelAgentStates() {
     const byAgentId = new Map();
 
     for (const agent of getPanelAgents()) {
-        if (isAgentEnabledForCurrentScope(agent)) {
+        // SillyBunny: only 'panel'-mode companions belong in the tracker panel; 'card' and 'hidden' are excluded.
+        if (isAgentEnabledForCurrentScope(agent) && isPanelDisplayMode(agent)) {
             byAgentId.set(agent.id, { agentId: agent.id, agent, latest: null, history: [] });
         }
     }
@@ -377,9 +392,17 @@ export function collectPanelAgentStates() {
                 continue;
             }
 
-            let state = byAgentId.get(agentId);
+            // SillyBunny: resolve the agent up front so we can filter by display mode before
+            // creating any panel state. 'card' and 'hidden' results stay out of the panel;
+            // orphaned results fall back to the mode stored on the result itself.
+            const existingState = byAgentId.get(agentId);
+            const agent = existingState?.agent ?? getPanelAgents().find(candidate => candidate.id === agentId) ?? null;
+            if (!isPanelDisplayMode(agent, result)) {
+                continue;
+            }
+
+            let state = existingState;
             if (!state) {
-                const agent = getPanelAgents().find(candidate => candidate.id === agentId) ?? null;
                 state = { agentId, agent, latest: null, history: [] };
                 byAgentId.set(agentId, state);
             }

--- a/tests/in-chat-agents-companion-panel.test.js
+++ b/tests/in-chat-agents-companion-panel.test.js
@@ -72,7 +72,7 @@ describe('companion tracker panel', () => {
             getAgents: jest.fn(() => agents),
             getCompanionConfig: jest.fn(agent => ({
                 trigger: agent?.companion?.trigger === 'manual' ? 'manual' : 'auto',
-                displayMode: agent?.companion?.displayMode ?? 'card',
+                displayMode: agent?.companion?.displayMode ?? 'panel',
             })),
             isAgentEnabledForCurrentScope: jest.fn(agent => Boolean(agent?.enabled)),
             isCompanionAgent: jest.fn(agent => agent?.execution === 'companion' || agent?.category === 'companion'),
@@ -493,9 +493,9 @@ describe('companion tracker panel', () => {
             }
             if (arg === actionButton) {
                 return {
-                attr: jest.fn(name => (name === 'data-action' ? 'panel-run-latest' : undefined)),
-                closest: jest.fn(() => section),
-                prop: button.prop,
+                    attr: jest.fn(name => (name === 'data-action' ? 'panel-run-latest' : undefined)),
+                    closest: jest.fn(() => section),
+                    prop: button.prop,
                 };
             }
             return { length: 0, on: jest.fn(), append: jest.fn(), html: jest.fn(), toggle: jest.fn() };
@@ -719,5 +719,71 @@ describe('companion tracker panel', () => {
         expect(companionUi.insertChoiceIntoMessageInput).toHaveBeenCalledWith('B) Stay here');
         expect(panelElement.removeClass).not.toHaveBeenCalled();
         expect(panelElement.attr).not.toHaveBeenCalledWith('aria-hidden', 'true');
+    });
+
+    test('keeps card and hidden companions out of the tracker panel', async () => {
+        agents = [
+            { id: 'card-agent', name: 'Card Note', execution: 'companion', enabled: true, companion: { displayMode: 'card' } },
+            { id: 'hidden-agent', name: 'Hidden Feedback', execution: 'companion', enabled: true, companion: { displayMode: 'hidden' } },
+            { id: 'panel-agent', name: 'Panel Tracker', execution: 'companion', enabled: true, companion: { displayMode: 'panel' } },
+        ];
+        const panel = await importPanel();
+
+        const message = { is_user: false, is_system: false, mes: 'reply' };
+        chat.push(message);
+        companionResultsByMessage.set(message, {
+            'card-agent': { status: 'done', content: 'inline card content', agentName: 'Card Note' },
+            'hidden-agent': { status: 'done', content: 'hidden feedback', agentName: 'Hidden Feedback' },
+            'panel-agent': { status: 'done', content: 'panel state', agentName: 'Panel Tracker' },
+        });
+
+        const states = panel.collectPanelAgentStates();
+
+        expect(states).toHaveLength(1);
+        expect(states[0].agentId).toBe('panel-agent');
+        expect(states[0].latest.result.content).toBe('panel state');
+
+        const html = panel.buildPanelHtml();
+        expect(html).toContain('Panel Tracker');
+        expect(html).not.toContain('Card Note');
+        expect(html).not.toContain('Hidden Feedback');
+        expect(panel.shouldShowCompanionPanelHandle()).toBe(true);
+    });
+
+    test('hides the panel handle when only card/hidden companions are enabled', async () => {
+        agents = [
+            { id: 'card-only', name: 'Card Only', execution: 'companion', enabled: true, companion: { displayMode: 'card' } },
+            { id: 'hidden-only', name: 'Hidden Only', execution: 'companion', enabled: true, companion: { displayMode: 'hidden' } },
+        ];
+        const panel = await importPanel();
+
+        const message = { is_user: false, is_system: false, mes: 'reply' };
+        chat.push(message);
+        companionResultsByMessage.set(message, {
+            'card-only': { status: 'done', content: 'card', agentName: 'Card Only' },
+            'hidden-only': { status: 'done', content: 'hidden', agentName: 'Hidden Only' },
+        });
+
+        expect(panel.shouldShowCompanionPanelHandle()).toBe(false);
+        expect(panel.collectPanelAgentStates()).toHaveLength(0);
+        expect(panel.buildPanelHtml()).toContain('No companion agents are enabled');
+    });
+
+    test('excludes orphaned card/hidden results, keeps panel results', async () => {
+        agents = [];
+        const panel = await importPanel();
+
+        const message = { is_user: false, is_system: false, mes: 'reply' };
+        chat.push(message);
+        companionResultsByMessage.set(message, {
+            'orphan-card': { status: 'done', content: 'card orphan', agentName: 'Old Card', displayMode: 'card' },
+            'orphan-panel': { status: 'done', content: 'panel orphan', agentName: 'Old Panel', displayMode: 'panel' },
+            'orphan-legacy': { status: 'done', content: 'legacy', agentName: 'Legacy' },
+        });
+
+        const states = panel.collectPanelAgentStates();
+
+        expect(states.map(state => state.agentId).sort()).toEqual(['orphan-legacy', 'orphan-panel']);
+        expect(states.find(state => state.agentId === 'orphan-card')).toBeUndefined();
     });
 });


### PR DESCRIPTION
## Summary

The slide-out tracker panel was showing companions regardless of their Display setting. Specifically:

- **"Hidden feedback note"** (`hidden`) companions appeared in the tracker panel — they should be hidden everywhere.
- **"Show note card"** (`card`) companions appeared in *both* the inline note card under the reply *and* the tracker panel — `card` mode should only render inline.

## Root Cause

`collectPanelAgentStates()` in `companion/companion-panel.js` had no display-mode filter:

- The pre-population loop added every enabled companion, regardless of mode.
- The results walk added every stored result (except suppressed Message-Inbox ones).

The inline path already filters correctly via `isHiddenCompanionResult` in `companion-ui.js` (`OFF_LEDGER_DISPLAY_MODES = {\"hidden\", \"panel\"}`), so the asymmetry was purely on the panel side.

## Fix

Added an `isPanelDisplayMode(agent, result)` helper in `companion-panel.js` and applied it in both code paths:

- **Pre-population**: enabled companions are only added if their `displayMode === \"panel\"`.
- **Results walk**: agent config is the source of truth for live agents; orphaned results (deleted agent) fall back to the mode stored on the result, defaulting to `\"panel\"` (the product default).

`shouldShowCompanionPanelHandle()` and `buildPanelHtml()` both flow through `collectPanelAgentStates()`, so the handle auto-hides when only `card`/`hidden` companions are enabled.

## Extras

- Corrected stale JSDoc union in `agent-store.js` (`displayMode` now documents `\"card\"|\"panel\"|\"hidden\"`; `panel` was already the runtime default).
- Panel test mock default for `getCompanionConfig` now matches production (`panel` instead of `card`).
- Three new tests covering card/hidden exclusion, handle visibility, and orphan filtering.

## Verification

- `jest tests/in-chat-agents-companion-panel.test.js` — **21/21 tests pass** (18 existing + 3 new).
- `eslint` on all three changed files — **clean**.
- `bun run lint` (full project pass) — **clean**.

## Files Changed

| File | What |
|---|---|
| `public/scripts/extensions/in-chat-agents/companion/companion-panel.js` | +`isPanelDisplayMode` helper; gated pre-population and results walk in `collectPanelAgentStates` |
| `public/scripts/extensions/in-chat-agents/agent-store.js` | JSDoc: add `panel` to `displayMode` union |
| `tests/in-chat-agents-companion-panel.test.js` | Mock default fix + 3 new filter tests |

## Scope (intentionally unchanged)

- Inline card rendering (`companion-ui.js`) — already correct.
- Companion dashboard "recent notes" (`companion-dashboard.js`) — management/history view, not the live tracker panel referenced in the bug.
- Feedback injection — governed separately by `companion.feedback.enabled`; `hidden` companions still feed future runs.