### PR TITLE
feat: add edit button to companion previous states in tracker panel

### DIFF
--- a/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
@@ -548,8 +548,11 @@ function buildPanelAgentSection(state) {
             <details class="ica--tpanel-history">
                 <summary>Previous states (${state.history.length})</summary>
                 ${state.history.map(entry => `
-                    <div class="ica--tpanel-history-entry">
-                        <div class="ica--tpanel-history-head">Message #${entry.messageIndex}</div>
+                    <div class="ica--tpanel-history-entry" data-message-index="${entry.messageIndex}">
+                        <div class="ica--tpanel-history-head">
+                            <span>Message #${entry.messageIndex}</span>
+                            <button type="button" class="ica--cdash-action" data-action="panel-edit-note" title="Edit this state's text" aria-label="Edit history entry"><i class="fa-solid fa-pen-to-square"></i></button>
+                        </div>
                         <div class="ica--tpanel-agent-body">${buildPanelEntryBody(agentId, entry)}</div>
                     </div>
                 `).join('')}
@@ -698,7 +701,7 @@ async function handlePanelAction(event) {
 
     const section = button.closest('.ica--tpanel-agent');
     const agentId = section.attr('data-agent-id') || '';
-    const messageIndex = Number(section.attr('data-message-index'));
+    const messageIndex = Number(button.closest('[data-message-index]').attr('data-message-index'));
 
     if (action === 'panel-run-latest') {
         if (!agentId) {

--- a/public/scripts/extensions/in-chat-agents/style.css
+++ b/public/scripts/extensions/in-chat-agents/style.css
@@ -1965,6 +1965,9 @@ button.ica--card-pill--version-update {
 }
 
 .ica--tpanel-history-head {
+    display: flex;
+    align-items: center;
+    gap: 6px;
     font-size: calc(var(--mainFontSize) * 0.72);
     opacity: 0.55;
     margin-bottom: 4px;

--- a/tests/in-chat-agents-companion-panel.test.js
+++ b/tests/in-chat-agents-companion-panel.test.js
@@ -292,6 +292,28 @@ describe('companion tracker panel', () => {
         expect(html).toContain('No state yet');
     });
 
+    test('renders edit buttons with per-entry message indices on history entries', async () => {
+        const tracker = { id: 'tracker-1', name: 'Scene Tracker', execution: 'companion', enabled: true };
+        agents = [tracker];
+        const panel = await importPanel();
+
+        for (let index = 0; index < 3; index++) {
+            const message = { is_user: false, is_system: false, mes: `reply ${index}` };
+            chat.push(message);
+            companionResultsByMessage.set(message, {
+                'tracker-1': { status: 'done', content: `state ${index}`, agentName: 'Scene Tracker' },
+            });
+        }
+
+        const html = panel.buildPanelHtml();
+
+        expect(html).toContain('Previous states (2)');
+        expect(html).toMatch(/ica--tpanel-history-entry[\s\S]*?data-message-index="1"/);
+        expect(html).toMatch(/ica--tpanel-history-entry[\s\S]*?data-message-index="0"/);
+        const editNoteMatches = html.match(/data-action="panel-edit-note"/g);
+        expect(editNoteMatches).toHaveLength(3);
+    });
+
     test('shows enabled memory shard before threshold and offers shard compaction after a run', async () => {
         agents = [
             { id: 'memory-shard', name: 'Memory Shard', sourceTemplateId: 'tpl-memory-shard-companion', execution: 'companion', enabled: true, companion: { minContextTokens: 30000 } },


### PR DESCRIPTION
## Summary

Adds an edit button to each **Previous states** entry in the companion slide-out tracker panel.

### Why
When a companion has been running for several messages, its earlier notes may drift or become nonsensical. Users need a way to manually correct historical states without running a fresh cycle.

### Changes
- **companion-panel.js**: Each history entry now carries its own `data-message-index` and a `panel-edit-note` button. `handlePanelAction` resolves the target message index from the closest `[data-message-index]` ancestor so the edit popup opens on the correct historical message.
- **style.css**: Added flex layout to `.ica--tpanel-history-head` so the label and edit button align horizontally.
- **tests**: New test verifies that history entries render with per-entry message indices and edit buttons.

### Testing
```
npm run test:unit --prefix tests -- in-chat-agents-companion-panel
```
All 22 tests pass.