### PR TITLE
fix: prevent Windows file locks during chat integrity checks

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -6,7 +6,6 @@ import { Buffer } from 'node:buffer';
 import { promises as dnsPromise } from 'node:dns';
 import os from 'node:os';
 import crypto from 'node:crypto';
-import readline from 'node:readline';
 
 import yaml from 'yaml';
 import util from 'node:util';
@@ -2181,35 +2180,34 @@ export function tryDeleteFile(filePath) {
 }
 
 /**
- * Reads the first line of a file asynchronously.
+ * Reads the first line of a file using synchronous I/O.
+ * Returns a Promise for backwards compatibility, but the file descriptor
+ * is guaranteed to be released before the promise resolves. This prevents
+ * Windows file lock issues (EPERM) when the caller immediately performs
+ * synchronous file operations after awaiting this function.
  * @param {string} filePath Path to the file
  * @returns {Promise<string>} The first line of the file
  */
 export function readFirstLine(filePath) {
-    const stream = fs.createReadStream(filePath, { encoding: 'utf8' });
-    const rl = readline.createInterface({ input: stream });
-    return new Promise((resolve, reject) => {
-        let resolved = false;
-        rl.on('line', line => {
-            resolved = true;
-            rl.close();
-            stream.close();
-            resolve(line);
-        });
-
-        rl.on('error', error => {
-            resolved = true;
-            reject(error);
-        });
-
-        // Handle empty files
-        stream.on('end', () => {
-            if (!resolved) {
-                resolved = true;
-                resolve('');
-            }
-        });
-    });
+    let fd;
+    try {
+        fd = fs.openSync(filePath, 'r');
+        const buf = Buffer.alloc(1);
+        let line = '';
+        while (true) {
+            const bytesRead = fs.readSync(fd, buf, 0, 1, null);
+            if (bytesRead === 0) break;
+            const char = buf.toString('utf8', 0, 1);
+            if (char === '\n') break;
+            if (char === '\r') continue;
+            line += char;
+        }
+        return Promise.resolve(line);
+    } finally {
+        if (fd !== undefined) {
+            fs.closeSync(fd);
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
## Problem

On Windows, saving group chats fails with:

```
Temp file rename failed for data\default-user\group chats\<timestamp>.jsonl. Falling back to a copy replacement. EPERM
Found an invalid or corrupted chat file: data\default-user\group chats\<timestamp>.jsonl
```

This affects group chats specifically because they tend to produce larger files that exercise the rename/copy fallback paths more frequently.

## Root Cause

`trySaveChat` in `src/endpoints/chats.js` calls `checkChatIntegrity` before writing, which internally calls `readFirstLine` from `src/util.js`.

The previous `readFirstLine` used **asynchronous** file I/O (`fs.createReadStream` + `readline`). Although it called `rl.close()` and `stream.close()`, these operations are asynchronous — the file descriptor is **not** released by the time the returned promise resolves.

Immediately after `readFirstLine` resolves, `trySaveChat` proceeds to `tryWriteFileSync` which is **synchronous**. On Windows, `sleepSync` (Atomics.wait) blocks the main thread inside `runWithWindowsRetries`, preventing the event loop from ever processing the async file-handle close. The file remains locked, causing `fs.renameSync` and `fs.copyFileSync` to fail with `EPERM`.

## Fix

Rewrites `readFirstLine` to use **synchronous** file I/O (`fs.openSync`, `fs.readSync`, `fs.closeSync`) with `fs.closeSync` in a `finally` block. This guarantees the file descriptor is released synchronously before the promise resolves, eliminating the lock contention on Windows.

The function still returns a `Promise<string>` for backwards compatibility with all existing callers.

## Changes

- `src/util.js`: Rewrite `readFirstLine` from async stream-based to sync I/O; remove unused `readline` import.