### PR TITLE
fix: clamp unmapped SB minors to highest synced ST version

### DIFF
--- a/public/scripts/sillybunny-version-map.js
+++ b/public/scripts/sillybunny-version-map.js
@@ -9,8 +9,34 @@ export const SILLYBUNNY_TO_ST_MINOR = {
 };
 
 /**
+ * Returns the highest SillyBunny minor version currently mapped in
+ * SILLYBUNNY_TO_ST_MINOR, or null if the table is empty.
+ * Used as a fallback anchor when a future SillyBunny minor has not yet been
+ * explicitly added to the mapping table.
+ */
+function getMaxMappedSillyBunnyMinor() {
+    const mappedMinors = Object.keys(SILLYBUNNY_TO_ST_MINOR).map(Number);
+    if (mappedMinors.length === 0) {
+        return null;
+    }
+
+    return Math.max(...mappedMinors);
+}
+
+/**
  * Converts a SillyBunny version string to its SillyTavern equivalent.
  * Used by versionCompare() to check if the current SB version meets extension requirements.
+ *
+ * When the input minor version is explicitly present in SILLYBUNNY_TO_ST_MINOR,
+ * the corresponding SillyTavern minor is used directly.
+ *
+ * When the input minor version is GREATER than the highest explicitly mapped
+ * SillyBunny minor (i.e., a future SillyBunny version that has not yet been added
+ * to the mapping table after a version bump), we clamp to the highest synced
+ * SillyTavern minor. This preserves extension compatibility for version bumps
+ * that do not sync to a new SillyTavern upstream release, avoiding the
+ * regression where SB 1.7.0 erroneously compared as smaller than ST 1.18.x.
+ *
  * @param {string} version - A semver-like version string (e.g., "1.6.4")
  * @returns {string} The mapped ST version (e.g., "1.18.4"), or the original if no mapping exists
  */
@@ -28,10 +54,16 @@ export function mapSillyBunnyVersionToStEquivalent(version) {
         return version;
     }
 
-    const mappedMinor = SILLYBUNNY_TO_ST_MINOR[numericMinor];
-    if (mappedMinor === undefined) {
+    const explicitMappedMinor = SILLYBUNNY_TO_ST_MINOR[numericMinor];
+    if (explicitMappedMinor !== undefined) {
+        return `${numericMajor}.${explicitMappedMinor}.${patch}${suffix}`;
+    }
+
+    const maxSbMinor = getMaxMappedSillyBunnyMinor();
+    if (maxSbMinor === null || numericMinor <= maxSbMinor) {
         return version;
     }
 
-    return `${numericMajor}.${mappedMinor}.${patch}${suffix}`;
+    const maxStMinor = SILLYBUNNY_TO_ST_MINOR[maxSbMinor];
+    return `${numericMajor}.${maxStMinor}.${patch}${suffix}`;
 }

--- a/tests/sillybunny-version-map.test.js
+++ b/tests/sillybunny-version-map.test.js
@@ -15,9 +15,19 @@ describe('mapSillyBunnyVersionToStEquivalent', () => {
         expect(mapSillyBunnyVersionToStEquivalent('1.6.4-beta')).toBe('1.18.4-beta');
     });
 
-    test('passes through unmapped SB minor versions', () => {
-        expect(mapSillyBunnyVersionToStEquivalent('1.7.0')).toBe('1.7.0');
-        expect(mapSillyBunnyVersionToStEquivalent('1.99.5')).toBe('1.99.5');
+    test('clamps future unmapped SB minors to the highest synced ST version', () => {
+        // SB 1.7.0 is not yet in SILLYBUNNY_TO_ST_MINOR, but should map to ST 1.18.0
+        // (the highest synced ST minor) instead of passing through as 1.7.0.
+        expect(mapSillyBunnyVersionToStEquivalent('1.7.0')).toBe('1.18.0');
+        expect(mapSillyBunnyVersionToStEquivalent('1.99.5')).toBe('1.18.5');
+        expect(mapSillyBunnyVersionToStEquivalent('1.8.1')).toBe('1.18.1');
+        expect(mapSillyBunnyVersionToStEquivalent('1.7.3-beta')).toBe('1.18.3-beta');
+    });
+
+    test('passes through SB minors lower than the minimum mapped entry', () => {
+        // SB 1.5.x is below the minimum mapped entry (6); pass through unchanged.
+        expect(mapSillyBunnyVersionToStEquivalent('1.5.0')).toBe('1.5.0');
+        expect(mapSillyBunnyVersionToStEquivalent('1.0.1')).toBe('1.0.1');
     });
 
     test('passes through non-1.x major versions', () => {


### PR DESCRIPTION
## Problem

Issue #409 identified a **recurring regression**: when SillyBunny's minor version is bumped (e.g., to 1.7.0) but `SILLYBUNNY_TO_ST_MINOR` hasn't been updated yet, `mapSillyBunnyVersionToStEquivalent` returns the unmapped version as-is.

Since `1.7.0 < 1.18.0`, extensions requiring ST 1.17+ incorrectly fail activation on SB 1.7.0, even though SB 1.7.0 is functionally equivalent to ST 1.18.x.

**Root cause**: PR #410 fixed this for SB 1.6.x by replacing a fragile `+10` offset with an explicit mapping table, but the fix regresses on every new SB minor bump — exactly the scenario the issue reporter warned about.

## Solution

Implement a **clamp-to-max** fallback: when the SB minor is **greater than** the highest explicitly mapped SB minor in the table, clamp to the highest synced ST minor instead of passing through unchanged.

- SB 1.6.x → ST 1.18.x (explicit mapping, unchanged)
- SB 1.7.0 → ST 1.18.0 (clamped to max synced ST minor)
- SB 1.5.x → 1.5.x (below table minimum, passes through unchanged)

This preserves extension compatibility across SB version bumps that don't sync to a new ST release, while still requiring explicit table updates when SB syncs to a new ST minor version.

## Changes

- `public/scripts/sillybunny-version-map.js`: Added `getMaxMappedSillyBunnyMinor()` helper and clamping fallback logic in `mapSillyBunnyVersionToStEquivalent()`
- `tests/sillybunny-version-map.test.js`: Updated tests to verify clamping behavior for future unmapped minors (1.7.0, 1.99.5) and pass-through for minors below the table minimum (1.5.0, 1.0.1)

## Testing

All 15 version-mapping tests pass, including:
- Explicit mapping: SB 1.6.x → ST 1.18.x
- Clamping: SB 1.7.0/1.8.x/1.99.x → ST 1.18.x
- Pass-through: SB 1.5.x and below unchanged
- Suffix preservation: `1.7.3-beta` → `1.18.3-beta`

Closes #409