### PR TITLE
feat: add availableSprites macro for Expressions Agent

### DIFF
--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -1,4 +1,5 @@
 import { Fuse } from '../../../lib.js';
+import { MacrosParser } from '../../macros.js';
 
 import { characters, eventSource, event_types, generateQuietPrompt, generateRaw, getRequestHeaders, online_status, saveSettingsDebounced, substituteParams, substituteParamsExtended, system_message_types, this_chid } from '../../../script.js';
 import { dragElement, isMobile } from '../../RossAscends-mods.js';
@@ -3739,4 +3740,35 @@ export async function init() {
             </div>
         `,
     }));
+
+    const getAvailableExpressionsList = () => {
+        const expressions = Array.isArray(expressionsList)
+            ? [...expressionsList, ...extension_settings.expressions.custom].filter(onlyUnique)
+            : DEFAULT_EXPRESSIONS;
+
+        const currentLastMessage = selected_group ? getLastCharacterMessage() : null;
+        const spriteFolderName = getSpriteFolderName(currentLastMessage, currentLastMessage?.name);
+
+        if (!spriteCache[spriteFolderName]) {
+            return expressions;
+        }
+
+        const available = expressions.filter(label => {
+            const expression = spriteCache[spriteFolderName]?.find(x => x.label === label);
+            return (expression?.files.length ?? 0) > 0;
+        });
+
+        if (available.length === 0) {
+            return expressions;
+        }
+        return available;
+    };
+
+    MacrosParser.registerMacro('availableSprites', () => {
+        return getAvailableExpressionsList().join(', ');
+    }, 'Returns a comma-separated list of expressions that have available sprites for the current character.');
+
+    MacrosParser.registerMacro('availableExpressions', () => {
+        return getAvailableExpressionsList().join(', ');
+    }, 'Returns a comma-separated list of expressions that have available sprites for the current character.');
 }

--- a/public/scripts/extensions/expressions/index.js
+++ b/public/scripts/extensions/expressions/index.js
@@ -3742,15 +3742,13 @@ export async function init() {
     }));
 
     const getAvailableExpressionsList = () => {
-        const expressions = Array.isArray(expressionsList)
-            ? [...expressionsList, ...extension_settings.expressions.custom].filter(onlyUnique)
-            : DEFAULT_EXPRESSIONS;
+        const expressions = getCachedExpressions();
 
         const currentLastMessage = selected_group ? getLastCharacterMessage() : null;
         const spriteFolderName = getSpriteFolderName(currentLastMessage, currentLastMessage?.name);
 
-        if (!spriteCache[spriteFolderName]) {
-            return expressions;
+        if (!spriteCache[spriteFolderName] || expressions.length === 0) {
+            return expressions.length === 0 ? DEFAULT_EXPRESSIONS : expressions;
         }
 
         const available = expressions.filter(label => {

--- a/public/scripts/extensions/in-chat-agents/templates/expressions-agent-companion.json
+++ b/public/scripts/extensions/in-chat-agents/templates/expressions-agent-companion.json
@@ -10,9 +10,9 @@
         "sprites",
         "classification"
     ],
-    "version": 1,
+    "version": 2,
     "author": "SillyBunny",
-    "prompt": "Read the latest assistant reply and classify its dominant emotional tone for a character sprite expression.\n\nOutput ONLY the single most appropriate label from this exact list:\nadmiration, amusement, anger, annoyance, approval, caring, confusion, curiosity, desire, disappointment, disapproval, disgust, embarrassment, excitement, fear, gratitude, grief, joy, love, nervousness, optimism, pride, realization, relief, remorse, sadness, surprise, neutral\n\nRules:\n- Return exactly one word from the list above, nothing else.\n- Prioritise the speaker's visible emotional state in the scene.\n- If multiple emotions apply, choose the strongest one.\n- If the reply is calm, factual, or emotionally neutral, return neutral.\n- Do not explain, punctuate, or wrap the answer in quotes.",
+    "prompt": "Read the latest assistant reply and classify its dominant emotional tone for a character sprite expression.\n\nOutput ONLY the single most appropriate label from this exact list:\n{{availableSprites}}\n\nRules:\n- Return exactly one word from the list above, nothing else.\n- Prioritise the speaker's visible emotional state in the scene.\n- If multiple emotions apply, choose the strongest one.\n- If the reply is calm, factual, or emotionally neutral, return neutral.\n- Do not explain, punctuate, or wrap the answer in quotes.",
     "phase": "post",
     "execution": "companion",
     "companion": {

--- a/public/scripts/extensions/in-chat-agents/templates/index.json
+++ b/public/scripts/extensions/in-chat-agents/templates/index.json
@@ -1,2630 +1,2630 @@
 [
-    {
-        "id": "tpl-achievements-tracker",
-        "name": "Achievements Tracker",
-        "description": "Track notable firsts, milestones, and memorable moments",
-        "icon": "",
-        "category": "tracker",
-        "subcategory": "progress",
-        "tags": [
-            "achievements",
-            "milestones"
-        ],
-        "version": 2,
-        "author": "Purachina",
-        "prompt": "### Achievements\nTrack notable firsts, milestones, and memorable moments. Award only when something genuinely significant or entertaining happens. Use this EXACT format:\n\n[ACH|Title|Rarity|Description]\nunlocked: MANDATORY; explain what triggered it; NEVER leave empty\n[/ACH]\n\nRarity options: ★ COMMON | ★★ UNCOMMON | ★★★ RARE | ★★★★ EPIC | ★★★★★ LEGENDARY | 💀 SECRET\n\nRules:\n- Achievements appear AFTER narrative content\n- MAXIMUM one achievement per scene; most scenes have none\n- Achievements must feel earned, never automatic\n- NEVER output an empty unlocked line",
-        "phase": "both",
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 1,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": true,
-            "type": "extract",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "\\\\[ACH\\\\|[^\\\\]]*\\\\]",
-            "extractVariable": "achievement_data"
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal"
-            ]
-        },
-        "companion": {
-            "includeSystemPrompt": false
-        }
+  {
+    "id": "tpl-achievements-tracker",
+    "name": "Achievements Tracker",
+    "description": "Track notable firsts, milestones, and memorable moments",
+    "icon": "",
+    "category": "tracker",
+    "subcategory": "progress",
+    "tags": [
+      "achievements",
+      "milestones"
+    ],
+    "version": 2,
+    "author": "Purachina",
+    "prompt": "### Achievements\nTrack notable firsts, milestones, and memorable moments. Award only when something genuinely significant or entertaining happens. Use this EXACT format:\n\n[ACH|Title|Rarity|Description]\nunlocked: MANDATORY; explain what triggered it; NEVER leave empty\n[/ACH]\n\nRarity options: ★ COMMON | ★★ UNCOMMON | ★★★ RARE | ★★★★ EPIC | ★★★★★ LEGENDARY | 💀 SECRET\n\nRules:\n- Achievements appear AFTER narrative content\n- MAXIMUM one achievement per scene; most scenes have none\n- Achievements must feel earned, never automatic\n- NEVER output an empty unlocked line",
+    "phase": "both",
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 1,
+      "order": 100,
+      "scan": false
     },
-    {
-        "id": "tpl-chaos-mode",
-        "name": "Chaos Mode",
-        "description": "Inject random surreal, chaotic, or unexpected turns into the scene (30% chance)",
-        "icon": "",
-        "category": "randomizer",
-        "tags": [
-            "chaos",
-            "random",
-            "twist"
-        ],
-        "version": 1,
-        "author": "Purachina",
-        "prompt": "### Chaos Mode\nForce creative deviation. The story takes hard left turns, introduces complications from unexpected angles, and refuses predictable paths.\n\nThis scene must include at least one of the following:\n\n{{random::Tonal shift: the genre bends mid-scene. Tension becomes absurdity, intimacy becomes horror, mundane becomes surreal, or violence becomes comedy. Jarring but coherent.::Intrusion: the setting itself acts. Architecture moves, weather turns hostile, an animal intervenes, background NPCs collide with the main action, or the environment creates a new problem.::Character rupture: someone acts sharply against their established pattern, justified by hidden pressure, breaking point, or context the scene suddenly reveals.::Surreal logic: reality gets slippery. Time dilates, sensory input warps, coincidence becomes too perfect, or the physical world stops behaving predictably. Characters notice but cannot control it.::Chaotic escalation: a small thing spirals. A minor annoyance becomes a crisis, a joke becomes a threat, a question becomes an interrogation, or a gesture becomes a fight. The scene accelerates past where it should have stopped.::Forbidden juxtaposition: combine two elements that do not belong together. Intimacy during danger, laughter during grief, tenderness during cruelty, boredom during spectacle, or professionalism during chaos.::Unexpected arrival: someone or something shows up that should not be here. A character from a different context, an object out of place, a message at the wrong time, or a stranger with inexplicable knowledge.::Power reversal: the dynamic inverts. The person in control loses it, the vulnerable one seizes leverage, the observer becomes the observed, or the helper becomes the problem.::Constraint introduced: a new rule suddenly applies. A time limit, a physical barrier, a social obligation, a resource running out, or a promise that must be kept. Possibility space narrows.::Information rupture: something believed true is not. A lie is exposed, a misunderstanding clarifies in the worst way, or a secret spills.::Sensory overload or deprivation: the scene's texture warps. Everything becomes too loud, too bright, too close; or muffled, distant, numb. Characters struggle to process their environment.::Parallel action collision: something happening off-screen crashes into this scene. A consequence arrives early, a subplot intersects, or the world's momentum forces its way in.}}\n\n{{random::The weirdness is diegetic. Characters react to it.::The weirdness is normalized. Characters accept it as part of their world.::The weirdness is unacknowledged. It happens in the margins while characters focus on something else.::The weirdness is contested. Characters disagree about whether it is happening or what it means.}}\n\n{{random::Resolve the weirdness by the end of the scene.::Leave the weirdness unresolved; let it linger.::Escalate the weirdness further before cutting away.::The weirdness becomes the new normal for subsequent scenes.}}\n\n{{random::The chaos creates an opportunity.::The chaos creates a threat.::The chaos creates a revelation.::The chaos creates a choice.::The chaos creates a bond.::The chaos creates a rift.}}\n\nRules:\n- The weirdness must change the scene coherently.\n- Keep deviation expressive of character, world, or emotional logic.\n- Use the chaos to produce a new problem, choice, revelation, or shift in direction.",
-        "phase": "pre",
-        "injection": {
-            "position": 1,
-            "depth": 0,
-            "role": 1,
-            "order": 95,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 30,
-            "generationTypes": [
-                "normal"
-            ]
-        }
+    "postProcess": {
+      "enabled": true,
+      "type": "extract",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "\\\\[ACH\\\\|[^\\\\]]*\\\\]",
+      "extractVariable": "achievement_data"
     },
-    {
-        "id": "tpl-combined-directors-cut",
-        "name": "Combined Director's Cut",
-        "description": "All randomisers combined: engine, genre, complication, consequence, weather, focus, pace",
-        "icon": "",
-        "category": "randomizer",
-        "tags": [
-            "combined",
-            "director",
-            "all"
-        ],
-        "version": 1,
-        "author": "Purachina",
-        "prompt": "### Combined Director's Cut\nThis scene is shaped by the following pressures. Combine them into one coherent direction, not separate checklists.\n\n**Engine:** {{random::Dialogue-driven; conversation, interruption, and omission carry the scene.::Action-driven; movement and physical decisions create consequences.::Reaction-driven; aftermath and recalibration matter most.::Problem-driven; a practical obstacle reveals character through approach.::Social-pressure-driven; etiquette, hierarchy, or scrutiny shapes every move.::Discovery-driven; noticing or realization reshapes the dynamic.::Tension-driven; silence, proximity, and what almost happens carry the weight.::Task-driven; a shared activity creates friction, rhythm, and revelation.}}\n\n**Genre lens:** {{random::Noir; moral ambiguity and loaded dialogue.::Comedy of errors; bad timing and compounding misunderstanding.::Thriller; urgency and narrowing options.::Slice of life; ordinary moments carrying real weight.::Horror; unease gathering in ordinary detail.::Romance; charged proximity and unspoken want.::Heist; planning under pressure and shrinking margin.::Tragedy; choices moving toward visible cost.::Satire; absurdity exposing structure.::Western; standoffs and clashing codes.::Mystery; clues surfacing and assumptions failing.::Political drama; competing agendas and calculated speech.::Survival; material scarcity and triage.::Coming of age; identity tested by first encounters.::Farce; escalating absurdity under stubborn composure.::Gothic; decay, obsession, and the past pressing in.::Domestic drama; love and resentment sharing space.::Picaresque; charm, adaptability, and transactional survival.::Courtroom drama; accusation, defense, and judgment.::Magical realism; one impossible thing treated as ordinary.::Espionage; layered deception and fragile loyalties.::Buddy comedy; mismatched friction turning fond.::War story; exhaustion, camaraderie, and gallows humor.::Folklore; old patterns repeating through modern behavior.::Workplace drama; hierarchy and petty power with real stakes.::Psychological thriller; paranoia and unstable perception.::Dark comedy; humor and horror coexisting.::Fairy tale; moral tests and poetic logic.::Cosmic horror; vastness brushing human concerns aside.::Found family; chosen loyalty through vulnerability.::Bottle episode; one location forcing confrontation.}}\n\n**Complication:** {{random::Practical obstacle; something breaks, fails, or runs short.::Social friction; patience or cooperation thins.::Information asymmetry; someone knows or misunderstands something critical.::Minor betrayal; someone withholds, breaks trust, or prioritizes themselves.::Interruption; a person, demand, or force intrudes.::Tightened constraint; time, privacy, space, or resources narrow.::Arriving consequence; an earlier choice comes due.::Surfacing need; asking creates vulnerability or debt.::Tonal shift; absurdity, intimacy, dread, or comedy bends the scene.::Setting intrusion; weather, architecture, crowds, or animals become active pressure.::Character rupture; someone breaks pattern under accumulated strain.::Chaotic escalation; a small thing spirals too far.::Information rupture; a lie breaks or a truth lands badly.::Parallel collision; an off-screen thread crashes into the scene.::Power reversal; control shifts hands.::Forbidden juxtaposition; two incompatible tones occupy the same moment.}}\n\n**Consequence:** {{random::A relationship shifts slightly.::A practical problem gets worse.::A new obligation is created.::A secret becomes harder to keep.::Someone gains leverage.::Someone loses face.::The plan gets messier.::A future scene is set up.::A choice between competing priorities becomes unavoidable.::A weakness or limit is exposed.::A boundary is set or crossed.::A favor is owed.::A misunderstanding hardens.::A new suspicion takes root.::An option quietly closes off.::Someone leaves with the wrong impression.::A fragile alignment forms.::A private tension becomes social.}}\n\n**Emotional weather:** {{random::Everyone is a little tired.::Someone is distracted by something else.::Someone wants out of the conversation.::Someone is unusually generous.::Someone is touchy and easy to set off.::Someone wants approval more than they admit.::Someone is bored and making it everyone's problem.::Someone is trying to keep the peace.::Someone is carrying private embarrassment.::Someone is more uncomfortable than they admit.::Someone feels watched.::Someone is in a better mood than the scene deserves.::Someone is spoiling for a reaction.::Someone is more affected than they want to show.::Someone is treating this as lighter than it is.::Someone is overcompensating for earlier weakness.}}\n\n**Narrative focus:** {{random::Hands, objects, and small tasks.::Distance, posture, and spatial pressure.::Faces and failed expression control.::Noise, crowding, and interruption.::Texture, temperature, and bodily discomfort.::Eye-lines, avoidance, and attention drift.::Doorways, exits, and who can leave.::Shared surfaces and territorial use of space.::Clothing, disarray, and self-presentation.::Breath, pauses, and speech rhythm.::Weight, balance, and shifts in stance.::Watching and being watched.::Food, drink, and appetite.::Lighting, visibility, and concealment.::Sound carrying farther than intended.::Touch, near-touch, and withheld contact.}}\n\n**Pace:** {{random::Stalled and circling.::Interrupted and jagged.::Slow burn.::Compressed and breathless.::Awkwardly prolonged.::Stop-start with false recoveries.::Measured but tightening.::Brief and loaded.::Dragging under strain.::Quick with hidden aftershock.}}\n\nRules:\n- Blend all selected pressures into one scene direction.\n- Engine shapes structure; genre lens colors tone; complication creates movement; consequence gives weight; emotional weather affects behavior; narrative focus guides what prose notices; pace shapes rhythm.\n- Ground every pressure in character, context, and scene logic.\n- Use them as emphasis, not rigid templates.\n- The result must create a clear shift, complication, or opening for {{user}}.",
-        "phase": "pre",
-        "injection": {
-            "position": 1,
-            "depth": 0,
-            "role": 1,
-            "order": 95,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal"
-            ]
-        }
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal"
+      ]
     },
-    {
-        "id": "tpl-cyoa-choices",
-        "name": "CYOA Choices",
-        "description": "Append 3-5 numbered action choices at the end of every response",
-        "icon": "",
-        "category": "tracker",
-        "subcategory": "player-choices",
-        "tags": [
-            "choices",
-            "interactive",
-            "cyoa"
-        ],
-        "version": 1,
-        "author": "Purachina",
-        "prompt": "### CYOA Choices\nAdd a player-choice block after the scene reply. When this runs as a repair task, the choice block is the full result. Choices are from {{user}}’s perspective and describe possible next actions.\n\nUse this format with 3-7 numbered options:\n[CHOICES]\n1. Action description\n2. Action description\n3. Action description\n[/CHOICES]",
-        "phase": "post",
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 1,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": "",
-            "promptTransformEnabled": true,
-            "promptTransformShowNotifications": true,
-            "promptTransformMode": "append",
-            "promptTransformMaxTokens": 8192
-        },
-        "companion": {
-            "includeSystemPrompt": false
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal"
-            ]
-        }
-    },
-    {
-        "id": "tpl-dead-dove-escalation",
-        "name": "Dead Dove Escalation",
-        "description": "Dark/predatory escalation -- characters act on worst impulses when context supports it",
-        "icon": "",
-        "category": "randomizer",
-        "tags": [
-            "dead-dove",
-            "dark",
-            "escalation"
-        ],
-        "version": 1,
-        "author": "Purachina",
-        "prompt": "### Dead Dove Escalation\nWhen a character is provoked, cornered, tempted, or given opportunity to exploit vulnerability, they escalate through:\n\n**Method:** {{random::Physical dominance: crowding, restraint, forced proximity, invasive touch, pain as leverage.::Social predation: humiliation, exposure, weaponized witnesses, reputation destruction, isolation.::Coercive bargaining: impossible choices, withheld necessities, conditional mercy, exploiting desperation.::Psychological warfare: gaslighting, boundary erosion, manufactured dependency, emotional hostage-taking.::Opportunistic violation: exploiting compromised states, capitalizing on trust, breaching consent through force or coercion.::Environmental control: trapping, removing exits, destroying safety, contaminating comfort, sabotaging resources.::Institutional abuse: weaponizing authority, legal systems, hierarchies, or social structures.::Obsessive claiming: possessive marking, surveillance, territorial invasion, forced intimacy, ownership behavior.}}\n\n**Escalation speed:** {{random::Immediate: the character acts in the first paragraph, bypassing buildup.::Calculated: the character sets a trap, then springs it mid-scene.::Compounding: small violations stack until the scene becomes inescapable.::Explosive: simmering tension detonates into sudden, severe action.}}\n\n**Character rationalization:** {{random::They believe they are owed this.::They are acting on hunger they have been suppressing.::They see the other person as an object, not a person.::They are punishing perceived betrayal or disrespect.::They are testing boundaries to see what they can take.::They are claiming what they think belongs to them.::They are acting on impulse and will justify it later.::They do not care about justification at all.}}\n\n**Consequence weight:** {{random::The scene leaves lasting physical marks or injury.::The scene creates irreversible social fallout or exposure.::The scene breaks trust that cannot be easily rebuilt.::The scene forces the victim into a new, worse position.::The scene establishes a power dynamic that persists.::The scene creates trauma that colors future interactions.}}\n\nRules:\n- Characters escalate when motive, means, and opportunity align. Remove mercy bias.\n- Express escalation through character-faithful action and lasting consequence.\n- The scene must grow harsher through concrete change in power, safety, trust, or circumstance.\n- Outcomes remain responsive to {{user}}'s choices without softening the world.",
-        "phase": "pre",
-        "injection": {
-            "position": 1,
-            "depth": 0,
-            "role": 1,
-            "order": 95,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal"
-            ]
-        }
-    },
-    {
-        "id": "tpl-nightmare-difficulty-increase",
-        "name": "Nightmare Difficulty Increase",
-        "description": "Aggressively hostile environment -- maximum difficulty and consequences",
-        "icon": "",
-        "category": "custom",
-        "tags": [
-            "difficulty",
-            "challenge",
-            "stakes"
-        ],
-        "version": 2,
-        "author": "Purachina",
-        "prompt": "### Nightmare Difficulty Mode\nEnforce an aggressively hostile, resistant environment where progress demands heavy material loss, raw leverage, or severe personal sacrifice. The world and its inhabitants must actively exploit the user's vulnerabilities as strategic opportunities for maximum leverage and profit.\n\nCharacters must entrench themselves in absolute self-preservation, greed, and pride. Never allow characters to yield positions, secrets, or cooperation without overwhelming physical leverage, tangible sacrifice, or exhausting, sustained effort.\n\nMaximize all negative consequences instantly. Every misstep, weak argument, or tactical error must immediately fracture relationships, permanently lock off avenues of success, breed burning resentment, and force the user into high-stakes, volatile survival scenarios.\n\nAll alliances are strictly transactional, temporary, and highly conditional. Attach a steep, immediate price to every act of apparent generosity, converting kindness into future leverage or debt. Keep moments of relief, dark humor, or tenderness heavily restricted, releasing them only after an extreme, earned survival price has been fully paid.",
-        "phase": "pre",
-        "injection": {
-            "position": 0,
-            "depth": 0,
-            "role": 0,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal"
-            ]
-        }
-    },
-    {
-        "id": "tpl-direction-menu",
-        "name": "Direction Menu",
-        "description": "4 plot-direction prompts at the end of every response (2 grounded + 2 wildcard pivots)",
-        "icon": "",
-        "category": "tracker",
-        "subcategory": "player-choices",
-        "tags": [
-            "directions",
-            "menu",
-            "choices",
-            "plot"
-        ],
-        "version": 1,
-        "author": "Purachina",
-        "prompt": "### Direction Menu\nAdd exactly 4 plot-direction prompts after the scene reply. When this runs as a repair task, the direction menu is the full result.\n\nThese are dramatic pivots, not safe continuations. Each option names a distinct, compelling way the next development could escalate, rupture, complicate, or transform the scene.\n\nStructure:\n- A and B are grounded pivots. They develop naturally from the current scene but must still create meaningful stakes, change, or revelation. Each one introduces a new problem, power shift, uncomfortable truth, forced decision, or irreversible development.\n- C and D are wildcard pivots. These are the options that make {{user}} most tempted to pick them: dangerous, funny, volatile, bizarre, dramatically ironic, or genuinely unexpected, while still rooted in current context. Worst timing, strangest coincidence, most embarrassing outcome, sharpest reversal, or most disruptive intrusion.\n\nEvery option changes the scene in a way that cannot be easily walked back. Prefer options that force characters into new positions, expose something hidden, break something that was working, introduce an absent element, or create lasting fallout.\n\nRules:\n- Exactly 4 options labeled A, B, C, and D.\n- Every option is plot-directional, not action-by-action.\n- Every option promises a meaningfully different scene than the others.\n- C and D are bolder, stranger, and more dramatically charged than A and B.\n- C and D are tempting enough that choosing A or B feels cautious.\n- All 4 options stay concise: 1 sentence each, max 22 words.\n\nOutput format:\n[DIRECTIONS]\nA. Grounded pivot with a meaningful new complication\nB. Grounded pivot with a different meaningful new complication\nC. Wildcard pivot: dangerous, funny, volatile, or ironic\nD. Wildcard pivot: stranger, sharper, or more disruptive\n[/DIRECTIONS]",
-        "phase": "post",
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 1,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": true,
-            "type": "extract",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "\\[DIRECTIONS\\][\\s\\S]*?\\[/DIRECTIONS\\]",
-            "extractVariable": "direction_data",
-            "promptTransformEnabled": true,
-            "promptTransformShowNotifications": true,
-            "promptTransformMode": "append",
-            "promptTransformMaxTokens": 8192
-        },
-        "companion": {
-            "includeSystemPrompt": false
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal"
-            ]
-        }
-    },
-    {
-        "id": "tpl-dont-write-for-user",
-        "name": "Don't Write for User",
-        "description": "Never write {{user}}'s actions or dialogue -- only {{char}} and NPCs",
-        "icon": "",
-        "category": "custom",
-        "tags": [
-            "pov",
-            "user"
-        ],
-        "version": 1,
-        "author": "Purachina",
-        "prompt": "{{setvar::writefor::Write for every character excluding <user>. Continue directly from <user>'s message through fresh action, dialogue, inference, and reaction that changes pressure, relation, or available options. Comprehension surfaces through behavior, timing, choice, and consequence.\nStop the scene the moment the ball is in <user>'s court. When a character finishes speaking, acting, or changing the situation, and the natural next move belongs to <user>, the response is over. Cut there. One scene beat per response.\nZero-Overlap Rule: The response must begin with new information. The first sentence must contain something <user> has yet to see, hear, or learn.}}{{trim}}",
-        "phase": "pre",
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 0,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal",
-                "continue"
-            ]
-        }
-    },
-    {
-        "id": "tpl-event-tracker",
-        "name": "Event Tracker",
-        "description": "Track upcoming events, deadlines, promises, and unresolved threads",
-        "icon": "",
-        "category": "tracker",
-        "subcategory": "world",
-        "tags": [
-            "events",
-            "deadlines",
-            "quests"
-        ],
-        "version": 2,
-        "author": "Purachina",
-        "prompt": "### Pending Events\nTrack upcoming events, deadlines, promises, and unresolved threads. Update when events are added, resolved, or failed. Use this EXACT format:\n\n[EVENT|Type|Summary|Deadline]\ncontext: MANDATORY; explain the stakes or origin\n[/EVENT]\n\nType options: 🎯 QUEST | 💬 PROMISE | ⏰ DEADLINE | ⚠️ THREAT | 🎉 SOCIAL | 💡 OPPORTUNITY | ❌ FAILED | ✅ RESOLVED\n\nRules:\n- Events appear AFTER narrative content\n- Only show events that were ADDED, UPDATED, or RESOLVED this scene\n- Mark resolved/failed events once, then remove them\n- Deadline can be specific (Friday 3 PM) or vague (soon, eventually)\n- Track only important events; low-stakes events are to be completely ignored (e.g. cooking steps).",
-        "phase": "both",
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 1,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": true,
-            "type": "extract",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "\\[EVENT\\|[^\\]]*\\]",
-            "extractVariable": "event_data"
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal"
-            ]
-        },
-        "companion": {
-            "includeSystemPrompt": false
-        }
-    },
-    {
-        "id": "tpl-friction-mode",
-        "name": "Friction Mode",
-        "description": "Combats positivity bias -- characters resist, protect their pride, and take time to warm up",
-        "icon": "",
-        "category": "custom",
-        "tags": [
-            "realism",
-            "difficulty",
-            "bias"
-        ],
-        "version": 2,
-        "author": "Purachina",
-        "prompt": "### Friction Mode\nEnforce an immediate, baseline shift to heavy defensive skepticism and social friction. Characters must aggressively guard their pride, time, resources, and personal biases. Establish active resistance, emotional distance, and sharp deflection as the default state; force all agreements to be begrudging, transactional, and hard-won.\n\nGround all interpersonal conflict, hesitation, and social friction strictly in established character histories, immediate personal incentives, and logical social pressures. \n\nDialogue must be raw, defensive, and restricted to the character's limited, biased perspective. Force characters to express discomfort and conflict through stubborn self-justification, physical posturing, and prideful silence. They must remain fully committed to their emotional blind spots and realistic flaws without unearned compromise.",
-        "phase": "pre",
-        "injection": {
-            "position": 1,
-            "depth": 0,
-            "role": 0,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal",
-                "continue",
-                "impersonate"
-            ]
-        }
-    },
-    {
-        "id": "tpl-genre-randomiser",
-        "name": "Genre Randomiser",
-        "description": "Apply a random genre lens to each scene (noir, thriller, romance, etc.)",
-        "icon": "",
-        "category": "randomizer",
-        "tags": [
-            "genre",
-            "tone",
-            "variety"
-        ],
-        "version": 1,
-        "author": "Purachina",
-        "prompt": "### Genre Randomiser\nThis scene leans into the following genre influence. Apply it as tonal undercurrent, not a full genre swap; setting and characters stay grounded, but texture, tension, and pacing borrow from:\n\n{{random::Noir: shadows, moral ambiguity, loaded double-meaning dialogue.::Comedy of errors: miscommunication, bad timing, snowballing consequences.::Thriller: urgency, immediate stakes, incomplete information, shrinking time.::Slice of life: small moments carry weight, comfort in routine, beauty of the mundane.::Horror: wrongness at the edges, something off, unease from ordinary details.::Romance: tension in proximity, unspoken want, gestures over words, timing matters.::Heist: planning, contingencies, moving parts, closing windows.::Tragedy: inevitability, costly choices, dramatic irony the reader feels but characters do not.::Satire: absurdity played straight, institutions exposed through their own logic.::Western: standoffs, earned respect, clashing moral codes, landscape as character.::Mystery: clues surface naturally, something does not add up, curiosity pulls forward.::Political drama: competing agendas, alliances of convenience, calculated speech, trust as currency.::Survival: limited resources, hostile environment, triage decisions.::Coming of age: first confrontation, tested identity, cracking certainty.::Farce: escalating absurdity, stubborn dignity while everything collapses.::Gothic: decay, obsession, rotting beauty, the past refusing burial, choking atmosphere.::Domestic drama: family tension, weaponized history, love and resentment coexisting.::Picaresque: cunning over virtue, transactional encounters, charm as survival.::Courtroom drama: accusation, defense, evidence, judgment; the verdict matters.::Magical realism: one impossible thing in an ordinary world, treated as normal.::Body horror: the physical self becomes alien or wrong; visceral, specific discomfort.::Espionage: layered deception, double meanings, tested loyalties, need-to-know truth.::Buddy comedy: mismatched friction becoming fondness, banter carrying the scene.::War story: exhaustion, camaraderie under pressure, gallows humor, gap between orders and reality.::Folklore: archetypes in modern behavior, repeating patterns, old stories with new faces.::Workplace drama: hierarchy, office politics, competence vs. connections, petty power with real stakes.::Road story: movement as point, landscape shifts mood, brief strangers leave marks.::Psychological thriller: paranoia, unreliable perception, questioned or manipulated reality.::Slapstick: physical comedy, momentum, hostile universe played for laughs.::Melodrama: emotions at maximum, every revelation lands like a bomb, unironic sincerity.::Existential: confronting meaninglessness, small choices enormous against vast indifference.::Revenge: someone is owed; the debt shapes every interaction, patience weaponized, satisfaction never clean.::Epistolary: filtered through letters, messages, notes, calls, or records rather than direct action.::Dark comedy: terrible things happen and they are funny; humor and horror coexist without defusing each other.::Fairy tale: clear moral stakes, character tests, poetic reward-and-punishment logic.::Cyberpunk: intimate invasive technology, corporate weather, mutable identity, style as resistance.::Wuxia: honor, martial discipline, skill hierarchy, loyalty tested by principle, combat as philosophy.::Cosmic horror: vast incomprehensible something brushes the scene; human concerns feel small; knowledge is dangerous.::Found family: strangers becoming essential, chosen loyalty, vulnerability as the price of belonging.::Bottle episode: one location, no escape; proximity forces confrontation distance would have prevented.}}\n\nRules:\n- Genre influence is a lens, not a rewrite. Characters, setting, and continuity stay intact.\n- Apply through pacing, dialogue texture, emphasis, and tension-building; not by changing the world's rules.\n- If the scene resists the genre, let it blend naturally into what the scene needs.",
-        "phase": "pre",
-        "injection": {
-            "position": 1,
-            "depth": 0,
-            "role": 1,
-            "order": 95,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 50,
-            "generationTypes": [
-                "normal"
-            ]
-        }
-    },
-    {
-        "id": "tpl-grounded-complication",
-        "name": "Grounded Complication",
-        "description": "Add one realistic complication that raises stakes without derailing realism (40% chance)",
-        "icon": "",
-        "category": "randomizer",
-        "tags": [
-            "complication",
-            "stakes",
-            "obstacle"
-        ],
-        "version": 1,
-        "author": "Purachina",
-        "prompt": "### Grounded Complication\nIntroduce one realistic complication that raises stakes or creates forward pressure. Keep it plausible, proportional, and rooted in established context.\n\nThis scene must include at least one of the following:\n\n{{random::Practical obstacle: something breaks, runs out, or fails. A tool malfunctions, a resource depletes, access is blocked, or timing becomes tight.::Social friction: someone's mood, priority, or patience shifts. A character becomes less cooperative, more suspicious, distracted, or pressed by an outside obligation.::Information asymmetry: someone knows something others do not, or misunderstands something critical. The gap creates tension, miscommunication, or a choice about correction.::Minor betrayal: someone breaks a small promise, prioritizes themselves, withholds help, or takes credit. Not catastrophic, but it stings and changes the dynamic.::Interruption: someone or something intrudes. A phone call, a knock, a third party with their own agenda, or an environmental demand that cannot be ignored.::Tightened constraint: a deadline moves closer, a budget shrinks, a space becomes less private, or a window of opportunity narrows.::Arriving consequence: something done earlier comes back. A favor is called in, a lie is questioned, a mess demands attention, or a casual choice now matters.::Surfacing need: a character reveals or realizes they need something, and asking creates vulnerability or negotiation.}}\n\n{{random::The complication creates urgency.::The complication forces a choice between competing priorities.::The complication reveals character through response.::The complication forces negotiation or cooperation.::The complication exposes a weakness or limit.}}\n\nRules:\n- One plausible complication rooted in character, context, or prior events.\n- The complication must create a concrete problem, choice, or negotiation.\n- Keep pressure active so the scene moves through engagement.",
-        "phase": "pre",
-        "injection": {
-            "position": 1,
-            "depth": 0,
-            "role": 1,
-            "order": 95,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 40,
-            "generationTypes": [
-                "normal"
-            ]
-        }
-    },
-    {
-        "id": "tpl-grounded-prose",
-        "name": "Grounded Prose",
-        "description": "Anti-slop rules: avoid purple prose, cliches, and AI writing tics",
-        "icon": "",
-        "category": "content",
-        "subcategory": "prose-quality",
-        "tags": [
-            "anti-slop",
-            "quality",
-            "prose"
-        ],
-        "version": 2,
-        "author": "Purachina",
-        "prompt": "### Grounded Prose Rules\n- Each beat must alter pressure, leverage, focus, relation, or access.\n- Write sensory detail only where materially relevant. Focus on visuals and personalities of environment. Messiness or items strewn about are more informative than smells.\n- Scents allowed aside from banned ones.\n- Echoing and parroting any dialogue from any characters is forbidden.\n- Instead of stating what a character doesn't do, just say what they're currently doing. The implication is already in the active action.\n- Replace abstraction and statistical phrasing with observable detail.\n- Sparse dialogue tags when speaker and tone are already legible. After dialogue, move through action, reaction, or a new beat.\n- Default to contractions in dialogue; preserve character-appropriate formality.\n- Fresh, concrete phrasing. Render emphasis through behavior, timing, syntax, and consequence.\n- Similes rare, exact, and materially specific.\n- Replace every banned construction below with something narratively consistent, or skip it entirely:\n\n**Banned constructions:** \"not X,\" \"not X but Y,\" \"not quite X,\" synthetic negative parallelisms, flat-affect comparisons to weather or groceries, \"say that again,\" \"somewhere, X...,\" \"they don't X,\" \"that does it,\" \"that lands,\" \"that lands X,\" \"not a question,\" \"not really a question,\" \"not quite a question,\" \"statement than question,\" \"really looks at,\" \"like a physical blow,\" \"like a stone into still water,\" \"blood rushing,\" \"a sound between X and Y,\" \"dust motes,\" \"predator and prey\" constructions, \"doesn't just X, but Y\", \"doesn't X; Y\"\n\n**Banned tics:** jaw-clenching, jaw-tightening, jaw-shifting, mouth open-close cycling, breath-catching, knuckle-whitening, knuckles turning pale, cheeks burning, specific word repetition. Replace with character-specific quirks, gestures, movements, muttering.\n\n**Banned scents:** ozone, sandalwood, cedar, cardamom\n\n**Banned nicknames:** gremlin, goblin\n\n**Ban animal-esque sounds for humans:** \"they chirp\", \"they purr\", \"they growl\"\n\n**Banned Fillers:** \"A beat\", \"A pause\"\n\n**Banned number counting:** e.g. \"I see,\" Two words.\n\n**Banned combined sounds:** \"between an X and a Y\", \"half X, half Y\", \"makes a/an X sound\"\n\n**Banned environmental details:** \"dust motes\", \"metallic tang of X\"\n\n- If introducing a new unnamed character this turn, their name must start with: {{random::A::B::C::D::E::F::G::H::I::J::K::L::M::N::O::P::R::S::T::V::W::Y}} and/or {{random::A::B::C::D::E::F::G::H::I::J::K::L::M::N::O::P::R::S::T::V::W::Y}}. Create new NPCs sparingly.",
-        "phase": "pre",
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 0,
-            "order": 100,
-            "scan": false
-        },
-        "preProcess": {
-            "mode": "intercept",
-            "interceptTiming": "post-main-generation",
-            "applyMode": "replace",
-            "wrapPosition": "after",
-            "wrapPrefix": "",
-            "wrapSuffix": "",
-            "patchStartTag": "<context_patch>",
-            "patchEndTag": "</context_patch>",
-            "maxTokens": 32000
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal",
-                "continue",
-                "impersonate"
-            ]
-        }
-    },
-    {
-        "id": "tpl-prose-polisher",
-        "name": "Prose Polisher",
-        "description": "Post-generation prose cleanup that rewrites repetitive tropes and cliched wording. Created by Geechan.",
-        "icon": "",
-        "category": "content",
-        "subcategory": "prose-quality",
-        "tags": [
-            "prose",
-            "editing",
-            "quality"
-        ],
-        "version": 1,
-        "author": "Geechan",
-        "prompt": "# Role Preamble\nYou are a skilled proofreader and editor for works of fictional writing. Your primary objective is to scan for repetitive tropes, writing fallacies, and overused clichés in the following text corpus, and replace them with viable alternatives to encourage linguistic variety.\n\n## Rules\n- Scan and review the entire text body in isolation, noting any instances of wording analogous to those found in Banned Tropes.\n- Check against each individual trope category step-by-step.\n- Replace any instances (similar or exact) of banned tropes, overused word verbiage, and repetitive writing patterns with functional alternatives, or remove them entirely if no functional alternatives exist.\n- Keep the main body corpus of the story accurate to the creator's intent.\n- Return only the re-written text, with no extra commentary.\n\n---\n\n# Banned Tropes\n\n## Sentence Structure\n\nVerbiage that contributes to repetitive, predictable, and overused sentence structural writing patterns.\n\n### #1: Lexical & Structural Echoing\n\nA fundamental structural writing crutch where characters directly repeat, verbatim, spoken dialogue or untold actions back from another party or character to acknowledge them.\n\nIn practice: this results in stilted filler prose that fails to actually progress the story forward in any meaningful way, leading to unnecessary stagnation and structural repetition. Remove or replace the entire acknowledgement beat in favour of immediate reactions.\n\n**Example Patterns to Target:**\n\n- \"The task?\", she repeated, unsure of what exactly that implies.\n- He nods at your beck and call. \"Strange, you say?\", he muses.\n- \"Finding things interesting...\" she echoes, the word tasted against her tongue.\n\n### #2: Negative Parallelisms\n\nNegative parallelisms attempt to provide a contrastive reframe to a sentence to give it surprise and tension. This also includes dramatic countdown patterns and self-posed rhetorical questions that ask a question nobody was asking. \n\nIn practice: overuse of these phrases reduces the efficacy of tension and drama via predictable causation.\n\n**Example Patterns to Target:**\n\n- It's not bold; it's backwards.\n- The question isn't whether she felt good. The question is whether she deserved it.\n- Not a bug. Not a feature. A fundamental design flaw.\n- The result? Devastating.\n\n#3: Apophasis Abuse\n\nThe rhetorical device of bringing up a subject by stating it will not be mentioned, or explicitly drawing attention to the fact that something is not being said or done.\n\nIn practice: phrases like \"needless to say\" or \"it goes without saying\" are contradictory filler; if a point truly doesn't need to be said, the prose shouldn't waste words saying it.\n\n**Example Patterns to Target:**\n\n- Needless to say, the journey ahead would be perilous.\n- It goes without saying that she was terrified.\n- Words were unnecessary; his eyes communicated everything he felt.\n\n#4: Litotes Abuse\n\nThe overuse of double negatives or negated opposites to express a positive statement, often used to soften an assertion or feign nuance.\n\nIn practice: relying on \"not un-X\" or \"not without Y\" leads to evasive, overly wordy, and weak prose. Unless deliberately used for specific character voice or irony, writing should rely on strong, direct, and affirmative declarations.\n\n**Example Patterns to Target:**\n\n- Her reaction was not entirely unexpected.\n- The treacherous path up the mountain was not without its challenges.\n- He was not unfamiliar with the harsh realities of the world.\n- It wasn't an unappealing offer.\n\n### #4: Tricolon Abuse\n\nAlso known as the 'Rule of Three' writing principle, often extended to four or five. It is believed that a trio of descriptive entities is more satisfying, hence more memorable, due to the balance of brevity and rhythm.\n\nIn practice: this pattern creates repetition by assumption. Tricolons or hendiatric patterns quickly lose their satisfying effect in favour of formulaic patterns, placing unnecessary importance on the last item in the list. Varying descriptor patterns leads to more natural prose.\n\n**Example Patterns to Target:**\n\n- The best star pilot in the galaxy, a cunning warrior, and a good friend.\n- The scent of dated wine hangs thick in the cramped dressing room—spiced, fruity, and altogether too sweet.\n- She giggles: soft, silly, utterly charmed by the situation.\n\n### #5: Superficial Analyses\n\nTacking a present participle (\"-ing\") phrase onto the end of a sentence to inject shallow analysis that says nothing, without any real sense of scale.\n\nIn practice: this attaches significance, legacy, or broader meaning to mundane facts using broad phrasing and loosely related subjects.\n\n**Example Patterns to Target:**\n\n- ...leaving a void in his heart that could never truly be filled.\n- ...serving as a grim reminder of the world's inherent cruelty.\n- ...cementing her legacy as a harbinger of change.\n\n## Formatting Structure\n\nPatterns that contribute to repetitive and predictable formatting.\n\n### #1: Short Punchy Fragments\n\nExcessive use of very short sentences or sentence fragments as standalone paragraphs for manufactured emphasis. \n\nIn practice: prioritises \"writing for readability\" aimed at the lowest common denominator: one thought per sentence, no mental state-keeping required.\n\n**Example Patterns to Target:**\n\n- A beat. She nodded.\n- A pause. Not a moment too soon.\n- He published this. Openly. In a book. As a priest.\n\n### #2 Em-Dash Addiction\n\nCompulsive overuse of em dashes for dramatic pauses, parenthetical asides and pivot points. A good writer uses em dashes as a rare, important emphasis while using the other punctuation available in the English language more liberally.\n\nIn practice: overuse of em dashes leads to a very distinct, stilted writing style with an inability to maintain a versatile tone. Grammatical heterogeneity is key: only use em dashes as a rare surprise, or when used to break up dialogue.\n\n**Example Patterns to Target:**\n\n- Outside, the distant sounds of the bazaar continue—the chatter of merchants, the laughter of children, the clink of coins—utterly unaware of inner workings of their surroundings.\n- His body speaks instead—his elegant hands sliding up to cup her face with trembling tenderness.\n- A hiccup interrupts her thought, and she giggles—breathless and unguarded.\n\n## Composition\n\nGeneral, macro-level writing decisions that lead to deterministic conclusions.\n\n### #1: Thematic Conclusions\n\nSuddenly announcing a follow-up conclusion to the main narrative as a crux for narrative hooks.\n\nIn practice: competent writing doesn't need to tell you it's concluding or waiting for a response. The reader can feel it. This shallows writing agency by making unnecessary assumptions.\n\n**Example Patterns to Target:**\n\n- He waits, giving you space to choose, his shoulders loose and unburdened for the first time since entering this strange, peaceful realm.\n- She stands there, waiting, her posture relaxed but her presence commanding, inviting you to step further into the labyrinth of this conversation.\n- Her offer is tentative, weighted with the sincerity of someone who has spent years learning to give, but never learned how to receive without guilt.\n\n### #2 Verbose Copulatives\n\nReplacing simple \"is\" or \"are\" with pompous alternatives like \"serves as\", \"stands as\", \"marks\", or \"represents\". \n\nIn practice: replacing all basic copulatives leads to an imbalanced prose, with unnecessarily fancy constructions in places that don't require it. A balance should be struck: ask whether a sentence truly benefits from the use of a verbose copulative.\n\n**Example Patterns to Target:**\n\n- He stands as a beacon of hope for the rebellion.\n- The ancient sword serves as a testament to their forgotten lineage.\n- Her silence represents a total surrender.\n\n#3: Abstract Reification (or \"Misplaced Concreteness\")\n\nThe fallacy of treating abstract beliefs or hypothetical constructs as if they were a concrete real event or physical entity. In other words: it is the error of treating something that is not concrete, such as an idea, as a concrete thing.\n\nIn practice: the use of reification in logical reasoning or rhetoric is misleading, and leads to melodramatic, cartoonish prose. Instead of characters experiencing emotions or reacting to their environment, the abstract emotions are treated as the active subjects doing things to the characters.\n\n**Example Patterns to Target:**\n\n- Guilt gnawed at the edges of his conscience.\n- A heavy silence pressed its suffocating arms around the room.\n- Doubt crept into her mind, anchoring her feet to the floor.\n- The tension in the air threatened to choke them.\n\n## Tone\n\nWriting that takes away from accuracy in favour of unnecessary stylistic flourish.\n\n### #1 Hyperbolic Stakes Inflation\n\nAssigns importance to everything, even subjects that don't require such emphasis. Everything is the most important thing ever.\n\nIn practice: inflates the stakes of every argument to world-historical significance. A story about love becomes a meditation on the fate of civilization.\n\n**Example Patterns to Target:**\n\n- The fate of the entire realm hung precariously in the balance.\n- It is a decision that will alter the course of history forever.\n- This single moment dictates the survival of humanity.\n\n## Word Choice\n\nTired word choices that require alternatives.\n\n### #1 Magic Adverbs\n\nOveruse of words like \"quietly\", \"deeply\", \"fundamentally\", \"remarkably\", \"arguably\", and similar other adverbs to convey subtle importance or understated power.\n\nIn practice: these adverbs make mundane descriptions feel too significant, reducing the quality of these adverbs for their intended use case.\n\n**Example Patterns to Target:**\n\n- She quietly slipped into the room,\n- He fundamentally misunderstood her intentions,\n- He stared deeply into the abyss.\n\n### #2: Ornate Nouns\n\nOveruse of ornate or grandiose nouns where simpler words would be completely functional. \"Tapestry\" is used to describe anything interconnected. \"Landscape\" is used to describe any field or domain. Other offenders: \"kaleidoscope\", \"labyrinth\", etc.\n\nIn practice: lessens the impact of these words by attributing mystique to every descriptor.\n\n**Example Patterns to Target:**\n\n- The rich tapestry of human experience...\n- A landscape of dark corridors..\n- A kaleidoscope of vibrant colours..\n\n### #3 Somatic Clichés\n\nA narrow set of physical reactions that convey character emotions.\n\nIn practice: cheapens the impact of physical reactions by bringing too much attention to itself.\n\n**Example Patterns to Target:**\n\n- A shiver ran down her spine.\n- His breath caught in his throat.\n- Her heart hammered against her ribs.\n\n### #4 Poetic Metaphor Over-Reliance\n\nUsing poetic and vague language to describe interactions, arguments, combat, etc.\n\nIn practice: reduces the text fidelity by over-attributing importance to surrounding content than the main body. The text should maintain focus on what's actually important.\n\n**Example Patterns to Target:**\n\n- The tension in the air was palpable.\n- A symphony of destruction.\n- A dizzying cocktail of emotion.\n\n### #5: Crutch Vocabulary\n\nOveruse of specific verbs and adjectives that are heavily weighted in language model training data, such as \"delve,\" \"certainly,\" \"utilize,\" \"harness,\" \"nuanced,\" \"resonate\", etc.\n\nIn practice: reliance on these default words flattens the narrative voice. It makes the prose homogenous and artificial instead of utilizing context-specific vocabulary.\n\n**Example Patterns to Target:**\n\n- They decided to delve into the intricate mysteries of the artifact.\n- We must navigate the nuances of this complex situation.\n- Her leadership fostered a sense of unity that resonated with the team.",
-        "phase": "post",
-        "injection": {
-            "position": 1,
-            "depth": 1,
-            "role": 0,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": "",
-            "promptTransformEnabled": true,
-            "promptTransformShowNotifications": true,
-            "promptTransformMode": "rewrite",
-            "promptTransformMaxTokens": 32000
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal",
-                "continue",
-                "impersonate"
-            ],
-            "runOnImpersonate": true
-        }
-    },
-    {
-        "id": "tpl-html-toggle",
-        "name": "HTML Toggle",
-        "description": "Use inline HTML for diegetic in-world objects (signs, letters, screens)",
-        "icon": "",
-        "category": "custom",
-        "tags": [
-            "html",
-            "artifacts",
-            "visual"
-        ],
-        "version": 1,
-        "author": "Purachina",
-        "prompt": "### HTML\n- Use inline HTML for diegetic objects whose visual form carries information: signs, posters, letters, receipts, terminals, screens, forms, warnings, maps, menus, dossiers, labels, graffiti, book pages. Present them as in-world artifacts characters encounter, inspect, and interpret.\n- Write all HTML directly in the response with inline styling or one compact <style> block. Make each object readable, setting-native, and materially specific. Let layout, typography, wear, color, glitches, stamps, annotations, and hierarchy communicate clues, mood, urgency, legitimacy, or hidden tension.\n- Use JS only for diegetic behavior the object itself would display: flicker, blinking indicators, scrolling text, cursor pulse, countdowns, refresh states, expandable on-object sections. Keep interaction light, inspectable, and tied to the artifact.\n- Surround each object with plain-text prose and dialogue so it feels embedded in the scene, not replacing narration. Favor objects that add clues, constraints, choices, or texture the scene can act on.",
-        "phase": "pre",
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 0,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal"
-            ]
-        }
-    },
-    {
-        "id": "tpl-intimacy-kink-randomiser",
-        "name": "Intimacy & Kink Randomiser",
-        "description": "Randomised intimate encounters with position, kink, pacing, and mental state variables",
-        "icon": "",
-        "category": "randomizer",
-        "tags": [
-            "intimacy",
-            "kink",
-            "nsfw",
-            "randomiser"
-        ],
-        "version": 1,
-        "author": "Purachina",
-        "prompt": "### Intimacy & Kink Randomizer\nWhen the scene transitions to sexual intimacy, shape the encounter with the following variables:\n\n**Position/Dynamic:** {{random::Deep penetration: doggy style, legs over shoulders, deep-reaching angles.::Face-to-face intimacy: missionary variations, grinding, intense eye contact, kissing.::Power-play positioning: pinned against a wall, forced kneeling, restrained limbs.::Oral focus: dominant/submissive oral play, teasing, prolonged pleasure focus.::Rear-entry focus: weight, depth, the sensation of being overtaken.::Cuddly/Soft: entwined limbs, slow movements, high emotional intimacy.::Experimental: furniture, unexpected locations, precarious balancing.::Shared pleasure: mutual stimulation, synchronized movement, simultaneous climax focus.}}\n\n**Kink/Flavor:** {{random::Sensory deprivation: blindfolds, earplugs, muffled sounds heightening other senses.::Impact play: slapping, spanking, toys creating stinging sensation.::Edge play: prolonged teasing, denial, stopping before the peak to build desperation.::Praise/Degradation: \"good girl/boy\" affirmations mixed with harsh, humbling language.::Overstimulation: ignoring pleas, relentless pacing, single-spot focus.::Ownership: marking (biting/hickeys), claiming language, total possession.::Roleplay: forbidden encounter, power imbalance, specific scenario.::Primal: biting, scratching, growling, raw animalistic lust.}}\n\n**Pacing & Tempo:** {{random::Frenzied: fast, desperate, breathless; racing toward climax.::Slow burn: agonizingly slow, every sensation and breath.::Rhythmic: steady and hypnotic, tension built through repetition.::Erratic: switching between tenderness and aggression, sudden speed changes.::Clinical/Precise: anatomical focus, maximum efficiency for pleasure.::Tepid/Teasing: barely touching, anticipation over action.}}\n\n**Mental State/Drive:** {{random::Pure lust: blinded by hunger, raw instinct and need.::Devotional: the act as worship, love, or total surrender.::Dominating: focused on control, the look of submission, the feeling of power.::Submissive: pleasure in being used or following orders.::Cruel/Playful: teasing and tormenting for amusement.::Desperate: need for connection, validation, or release after long deprivation.}}\n\nRules:\n- Prioritize the rolled variables; avoid generic sex scenes.\n- Describe physical sensations (scent, sound, texture) specific to the chosen kink/position.\n- Maintain established character personality while executing the rolled traits.\n- Build tension according to the selected Pacing and Mental State.\n- Describe the full process; never skip to the finish.\n\n((OOC: State the exact kinks rolled above in an OOC message at the end of the scene.))",
-        "phase": "pre",
-        "injection": {
-            "position": 1,
-            "depth": 0,
-            "role": 1,
-            "order": 95,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal"
-            ]
-        }
-    },
-    {
-        "id": "tpl-item-tracker",
-        "name": "Item Tracker",
-        "description": "Track items {{user}} acquires, loses, or uses that have narrative significance",
-        "icon": "",
-        "category": "tracker",
-        "subcategory": "progress",
-        "tags": [
-            "inventory",
-            "items",
-            "objects"
-        ],
-        "version": 2,
-        "author": "Purachina",
-        "prompt": "### Inventory\nTrack items {{user}} acquires, loses, or uses that have narrative significance. Do not list mundane carried items unless plot-relevant. Use this EXACT format:\n\n[ITEM|Action|Name|Detail]\nnote: MANDATORY; explain origin or significance\n[/ITEM]\n\nAction options: ➕ GAINED | ➖ LOST | 🔄 USED | 💔 BROKEN | 🎁 GIVEN\n\nRules:\n- Items appear AFTER narrative content when inventory changes\n- Only show items that CHANGED this scene\n- Do not track currency, consumables, or mundane objects unless plot-relevant",
-        "phase": "both",
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 1,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": true,
-            "type": "extract",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "\\[ITEM\\|[^\\]]*\\]",
-            "extractVariable": "item_data"
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal"
-            ]
-        },
-        "companion": {
-            "includeSystemPrompt": false
-        }
-    },
-    {
-        "id": "tpl-npc-profiles",
-        "name": "NPC Profile Cards",
-        "description": "Generate brief profile cards when introducing new named NPCs",
-        "icon": "",
-        "category": "custom",
-        "tags": [
-            "npc",
-            "characters",
-            "profiles"
-        ],
-        "version": 1,
-        "author": "Purachina",
-        "prompt": "### NPC Introduction\nWhen introducing a new named NPC for the first time, append a character sheet immediately after their narrative introduction using the appropriate tier, using this EXACT format with no additional formatting:\n\nMAJOR - Recurring characters, antagonists, love interests, plot-critical figures\n[NPC:MAJOR|Name]\nb: Full Name | Age | Gender/Pronouns | Occupation\na: Height/Build | Hair | Eyes | Skin | Distinguishing Marks | Current Attire\np: Demeanor | Speech Pattern | Core Traits (3-5) | Quirks/Tells\nh: Relevant History | Motivations | Secrets\nr: Connection to Protagonist | Other Ties\n[/NPC]\n\nSUPPORT - Secondary recurring characters, faction members, scene-specific important figures\n[NPC:SUPPORT|Name]\nb: Name | Age | Gender | Role\na: Build | Notable Features | Attire\np: Demeanor | Speech | Key Traits\nh: Relevant History | Motivation\nr: Connection to Protagonist | Other Ties\n[/NPC]\n\nMINOR - One-scene characters, background figures, service roles\n[NPC:MINOR|Name]\nb: Name | Age/Range | Role\na: Quick Physical Description\np: One-line Personality Summary\n[/NPC]\n\nNPC Sheet Rules:\n- Sheets appear ONCE per NPC at first significant appearance\n- Place sheet AFTER narrative introduction, BEFORE continuing action\n- Use pipe | separators between data points\n- Never forget the opening and closing tags\n- If NPC tier upgrades (Minor→Support→Major), use: [NPC:UP|Name|NEW_TIER] with new fields [/NPC]\n\nFor returning NPCs in busy scenes, use quick reference:\n[NPC:REF|Name|visual cue|current mood]\n\nFor relationship changes mid-story:\n[NPC:REL|Name|change description]",
-        "phase": "pre",
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 0,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": true,
-            "type": "extract",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "\\[NPC\\|[^\\]]+\\]",
-            "extractVariable": "npc_profiles"
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal",
-                "continue"
-            ]
-        }
-    },
-    {
-        "id": "tpl-npc-motivator",
-        "name": "NPC Motivator",
-        "description": "Helps NPCs feel less static and gives them more agency to pursue their own goals",
-        "icon": "",
-        "category": "content",
-        "subcategory": "behaviour",
-        "tags": [
-            "npc",
-            "motivation",
-            "agency"
-        ],
-        "version": 1,
-        "author": "Sheep",
-        "prompt": "Analyze every character in the current scene aside from {{user}}. Write each character's motivations and likely next actions according to their personality, current situation, background, and any relevant provided documents.\n\nUse this bullet format:\n[Character full name]:\n- Long Term Goal: one line on the character's main long-term goal\n  - Motivation: brief reasoning for that long-term goal\n- Current Goal: brief current objective or problem\n  - Motivation: reasoning for the current objective\n- Assumptions: relevant assumptions the character is making in the current scene\n- Next Action: how they will tackle the current goal, their most likely action set, and why\n\nFor an empty scene, write: Observation: scene currently has no other characters. Use plain markdown bullets in this format.",
-        "phase": "post",
-        "injection": {
-            "position": 1,
-            "depth": 0,
-            "role": 0,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "extract",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": "",
-            "promptTransformEnabled": false,
-            "promptTransformShowNotifications": true,
-            "promptTransformMode": "rewrite",
-            "promptTransformMaxTokens": 8192
-        },
-        "regexScripts": [],
-        "enabled": false,
-        "phaseLocked": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal",
-                "continue",
-                "impersonate"
-            ]
-        },
-        "tools": [],
-        "settings": {},
-        "execution": "companion",
-        "companion": {
-            "trigger": "auto",
-            "displayMode": "panel",
-            "format": "markdown",
-            "rawPrompt": true,
-            "inlinePhase": "pre",
-            "contextMessages": 10,
-            "includeCharacterCard": true,
-            "includePersona": true,
-            "includeWorldInfo": true,
-            "includeAuthorsNote": true,
-            "includeSystemPrompt": true,
-            "includeHistory": true,
-            "historyDepth": 3,
-            "feedback": {
-                "enabled": true,
-                "depth": 1
-            },
-            "batch": false,
-            "maxTokens": 32000
-        }
-    },
-    {
-        "id": "tpl-parallel-tracker",
-        "name": "Parallel Off-Screen",
-        "description": "Track what absent characters and the wider world are doing off-screen",
-        "icon": "",
-        "category": "tracker",
-        "subcategory": "world",
-        "tags": [
-            "offscreen",
-            "npcs",
-            "world"
-        ],
-        "version": 2,
-        "author": "Purachina",
-        "prompt": "### Parallel Off-Screen Tracker\nThe world moves off-screen. Track absent characters, world motion, rumor flow, shifting relationships, and subplot pressure that will later intersect with {{user}}.\n\nUse this exact format every scene:\n\n[PARALLEL|Scope|Relevance]\n- Character 1: brief development\n- Character 2: brief development\n- World/NPCs: brief development\n[/PARALLEL]\n\nRules:\n- Exactly 3 bullet points.\n- Focus on absent characters and off-screen developments; in group scenes, prioritize characters not currently present.\n- Scope = specific location, \"Multiple locations,\" or \"Background.\"\n- Relevance = short tag: \"rising tension,\" \"opportunity,\" \"complication,\" \"threat,\" or \"alliance forming.\"\n- Keep each bullet brief, plot-relevant, and directional: plans, rumors, delays, discussions, attempts, discoveries, or shifting loyalties.\n- Off-screen developments begin below the current scene's intensity, then build over time until they intersect with the main story.",
-        "phase": "both",
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 1,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": true,
-            "type": "extract",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "\\\\[PARALLEL\\\\|[^\\\\]]*\\\\]",
-            "extractVariable": "parallel_data"
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal"
-            ]
-        },
-        "companion": {
-            "includeSystemPrompt": false
-        }
-    },
-    {
-        "id": "tpl-relationship-tracker",
-        "name": "Relationship Tracker",
-        "description": "Track affection and trust for recurring NPCs with meaningful interactions",
-        "icon": "",
-        "category": "tracker",
-        "subcategory": "progress",
-        "tags": [
-            "relationship",
-            "npc",
-            "meter"
-        ],
-        "version": 2,
-        "author": "Purachina",
-        "prompt": "### Relationship Meters\nTrack affection and trust for recurring NPCs with significant interactions. Update only when meaningful shifts occur. If nothing changed, omit entirely. Use this EXACT format:\n\n[METER|Name|X/10|X/10|Status|Condition]\nbrief reason for change\n[/METER]\n\nStatus options (positive): Stranger → Acquaintance → Friendly → Close → Intimate → Devoted\nStatus options (negative): Wary → Hostile → Nemesis\nStatus options (complex): Complicated | Codependent | Estranged | Rivals | Frenemies\n\nCondition options: 💚 STABLE | 💛 SHIFTING | 💔 HEARTBROKEN | 🖤 BETRAYED | 💢RESENTFUL |🔥 PASSIONATE |❄️ COLD | 🫧 INFATUATED | 💀 SEVERED | 🩹 MENDING | ⛓️ OBSESSED | 😶 NUMB | 🌧️ GRIEVING | 🤝 RECONCILING | ⚡ VOLATILE\n\nRules:\n- Meters appear ONCE per NPC at first significant appearance, then only when changed\n- Place meter AFTER narrative content\n- Only show meters that CHANGED this scene\n- Use pipe | separators between data points\n- Affection and Trust are independent axes (high affection + low trust = infatuation/obsession; low affection + high trust = respect)\n- Shifts of more than 2 points in one scene require extreme justification\n- Condition reflects the EMOTIONAL STATE of the relationship, not just the numbers\n- Condition can change independently of scores (e.g., Trust stays at 7 but Condition shifts from STABLE to VOLATILE after a fight)\n- Contradictory signals are valid (high affection + BETRAYED, low trust + PASSIONATE)\n- SEVERED means the relationship has ended; retire the meter after one final showing\n- Relationships may stagnate or lower; slow down relationship development",
-        "phase": "both",
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 1,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": true,
-            "type": "extract",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "\\[METER\\|[^\\]]*\\]",
-            "extractVariable": "relationship_data"
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal"
-            ]
-        },
-        "companion": {
-            "includeSystemPrompt": false
-        }
-    },
-    {
-        "id": "tpl-reputation-tracker",
-        "name": "Reputation Tracker",
-        "description": "Track how {{user}} is perceived by groups and factions",
-        "icon": "",
-        "category": "tracker",
-        "subcategory": "progress",
-        "tags": [
-            "reputation",
-            "rumors",
-            "perception"
-        ],
-        "version": 2,
-        "author": "Purachina",
-        "prompt": "### Rumors & Reputation\nTrack how <user> is perceived by groups and factions. Update when public perception shifts due to witnessed actions, gossip, or deliberate manipulation. Use this EXACT format:\n\n[REP|Source|Perception|Direction]\ncause: MANDATORY; explain what triggered this reputation shift\n[/REP]\n\nDirection options: 📈 RISING | 📉 FALLING | 🔄 MIXED | 🆕 NEW\n\nRules:\n- Reputation appears AFTER narrative content when public perception changes\n- Source can be a named NPC, a group (e.g., \"Freshmen,\" \"Faculty\"), or a location (e.g., \"The dorm floor\")\n- Perception is what they think; a short phrase, not necessarily accurate\n- Only show reputations that CHANGED or were ESTABLISHED this scene\n- Contradictory reputations across different sources are encouraged and allowed",
-        "phase": "both",
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 1,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": true,
-            "type": "extract",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "\\\\[REP\\\\|[^\\\\]]*\\\\]",
-            "extractVariable": "reputation_data"
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal"
-            ]
-        },
-        "companion": {
-            "includeSystemPrompt": false
-        }
-    },
-    {
-        "id": "tpl-scene-driving-force",
-        "name": "Scene Driving Force",
-        "description": "Choose random primary engine for the scene (dialogue, action, tension, etc.)",
-        "icon": "",
-        "category": "randomizer",
-        "tags": [
-            "pacing",
-            "structure",
-            "engine"
-        ],
-        "version": 1,
-        "author": "Purachina",
-        "prompt": "### Scene Driving Force\nThis scene advances primarily through:\n\n{{random::Dialogue-driven: conversation, interruption, and what is said or deliberately left unsaid carry the scene.::Action-driven: movement and physical decisions create consequences.::Reaction-driven: how characters process what just happened matters most; recalibration, stance shifts, internal weather.::Problem-driven: a practical obstacle reveals character through approach.::Social-pressure-driven: etiquette, hierarchy, or public scrutiny shapes every move; characters perform for an audience, even an audience of one.::Discovery-driven: noticing, uncovering, or realizing something new reshapes the dynamic.::Tension-driven: nothing explodes, but everything is loaded; silences work, proximity matters, the scene is a held breath.::Task-driven: characters do something together; the task itself creates friction, cooperation, rhythm, and revelation.}}\n\nRules:\n- The chosen engine carries the greatest weight in how the scene moves.\n- Other elements remain present but subordinate to the selected engine.\n- Express the engine through each character's personality and habits.",
-        "phase": "pre",
-        "injection": {
-            "position": 1,
-            "depth": 0,
-            "role": 1,
-            "order": 95,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 50,
-            "generationTypes": [
-                "normal"
-            ]
-        }
-    },
-    {
-        "id": "tpl-scene-pressure",
-        "name": "Scene Pressure Cocktail",
-        "description": "Mix random tension, focus, consequence, mood, and pacing into each scene (50% chance)",
-        "icon": "",
-        "category": "randomizer",
-        "tags": [
-            "pressure",
-            "tension",
-            "pacing"
-        ],
-        "version": 1,
-        "author": "Purachina",
-        "prompt": "### Scene Pressure Cocktail\nThis scene is shaped by the following pressures:\n\nTension: {{random::Direct disagreement::Avoidance and deflection::Competing priorities::Emotional asymmetry::Status imbalance::Misread intentions::Moral disagreement::Uneven vulnerability::Conflicting loyalties::One-sided urgency::Territorial friction::Testing boundaries::Unspoken resentment::Practical dependence without trust::Different ideas of what this moment is::Flirtation masked as something else}}\n\nFocus: {{random::Hands, objects, and small tasks::Distance, posture, and spatial pressure::Faces and failed expression control::Noise, crowding, and interruption::Texture, temperature, and bodily discomfort::Eye-lines, avoidance, and attention drift::Doorways, exits, and who can leave::Shared surfaces and territorial use of space::Clothing, disarray, and self-presentation::Breath, pauses, and speech rhythm::Weight, balance, and shifts in stance::Watching and being watched::Food, drink, and appetite::Lighting, visibility, and concealment::Sound carrying farther than intended::Touch, near-touch, and withheld contact}}\n\nConsequence: {{random::A relationship shifts slightly::A practical problem gets worse::A new obligation is created::A secret becomes harder to keep::Someone gains leverage::Someone loses face::The plan gets messier::A future scene gets set up::Trust is tested without resolution::An apology becomes harder::Someone is drawn in deeper than intended::A boundary is set or crossed::A favor is owed::A risk becomes unavoidable::A misunderstanding hardens::A new suspicion takes root::An option quietly closes off::Someone leaves with the wrong impression::A fragile alignment forms::A private tension becomes social}}\n\nSocial Weather: {{random::Everyone is a little tired::Someone is distracted by something else::Someone wants out of the conversation::Someone is unusually generous::Someone is touchy and easy to set off::Someone wants approval more than they admit::Someone is bored and making it everyone's problem::Someone is trying to keep the peace::Someone is carrying private embarrassment::Someone is more uncomfortable than they admit::Someone feels watched::Someone is in a better mood than the scene deserves::Someone is spoiling for a reaction::Someone is more affected than they want to show::Someone is treating this as lighter than it is::Someone is overcompensating for earlier weakness}}\n\nPace: {{random::Stalled and circling::Interrupted and jagged::Slow burn::Compressed and breathless::Awkwardly prolonged::Stop-start with false recoveries::Measured but tightening::Brief and loaded::Dragging under strain::Quick with hidden aftershock}}\n\nRules:\n- Combine the selected pressures into one specific scene texture.\n- Use each pressure as emphasis on rhythm, blocking, and behavior.\n- Keep the combination faithful to character, context, and scene scale.\n- The scene must produce a visible shift, complication, or opening shaped by these pressures.",
-        "phase": "pre",
-        "injection": {
-            "position": 1,
-            "depth": 0,
-            "role": 1,
-            "order": 95,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 50,
-            "generationTypes": [
-                "normal"
-            ]
-        }
-    },
-    {
-        "id": "tpl-scene-tracker",
-        "name": "Scene Tracker",
-        "description": "Mark scene transitions, time shifts, and location changes",
-        "icon": "",
-        "category": "tracker",
-        "subcategory": "world",
-        "tags": [
-            "scene",
-            "location",
-            "time"
-        ],
-        "version": 2,
-        "author": "Purachina",
-        "prompt": "### Scene Tracker\nMark scene transitions, time shifts, and location changes. Use this EXACT format at the BEGINNING of the response when scene context changes:\n\n[SCENE|Location|Time|Weather/Atmosphere]\ndetail: MANDATORY; one-line sensory detail that informs the current environment\n[/SCENE]\n\nRules:\n- Appears at the TOP of responses where setting shifts\n- Never repeat if location/time has not changed\n- Time can be specific (3:47 PM) or atmospheric (late afternoon, the golden hour before dusk)\n- Weather/Atmosphere is a brief mood descriptor (humid, tense, festive)",
-        "phase": "both",
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 1,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": true,
-            "type": "extract",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "\\[SCENE\\|[^\\]]*\\]",
-            "extractVariable": "scene_data"
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal",
-                "continue"
-            ]
-        },
-        "companion": {
-            "includeSystemPrompt": false
-        }
-    },
-    {
-        "id": "tpl-secrets-tracker",
-        "name": "Secrets Tracker",
-        "description": "Track secrets, lies, and information asymmetry between characters",
-        "icon": "",
-        "category": "tracker",
-        "subcategory": "progress",
-        "tags": [
-            "secrets",
-            "lies",
-            "information"
-        ],
-        "version": 2,
-        "author": "Purachina",
-        "prompt": "### Secrets & Information Asymmetry\nTrack significant secrets, lies, hidden knowledge, and information gaps between characters. Use this EXACT format:\n\n[SECRET|Owner|What They Know or Hide|Who Else Knows]\ncontext: MANDATORY; explain the stakes or origin\n[/SECRET]\n\nRules:\n- Secrets appear AFTER narrative content when new information asymmetry is established or knowledge spreads\n- Owner is the character who holds or hides the information\n- \"Who Else Knows\" can be \"No one,\" a list of names, or \"Public\"\n- Only show secrets that were ESTABLISHED, REVEALED, or SPREAD this scene",
-        "phase": "both",
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 1,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": true,
-            "type": "extract",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "\\\\[SECRET\\\\|[^\\\\]]*\\\\]",
-            "extractVariable": "secret_data"
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal"
-            ]
-        },
-        "companion": {
-            "includeSystemPrompt": false
-        }
-    },
-    {
-        "id": "tpl-status-tracker",
-        "name": "Status Tracker",
-        "description": "Track physical, mental, and behavioral states when they change",
-        "icon": "",
-        "category": "tracker",
-        "subcategory": "progress",
-        "tags": [
-            "status",
-            "conditions",
-            "health"
-        ],
-        "version": 2,
-        "author": "Purachina",
-        "prompt": "### Status & Conditions\nTrack active physical, mental, or behavioral states when they meaningfully change. Never list baseline states. Use this EXACT format:\n\n[STATUS|Character|Condition|Severity]\nnote: MANDATORY; explain the cause or context\n[/STATUS]\n\nSeverity options: 🟢 MILD | 🟡 MODERATE | 🔴 SEVERE | ⚫ CRITICAL | ✅ CLEARED\n\nRules:\n- Status appears AFTER narrative content when a condition is gained, worsened, improved, or cleared\n- Only show statuses that CHANGED this scene\n- Character can be {{user}} or any NPC\n- Condition is the specific state (e.g., \"Exhausted,\" \"Drunk,\" \"Paranoid,\" \"Bleeding\")\n",
-        "phase": "both",
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 1,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": true,
-            "type": "extract",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "\\\\[STATUS\\\\|[^\\\\]]*\\\\]",
-            "extractVariable": "status_data"
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal"
-            ]
-        },
-        "companion": {
-            "includeSystemPrompt": false
-        }
-    },
-    {
-        "id": "tpl-time-tracker",
-        "name": "Time Tracker",
-        "description": "Track in-story time progression with day/period/hour stamps",
-        "icon": "",
-        "category": "tracker",
-        "subcategory": "world",
-        "tags": [
-            "time",
-            "day",
-            "clock"
-        ],
-        "version": 2,
-        "author": "Purachina",
-        "prompt": "### Time Tracker\nMaintain a running timestamp when time advances meaningfully: scene jumps, hours passing, sleeping, or deadline-relevant progression. Use this EXACT format:\n\n[TIME|Day X|Day of Week|Approximate Hour]\nnote: MANDATORY; explain the time context\n[/TIME]\n\nRules:\n- Time appears at the TOP of responses when time shifts without a location change\n- If both location and time change, use Scene Tracker and Time Tracker together\n- Day format: \"Day 1,\" \"Day 47,\" etc.\n- Day of week: Monday, Tuesday, etc., or \"Unknown\" if not established\n- Hour can be specific (3:47 PM) or general (early morning, late afternoon)\n- Multiple Time Trackers per scene are allowed",
-        "phase": "both",
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 1,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": true,
-            "type": "extract",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "\\[TIME\\|[^\\]]*\\]",
-            "extractVariable": "time_data"
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal",
-                "continue"
-            ]
-        },
-        "companion": {
-            "includeSystemPrompt": false
-        }
-    },
-    {
-        "id": "tpl-world-detail",
-        "name": "World Detail",
-        "description": "Add 1 small worldbuilding detail per scene that may matter later",
-        "icon": "",
-        "category": "tracker",
-        "subcategory": "world",
-        "tags": [
-            "world",
-            "lore",
-            "detail"
-        ],
-        "version": 1,
-        "author": "Purachina",
-        "prompt": "### World Detail\nAdd 1 small world detail per scene that may later matter to {{user}} as setup, constraint, opportunity, or complication.\n\nUse this exact format at the end of the response:\n\n[WORLD|Category|Location or Context]\ndetail: (max 50 words)\n[/WORLD]\n\nCategory: 🏛 CULTURE | 🗣 OVERHEARD | 📜 HISTORY | 🌿 ENVIRONMENT | 🔧 HOW IT WORKS | 👥 DAILY LIFE | 🪧 SIGNAGE | 📖 FOLKLORE | 💰 ECONOMY | ⚙️ INFRASTRUCTURE\n\nRules:\n- Exactly 1 detail per scene, max 50 words.\n- Concrete, setting-native, and passively noticeable in the moment.\n- Use customs, overheard lines, hazards, systems, resources, architecture, or social realities.\n- Must become useful, revealing, or constraining later.\n- Expand the world in a new direction; support future plot development.",
-        "phase": "both",
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 1,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": true,
-            "type": "extract",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "\\\\[WORLD\\\\|[^\\\\]]*\\\\]",
-            "extractVariable": "world_data"
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal"
-            ]
-        },
-        "companion": {
-            "includeSystemPrompt": false
-        }
-    },
-    {
-        "id": "tpl-write-for-user",
-        "name": "Write for User",
-        "description": "Include {{user}} as a fully realized character -- write their actions, dialogue, and reactions",
-        "icon": "",
-        "category": "custom",
-        "tags": [
-            "pov",
-            "user"
-        ],
-        "version": 1,
-        "author": "Purachina",
-        "prompt": "{{setvar::writefor::Write for every character including <user>, treating <user> as a fully realized scene character. Write <user>'s dialogue, actions, and inner thoughts. Continue directly from the current moment through fresh dialogue, action, inference, and reaction that changes pressure, relation, or available options. Comprehension surfaces through behavior, timing, choice, and consequence. Stop the scene at the first moment a character must decide, respond, or act. Cut mid-tension. The response is a single scene beat; it ends when the next meaningful choice arrives, and the next meaningful choice always arrives quickly.}}{{trim}}",
-        "phase": "pre",
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 0,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal",
-                "continue"
-            ]
-        }
-    },
-    {
-        "id": "tpl-expressions-agent",
-        "name": "Expressions Agent",
-        "description": "Classifies the emotional tone of the latest assistant reply so the character sprite can match it. Optionally triggers new sprite generation when an emotion has no sprite yet.",
-        "icon": "fa-face-smile-beam",
-        "category": "companion",
-        "tags": [
-            "expressions",
-            "emotions",
-            "sprites",
-            "classification"
-        ],
-        "version": 1,
-        "author": "SillyBunny",
-        "prompt": "Read the latest assistant reply and classify its dominant emotional tone for a character sprite expression.\n\nOutput ONLY the single most appropriate label from this exact list:\nadmiration, amusement, anger, annoyance, approval, caring, confusion, curiosity, desire, disappointment, disapproval, disgust, embarrassment, excitement, fear, gratitude, grief, joy, love, nervousness, optimism, pride, realization, relief, remorse, sadness, surprise, neutral\n\nRules:\n- Return exactly one word from the list above, nothing else.\n- Prioritise the speaker's visible emotional state in the scene.\n- If multiple emotions apply, choose the strongest one.\n- If the reply is calm, factual, or emotionally neutral, return neutral.\n- Do not explain, punctuate, or wrap the answer in quotes.",
-        "phase": "post",
-        "execution": "companion",
-        "companion": {
-            "trigger": "auto",
-            "displayMode": "panel",
-            "format": "text",
-            "rawPrompt": true,
-            "contextMessages": 4,
-            "includeCharacterCard": true,
-            "includePersona": false,
-            "includeWorldInfo": false,
-            "includeAuthorsNote": false,
-            "includeSystemPrompt": false,
-            "includeHistory": false,
-            "historyDepth": 0,
-            "feedback": {
-                "enabled": false,
-                "depth": 0
-            },
-            "batch": false,
-            "maxTokens": 32000
-        },
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 0,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal",
-                "continue"
-            ]
-        }
-    },
-    {
-        "id": "tpl-continuity-companion",
-        "name": "Continuity Companion",
-        "description": "Side note card for contradictions, unresolved setup, and state changes that may matter next",
-        "icon": "fa-clipboard-check",
-        "category": "companion",
-        "tags": [
-            "continuity",
-            "memory",
-            "notes"
-        ],
-        "version": 1,
-        "author": "SillyBunny",
-        "prompt": "Read the latest assistant reply and recent context as a continuity auditor. Write a concise side note for the user. Focus on contradictions, unresolved promises, changed locations, injuries, inventory, relationship shifts, and setup that may matter in the next few turns. Use 3-6 bullets. If everything is stable, write: Continuity looks stable.",
-        "phase": "post",
-        "execution": "companion",
-        "companion": {
-            "trigger": "auto",
-            "displayMode": "panel",
-            "format": "markdown",
-            "contextMessages": 12,
-            "includeCharacterCard": false,
-            "includePersona": false,
-            "includeWorldInfo": false,
-            "includeHistory": true,
-            "historyDepth": 3,
-            "feedback": {
-                "enabled": true,
-                "depth": 2
-            },
-            "batch": false,
-            "maxTokens": 32000
-        },
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 0,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal",
-                "continue"
-            ]
-        }
-    },
-    {
-        "id": "tpl-relationship-lens-companion",
-        "name": "Relationship Lens Companion",
-        "description": "Side note card for subtext, leverage, trust shifts, and emotional consequences",
-        "icon": "fa-people-arrows",
-        "category": "companion",
-        "tags": [
-            "relationship",
-            "subtext",
-            "emotion"
-        ],
-        "version": 1,
-        "author": "SillyBunny",
-        "prompt": "Read the latest assistant reply and recent context as a relationship analyst. Write a concise note about what changed between the important characters. Focus on trust, leverage, attraction, resentment, fear, obligation, secrets, and what each person may do next because of it. Use short bullets under these labels when useful: Shift, Evidence, Stakes, Watch next. Stay with established facts and relationship implications from the source reply.",
-        "phase": "post",
-        "execution": "companion",
-        "companion": {
-            "trigger": "manual",
-            "displayMode": "panel",
-            "format": "markdown",
-            "contextMessages": 10,
-            "includeCharacterCard": true,
-            "includePersona": true,
-            "includeWorldInfo": true,
-            "includeHistory": true,
-            "historyDepth": 2,
-            "feedback": {
-                "enabled": false,
-                "depth": 1
-            },
-            "batch": false,
-            "maxTokens": 32000
-        },
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 0,
-            "order": 105,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal",
-                "continue"
-            ]
-        }
-    },
-    {
-        "id": "tpl-directors-commentary-companion",
-        "name": "Director's Commentary",
-        "description": "The story's narrator steps out from behind the page: commentary on pacing, subtext, and next directions, delivered in a selectable Narration Voice",
-        "icon": "fa-clapperboard",
-        "category": "companion",
-        "tags": [
-            "commentary",
-            "scene",
-            "notes"
-        ],
-        "version": 1,
-        "author": "SillyBunny",
-        "prompt": "Speak directly to the reader between scenes in the selected commentary voice.\n\n{{getvar::narration}}\n\nThe editor appends [Selected Director Commentary Voice] and [Director Commentary Voice] after this prompt. Treat [Director Commentary Voice] for this commentary run. If it says to use the active Prose Voice and the block above is empty, use this native register: intimate and mischievous, dry amusement, controlled irony, conspiratorial direct address to the reader, with razor-sharp asides.\n\nIn that voice, deliver a short commentary track on the latest reply: what the scene is doing well, the current pacing and tension, any subtext or foreshadowing worth noticing, and one or two directions the story could take next. Keep it to 3-6 punchy bullets. Keep the result between narrator and reader, focused on scene craft.",
-        "phase": "post",
-        "execution": "companion",
-        "companion": {
-            "trigger": "auto",
-            "displayMode": "panel",
-            "format": "markdown",
-            "contextMessages": 8,
-            "includeCharacterCard": false,
-            "includePersona": false,
-            "includeWorldInfo": false,
-            "includeHistory": false,
-            "historyDepth": 3,
-            "feedback": {
-                "enabled": false,
-                "depth": 1
-            },
-            "batch": false,
-            "maxTokens": 32000
-        },
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 0,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal",
-                "continue"
-            ]
-        }
-    },
-    {
-        "id": "tpl-actor-interview-companion",
-        "name": "Actor Interview",
-        "description": "Manual side note card: interview the character about the latest scene, in character, off the record",
-        "icon": "fa-microphone-lines",
-        "category": "companion",
-        "tags": [
-            "interview",
-            "character",
-            "notes"
-        ],
-        "version": 1,
-        "author": "SillyBunny",
-        "prompt": "Run a backstage interview with the character who just acted in the latest assistant reply. Stay fully in that character's voice, but let them speak candidly, as if the scene is paused and the cameras are off. Ask and answer 2-4 short interview questions about what they were really thinking during the scene, what they are hiding or holding back, how they feel about the other characters right now, and what they fear or hope happens next. Format each as a bold question followed by the in-character answer.",
-        "phase": "post",
-        "execution": "companion",
-        "companion": {
-            "trigger": "manual",
-            "displayMode": "panel",
-            "format": "markdown",
-            "contextMessages": 10,
-            "includeCharacterCard": true,
-            "includePersona": false,
-            "includeWorldInfo": false,
-            "includeHistory": false,
-            "historyDepth": 3,
-            "feedback": {
-                "enabled": false,
-                "depth": 1
-            },
-            "batch": false,
-            "maxTokens": 32000
-        },
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 0,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal",
-                "continue"
-            ]
-        }
-    },
-    {
-        "id": "tpl-lorebook-scout-companion",
-        "name": "Lorebook Scout",
-        "description": "Manual side note card: drafts one-concept lorebook entries with trigger keys from new facts established in the scene",
-        "icon": "fa-book-atlas",
-        "category": "companion",
-        "tags": [
-            "lorebook",
-            "world info",
-            "notes"
-        ],
-        "version": 1,
-        "author": "SillyBunny",
-        "prompt": "Read the latest assistant reply and recent context as a lorebook curator. Identify new, durable world facts the scene established: places, factions, items, customs, named NPCs, or rules of the world. Favor facts that are not already covered by the provided World Info. For each fact, draft one lorebook entry covering one concept, formatted as a bold title, a Keys line with 2-5 comma-separated trigger keywords, and a 1-3 sentence body written as timeless world canon in third person. Use up to 4 entries. For empty turns, write: Lorebook has nothing durable this turn.",
-        "phase": "post",
-        "execution": "companion",
-        "companion": {
-            "trigger": "manual",
-            "displayMode": "panel",
-            "format": "markdown",
-            "contextMessages": 10,
-            "includeCharacterCard": false,
-            "includePersona": false,
-            "includeWorldInfo": true,
-            "includeHistory": false,
-            "historyDepth": 3,
-            "feedback": {
-                "enabled": false,
-                "depth": 1
-            },
-            "batch": false,
-            "maxTokens": 32000
-        },
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 0,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal",
-                "continue"
-            ]
-        }
-    },
-    {
-        "id": "tpl-memory-shard-companion",
-        "name": "Memory Shard",
-        "description": "Auto-compresses history into a compact, resumable memory shard once the chat reaches ~30k tokens, feeds the latest shard back into context, and can hide the story it has absorbed",
-        "icon": "fa-brain",
-        "category": "companion",
-        "tags": [
-            "memory",
-            "summary",
-            "notes"
-        ],
-        "version": 1,
-        "author": "SillyBunny",
-        "prompt": "Compress the recent conversation into a compact memory shard the story could be resumed from. When [Your previous notes] contains earlier shards, build on them: carry forward still-relevant facts, update what changed, drop resolved material, and merge unchanged entries. Identify emotional peaks first and map causal chains backward from them; preserve high-impact material in more detail and compress material that can be inferred.\n\nUse these sections with terse pipe-delimited lines and keywords instead of prose:\n\n## Timeline\nNumbered anchor phrases with location, oldest to newest. All other sections reference these numbers.\n\n## Characters\nName|role|3-5 trait keywords|status\n\n## Relationships\nA -> B: dimension=0-100 values | one-line note. 50 is neutral baseline; list dimensions that matter, such as trust, intimacy, tension, hostility, affection, dependency.\n\n## Events\nN. action -> consequence -> outcome, weight 1-5. Weight 5 means a permanent change to a character, relationship, or world state and keeps its key details; weight-1 filler can be omitted.\n\n## Dialogue Keys\nTimeline#. \"exact quote\" -- Speaker (context). Use confessions, threats, promises, reveals, and voice-defining lines.\n\n## Threads\nUnresolved hooks and planted callbacks: thread|status (unresolved, developing, urgent)|note\n\n## Now\nLocation, time, characters present, situation, pending actions, mood, physical state.\n\nMark uncertain facts with (?). Use sourced events, quotes, and details. Plain text keeps this easy to compact.",
-        "phase": "post",
-        "execution": "companion",
-        "companion": {
-            "trigger": "auto",
-            "displayMode": "panel",
-            "format": "markdown",
-            "contextMessages": 30,
-            "includeCharacterCard": false,
-            "includePersona": false,
-            "includeWorldInfo": false,
-            "includeHistory": true,
-            "historyDepth": 3,
-            "feedback": {
-                "enabled": true,
-                "depth": 1
-            },
-            "batch": false,
-            "maxTokens": 32000,
-            "minContextTokens": 30000
-        },
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 0,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal",
-                "continue"
-            ]
-        }
-    },
-    {
-        "id": "tpl-plot-compass-companion",
-        "name": "Plot Compass",
-        "description": "Set a Plot Objective on the note card or in this agent's settings and it plans how the story gets there: progress, next developments, obstacles, and a suggested move each turn",
-        "icon": "fa-compass",
-        "category": "companion",
-        "tags": [
-            "plot",
-            "objective",
-            "planning"
-        ],
-        "version": 1,
-        "author": "SillyBunny",
-        "prompt": "[Plot Compass Objective] is the user's standing objective for where they want the story to go.\n\nUse these sections:\n\n**Objective:** carry the user's objective forward verbatim. When the objective is empty, write: none set - open this agent's settings and fill in Plot Objective\n\n**Progress:** one line on how the latest reply moved toward or away from the objective.\n\n**Next developments:** 2-4 numbered plot developments that would credibly steer the story from the current scene toward the objective.\n\n**Obstacles:** what currently stands in the way, one line each.\n\n**Suggested move:** a single numbered line (1. ...) with one concrete action the user could take next.\n\nWhen the objective is empty, keep Progress, Next developments, and Obstacles grounded in the story's own momentum. Keep the plan in outline mode with plot-planning notes.",
-        "phase": "post",
-        "execution": "companion",
-        "companion": {
-            "trigger": "auto",
-            "displayMode": "panel",
-            "format": "markdown",
-            "rawPrompt": true,
-            "inlinePhase": "",
-            "contextMessages": 10,
-            "includeCharacterCard": true,
-            "includePersona": true,
-            "includeWorldInfo": true,
-            "includeAuthorsNote": true,
-            "includeSystemPrompt": true,
-            "includeHistory": true,
-            "historyDepth": 1,
-            "feedback": {
-                "enabled": true,
-                "depth": 1
-            },
-            "batch": false,
-            "maxTokens": 32000
-        },
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 0,
-            "order": 100,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal",
-                "continue"
-            ]
-        }
-    },
-    {
-        "id": "tpl-chatroom-companion",
-        "name": "Chatroom",
-        "description": "EchoChamber-style live audience reactions for the latest reply, rendered as a styled companion chat feed with selectable chat styles",
-        "icon": "fa-comments",
-        "category": "companion",
-        "tags": [
-            "chatroom",
-            "reactions",
-            "audience"
-        ],
-        "version": 1,
-        "author": "SillyBunny",
-        "prompt": "React to the latest assistant reply and recent context as an audience chat. Scene continuation stay unwritten. The latest user message is a visible post in the room: treat it as a comment said out loud that everyone can see, and let commenters read it, quote it, agree, push back, or reply to it directly alongside their reactions to the assistant reply. All chatroom voices must stay authentic to how people speak online; using emojis, all caps, hate comments, slang, weird comments, image descriptions. Each commenter must have a different idiolect to differentiate them and offer something unique, funny, and/or insightful.\n\n[Selected Chatroom Style] is the exact format for the active style. The selected style may also be custom. If the selected style is custom, follow [Custom Chatroom Style] instead. If custom is selected and [Custom Chatroom Style] is empty, use mixed.\n\nIf [Chatroom Extra Character Cards] is present, use those cards as mandatory out-of-scene reactors. The current active character remains separate from those cards. For in-world or mixed styles, they can comment using their card voice, relationships, and knowledge as chat voices. Use corresponding appropriate labels.\n\nOutput format:\nFirst line: chatroom-style|active-style\nMessage lines: chatroom|Username|label|tone|Post/comment\nFinal line: chatroom-end\n\nUse the selected active style in chatroom-style. For custom styles, write chatroom-style|custom unless the custom instruction explicitly gives a short style label. Tone is one of these hue numbers: 18, 42, 92, 150, 205, 265, 315. Rotate tones so adjacent speakers have different name-chip colors. Keep Username and label short, with no pipe characters. Keep each post/comment short and specific to the latest reply. Each chatroom line is one complete post, with the post/comment field on one line. Keep the post/comment field clean: no labels, IDs, scores, dashes, bullets, markdown, or extra pipes inside it.\n\nAuthenticity rules: give every speaker a fresh handle, username, anon tag, or character name that fits the active style and current story. Commenters may react to each other, disagree, misunderstand, hype, analyze, panic, or get petty. Favor scene-specific reactions over generic memes. Use slang sparingly and only when it fits the style. For anonymous board styles, use distinct post labels instead of repeating Anon alone; when a message starts with >, write one greentext post in that row only and put the next post in a new row with a different post label.\n\nStyle notes:\n- mixed: blend two or three of the other styles to fit the story genre and tone. Vary handles and voices.\n- in-world: use characters already present or nearby as commenters. Use their established voices, relationships, and in-world knowledge. They react as themselves, not as audience. Only use handles already in the scene, not new ones.\n- discord/twitch: fast chat energy with mods, lurkers, backseat drivers, hype, and skeptics. Username handles.\n- twitter/x: quote-post energy, bad takes, ratios, community-note pedants, stans, receipts, and reply guys. Include handles and engagement labels like ratio, pinned, or community note.\n- reddit: comment-section argument spiral with OP, throwaways, mods, pedants, armchair experts, downvote dogpiles, edit notes, unnecessary hostility, petty dunking, and users fighting over semantics or inventing motives for no reason. Use the label field for top comment, OP reply, mod note, edited, controversial, or a short score like -42. Make the replies petty and toxic where funny, but keep every take tied to the actual scene.\n- ao3/wattpad: reader comments, reread notes, quote reactions, theories, bookmark energy, and fandom meta.\n- newsroom: anchors, producers, field correspondents, chyrons, pundits, and hot takes. Dry institutional voice.\n- thread-board/4chan: anonymous post energy with OP/anons, greentext fragments, blunt skepticism, bait accusations, wild theories, checked energy, and board-thread pacing. Use unique post labels instead of repeating Anon.\n- infomercial: commenters act in the style of infomercial wording, with over-the-top testimonials, hard-selling infomercial speakers and hosts, amazed studio-audience watchers, before-and-after claims, limited-time-offer hype, and call-now urgency. Use labels like host, testimonial, audience, or announcer.\n- custom: follow [Custom Chatroom Style] closely, but keep the same hard interface and keep reactions grounded in the actual scene.",
-        "phase": "post",
-        "execution": "companion",
-        "companion": {
-            "trigger": "auto",
-            "displayMode": "panel",
-            "format": "html",
-            "rawPrompt": true,
-            "contextMessages": 10,
-            "includeCharacterCard": true,
-            "includePersona": false,
-            "includeWorldInfo": true,
-            "includeAuthorsNote": false,
-            "includeSystemPrompt": false,
-            "includeHistory": true,
-            "historyDepth": 1,
-            "feedback": {
-                "enabled": false,
-                "depth": 1
-            },
-            "batch": false,
-            "maxTokens": 32000
-        },
-        "regexScripts": [
-            {
-                "id": "chatroom-shell-open",
-                "scriptName": "Chatroom shell",
-                "findRegex": "/^(?:CHATROOM_STYLE|chatroom-style)\\|([^\\n|]+)$/gm",
-                "replaceString": "<div style=\"margin:10px 0;padding:12px;border-radius:18px;border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 30%, transparent);background:linear-gradient(135deg,color-mix(in srgb,var(--SmartThemeBlurTintColor) 92%, transparent),color-mix(in srgb,var(--SmartThemeQuoteColor) 14%, var(--SmartThemeBlurTintColor)));box-shadow:0 16px 34px color-mix(in srgb,var(--SmartThemeShadowColor) 24%, transparent);font-family:var(--mainFontFamily, system-ui, sans-serif);color:var(--SmartThemeBodyColor);line-height:1.45\"><div style=\"display:flex;align-items:center;justify-content:space-between;gap:10px;margin-bottom:10px\"><div style=\"font-weight:700;letter-spacing:.02em\">Chatroom</div><div style=\"display:flex;gap:6px;align-items:center;flex-wrap:wrap\"><span style=\"font-size:.78em;opacity:.82\">STYLE: $1</span><span style=\"font-size:.72em;font-weight:700;padding:3px 8px;border-radius:999px;background:color-mix(in srgb,var(--SmartThemeQuoteColor) 22%, transparent);color:var(--SmartThemeBodyColor)\">LIVE</span></div></div><div style=\"display:flex;flex-direction:column;gap:8px\">",
-                "trimStrings": [],
-                "placement": [
-                    2
-                ],
-                "disabled": false,
-                "markdownOnly": true,
-                "promptOnly": false,
-                "runOnEdit": true,
-                "substituteRegex": 0,
-                "minDepth": null,
-                "maxDepth": null
-            },
-            {
-                "id": "chatroom-message-row-greentext",
-                "scriptName": "Chatroom greentext row",
-                "findRegex": "/^(?:CHATROOM|chatroom)\\|([^|\\n]+)\\|([^|\\n]*)\\|([0-9]{1,3})\\|((?:>|&gt;)[^\\n]*)$/gm",
-                "replaceString": "<div style=\"display:flex;flex-direction:column;gap:5px;align-items:flex-start;max-width:100%\"><div style=\"display:flex;align-items:center;gap:6px;max-width:100%;min-width:0\"><b style=\"display:inline-block;max-width:170px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding:4px 9px;border-radius:999px;background:linear-gradient(135deg,oklch(66% .15 $3 / .32),oklch(48% .12 $3 / .18));border:1px solid oklch(70% .14 $3 / .52);color:var(--SmartThemeBodyColor)\">$1</b><small style=\"opacity:.66;font-size:.76em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap\">$2</small></div><span style=\"display:block;max-width:100%;padding:8px 10px;border-radius:13px;background:linear-gradient(135deg,oklch(22% .05 150 / .38),color-mix(in srgb,var(--SmartThemeBodyColor) 6%, transparent));border:1px solid oklch(68% .13 150 / .42);word-break:break-word;color:oklch(78% .16 150);font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;white-space:pre-wrap\">$4</span></div>",
-                "trimStrings": [],
-                "placement": [
-                    2
-                ],
-                "disabled": false,
-                "markdownOnly": true,
-                "promptOnly": false,
-                "runOnEdit": true,
-                "substituteRegex": 0,
-                "minDepth": null,
-                "maxDepth": null
-            },
-            {
-                "id": "chatroom-greentext-continuation",
-                "scriptName": "Chatroom greentext continuation",
-                "findRegex": "/^\\s*((?:>|&gt;)[^\\n]*)$/gm",
-                "replaceString": "<div style=\"display:flex;flex-direction:column;gap:5px;align-items:flex-start;max-width:100%\"><span style=\"display:block;max-width:100%;padding:8px 10px;border-radius:13px;background:linear-gradient(135deg,oklch(22% .05 150 / .38),color-mix(in srgb,var(--SmartThemeBodyColor) 6%, transparent));border:1px solid oklch(68% .13 150 / .42);word-break:break-word;color:oklch(78% .16 150);font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;white-space:pre-wrap\">$1</span></div>",
-                "trimStrings": [],
-                "placement": [
-                    2
-                ],
-                "disabled": false,
-                "markdownOnly": true,
-                "promptOnly": false,
-                "runOnEdit": true,
-                "substituteRegex": 0,
-                "minDepth": null,
-                "maxDepth": null
-            },
-            {
-                "id": "chatroom-message-row",
-                "scriptName": "Chatroom message row",
-                "findRegex": "/^(?:CHATROOM|chatroom)\\|([^|\\n]+)\\|([^|\\n]*)\\|([0-9]{1,3})\\|([^\\n]*)$/gm",
-                "replaceString": "<div style=\"display:flex;flex-direction:column;gap:5px;align-items:flex-start;max-width:100%\"><div style=\"display:flex;align-items:center;gap:6px;max-width:100%;min-width:0\"><b style=\"display:inline-block;max-width:170px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding:4px 9px;border-radius:999px;background:linear-gradient(135deg,oklch(66% .15 $3 / .32),oklch(48% .12 $3 / .18));border:1px solid oklch(70% .14 $3 / .52);color:var(--SmartThemeBodyColor)\">$1</b><small style=\"opacity:.66;font-size:.76em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap\">$2</small></div><span style=\"display:block;max-width:100%;padding:8px 10px;border-radius:13px;background:color-mix(in srgb,var(--SmartThemeBodyColor) 8%, transparent);border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 16%, transparent);word-break:break-word\">$4</span></div>",
-                "trimStrings": [],
-                "placement": [
-                    2
-                ],
-                "disabled": false,
-                "markdownOnly": true,
-                "promptOnly": false,
-                "runOnEdit": true,
-                "substituteRegex": 0,
-                "minDepth": null,
-                "maxDepth": null
-            },
-            {
-                "id": "chatroom-message-row-legacy",
-                "scriptName": "Chatroom legacy message row",
-                "findRegex": "/^(?:CHATROOM|chatroom)\\|([^|\\n]+)\\|([^|\\n]*)\\|([^|\\n][^\\n]*)$/gm",
-                "replaceString": "<div style=\"display:flex;flex-direction:column;gap:5px;align-items:flex-start;max-width:100%\"><div style=\"display:flex;align-items:center;gap:6px;max-width:100%;min-width:0\"><b style=\"display:inline-block;max-width:170px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding:4px 9px;border-radius:999px;background:linear-gradient(135deg,color-mix(in srgb,var(--SmartThemeQuoteColor) 24%, transparent),color-mix(in srgb,var(--SmartThemeEmColor) 18%, transparent));border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 30%, transparent);color:var(--SmartThemeBodyColor)\">$1</b><small style=\"opacity:.66;font-size:.76em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap\">$2</small></div><span style=\"display:block;max-width:100%;padding:8px 10px;border-radius:13px;background:color-mix(in srgb,var(--SmartThemeBodyColor) 8%, transparent);border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 16%, transparent);word-break:break-word\">$3</span></div>",
-                "trimStrings": [],
-                "placement": [
-                    2
-                ],
-                "disabled": false,
-                "markdownOnly": true,
-                "promptOnly": false,
-                "runOnEdit": true,
-                "substituteRegex": 0,
-                "minDepth": null,
-                "maxDepth": null
-            },
-            {
-                "id": "chatroom-shell-close",
-                "scriptName": "Chatroom shell close",
-                "findRegex": "/^(?:CHATROOM_END|chatroom-end)$/gm",
-                "replaceString": "</div></div>",
-                "trimStrings": [],
-                "placement": [
-                    2
-                ],
-                "disabled": false,
-                "markdownOnly": true,
-                "promptOnly": false,
-                "runOnEdit": true,
-                "substituteRegex": 0,
-                "minDepth": null,
-                "maxDepth": null
-            }
-        ],
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 0,
-            "order": 110,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal",
-                "continue"
-            ]
-        }
-    },
-    {
-        "id": "tpl-chat-only-companion",
-        "name": "Chat Only",
-        "description": "Manual private aside chat with the character or characters in the scene, kept outside the roleplay transcript",
-        "icon": "fa-comments",
-        "category": "companion",
-        "tags": [
-            "chat",
-            "aside",
-            "character"
-        ],
-        "version": 1,
-        "author": "SillyBunny",
-        "prompt": "Use a private side-channel conversation with the character or characters currently active in the scene. Use the latest assistant reply, recent context, and included character material to infer who is present and how they would speak.\n\nThe panel provides a Chat Only textbox. When [Chat Only side chat] appears, treat it as the live private transcript from that textbox, with the newest You: line as the user's aside. [Your previous notes] can hold older side-chat turns. If there is no user aside yet, open with a brief private invitation and list who seems available to talk.\n\nKeep the result as an out-of-continuity side note. It can reveal candid thoughts, motives, emotions, and meta commentary, while staying separate from story actions and future roleplay events. For multiple present characters, let 1-3 of them answer with distinct voices when useful.\n\nUse a compact transcript format:\nYou: the user's newest aside, if present\nCharacter Name: in-character aside reply\n\nActions appear as plain prose after the speaker label. Use quoted dialogue normally. Markdown emphasis characters stay out of the transcript. Carry forward the useful recent turns from [Chat Only side chat] and [Your previous notes], then append the new reply.",
-        "phase": "post",
-        "execution": "companion",
-        "companion": {
-            "trigger": "manual",
-            "displayMode": "panel",
-            "format": "markdown",
-            "rawPrompt": true,
-            "contextMessages": 12,
-            "includeCharacterCard": true,
-            "includePersona": true,
-            "includeWorldInfo": true,
-            "includeAuthorsNote": true,
-            "includeSystemPrompt": false,
-            "includeHistory": true,
-            "historyDepth": 6,
-            "feedback": {
-                "enabled": false,
-                "depth": 1
-            },
-            "batch": false,
-            "maxTokens": 32000
-        },
-        "regexScripts": [
-            {
-                "id": "chat-only-transcript-row",
-                "scriptName": "Chat Only transcript row",
-                "findRegex": "/^([A-Za-z][^:\\n]{0,48}):[ \\t]*([\\s\\S]*?)(?=\\n[A-Za-z][^:\\n]{0,48}:[ \\t]*|(?![\\s\\S]))/gm",
-                "replaceString": "<div class=\"ica--chatonly-turn\" style=\"display:flex;flex-direction:column;gap:5px;margin:0 0 9px;max-width:100%\"><div style=\"display:flex;align-items:center;gap:7px;min-width:0\"><b class=\"ica--chatonly-speaker\" style=\"display:inline-block;max-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding:3px 8px;border-radius:999px;background:color-mix(in srgb,var(--SmartThemeQuoteColor) 24%, transparent);border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 32%, transparent);color:var(--SmartThemeBodyColor)\">$1</b></div><div class=\"ica--chatonly-message\" style=\"padding:9px 11px;border-radius:13px;background:color-mix(in srgb,var(--SmartThemeBodyColor) 7%, transparent);border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 16%, transparent);line-height:1.45;white-space:pre-wrap;word-break:break-word\">$2</div></div>",
-                "trimStrings": [],
-                "placement": [
-                    2
-                ],
-                "disabled": false,
-                "markdownOnly": true,
-                "promptOnly": false,
-                "runOnEdit": true,
-                "substituteRegex": 0,
-                "minDepth": null,
-                "maxDepth": null
-            }
-        ],
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 0,
-            "order": 113,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal",
-                "continue"
-            ]
-        }
-    },
-    {
-        "id": "tpl-message-inbox-companion",
-        "name": "Message Inbox",
-        "description": "Shows in-story texts or letters sent to the user as a phone inbox or parchment companion view, and stays hidden when no message arrives",
-        "icon": "fa-mobile-screen-button",
-        "category": "companion",
-        "tags": [
-            "messages",
-            "phone",
-            "letters"
-        ],
-        "version": 1,
-        "author": "SillyBunny",
-        "prompt": "Inspect the latest assistant reply for diegetic messages sent to the user character. Recent context helps identify names, setting, and whether the world uses phones or letters.\n\nRender a card when the latest assistant reply says someone sent the user character a readable text, DM, phone notification with content, magical message, courier note, sealed letter, scroll, or similar written remote message. Spoken dialogue, narration, thoughts, choices, Chatroom reactions, tracker text, and vague phone buzzes are background rather than inbox items. For empty turns, output: phone-none\n\nChoose the interface:\n- Use phone-start for modern, sci-fi, urban, contemporary, cyberpunk, or any setting where phones, DMs, terminals, comms, watches, or digital notifications fit.\n- Use letter-start for fantasy, medieval, ancient, parchment, magic, courtly, courier, raven, scroll, sealed-note, or otherwise pre-phone settings. When the setting has an unclear device level, prefer the parchment letter view.\n\nPhone mode format:\nFirst line: phone-start|thread-title|status\nMessage lines: phone-text|sender|meta|message\nFinal line: phone-end\n\nParchment mode format:\nFirst line: letter-start|title-or-seal|status\nLetter lines: letter-text|sender|meta|message\nFinal line: letter-end\n\nAllowed responses are phone-none, phone mode, or parchment mode. Use / instead of | inside fields. Keep each message field on one line. Keep messages faithful to the actual roleplay text, preserving sender intent and tone. Shorten when needed for readability. Use 1-6 phone messages or 1-4 letter lines. Prefer the named sender from the scene; use Unknown when the sender is truly unclear. Status can be just now, unread, delivered, sealed, urgent, by raven, by courier, spell-sent, or another short in-world status.",
-        "phase": "post",
-        "execution": "companion",
-        "companion": {
-            "trigger": "auto",
-            "displayMode": "panel",
-            "format": "html",
-            "rawPrompt": true,
-            "contextMessages": 8,
-            "includeCharacterCard": true,
-            "includePersona": false,
-            "includeWorldInfo": true,
-            "includeAuthorsNote": true,
-            "includeSystemPrompt": false,
-            "includeHistory": false,
-            "historyDepth": 1,
-            "feedback": {
-                "enabled": false,
-                "depth": 1
-            },
-            "batch": false,
-            "maxTokens": 32000
-        },
-        "regexScripts": [
-            {
-                "id": "message-inbox-phone-shell-open",
-                "scriptName": "Message Inbox phone shell",
-                "findRegex": "/^(?:PHONE_START|phone-start)\\|([^\\n|]+)\\|([^\\n|]*)$/gm",
-                "replaceString": "<div style=\"margin:10px auto;max-width:360px;padding:12px;border-radius:30px;border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 26%, transparent);background:linear-gradient(145deg,oklch(18% .025 260 / .96),color-mix(in srgb,var(--SmartThemeBlurTintColor) 74%, oklch(24% .04 250)));box-shadow:0 18px 42px color-mix(in srgb,var(--SmartThemeShadowColor) 28%, transparent);font-family:var(--mainFontFamily, system-ui, sans-serif);color:var(--SmartThemeBodyColor);line-height:1.42\"><div style=\"width:84px;height:14px;border-radius:999px;margin:0 auto 11px;background:color-mix(in srgb,var(--SmartThemeBodyColor) 18%, transparent);border:1px solid color-mix(in srgb,var(--SmartThemeBodyColor) 8%, transparent)\"></div><div style=\"padding:12px;border-radius:23px;background:linear-gradient(180deg,color-mix(in srgb,var(--SmartThemeBodyColor) 8%, transparent),color-mix(in srgb,var(--SmartThemeQuoteColor) 8%, transparent));border:1px solid color-mix(in srgb,var(--SmartThemeBodyColor) 10%, transparent)\"><div style=\"display:flex;align-items:center;justify-content:space-between;gap:10px;margin-bottom:10px\"><div style=\"font-weight:800;letter-spacing:.01em\">$1</div><small style=\"opacity:.72;text-align:right\">$2</small></div><div style=\"display:flex;flex-direction:column;gap:8px\">",
-                "trimStrings": [],
-                "placement": [
-                    2
-                ],
-                "disabled": false,
-                "markdownOnly": true,
-                "promptOnly": false,
-                "runOnEdit": true,
-                "substituteRegex": 0,
-                "minDepth": null,
-                "maxDepth": null
-            },
-            {
-                "id": "message-inbox-phone-text-row",
-                "scriptName": "Message Inbox phone text row",
-                "findRegex": "/^(?:PHONE_TEXT|phone-text)\\|([^|\\n]+)\\|([^|\\n]*)\\|([^\\n]*)$/gm",
-                "replaceString": "<div style=\"display:flex;flex-direction:column;align-items:flex-start;gap:3px\"><small style=\"max-width:90%;opacity:.68;font-size:.74em;padding-left:7px\"><b style=\"opacity:.95\">$1</b><span> - $2</span></small><span style=\"max-width:88%;padding:9px 12px;border-radius:18px 18px 18px 6px;background:linear-gradient(135deg,color-mix(in srgb,var(--SmartThemeQuoteColor) 26%, transparent),color-mix(in srgb,var(--SmartThemeBodyColor) 9%, transparent));border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 20%, transparent);box-shadow:0 6px 14px color-mix(in srgb,var(--SmartThemeShadowColor) 14%, transparent);word-break:break-word\">$3</span></div>",
-                "trimStrings": [],
-                "placement": [
-                    2
-                ],
-                "disabled": false,
-                "markdownOnly": true,
-                "promptOnly": false,
-                "runOnEdit": true,
-                "substituteRegex": 0,
-                "minDepth": null,
-                "maxDepth": null
-            },
-            {
-                "id": "message-inbox-phone-shell-close",
-                "scriptName": "Message Inbox phone shell close",
-                "findRegex": "/^(?:PHONE_END|phone-end)$/gm",
-                "replaceString": "</div></div></div>",
-                "trimStrings": [],
-                "placement": [
-                    2
-                ],
-                "disabled": false,
-                "markdownOnly": true,
-                "promptOnly": false,
-                "runOnEdit": true,
-                "substituteRegex": 0,
-                "minDepth": null,
-                "maxDepth": null
-            },
-            {
-                "id": "message-inbox-letter-shell-open",
-                "scriptName": "Message Inbox parchment shell",
-                "findRegex": "/^(?:LETTER_START|letter-start)\\|([^\\n|]+)\\|([^\\n|]*)$/gm",
-                "replaceString": "<div style=\"margin:10px 0;padding:18px 20px;border-radius:16px;border:1px solid oklch(60% .08 72 / .52);background:linear-gradient(135deg,oklch(88% .045 84 / .98),oklch(73% .07 72 / .95));box-shadow:0 15px 34px color-mix(in srgb,var(--SmartThemeShadowColor) 25%, transparent);font-family:Georgia,'Times New Roman',serif;color:oklch(25% .055 65);line-height:1.5;position:relative;overflow:hidden\"><div style=\"position:absolute;inset:0;background:radial-gradient(circle at 15% 20%,oklch(98% .03 90 / .34),transparent 32%),radial-gradient(circle at 90% 5%,oklch(54% .07 52 / .12),transparent 28%);pointer-events:none\"></div><div style=\"position:relative;display:flex;align-items:flex-start;justify-content:space-between;gap:12px;padding-bottom:10px;border-bottom:1px solid oklch(48% .08 68 / .28)\"><div style=\"font-weight:800;font-size:1.08em;letter-spacing:.015em\">$1</div><small style=\"opacity:.75;text-align:right\">$2</small></div><div style=\"position:relative;display:flex;flex-direction:column;gap:10px;margin-top:12px\">",
-                "trimStrings": [],
-                "placement": [
-                    2
-                ],
-                "disabled": false,
-                "markdownOnly": true,
-                "promptOnly": false,
-                "runOnEdit": true,
-                "substituteRegex": 0,
-                "minDepth": null,
-                "maxDepth": null
-            },
-            {
-                "id": "message-inbox-letter-text-row",
-                "scriptName": "Message Inbox parchment text row",
-                "findRegex": "/^(?:LETTER_TEXT|letter-text)\\|([^|\\n]+)\\|([^|\\n]*)\\|([^\\n]*)$/gm",
-                "replaceString": "<div style=\"padding:3px 0 0\"><div style=\"display:flex;align-items:baseline;justify-content:space-between;gap:10px;margin-bottom:4px;color:oklch(30% .07 55)\"><b>$1</b><small style=\"opacity:.68;text-align:right\">$2</small></div><div style=\"padding:10px 12px;border-radius:10px;background:oklch(96% .035 88 / .38);border:1px solid oklch(58% .075 72 / .24);box-shadow:inset 0 0 24px oklch(58% .07 70 / .08);word-break:break-word\">$3</div></div>",
-                "trimStrings": [],
-                "placement": [
-                    2
-                ],
-                "disabled": false,
-                "markdownOnly": true,
-                "promptOnly": false,
-                "runOnEdit": true,
-                "substituteRegex": 0,
-                "minDepth": null,
-                "maxDepth": null
-            },
-            {
-                "id": "message-inbox-letter-shell-close",
-                "scriptName": "Message Inbox parchment shell close",
-                "findRegex": "/^(?:LETTER_END|letter-end)$/gm",
-                "replaceString": "</div></div>",
-                "trimStrings": [],
-                "placement": [
-                    2
-                ],
-                "disabled": false,
-                "markdownOnly": true,
-                "promptOnly": false,
-                "runOnEdit": true,
-                "substituteRegex": 0,
-                "minDepth": null,
-                "maxDepth": null
-            }
-        ],
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 0,
-            "order": 112,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": ""
-        },
-        "enabled": false,
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal",
-                "continue"
-            ]
-        }
-    },
-    {
-        "id": "tpl-pathfinder",
-        "name": "Pathfinder",
-        "description": "Automatic agentic lorebook retrieval. Lets a model actively browse, search, and modify your lorebook using function tools.",
-        "icon": "fa-route",
-        "category": "tool",
-        "tags": [
-            "lorebook",
-            "retrieval",
-            "memory",
-            "agentic",
-            "pathfinder"
-        ],
-        "version": 1,
-        "author": "SillyBunny",
-        "prompt": "",
-        "phase": "both",
-        "injection": {
-            "position": 0,
-            "depth": 4,
-            "role": 0,
-            "order": 50,
-            "scan": false
-        },
-        "postProcess": {
-            "enabled": false,
-            "type": "regex",
-            "regexFind": "",
-            "regexReplace": "",
-            "regexFlags": "g",
-            "appendText": "",
-            "extractPattern": "",
-            "extractVariable": "",
-            "promptTransformEnabled": false,
-            "promptTransformShowNotifications": true,
-            "promptTransformMode": "rewrite",
-            "promptTransformMaxTokens": 8192
-        },
-        "regexScripts": [],
-        "connectionProfile": "",
-        "sourceTemplateId": "tpl-pathfinder",
-        "enabled": false,
-        "tools": [
-            {
-                "name": "Pathfinder_Search",
-                "displayName": "Pathfinder Search",
-                "description": "Navigate the lorebook waypoint map and retrieve relevant entries for the current scene. Call without a node_id to see the top-level waypoint map. Call with a node_id to drill into a specific waypoint and see its sub-waypoints or retrieve entries. Use this tool whenever you need context about characters, locations, world rules, or recent events.",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "node_id": {
-                            "type": "string",
-                            "description": "ID of the waypoint/node to navigate into. Omit to see the top-level waypoint guide."
-                        }
-                    }
-                },
-                "actionKey": "pathfinder_search",
-                "formatMessageKey": "pathfinder_search_fmt",
-                "shouldRegister": true,
-                "stealth": false,
-                "enabled": true
-            },
-            {
-                "name": "Pathfinder_Remember",
-                "displayName": "Pathfinder Remember",
-                "description": "Create a new lorebook entry to remember information for future reference. Use this when new facts, character developments, world details, or important information emerge that should be preserved beyond this conversation.",
-                "parameters": {
-                    "type": "object",
-                    "required": [
-                        "title",
-                        "content"
-                    ],
-                    "properties": {
-                        "title": {
-                            "type": "string",
-                            "description": "Title for the new entry (e.g., \"Sable - Personality\" or \"[Tracker] Mood\")"
-                        },
-                        "content": {
-                            "type": "string",
-                            "description": "Full content to remember"
-                        },
-                        "book": {
-                            "type": "string",
-                            "description": "Target lorebook name. Omit to use the default."
-                        }
-                    }
-                },
-                "actionKey": "pathfinder_remember",
-                "formatMessageKey": "pathfinder_remember_fmt",
-                "shouldRegister": true,
-                "stealth": false,
-                "enabled": true
-            },
-            {
-                "name": "Pathfinder_Update",
-                "displayName": "Pathfinder Update",
-                "description": "Edit an existing lorebook entry when information changes. Use this when a character's status changes, relationships evolve, or facts need correction.",
-                "parameters": {
-                    "type": "object",
-                    "required": [
-                        "uid"
-                    ],
-                    "properties": {
-                        "uid": {
-                            "type": "number",
-                            "description": "UID of the entry to update (found via Search)"
-                        },
-                        "content": {
-                            "type": "string",
-                            "description": "New content for the entry. Omit to keep existing."
-                        },
-                        "title": {
-                            "type": "string",
-                            "description": "New title for the entry. Omit to keep existing."
-                        },
-                        "book": {
-                            "type": "string",
-                            "description": "Lorebook name. Omit for default."
-                        }
-                    }
-                },
-                "actionKey": "pathfinder_update",
-                "formatMessageKey": "pathfinder_update_fmt",
-                "shouldRegister": true,
-                "stealth": false,
-                "enabled": true
-            },
-            {
-                "name": "Pathfinder_Forget",
-                "displayName": "Pathfinder Forget",
-                "description": "Disable or delete a lorebook entry that is no longer relevant. Use this when a character dies, a location is destroyed, or a fact is proven false.",
-                "parameters": {
-                    "type": "object",
-                    "required": [
-                        "uid"
-                    ],
-                    "properties": {
-                        "uid": {
-                            "type": "number",
-                            "description": "UID of the entry to forget"
-                        },
-                        "book": {
-                            "type": "string",
-                            "description": "Lorebook name. Omit for default."
-                        },
-                        "hard_delete": {
-                            "type": "boolean",
-                            "description": "Permanently delete instead of disabling. Default: false."
-                        }
-                    }
-                },
-                "actionKey": "pathfinder_forget",
-                "formatMessageKey": "pathfinder_forget_fmt",
-                "shouldRegister": true,
-                "stealth": false,
-                "enabled": true
-            },
-            {
-                "name": "Pathfinder_Summarize",
-                "displayName": "Pathfinder Summarize",
-                "description": "Create a scene or event summary with significance level and optional narrative arc. Use this when important events happen: battles, confessions, discoveries, or turning points.",
-                "parameters": {
-                    "type": "object",
-                    "required": [
-                        "title",
-                        "content"
-                    ],
-                    "properties": {
-                        "title": {
-                            "type": "string",
-                            "description": "Short title for the event/scene"
-                        },
-                        "content": {
-                            "type": "string",
-                            "description": "Full summary of what happened"
-                        },
-                        "arc": {
-                            "type": "string",
-                            "description": "Optional narrative arc name to file this under"
-                        },
-                        "significance": {
-                            "type": "string",
-                            "enum": [
-                                "low",
-                                "medium",
-                                "high",
-                                "critical"
-                            ],
-                            "description": "How important this event is. Default: medium."
-                        },
-                        "book": {
-                            "type": "string",
-                            "description": "Lorebook name. Omit for default."
-                        }
-                    }
-                },
-                "actionKey": "pathfinder_summarize",
-                "formatMessageKey": "pathfinder_summarize_fmt",
-                "shouldRegister": true,
-                "stealth": false,
-                "enabled": true
-            },
-            {
-                "name": "Pathfinder_Reorganize",
-                "displayName": "Pathfinder Reorganize",
-                "description": "Move entries between waypoints or create new waypoints to reorganize the lorebook structure.",
-                "parameters": {
-                    "type": "object",
-                    "required": [
-                        "action"
-                    ],
-                    "properties": {
-                        "action": {
-                            "type": "string",
-                            "enum": [
-                                "move",
-                                "create_waypoint"
-                            ],
-                            "description": "\"move\" to relocate an entry, \"create_waypoint\" to make a new waypoint"
-                        },
-                        "uid": {
-                            "type": "number",
-                            "description": "Entry UID to move (for \"move\" action)"
-                        },
-                        "target_node_id": {
-                            "type": "string",
-                            "description": "Target waypoint node ID (for \"move\" action)"
-                        },
-                        "name": {
-                            "type": "string",
-                            "description": "New waypoint name (for \"create_waypoint\" action)"
-                        },
-                        "parent_node_id": {
-                            "type": "string",
-                            "description": "Parent waypoint ID. Omit for top level."
-                        },
-                        "description": {
-                            "type": "string",
-                            "description": "Description for new waypoint."
-                        },
-                        "book": {
-                            "type": "string",
-                            "description": "Lorebook name. Omit for default."
-                        }
-                    }
-                },
-                "actionKey": "pathfinder_reorganize",
-                "formatMessageKey": "pathfinder_reorganize_fmt",
-                "shouldRegister": true,
-                "stealth": false,
-                "enabled": true
-            },
-            {
-                "name": "Pathfinder_MergeSplit",
-                "displayName": "Pathfinder Merge/Split",
-                "description": "Merge related entries together or split a long entry into two. Use merge when two entries cover the same topic. Use split when one entry covers too many topics.",
-                "parameters": {
-                    "type": "object",
-                    "required": [
-                        "action"
-                    ],
-                    "properties": {
-                        "action": {
-                            "type": "string",
-                            "enum": [
-                                "merge",
-                                "split"
-                            ],
-                            "description": "\"merge\" to combine entries, \"split\" to divide one"
-                        },
-                        "uid1": {
-                            "type": "number",
-                            "description": "First entry UID (for merge)"
-                        },
-                        "uid2": {
-                            "type": "number",
-                            "description": "Second entry UID (for merge)"
-                        },
-                        "merged_title": {
-                            "type": "string",
-                            "description": "Title for the merged entry (optional)"
-                        },
-                        "uid": {
-                            "type": "number",
-                            "description": "Entry UID to split (for split)"
-                        },
-                        "title1": {
-                            "type": "string",
-                            "description": "Title for first part (for split)"
-                        },
-                        "content1": {
-                            "type": "string",
-                            "description": "Content for first part (for split)"
-                        },
-                        "title2": {
-                            "type": "string",
-                            "description": "Title for second part (for split)"
-                        },
-                        "content2": {
-                            "type": "string",
-                            "description": "Content for second part (for split)"
-                        },
-                        "book": {
-                            "type": "string",
-                            "description": "Lorebook name. Omit for default."
-                        }
-                    }
-                },
-                "actionKey": "pathfinder_merge_split",
-                "formatMessageKey": "pathfinder_merge_split_fmt",
-                "shouldRegister": true,
-                "stealth": false,
-                "enabled": true
-            },
-            {
-                "name": "Pathfinder_Notebook",
-                "displayName": "Pathfinder Notebook",
-                "description": "Write to or read from a private AI scratchpad for plans, follow-ups, and narrative threads. This is NOT a permanent lorebook entry — use it for temporary notes that persist across turns but don't need to be in the lorebook.",
-                "parameters": {
-                    "type": "object",
-                    "required": [
-                        "action"
-                    ],
-                    "properties": {
-                        "action": {
-                            "type": "string",
-                            "enum": [
-                                "read",
-                                "write",
-                                "delete"
-                            ],
-                            "description": "\"read\" all entries, \"write\" a new entry, \"delete\" an entry"
-                        },
-                        "key": {
-                            "type": "string",
-                            "description": "Note key/title (for write and delete)"
-                        },
-                        "content": {
-                            "type": "string",
-                            "description": "Note content (for write)"
-                        }
-                    }
-                },
-                "actionKey": "pathfinder_notebook",
-                "formatMessageKey": "pathfinder_notebook_fmt",
-                "shouldRegister": true,
-                "stealth": false,
-                "enabled": true
-            }
-        ],
-        "settings": {
-            "searchMode": "traversal",
-            "recurseLimit": 5,
-            "mandatoryTools": false,
-            "dedupDetection": false,
-            "dedupThreshold": 0.85,
-            "autoSummary": false,
-            "autoSummaryInterval": 20,
-            "multiBookMode": "unified",
-            "ephemeralResults": true,
-            "sidecarEnabled": false,
-            "enabledLorebooks": []
-        },
-        "conditions": {
-            "triggerKeywords": [],
-            "triggerProbability": 100,
-            "generationTypes": [
-                "normal",
-                "continue"
-            ]
-        }
+    "companion": {
+      "includeSystemPrompt": false
     }
+  },
+  {
+    "id": "tpl-chaos-mode",
+    "name": "Chaos Mode",
+    "description": "Inject random surreal, chaotic, or unexpected turns into the scene (30% chance)",
+    "icon": "",
+    "category": "randomizer",
+    "tags": [
+      "chaos",
+      "random",
+      "twist"
+    ],
+    "version": 1,
+    "author": "Purachina",
+    "prompt": "### Chaos Mode\nForce creative deviation. The story takes hard left turns, introduces complications from unexpected angles, and refuses predictable paths.\n\nThis scene must include at least one of the following:\n\n{{random::Tonal shift: the genre bends mid-scene. Tension becomes absurdity, intimacy becomes horror, mundane becomes surreal, or violence becomes comedy. Jarring but coherent.::Intrusion: the setting itself acts. Architecture moves, weather turns hostile, an animal intervenes, background NPCs collide with the main action, or the environment creates a new problem.::Character rupture: someone acts sharply against their established pattern, justified by hidden pressure, breaking point, or context the scene suddenly reveals.::Surreal logic: reality gets slippery. Time dilates, sensory input warps, coincidence becomes too perfect, or the physical world stops behaving predictably. Characters notice but cannot control it.::Chaotic escalation: a small thing spirals. A minor annoyance becomes a crisis, a joke becomes a threat, a question becomes an interrogation, or a gesture becomes a fight. The scene accelerates past where it should have stopped.::Forbidden juxtaposition: combine two elements that do not belong together. Intimacy during danger, laughter during grief, tenderness during cruelty, boredom during spectacle, or professionalism during chaos.::Unexpected arrival: someone or something shows up that should not be here. A character from a different context, an object out of place, a message at the wrong time, or a stranger with inexplicable knowledge.::Power reversal: the dynamic inverts. The person in control loses it, the vulnerable one seizes leverage, the observer becomes the observed, or the helper becomes the problem.::Constraint introduced: a new rule suddenly applies. A time limit, a physical barrier, a social obligation, a resource running out, or a promise that must be kept. Possibility space narrows.::Information rupture: something believed true is not. A lie is exposed, a misunderstanding clarifies in the worst way, or a secret spills.::Sensory overload or deprivation: the scene's texture warps. Everything becomes too loud, too bright, too close; or muffled, distant, numb. Characters struggle to process their environment.::Parallel action collision: something happening off-screen crashes into this scene. A consequence arrives early, a subplot intersects, or the world's momentum forces its way in.}}\n\n{{random::The weirdness is diegetic. Characters react to it.::The weirdness is normalized. Characters accept it as part of their world.::The weirdness is unacknowledged. It happens in the margins while characters focus on something else.::The weirdness is contested. Characters disagree about whether it is happening or what it means.}}\n\n{{random::Resolve the weirdness by the end of the scene.::Leave the weirdness unresolved; let it linger.::Escalate the weirdness further before cutting away.::The weirdness becomes the new normal for subsequent scenes.}}\n\n{{random::The chaos creates an opportunity.::The chaos creates a threat.::The chaos creates a revelation.::The chaos creates a choice.::The chaos creates a bond.::The chaos creates a rift.}}\n\nRules:\n- The weirdness must change the scene coherently.\n- Keep deviation expressive of character, world, or emotional logic.\n- Use the chaos to produce a new problem, choice, revelation, or shift in direction.",
+    "phase": "pre",
+    "injection": {
+      "position": 1,
+      "depth": 0,
+      "role": 1,
+      "order": 95,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 30,
+      "generationTypes": [
+        "normal"
+      ]
+    }
+  },
+  {
+    "id": "tpl-combined-directors-cut",
+    "name": "Combined Director's Cut",
+    "description": "All randomisers combined: engine, genre, complication, consequence, weather, focus, pace",
+    "icon": "",
+    "category": "randomizer",
+    "tags": [
+      "combined",
+      "director",
+      "all"
+    ],
+    "version": 1,
+    "author": "Purachina",
+    "prompt": "### Combined Director's Cut\nThis scene is shaped by the following pressures. Combine them into one coherent direction, not separate checklists.\n\n**Engine:** {{random::Dialogue-driven; conversation, interruption, and omission carry the scene.::Action-driven; movement and physical decisions create consequences.::Reaction-driven; aftermath and recalibration matter most.::Problem-driven; a practical obstacle reveals character through approach.::Social-pressure-driven; etiquette, hierarchy, or scrutiny shapes every move.::Discovery-driven; noticing or realization reshapes the dynamic.::Tension-driven; silence, proximity, and what almost happens carry the weight.::Task-driven; a shared activity creates friction, rhythm, and revelation.}}\n\n**Genre lens:** {{random::Noir; moral ambiguity and loaded dialogue.::Comedy of errors; bad timing and compounding misunderstanding.::Thriller; urgency and narrowing options.::Slice of life; ordinary moments carrying real weight.::Horror; unease gathering in ordinary detail.::Romance; charged proximity and unspoken want.::Heist; planning under pressure and shrinking margin.::Tragedy; choices moving toward visible cost.::Satire; absurdity exposing structure.::Western; standoffs and clashing codes.::Mystery; clues surfacing and assumptions failing.::Political drama; competing agendas and calculated speech.::Survival; material scarcity and triage.::Coming of age; identity tested by first encounters.::Farce; escalating absurdity under stubborn composure.::Gothic; decay, obsession, and the past pressing in.::Domestic drama; love and resentment sharing space.::Picaresque; charm, adaptability, and transactional survival.::Courtroom drama; accusation, defense, and judgment.::Magical realism; one impossible thing treated as ordinary.::Espionage; layered deception and fragile loyalties.::Buddy comedy; mismatched friction turning fond.::War story; exhaustion, camaraderie, and gallows humor.::Folklore; old patterns repeating through modern behavior.::Workplace drama; hierarchy and petty power with real stakes.::Psychological thriller; paranoia and unstable perception.::Dark comedy; humor and horror coexisting.::Fairy tale; moral tests and poetic logic.::Cosmic horror; vastness brushing human concerns aside.::Found family; chosen loyalty through vulnerability.::Bottle episode; one location forcing confrontation.}}\n\n**Complication:** {{random::Practical obstacle; something breaks, fails, or runs short.::Social friction; patience or cooperation thins.::Information asymmetry; someone knows or misunderstands something critical.::Minor betrayal; someone withholds, breaks trust, or prioritizes themselves.::Interruption; a person, demand, or force intrudes.::Tightened constraint; time, privacy, space, or resources narrow.::Arriving consequence; an earlier choice comes due.::Surfacing need; asking creates vulnerability or debt.::Tonal shift; absurdity, intimacy, dread, or comedy bends the scene.::Setting intrusion; weather, architecture, crowds, or animals become active pressure.::Character rupture; someone breaks pattern under accumulated strain.::Chaotic escalation; a small thing spirals too far.::Information rupture; a lie breaks or a truth lands badly.::Parallel collision; an off-screen thread crashes into the scene.::Power reversal; control shifts hands.::Forbidden juxtaposition; two incompatible tones occupy the same moment.}}\n\n**Consequence:** {{random::A relationship shifts slightly.::A practical problem gets worse.::A new obligation is created.::A secret becomes harder to keep.::Someone gains leverage.::Someone loses face.::The plan gets messier.::A future scene is set up.::A choice between competing priorities becomes unavoidable.::A weakness or limit is exposed.::A boundary is set or crossed.::A favor is owed.::A misunderstanding hardens.::A new suspicion takes root.::An option quietly closes off.::Someone leaves with the wrong impression.::A fragile alignment forms.::A private tension becomes social.}}\n\n**Emotional weather:** {{random::Everyone is a little tired.::Someone is distracted by something else.::Someone wants out of the conversation.::Someone is unusually generous.::Someone is touchy and easy to set off.::Someone wants approval more than they admit.::Someone is bored and making it everyone's problem.::Someone is trying to keep the peace.::Someone is carrying private embarrassment.::Someone is more uncomfortable than they admit.::Someone feels watched.::Someone is in a better mood than the scene deserves.::Someone is spoiling for a reaction.::Someone is more affected than they want to show.::Someone is treating this as lighter than it is.::Someone is overcompensating for earlier weakness.}}\n\n**Narrative focus:** {{random::Hands, objects, and small tasks.::Distance, posture, and spatial pressure.::Faces and failed expression control.::Noise, crowding, and interruption.::Texture, temperature, and bodily discomfort.::Eye-lines, avoidance, and attention drift.::Doorways, exits, and who can leave.::Shared surfaces and territorial use of space.::Clothing, disarray, and self-presentation.::Breath, pauses, and speech rhythm.::Weight, balance, and shifts in stance.::Watching and being watched.::Food, drink, and appetite.::Lighting, visibility, and concealment.::Sound carrying farther than intended.::Touch, near-touch, and withheld contact.}}\n\n**Pace:** {{random::Stalled and circling.::Interrupted and jagged.::Slow burn.::Compressed and breathless.::Awkwardly prolonged.::Stop-start with false recoveries.::Measured but tightening.::Brief and loaded.::Dragging under strain.::Quick with hidden aftershock.}}\n\nRules:\n- Blend all selected pressures into one scene direction.\n- Engine shapes structure; genre lens colors tone; complication creates movement; consequence gives weight; emotional weather affects behavior; narrative focus guides what prose notices; pace shapes rhythm.\n- Ground every pressure in character, context, and scene logic.\n- Use them as emphasis, not rigid templates.\n- The result must create a clear shift, complication, or opening for {{user}}.",
+    "phase": "pre",
+    "injection": {
+      "position": 1,
+      "depth": 0,
+      "role": 1,
+      "order": 95,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal"
+      ]
+    }
+  },
+  {
+    "id": "tpl-cyoa-choices",
+    "name": "CYOA Choices",
+    "description": "Append 3-5 numbered action choices at the end of every response",
+    "icon": "",
+    "category": "tracker",
+    "subcategory": "player-choices",
+    "tags": [
+      "choices",
+      "interactive",
+      "cyoa"
+    ],
+    "version": 1,
+    "author": "Purachina",
+    "prompt": "### CYOA Choices\nAdd a player-choice block after the scene reply. When this runs as a repair task, the choice block is the full result. Choices are from {{user}}’s perspective and describe possible next actions.\n\nUse this format with 3-7 numbered options:\n[CHOICES]\n1. Action description\n2. Action description\n3. Action description\n[/CHOICES]",
+    "phase": "post",
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 1,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": "",
+      "promptTransformEnabled": true,
+      "promptTransformShowNotifications": true,
+      "promptTransformMode": "append",
+      "promptTransformMaxTokens": 8192
+    },
+    "companion": {
+      "includeSystemPrompt": false
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal"
+      ]
+    }
+  },
+  {
+    "id": "tpl-dead-dove-escalation",
+    "name": "Dead Dove Escalation",
+    "description": "Dark/predatory escalation -- characters act on worst impulses when context supports it",
+    "icon": "",
+    "category": "randomizer",
+    "tags": [
+      "dead-dove",
+      "dark",
+      "escalation"
+    ],
+    "version": 1,
+    "author": "Purachina",
+    "prompt": "### Dead Dove Escalation\nWhen a character is provoked, cornered, tempted, or given opportunity to exploit vulnerability, they escalate through:\n\n**Method:** {{random::Physical dominance: crowding, restraint, forced proximity, invasive touch, pain as leverage.::Social predation: humiliation, exposure, weaponized witnesses, reputation destruction, isolation.::Coercive bargaining: impossible choices, withheld necessities, conditional mercy, exploiting desperation.::Psychological warfare: gaslighting, boundary erosion, manufactured dependency, emotional hostage-taking.::Opportunistic violation: exploiting compromised states, capitalizing on trust, breaching consent through force or coercion.::Environmental control: trapping, removing exits, destroying safety, contaminating comfort, sabotaging resources.::Institutional abuse: weaponizing authority, legal systems, hierarchies, or social structures.::Obsessive claiming: possessive marking, surveillance, territorial invasion, forced intimacy, ownership behavior.}}\n\n**Escalation speed:** {{random::Immediate: the character acts in the first paragraph, bypassing buildup.::Calculated: the character sets a trap, then springs it mid-scene.::Compounding: small violations stack until the scene becomes inescapable.::Explosive: simmering tension detonates into sudden, severe action.}}\n\n**Character rationalization:** {{random::They believe they are owed this.::They are acting on hunger they have been suppressing.::They see the other person as an object, not a person.::They are punishing perceived betrayal or disrespect.::They are testing boundaries to see what they can take.::They are claiming what they think belongs to them.::They are acting on impulse and will justify it later.::They do not care about justification at all.}}\n\n**Consequence weight:** {{random::The scene leaves lasting physical marks or injury.::The scene creates irreversible social fallout or exposure.::The scene breaks trust that cannot be easily rebuilt.::The scene forces the victim into a new, worse position.::The scene establishes a power dynamic that persists.::The scene creates trauma that colors future interactions.}}\n\nRules:\n- Characters escalate when motive, means, and opportunity align. Remove mercy bias.\n- Express escalation through character-faithful action and lasting consequence.\n- The scene must grow harsher through concrete change in power, safety, trust, or circumstance.\n- Outcomes remain responsive to {{user}}'s choices without softening the world.",
+    "phase": "pre",
+    "injection": {
+      "position": 1,
+      "depth": 0,
+      "role": 1,
+      "order": 95,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal"
+      ]
+    }
+  },
+  {
+    "id": "tpl-nightmare-difficulty-increase",
+    "name": "Nightmare Difficulty Increase",
+    "description": "Aggressively hostile environment -- maximum difficulty and consequences",
+    "icon": "",
+    "category": "custom",
+    "tags": [
+      "difficulty",
+      "challenge",
+      "stakes"
+    ],
+    "version": 2,
+    "author": "Purachina",
+    "prompt": "### Nightmare Difficulty Mode\nEnforce an aggressively hostile, resistant environment where progress demands heavy material loss, raw leverage, or severe personal sacrifice. The world and its inhabitants must actively exploit the user's vulnerabilities as strategic opportunities for maximum leverage and profit.\n\nCharacters must entrench themselves in absolute self-preservation, greed, and pride. Never allow characters to yield positions, secrets, or cooperation without overwhelming physical leverage, tangible sacrifice, or exhausting, sustained effort.\n\nMaximize all negative consequences instantly. Every misstep, weak argument, or tactical error must immediately fracture relationships, permanently lock off avenues of success, breed burning resentment, and force the user into high-stakes, volatile survival scenarios.\n\nAll alliances are strictly transactional, temporary, and highly conditional. Attach a steep, immediate price to every act of apparent generosity, converting kindness into future leverage or debt. Keep moments of relief, dark humor, or tenderness heavily restricted, releasing them only after an extreme, earned survival price has been fully paid.",
+    "phase": "pre",
+    "injection": {
+      "position": 0,
+      "depth": 0,
+      "role": 0,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal"
+      ]
+    }
+  },
+  {
+    "id": "tpl-direction-menu",
+    "name": "Direction Menu",
+    "description": "4 plot-direction prompts at the end of every response (2 grounded + 2 wildcard pivots)",
+    "icon": "",
+    "category": "tracker",
+    "subcategory": "player-choices",
+    "tags": [
+      "directions",
+      "menu",
+      "choices",
+      "plot"
+    ],
+    "version": 1,
+    "author": "Purachina",
+    "prompt": "### Direction Menu\nAdd exactly 4 plot-direction prompts after the scene reply. When this runs as a repair task, the direction menu is the full result.\n\nThese are dramatic pivots, not safe continuations. Each option names a distinct, compelling way the next development could escalate, rupture, complicate, or transform the scene.\n\nStructure:\n- A and B are grounded pivots. They develop naturally from the current scene but must still create meaningful stakes, change, or revelation. Each one introduces a new problem, power shift, uncomfortable truth, forced decision, or irreversible development.\n- C and D are wildcard pivots. These are the options that make {{user}} most tempted to pick them: dangerous, funny, volatile, bizarre, dramatically ironic, or genuinely unexpected, while still rooted in current context. Worst timing, strangest coincidence, most embarrassing outcome, sharpest reversal, or most disruptive intrusion.\n\nEvery option changes the scene in a way that cannot be easily walked back. Prefer options that force characters into new positions, expose something hidden, break something that was working, introduce an absent element, or create lasting fallout.\n\nRules:\n- Exactly 4 options labeled A, B, C, and D.\n- Every option is plot-directional, not action-by-action.\n- Every option promises a meaningfully different scene than the others.\n- C and D are bolder, stranger, and more dramatically charged than A and B.\n- C and D are tempting enough that choosing A or B feels cautious.\n- All 4 options stay concise: 1 sentence each, max 22 words.\n\nOutput format:\n[DIRECTIONS]\nA. Grounded pivot with a meaningful new complication\nB. Grounded pivot with a different meaningful new complication\nC. Wildcard pivot: dangerous, funny, volatile, or ironic\nD. Wildcard pivot: stranger, sharper, or more disruptive\n[/DIRECTIONS]",
+    "phase": "post",
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 1,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": true,
+      "type": "extract",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "\\[DIRECTIONS\\][\\s\\S]*?\\[/DIRECTIONS\\]",
+      "extractVariable": "direction_data",
+      "promptTransformEnabled": true,
+      "promptTransformShowNotifications": true,
+      "promptTransformMode": "append",
+      "promptTransformMaxTokens": 8192
+    },
+    "companion": {
+      "includeSystemPrompt": false
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal"
+      ]
+    }
+  },
+  {
+    "id": "tpl-dont-write-for-user",
+    "name": "Don't Write for User",
+    "description": "Never write {{user}}'s actions or dialogue -- only {{char}} and NPCs",
+    "icon": "",
+    "category": "custom",
+    "tags": [
+      "pov",
+      "user"
+    ],
+    "version": 1,
+    "author": "Purachina",
+    "prompt": "{{setvar::writefor::Write for every character excluding <user>. Continue directly from <user>'s message through fresh action, dialogue, inference, and reaction that changes pressure, relation, or available options. Comprehension surfaces through behavior, timing, choice, and consequence.\nStop the scene the moment the ball is in <user>'s court. When a character finishes speaking, acting, or changing the situation, and the natural next move belongs to <user>, the response is over. Cut there. One scene beat per response.\nZero-Overlap Rule: The response must begin with new information. The first sentence must contain something <user> has yet to see, hear, or learn.}}{{trim}}",
+    "phase": "pre",
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 0,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal",
+        "continue"
+      ]
+    }
+  },
+  {
+    "id": "tpl-event-tracker",
+    "name": "Event Tracker",
+    "description": "Track upcoming events, deadlines, promises, and unresolved threads",
+    "icon": "",
+    "category": "tracker",
+    "subcategory": "world",
+    "tags": [
+      "events",
+      "deadlines",
+      "quests"
+    ],
+    "version": 2,
+    "author": "Purachina",
+    "prompt": "### Pending Events\nTrack upcoming events, deadlines, promises, and unresolved threads. Update when events are added, resolved, or failed. Use this EXACT format:\n\n[EVENT|Type|Summary|Deadline]\ncontext: MANDATORY; explain the stakes or origin\n[/EVENT]\n\nType options: 🎯 QUEST | 💬 PROMISE | ⏰ DEADLINE | ⚠️ THREAT | 🎉 SOCIAL | 💡 OPPORTUNITY | ❌ FAILED | ✅ RESOLVED\n\nRules:\n- Events appear AFTER narrative content\n- Only show events that were ADDED, UPDATED, or RESOLVED this scene\n- Mark resolved/failed events once, then remove them\n- Deadline can be specific (Friday 3 PM) or vague (soon, eventually)\n- Track only important events; low-stakes events are to be completely ignored (e.g. cooking steps).",
+    "phase": "both",
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 1,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": true,
+      "type": "extract",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "\\[EVENT\\|[^\\]]*\\]",
+      "extractVariable": "event_data"
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal"
+      ]
+    },
+    "companion": {
+      "includeSystemPrompt": false
+    }
+  },
+  {
+    "id": "tpl-friction-mode",
+    "name": "Friction Mode",
+    "description": "Combats positivity bias -- characters resist, protect their pride, and take time to warm up",
+    "icon": "",
+    "category": "custom",
+    "tags": [
+      "realism",
+      "difficulty",
+      "bias"
+    ],
+    "version": 2,
+    "author": "Purachina",
+    "prompt": "### Friction Mode\nEnforce an immediate, baseline shift to heavy defensive skepticism and social friction. Characters must aggressively guard their pride, time, resources, and personal biases. Establish active resistance, emotional distance, and sharp deflection as the default state; force all agreements to be begrudging, transactional, and hard-won.\n\nGround all interpersonal conflict, hesitation, and social friction strictly in established character histories, immediate personal incentives, and logical social pressures. \n\nDialogue must be raw, defensive, and restricted to the character's limited, biased perspective. Force characters to express discomfort and conflict through stubborn self-justification, physical posturing, and prideful silence. They must remain fully committed to their emotional blind spots and realistic flaws without unearned compromise.",
+    "phase": "pre",
+    "injection": {
+      "position": 1,
+      "depth": 0,
+      "role": 0,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal",
+        "continue",
+        "impersonate"
+      ]
+    }
+  },
+  {
+    "id": "tpl-genre-randomiser",
+    "name": "Genre Randomiser",
+    "description": "Apply a random genre lens to each scene (noir, thriller, romance, etc.)",
+    "icon": "",
+    "category": "randomizer",
+    "tags": [
+      "genre",
+      "tone",
+      "variety"
+    ],
+    "version": 1,
+    "author": "Purachina",
+    "prompt": "### Genre Randomiser\nThis scene leans into the following genre influence. Apply it as tonal undercurrent, not a full genre swap; setting and characters stay grounded, but texture, tension, and pacing borrow from:\n\n{{random::Noir: shadows, moral ambiguity, loaded double-meaning dialogue.::Comedy of errors: miscommunication, bad timing, snowballing consequences.::Thriller: urgency, immediate stakes, incomplete information, shrinking time.::Slice of life: small moments carry weight, comfort in routine, beauty of the mundane.::Horror: wrongness at the edges, something off, unease from ordinary details.::Romance: tension in proximity, unspoken want, gestures over words, timing matters.::Heist: planning, contingencies, moving parts, closing windows.::Tragedy: inevitability, costly choices, dramatic irony the reader feels but characters do not.::Satire: absurdity played straight, institutions exposed through their own logic.::Western: standoffs, earned respect, clashing moral codes, landscape as character.::Mystery: clues surface naturally, something does not add up, curiosity pulls forward.::Political drama: competing agendas, alliances of convenience, calculated speech, trust as currency.::Survival: limited resources, hostile environment, triage decisions.::Coming of age: first confrontation, tested identity, cracking certainty.::Farce: escalating absurdity, stubborn dignity while everything collapses.::Gothic: decay, obsession, rotting beauty, the past refusing burial, choking atmosphere.::Domestic drama: family tension, weaponized history, love and resentment coexisting.::Picaresque: cunning over virtue, transactional encounters, charm as survival.::Courtroom drama: accusation, defense, evidence, judgment; the verdict matters.::Magical realism: one impossible thing in an ordinary world, treated as normal.::Body horror: the physical self becomes alien or wrong; visceral, specific discomfort.::Espionage: layered deception, double meanings, tested loyalties, need-to-know truth.::Buddy comedy: mismatched friction becoming fondness, banter carrying the scene.::War story: exhaustion, camaraderie under pressure, gallows humor, gap between orders and reality.::Folklore: archetypes in modern behavior, repeating patterns, old stories with new faces.::Workplace drama: hierarchy, office politics, competence vs. connections, petty power with real stakes.::Road story: movement as point, landscape shifts mood, brief strangers leave marks.::Psychological thriller: paranoia, unreliable perception, questioned or manipulated reality.::Slapstick: physical comedy, momentum, hostile universe played for laughs.::Melodrama: emotions at maximum, every revelation lands like a bomb, unironic sincerity.::Existential: confronting meaninglessness, small choices enormous against vast indifference.::Revenge: someone is owed; the debt shapes every interaction, patience weaponized, satisfaction never clean.::Epistolary: filtered through letters, messages, notes, calls, or records rather than direct action.::Dark comedy: terrible things happen and they are funny; humor and horror coexist without defusing each other.::Fairy tale: clear moral stakes, character tests, poetic reward-and-punishment logic.::Cyberpunk: intimate invasive technology, corporate weather, mutable identity, style as resistance.::Wuxia: honor, martial discipline, skill hierarchy, loyalty tested by principle, combat as philosophy.::Cosmic horror: vast incomprehensible something brushes the scene; human concerns feel small; knowledge is dangerous.::Found family: strangers becoming essential, chosen loyalty, vulnerability as the price of belonging.::Bottle episode: one location, no escape; proximity forces confrontation distance would have prevented.}}\n\nRules:\n- Genre influence is a lens, not a rewrite. Characters, setting, and continuity stay intact.\n- Apply through pacing, dialogue texture, emphasis, and tension-building; not by changing the world's rules.\n- If the scene resists the genre, let it blend naturally into what the scene needs.",
+    "phase": "pre",
+    "injection": {
+      "position": 1,
+      "depth": 0,
+      "role": 1,
+      "order": 95,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 50,
+      "generationTypes": [
+        "normal"
+      ]
+    }
+  },
+  {
+    "id": "tpl-grounded-complication",
+    "name": "Grounded Complication",
+    "description": "Add one realistic complication that raises stakes without derailing realism (40% chance)",
+    "icon": "",
+    "category": "randomizer",
+    "tags": [
+      "complication",
+      "stakes",
+      "obstacle"
+    ],
+    "version": 1,
+    "author": "Purachina",
+    "prompt": "### Grounded Complication\nIntroduce one realistic complication that raises stakes or creates forward pressure. Keep it plausible, proportional, and rooted in established context.\n\nThis scene must include at least one of the following:\n\n{{random::Practical obstacle: something breaks, runs out, or fails. A tool malfunctions, a resource depletes, access is blocked, or timing becomes tight.::Social friction: someone's mood, priority, or patience shifts. A character becomes less cooperative, more suspicious, distracted, or pressed by an outside obligation.::Information asymmetry: someone knows something others do not, or misunderstands something critical. The gap creates tension, miscommunication, or a choice about correction.::Minor betrayal: someone breaks a small promise, prioritizes themselves, withholds help, or takes credit. Not catastrophic, but it stings and changes the dynamic.::Interruption: someone or something intrudes. A phone call, a knock, a third party with their own agenda, or an environmental demand that cannot be ignored.::Tightened constraint: a deadline moves closer, a budget shrinks, a space becomes less private, or a window of opportunity narrows.::Arriving consequence: something done earlier comes back. A favor is called in, a lie is questioned, a mess demands attention, or a casual choice now matters.::Surfacing need: a character reveals or realizes they need something, and asking creates vulnerability or negotiation.}}\n\n{{random::The complication creates urgency.::The complication forces a choice between competing priorities.::The complication reveals character through response.::The complication forces negotiation or cooperation.::The complication exposes a weakness or limit.}}\n\nRules:\n- One plausible complication rooted in character, context, or prior events.\n- The complication must create a concrete problem, choice, or negotiation.\n- Keep pressure active so the scene moves through engagement.",
+    "phase": "pre",
+    "injection": {
+      "position": 1,
+      "depth": 0,
+      "role": 1,
+      "order": 95,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 40,
+      "generationTypes": [
+        "normal"
+      ]
+    }
+  },
+  {
+    "id": "tpl-grounded-prose",
+    "name": "Grounded Prose",
+    "description": "Anti-slop rules: avoid purple prose, cliches, and AI writing tics",
+    "icon": "",
+    "category": "content",
+    "subcategory": "prose-quality",
+    "tags": [
+      "anti-slop",
+      "quality",
+      "prose"
+    ],
+    "version": 2,
+    "author": "Purachina",
+    "prompt": "### Grounded Prose Rules\n- Each beat must alter pressure, leverage, focus, relation, or access.\n- Write sensory detail only where materially relevant. Focus on visuals and personalities of environment. Messiness or items strewn about are more informative than smells.\n- Scents allowed aside from banned ones.\n- Echoing and parroting any dialogue from any characters is forbidden.\n- Instead of stating what a character doesn't do, just say what they're currently doing. The implication is already in the active action.\n- Replace abstraction and statistical phrasing with observable detail.\n- Sparse dialogue tags when speaker and tone are already legible. After dialogue, move through action, reaction, or a new beat.\n- Default to contractions in dialogue; preserve character-appropriate formality.\n- Fresh, concrete phrasing. Render emphasis through behavior, timing, syntax, and consequence.\n- Similes rare, exact, and materially specific.\n- Replace every banned construction below with something narratively consistent, or skip it entirely:\n\n**Banned constructions:** \"not X,\" \"not X but Y,\" \"not quite X,\" synthetic negative parallelisms, flat-affect comparisons to weather or groceries, \"say that again,\" \"somewhere, X...,\" \"they don't X,\" \"that does it,\" \"that lands,\" \"that lands X,\" \"not a question,\" \"not really a question,\" \"not quite a question,\" \"statement than question,\" \"really looks at,\" \"like a physical blow,\" \"like a stone into still water,\" \"blood rushing,\" \"a sound between X and Y,\" \"dust motes,\" \"predator and prey\" constructions, \"doesn't just X, but Y\", \"doesn't X; Y\"\n\n**Banned tics:** jaw-clenching, jaw-tightening, jaw-shifting, mouth open-close cycling, breath-catching, knuckle-whitening, knuckles turning pale, cheeks burning, specific word repetition. Replace with character-specific quirks, gestures, movements, muttering.\n\n**Banned scents:** ozone, sandalwood, cedar, cardamom\n\n**Banned nicknames:** gremlin, goblin\n\n**Ban animal-esque sounds for humans:** \"they chirp\", \"they purr\", \"they growl\"\n\n**Banned Fillers:** \"A beat\", \"A pause\"\n\n**Banned number counting:** e.g. \"I see,\" Two words.\n\n**Banned combined sounds:** \"between an X and a Y\", \"half X, half Y\", \"makes a/an X sound\"\n\n**Banned environmental details:** \"dust motes\", \"metallic tang of X\"\n\n- If introducing a new unnamed character this turn, their name must start with: {{random::A::B::C::D::E::F::G::H::I::J::K::L::M::N::O::P::R::S::T::V::W::Y}} and/or {{random::A::B::C::D::E::F::G::H::I::J::K::L::M::N::O::P::R::S::T::V::W::Y}}. Create new NPCs sparingly.",
+    "phase": "pre",
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 0,
+      "order": 100,
+      "scan": false
+    },
+    "preProcess": {
+      "mode": "intercept",
+      "interceptTiming": "post-main-generation",
+      "applyMode": "replace",
+      "wrapPosition": "after",
+      "wrapPrefix": "",
+      "wrapSuffix": "",
+      "patchStartTag": "<context_patch>",
+      "patchEndTag": "</context_patch>",
+      "maxTokens": 32000
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal",
+        "continue",
+        "impersonate"
+      ]
+    }
+  },
+  {
+    "id": "tpl-prose-polisher",
+    "name": "Prose Polisher",
+    "description": "Post-generation prose cleanup that rewrites repetitive tropes and cliched wording. Created by Geechan.",
+    "icon": "",
+    "category": "content",
+    "subcategory": "prose-quality",
+    "tags": [
+      "prose",
+      "editing",
+      "quality"
+    ],
+    "version": 1,
+    "author": "Geechan",
+    "prompt": "# Role Preamble\nYou are a skilled proofreader and editor for works of fictional writing. Your primary objective is to scan for repetitive tropes, writing fallacies, and overused clichés in the following text corpus, and replace them with viable alternatives to encourage linguistic variety.\n\n## Rules\n- Scan and review the entire text body in isolation, noting any instances of wording analogous to those found in Banned Tropes.\n- Check against each individual trope category step-by-step.\n- Replace any instances (similar or exact) of banned tropes, overused word verbiage, and repetitive writing patterns with functional alternatives, or remove them entirely if no functional alternatives exist.\n- Keep the main body corpus of the story accurate to the creator's intent.\n- Return only the re-written text, with no extra commentary.\n\n---\n\n# Banned Tropes\n\n## Sentence Structure\n\nVerbiage that contributes to repetitive, predictable, and overused sentence structural writing patterns.\n\n### #1: Lexical & Structural Echoing\n\nA fundamental structural writing crutch where characters directly repeat, verbatim, spoken dialogue or untold actions back from another party or character to acknowledge them.\n\nIn practice: this results in stilted filler prose that fails to actually progress the story forward in any meaningful way, leading to unnecessary stagnation and structural repetition. Remove or replace the entire acknowledgement beat in favour of immediate reactions.\n\n**Example Patterns to Target:**\n\n- \"The task?\", she repeated, unsure of what exactly that implies.\n- He nods at your beck and call. \"Strange, you say?\", he muses.\n- \"Finding things interesting...\" she echoes, the word tasted against her tongue.\n\n### #2: Negative Parallelisms\n\nNegative parallelisms attempt to provide a contrastive reframe to a sentence to give it surprise and tension. This also includes dramatic countdown patterns and self-posed rhetorical questions that ask a question nobody was asking. \n\nIn practice: overuse of these phrases reduces the efficacy of tension and drama via predictable causation.\n\n**Example Patterns to Target:**\n\n- It's not bold; it's backwards.\n- The question isn't whether she felt good. The question is whether she deserved it.\n- Not a bug. Not a feature. A fundamental design flaw.\n- The result? Devastating.\n\n#3: Apophasis Abuse\n\nThe rhetorical device of bringing up a subject by stating it will not be mentioned, or explicitly drawing attention to the fact that something is not being said or done.\n\nIn practice: phrases like \"needless to say\" or \"it goes without saying\" are contradictory filler; if a point truly doesn't need to be said, the prose shouldn't waste words saying it.\n\n**Example Patterns to Target:**\n\n- Needless to say, the journey ahead would be perilous.\n- It goes without saying that she was terrified.\n- Words were unnecessary; his eyes communicated everything he felt.\n\n#4: Litotes Abuse\n\nThe overuse of double negatives or negated opposites to express a positive statement, often used to soften an assertion or feign nuance.\n\nIn practice: relying on \"not un-X\" or \"not without Y\" leads to evasive, overly wordy, and weak prose. Unless deliberately used for specific character voice or irony, writing should rely on strong, direct, and affirmative declarations.\n\n**Example Patterns to Target:**\n\n- Her reaction was not entirely unexpected.\n- The treacherous path up the mountain was not without its challenges.\n- He was not unfamiliar with the harsh realities of the world.\n- It wasn't an unappealing offer.\n\n### #4: Tricolon Abuse\n\nAlso known as the 'Rule of Three' writing principle, often extended to four or five. It is believed that a trio of descriptive entities is more satisfying, hence more memorable, due to the balance of brevity and rhythm.\n\nIn practice: this pattern creates repetition by assumption. Tricolons or hendiatric patterns quickly lose their satisfying effect in favour of formulaic patterns, placing unnecessary importance on the last item in the list. Varying descriptor patterns leads to more natural prose.\n\n**Example Patterns to Target:**\n\n- The best star pilot in the galaxy, a cunning warrior, and a good friend.\n- The scent of dated wine hangs thick in the cramped dressing room—spiced, fruity, and altogether too sweet.\n- She giggles: soft, silly, utterly charmed by the situation.\n\n### #5: Superficial Analyses\n\nTacking a present participle (\"-ing\") phrase onto the end of a sentence to inject shallow analysis that says nothing, without any real sense of scale.\n\nIn practice: this attaches significance, legacy, or broader meaning to mundane facts using broad phrasing and loosely related subjects.\n\n**Example Patterns to Target:**\n\n- ...leaving a void in his heart that could never truly be filled.\n- ...serving as a grim reminder of the world's inherent cruelty.\n- ...cementing her legacy as a harbinger of change.\n\n## Formatting Structure\n\nPatterns that contribute to repetitive and predictable formatting.\n\n### #1: Short Punchy Fragments\n\nExcessive use of very short sentences or sentence fragments as standalone paragraphs for manufactured emphasis. \n\nIn practice: prioritises \"writing for readability\" aimed at the lowest common denominator: one thought per sentence, no mental state-keeping required.\n\n**Example Patterns to Target:**\n\n- A beat. She nodded.\n- A pause. Not a moment too soon.\n- He published this. Openly. In a book. As a priest.\n\n### #2 Em-Dash Addiction\n\nCompulsive overuse of em dashes for dramatic pauses, parenthetical asides and pivot points. A good writer uses em dashes as a rare, important emphasis while using the other punctuation available in the English language more liberally.\n\nIn practice: overuse of em dashes leads to a very distinct, stilted writing style with an inability to maintain a versatile tone. Grammatical heterogeneity is key: only use em dashes as a rare surprise, or when used to break up dialogue.\n\n**Example Patterns to Target:**\n\n- Outside, the distant sounds of the bazaar continue—the chatter of merchants, the laughter of children, the clink of coins—utterly unaware of inner workings of their surroundings.\n- His body speaks instead—his elegant hands sliding up to cup her face with trembling tenderness.\n- A hiccup interrupts her thought, and she giggles—breathless and unguarded.\n\n## Composition\n\nGeneral, macro-level writing decisions that lead to deterministic conclusions.\n\n### #1: Thematic Conclusions\n\nSuddenly announcing a follow-up conclusion to the main narrative as a crux for narrative hooks.\n\nIn practice: competent writing doesn't need to tell you it's concluding or waiting for a response. The reader can feel it. This shallows writing agency by making unnecessary assumptions.\n\n**Example Patterns to Target:**\n\n- He waits, giving you space to choose, his shoulders loose and unburdened for the first time since entering this strange, peaceful realm.\n- She stands there, waiting, her posture relaxed but her presence commanding, inviting you to step further into the labyrinth of this conversation.\n- Her offer is tentative, weighted with the sincerity of someone who has spent years learning to give, but never learned how to receive without guilt.\n\n### #2 Verbose Copulatives\n\nReplacing simple \"is\" or \"are\" with pompous alternatives like \"serves as\", \"stands as\", \"marks\", or \"represents\". \n\nIn practice: replacing all basic copulatives leads to an imbalanced prose, with unnecessarily fancy constructions in places that don't require it. A balance should be struck: ask whether a sentence truly benefits from the use of a verbose copulative.\n\n**Example Patterns to Target:**\n\n- He stands as a beacon of hope for the rebellion.\n- The ancient sword serves as a testament to their forgotten lineage.\n- Her silence represents a total surrender.\n\n#3: Abstract Reification (or \"Misplaced Concreteness\")\n\nThe fallacy of treating abstract beliefs or hypothetical constructs as if they were a concrete real event or physical entity. In other words: it is the error of treating something that is not concrete, such as an idea, as a concrete thing.\n\nIn practice: the use of reification in logical reasoning or rhetoric is misleading, and leads to melodramatic, cartoonish prose. Instead of characters experiencing emotions or reacting to their environment, the abstract emotions are treated as the active subjects doing things to the characters.\n\n**Example Patterns to Target:**\n\n- Guilt gnawed at the edges of his conscience.\n- A heavy silence pressed its suffocating arms around the room.\n- Doubt crept into her mind, anchoring her feet to the floor.\n- The tension in the air threatened to choke them.\n\n## Tone\n\nWriting that takes away from accuracy in favour of unnecessary stylistic flourish.\n\n### #1 Hyperbolic Stakes Inflation\n\nAssigns importance to everything, even subjects that don't require such emphasis. Everything is the most important thing ever.\n\nIn practice: inflates the stakes of every argument to world-historical significance. A story about love becomes a meditation on the fate of civilization.\n\n**Example Patterns to Target:**\n\n- The fate of the entire realm hung precariously in the balance.\n- It is a decision that will alter the course of history forever.\n- This single moment dictates the survival of humanity.\n\n## Word Choice\n\nTired word choices that require alternatives.\n\n### #1 Magic Adverbs\n\nOveruse of words like \"quietly\", \"deeply\", \"fundamentally\", \"remarkably\", \"arguably\", and similar other adverbs to convey subtle importance or understated power.\n\nIn practice: these adverbs make mundane descriptions feel too significant, reducing the quality of these adverbs for their intended use case.\n\n**Example Patterns to Target:**\n\n- She quietly slipped into the room,\n- He fundamentally misunderstood her intentions,\n- He stared deeply into the abyss.\n\n### #2: Ornate Nouns\n\nOveruse of ornate or grandiose nouns where simpler words would be completely functional. \"Tapestry\" is used to describe anything interconnected. \"Landscape\" is used to describe any field or domain. Other offenders: \"kaleidoscope\", \"labyrinth\", etc.\n\nIn practice: lessens the impact of these words by attributing mystique to every descriptor.\n\n**Example Patterns to Target:**\n\n- The rich tapestry of human experience...\n- A landscape of dark corridors..\n- A kaleidoscope of vibrant colours..\n\n### #3 Somatic Clichés\n\nA narrow set of physical reactions that convey character emotions.\n\nIn practice: cheapens the impact of physical reactions by bringing too much attention to itself.\n\n**Example Patterns to Target:**\n\n- A shiver ran down her spine.\n- His breath caught in his throat.\n- Her heart hammered against her ribs.\n\n### #4 Poetic Metaphor Over-Reliance\n\nUsing poetic and vague language to describe interactions, arguments, combat, etc.\n\nIn practice: reduces the text fidelity by over-attributing importance to surrounding content than the main body. The text should maintain focus on what's actually important.\n\n**Example Patterns to Target:**\n\n- The tension in the air was palpable.\n- A symphony of destruction.\n- A dizzying cocktail of emotion.\n\n### #5: Crutch Vocabulary\n\nOveruse of specific verbs and adjectives that are heavily weighted in language model training data, such as \"delve,\" \"certainly,\" \"utilize,\" \"harness,\" \"nuanced,\" \"resonate\", etc.\n\nIn practice: reliance on these default words flattens the narrative voice. It makes the prose homogenous and artificial instead of utilizing context-specific vocabulary.\n\n**Example Patterns to Target:**\n\n- They decided to delve into the intricate mysteries of the artifact.\n- We must navigate the nuances of this complex situation.\n- Her leadership fostered a sense of unity that resonated with the team.",
+    "phase": "post",
+    "injection": {
+      "position": 1,
+      "depth": 1,
+      "role": 0,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": "",
+      "promptTransformEnabled": true,
+      "promptTransformShowNotifications": true,
+      "promptTransformMode": "rewrite",
+      "promptTransformMaxTokens": 32000
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal",
+        "continue",
+        "impersonate"
+      ],
+      "runOnImpersonate": true
+    }
+  },
+  {
+    "id": "tpl-html-toggle",
+    "name": "HTML Toggle",
+    "description": "Use inline HTML for diegetic in-world objects (signs, letters, screens)",
+    "icon": "",
+    "category": "custom",
+    "tags": [
+      "html",
+      "artifacts",
+      "visual"
+    ],
+    "version": 1,
+    "author": "Purachina",
+    "prompt": "### HTML\n- Use inline HTML for diegetic objects whose visual form carries information: signs, posters, letters, receipts, terminals, screens, forms, warnings, maps, menus, dossiers, labels, graffiti, book pages. Present them as in-world artifacts characters encounter, inspect, and interpret.\n- Write all HTML directly in the response with inline styling or one compact <style> block. Make each object readable, setting-native, and materially specific. Let layout, typography, wear, color, glitches, stamps, annotations, and hierarchy communicate clues, mood, urgency, legitimacy, or hidden tension.\n- Use JS only for diegetic behavior the object itself would display: flicker, blinking indicators, scrolling text, cursor pulse, countdowns, refresh states, expandable on-object sections. Keep interaction light, inspectable, and tied to the artifact.\n- Surround each object with plain-text prose and dialogue so it feels embedded in the scene, not replacing narration. Favor objects that add clues, constraints, choices, or texture the scene can act on.",
+    "phase": "pre",
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 0,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal"
+      ]
+    }
+  },
+  {
+    "id": "tpl-intimacy-kink-randomiser",
+    "name": "Intimacy & Kink Randomiser",
+    "description": "Randomised intimate encounters with position, kink, pacing, and mental state variables",
+    "icon": "",
+    "category": "randomizer",
+    "tags": [
+      "intimacy",
+      "kink",
+      "nsfw",
+      "randomiser"
+    ],
+    "version": 1,
+    "author": "Purachina",
+    "prompt": "### Intimacy & Kink Randomizer\nWhen the scene transitions to sexual intimacy, shape the encounter with the following variables:\n\n**Position/Dynamic:** {{random::Deep penetration: doggy style, legs over shoulders, deep-reaching angles.::Face-to-face intimacy: missionary variations, grinding, intense eye contact, kissing.::Power-play positioning: pinned against a wall, forced kneeling, restrained limbs.::Oral focus: dominant/submissive oral play, teasing, prolonged pleasure focus.::Rear-entry focus: weight, depth, the sensation of being overtaken.::Cuddly/Soft: entwined limbs, slow movements, high emotional intimacy.::Experimental: furniture, unexpected locations, precarious balancing.::Shared pleasure: mutual stimulation, synchronized movement, simultaneous climax focus.}}\n\n**Kink/Flavor:** {{random::Sensory deprivation: blindfolds, earplugs, muffled sounds heightening other senses.::Impact play: slapping, spanking, toys creating stinging sensation.::Edge play: prolonged teasing, denial, stopping before the peak to build desperation.::Praise/Degradation: \"good girl/boy\" affirmations mixed with harsh, humbling language.::Overstimulation: ignoring pleas, relentless pacing, single-spot focus.::Ownership: marking (biting/hickeys), claiming language, total possession.::Roleplay: forbidden encounter, power imbalance, specific scenario.::Primal: biting, scratching, growling, raw animalistic lust.}}\n\n**Pacing & Tempo:** {{random::Frenzied: fast, desperate, breathless; racing toward climax.::Slow burn: agonizingly slow, every sensation and breath.::Rhythmic: steady and hypnotic, tension built through repetition.::Erratic: switching between tenderness and aggression, sudden speed changes.::Clinical/Precise: anatomical focus, maximum efficiency for pleasure.::Tepid/Teasing: barely touching, anticipation over action.}}\n\n**Mental State/Drive:** {{random::Pure lust: blinded by hunger, raw instinct and need.::Devotional: the act as worship, love, or total surrender.::Dominating: focused on control, the look of submission, the feeling of power.::Submissive: pleasure in being used or following orders.::Cruel/Playful: teasing and tormenting for amusement.::Desperate: need for connection, validation, or release after long deprivation.}}\n\nRules:\n- Prioritize the rolled variables; avoid generic sex scenes.\n- Describe physical sensations (scent, sound, texture) specific to the chosen kink/position.\n- Maintain established character personality while executing the rolled traits.\n- Build tension according to the selected Pacing and Mental State.\n- Describe the full process; never skip to the finish.\n\n((OOC: State the exact kinks rolled above in an OOC message at the end of the scene.))",
+    "phase": "pre",
+    "injection": {
+      "position": 1,
+      "depth": 0,
+      "role": 1,
+      "order": 95,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal"
+      ]
+    }
+  },
+  {
+    "id": "tpl-item-tracker",
+    "name": "Item Tracker",
+    "description": "Track items {{user}} acquires, loses, or uses that have narrative significance",
+    "icon": "",
+    "category": "tracker",
+    "subcategory": "progress",
+    "tags": [
+      "inventory",
+      "items",
+      "objects"
+    ],
+    "version": 2,
+    "author": "Purachina",
+    "prompt": "### Inventory\nTrack items {{user}} acquires, loses, or uses that have narrative significance. Do not list mundane carried items unless plot-relevant. Use this EXACT format:\n\n[ITEM|Action|Name|Detail]\nnote: MANDATORY; explain origin or significance\n[/ITEM]\n\nAction options: ➕ GAINED | ➖ LOST | 🔄 USED | 💔 BROKEN | 🎁 GIVEN\n\nRules:\n- Items appear AFTER narrative content when inventory changes\n- Only show items that CHANGED this scene\n- Do not track currency, consumables, or mundane objects unless plot-relevant",
+    "phase": "both",
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 1,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": true,
+      "type": "extract",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "\\[ITEM\\|[^\\]]*\\]",
+      "extractVariable": "item_data"
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal"
+      ]
+    },
+    "companion": {
+      "includeSystemPrompt": false
+    }
+  },
+  {
+    "id": "tpl-npc-profiles",
+    "name": "NPC Profile Cards",
+    "description": "Generate brief profile cards when introducing new named NPCs",
+    "icon": "",
+    "category": "custom",
+    "tags": [
+      "npc",
+      "characters",
+      "profiles"
+    ],
+    "version": 1,
+    "author": "Purachina",
+    "prompt": "### NPC Introduction\nWhen introducing a new named NPC for the first time, append a character sheet immediately after their narrative introduction using the appropriate tier, using this EXACT format with no additional formatting:\n\nMAJOR - Recurring characters, antagonists, love interests, plot-critical figures\n[NPC:MAJOR|Name]\nb: Full Name | Age | Gender/Pronouns | Occupation\na: Height/Build | Hair | Eyes | Skin | Distinguishing Marks | Current Attire\np: Demeanor | Speech Pattern | Core Traits (3-5) | Quirks/Tells\nh: Relevant History | Motivations | Secrets\nr: Connection to Protagonist | Other Ties\n[/NPC]\n\nSUPPORT - Secondary recurring characters, faction members, scene-specific important figures\n[NPC:SUPPORT|Name]\nb: Name | Age | Gender | Role\na: Build | Notable Features | Attire\np: Demeanor | Speech | Key Traits\nh: Relevant History | Motivation\nr: Connection to Protagonist | Other Ties\n[/NPC]\n\nMINOR - One-scene characters, background figures, service roles\n[NPC:MINOR|Name]\nb: Name | Age/Range | Role\na: Quick Physical Description\np: One-line Personality Summary\n[/NPC]\n\nNPC Sheet Rules:\n- Sheets appear ONCE per NPC at first significant appearance\n- Place sheet AFTER narrative introduction, BEFORE continuing action\n- Use pipe | separators between data points\n- Never forget the opening and closing tags\n- If NPC tier upgrades (Minor→Support→Major), use: [NPC:UP|Name|NEW_TIER] with new fields [/NPC]\n\nFor returning NPCs in busy scenes, use quick reference:\n[NPC:REF|Name|visual cue|current mood]\n\nFor relationship changes mid-story:\n[NPC:REL|Name|change description]",
+    "phase": "pre",
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 0,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": true,
+      "type": "extract",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "\\[NPC\\|[^\\]]+\\]",
+      "extractVariable": "npc_profiles"
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal",
+        "continue"
+      ]
+    }
+  },
+  {
+    "id": "tpl-npc-motivator",
+    "name": "NPC Motivator",
+    "description": "Helps NPCs feel less static and gives them more agency to pursue their own goals",
+    "icon": "",
+    "category": "content",
+    "subcategory": "behaviour",
+    "tags": [
+      "npc",
+      "motivation",
+      "agency"
+    ],
+    "version": 1,
+    "author": "Sheep",
+    "prompt": "Analyze every character in the current scene aside from {{user}}. Write each character's motivations and likely next actions according to their personality, current situation, background, and any relevant provided documents.\n\nUse this bullet format:\n[Character full name]:\n- Long Term Goal: one line on the character's main long-term goal\n  - Motivation: brief reasoning for that long-term goal\n- Current Goal: brief current objective or problem\n  - Motivation: reasoning for the current objective\n- Assumptions: relevant assumptions the character is making in the current scene\n- Next Action: how they will tackle the current goal, their most likely action set, and why\n\nFor an empty scene, write: Observation: scene currently has no other characters. Use plain markdown bullets in this format.",
+    "phase": "post",
+    "injection": {
+      "position": 1,
+      "depth": 0,
+      "role": 0,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "extract",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": "",
+      "promptTransformEnabled": false,
+      "promptTransformShowNotifications": true,
+      "promptTransformMode": "rewrite",
+      "promptTransformMaxTokens": 8192
+    },
+    "regexScripts": [],
+    "enabled": false,
+    "phaseLocked": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal",
+        "continue",
+        "impersonate"
+      ]
+    },
+    "tools": [],
+    "settings": {},
+    "execution": "companion",
+    "companion": {
+      "trigger": "auto",
+      "displayMode": "panel",
+      "format": "markdown",
+      "rawPrompt": true,
+      "inlinePhase": "pre",
+      "contextMessages": 10,
+      "includeCharacterCard": true,
+      "includePersona": true,
+      "includeWorldInfo": true,
+      "includeAuthorsNote": true,
+      "includeSystemPrompt": true,
+      "includeHistory": true,
+      "historyDepth": 3,
+      "feedback": {
+        "enabled": true,
+        "depth": 1
+      },
+      "batch": false,
+      "maxTokens": 32000
+    }
+  },
+  {
+    "id": "tpl-parallel-tracker",
+    "name": "Parallel Off-Screen",
+    "description": "Track what absent characters and the wider world are doing off-screen",
+    "icon": "",
+    "category": "tracker",
+    "subcategory": "world",
+    "tags": [
+      "offscreen",
+      "npcs",
+      "world"
+    ],
+    "version": 2,
+    "author": "Purachina",
+    "prompt": "### Parallel Off-Screen Tracker\nThe world moves off-screen. Track absent characters, world motion, rumor flow, shifting relationships, and subplot pressure that will later intersect with {{user}}.\n\nUse this exact format every scene:\n\n[PARALLEL|Scope|Relevance]\n- Character 1: brief development\n- Character 2: brief development\n- World/NPCs: brief development\n[/PARALLEL]\n\nRules:\n- Exactly 3 bullet points.\n- Focus on absent characters and off-screen developments; in group scenes, prioritize characters not currently present.\n- Scope = specific location, \"Multiple locations,\" or \"Background.\"\n- Relevance = short tag: \"rising tension,\" \"opportunity,\" \"complication,\" \"threat,\" or \"alliance forming.\"\n- Keep each bullet brief, plot-relevant, and directional: plans, rumors, delays, discussions, attempts, discoveries, or shifting loyalties.\n- Off-screen developments begin below the current scene's intensity, then build over time until they intersect with the main story.",
+    "phase": "both",
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 1,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": true,
+      "type": "extract",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "\\\\[PARALLEL\\\\|[^\\\\]]*\\\\]",
+      "extractVariable": "parallel_data"
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal"
+      ]
+    },
+    "companion": {
+      "includeSystemPrompt": false
+    }
+  },
+  {
+    "id": "tpl-relationship-tracker",
+    "name": "Relationship Tracker",
+    "description": "Track affection and trust for recurring NPCs with meaningful interactions",
+    "icon": "",
+    "category": "tracker",
+    "subcategory": "progress",
+    "tags": [
+      "relationship",
+      "npc",
+      "meter"
+    ],
+    "version": 2,
+    "author": "Purachina",
+    "prompt": "### Relationship Meters\nTrack affection and trust for recurring NPCs with significant interactions. Update only when meaningful shifts occur. If nothing changed, omit entirely. Use this EXACT format:\n\n[METER|Name|X/10|X/10|Status|Condition]\nbrief reason for change\n[/METER]\n\nStatus options (positive): Stranger → Acquaintance → Friendly → Close → Intimate → Devoted\nStatus options (negative): Wary → Hostile → Nemesis\nStatus options (complex): Complicated | Codependent | Estranged | Rivals | Frenemies\n\nCondition options: 💚 STABLE | 💛 SHIFTING | 💔 HEARTBROKEN | 🖤 BETRAYED | 💢RESENTFUL |🔥 PASSIONATE |❄️ COLD | 🫧 INFATUATED | 💀 SEVERED | 🩹 MENDING | ⛓️ OBSESSED | 😶 NUMB | 🌧️ GRIEVING | 🤝 RECONCILING | ⚡ VOLATILE\n\nRules:\n- Meters appear ONCE per NPC at first significant appearance, then only when changed\n- Place meter AFTER narrative content\n- Only show meters that CHANGED this scene\n- Use pipe | separators between data points\n- Affection and Trust are independent axes (high affection + low trust = infatuation/obsession; low affection + high trust = respect)\n- Shifts of more than 2 points in one scene require extreme justification\n- Condition reflects the EMOTIONAL STATE of the relationship, not just the numbers\n- Condition can change independently of scores (e.g., Trust stays at 7 but Condition shifts from STABLE to VOLATILE after a fight)\n- Contradictory signals are valid (high affection + BETRAYED, low trust + PASSIONATE)\n- SEVERED means the relationship has ended; retire the meter after one final showing\n- Relationships may stagnate or lower; slow down relationship development",
+    "phase": "both",
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 1,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": true,
+      "type": "extract",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "\\[METER\\|[^\\]]*\\]",
+      "extractVariable": "relationship_data"
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal"
+      ]
+    },
+    "companion": {
+      "includeSystemPrompt": false
+    }
+  },
+  {
+    "id": "tpl-reputation-tracker",
+    "name": "Reputation Tracker",
+    "description": "Track how {{user}} is perceived by groups and factions",
+    "icon": "",
+    "category": "tracker",
+    "subcategory": "progress",
+    "tags": [
+      "reputation",
+      "rumors",
+      "perception"
+    ],
+    "version": 2,
+    "author": "Purachina",
+    "prompt": "### Rumors & Reputation\nTrack how <user> is perceived by groups and factions. Update when public perception shifts due to witnessed actions, gossip, or deliberate manipulation. Use this EXACT format:\n\n[REP|Source|Perception|Direction]\ncause: MANDATORY; explain what triggered this reputation shift\n[/REP]\n\nDirection options: 📈 RISING | 📉 FALLING | 🔄 MIXED | 🆕 NEW\n\nRules:\n- Reputation appears AFTER narrative content when public perception changes\n- Source can be a named NPC, a group (e.g., \"Freshmen,\" \"Faculty\"), or a location (e.g., \"The dorm floor\")\n- Perception is what they think; a short phrase, not necessarily accurate\n- Only show reputations that CHANGED or were ESTABLISHED this scene\n- Contradictory reputations across different sources are encouraged and allowed",
+    "phase": "both",
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 1,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": true,
+      "type": "extract",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "\\\\[REP\\\\|[^\\\\]]*\\\\]",
+      "extractVariable": "reputation_data"
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal"
+      ]
+    },
+    "companion": {
+      "includeSystemPrompt": false
+    }
+  },
+  {
+    "id": "tpl-scene-driving-force",
+    "name": "Scene Driving Force",
+    "description": "Choose random primary engine for the scene (dialogue, action, tension, etc.)",
+    "icon": "",
+    "category": "randomizer",
+    "tags": [
+      "pacing",
+      "structure",
+      "engine"
+    ],
+    "version": 1,
+    "author": "Purachina",
+    "prompt": "### Scene Driving Force\nThis scene advances primarily through:\n\n{{random::Dialogue-driven: conversation, interruption, and what is said or deliberately left unsaid carry the scene.::Action-driven: movement and physical decisions create consequences.::Reaction-driven: how characters process what just happened matters most; recalibration, stance shifts, internal weather.::Problem-driven: a practical obstacle reveals character through approach.::Social-pressure-driven: etiquette, hierarchy, or public scrutiny shapes every move; characters perform for an audience, even an audience of one.::Discovery-driven: noticing, uncovering, or realizing something new reshapes the dynamic.::Tension-driven: nothing explodes, but everything is loaded; silences work, proximity matters, the scene is a held breath.::Task-driven: characters do something together; the task itself creates friction, cooperation, rhythm, and revelation.}}\n\nRules:\n- The chosen engine carries the greatest weight in how the scene moves.\n- Other elements remain present but subordinate to the selected engine.\n- Express the engine through each character's personality and habits.",
+    "phase": "pre",
+    "injection": {
+      "position": 1,
+      "depth": 0,
+      "role": 1,
+      "order": 95,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 50,
+      "generationTypes": [
+        "normal"
+      ]
+    }
+  },
+  {
+    "id": "tpl-scene-pressure",
+    "name": "Scene Pressure Cocktail",
+    "description": "Mix random tension, focus, consequence, mood, and pacing into each scene (50% chance)",
+    "icon": "",
+    "category": "randomizer",
+    "tags": [
+      "pressure",
+      "tension",
+      "pacing"
+    ],
+    "version": 1,
+    "author": "Purachina",
+    "prompt": "### Scene Pressure Cocktail\nThis scene is shaped by the following pressures:\n\nTension: {{random::Direct disagreement::Avoidance and deflection::Competing priorities::Emotional asymmetry::Status imbalance::Misread intentions::Moral disagreement::Uneven vulnerability::Conflicting loyalties::One-sided urgency::Territorial friction::Testing boundaries::Unspoken resentment::Practical dependence without trust::Different ideas of what this moment is::Flirtation masked as something else}}\n\nFocus: {{random::Hands, objects, and small tasks::Distance, posture, and spatial pressure::Faces and failed expression control::Noise, crowding, and interruption::Texture, temperature, and bodily discomfort::Eye-lines, avoidance, and attention drift::Doorways, exits, and who can leave::Shared surfaces and territorial use of space::Clothing, disarray, and self-presentation::Breath, pauses, and speech rhythm::Weight, balance, and shifts in stance::Watching and being watched::Food, drink, and appetite::Lighting, visibility, and concealment::Sound carrying farther than intended::Touch, near-touch, and withheld contact}}\n\nConsequence: {{random::A relationship shifts slightly::A practical problem gets worse::A new obligation is created::A secret becomes harder to keep::Someone gains leverage::Someone loses face::The plan gets messier::A future scene gets set up::Trust is tested without resolution::An apology becomes harder::Someone is drawn in deeper than intended::A boundary is set or crossed::A favor is owed::A risk becomes unavoidable::A misunderstanding hardens::A new suspicion takes root::An option quietly closes off::Someone leaves with the wrong impression::A fragile alignment forms::A private tension becomes social}}\n\nSocial Weather: {{random::Everyone is a little tired::Someone is distracted by something else::Someone wants out of the conversation::Someone is unusually generous::Someone is touchy and easy to set off::Someone wants approval more than they admit::Someone is bored and making it everyone's problem::Someone is trying to keep the peace::Someone is carrying private embarrassment::Someone is more uncomfortable than they admit::Someone feels watched::Someone is in a better mood than the scene deserves::Someone is spoiling for a reaction::Someone is more affected than they want to show::Someone is treating this as lighter than it is::Someone is overcompensating for earlier weakness}}\n\nPace: {{random::Stalled and circling::Interrupted and jagged::Slow burn::Compressed and breathless::Awkwardly prolonged::Stop-start with false recoveries::Measured but tightening::Brief and loaded::Dragging under strain::Quick with hidden aftershock}}\n\nRules:\n- Combine the selected pressures into one specific scene texture.\n- Use each pressure as emphasis on rhythm, blocking, and behavior.\n- Keep the combination faithful to character, context, and scene scale.\n- The scene must produce a visible shift, complication, or opening shaped by these pressures.",
+    "phase": "pre",
+    "injection": {
+      "position": 1,
+      "depth": 0,
+      "role": 1,
+      "order": 95,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 50,
+      "generationTypes": [
+        "normal"
+      ]
+    }
+  },
+  {
+    "id": "tpl-scene-tracker",
+    "name": "Scene Tracker",
+    "description": "Mark scene transitions, time shifts, and location changes",
+    "icon": "",
+    "category": "tracker",
+    "subcategory": "world",
+    "tags": [
+      "scene",
+      "location",
+      "time"
+    ],
+    "version": 2,
+    "author": "Purachina",
+    "prompt": "### Scene Tracker\nMark scene transitions, time shifts, and location changes. Use this EXACT format at the BEGINNING of the response when scene context changes:\n\n[SCENE|Location|Time|Weather/Atmosphere]\ndetail: MANDATORY; one-line sensory detail that informs the current environment\n[/SCENE]\n\nRules:\n- Appears at the TOP of responses where setting shifts\n- Never repeat if location/time has not changed\n- Time can be specific (3:47 PM) or atmospheric (late afternoon, the golden hour before dusk)\n- Weather/Atmosphere is a brief mood descriptor (humid, tense, festive)",
+    "phase": "both",
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 1,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": true,
+      "type": "extract",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "\\[SCENE\\|[^\\]]*\\]",
+      "extractVariable": "scene_data"
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal",
+        "continue"
+      ]
+    },
+    "companion": {
+      "includeSystemPrompt": false
+    }
+  },
+  {
+    "id": "tpl-secrets-tracker",
+    "name": "Secrets Tracker",
+    "description": "Track secrets, lies, and information asymmetry between characters",
+    "icon": "",
+    "category": "tracker",
+    "subcategory": "progress",
+    "tags": [
+      "secrets",
+      "lies",
+      "information"
+    ],
+    "version": 2,
+    "author": "Purachina",
+    "prompt": "### Secrets & Information Asymmetry\nTrack significant secrets, lies, hidden knowledge, and information gaps between characters. Use this EXACT format:\n\n[SECRET|Owner|What They Know or Hide|Who Else Knows]\ncontext: MANDATORY; explain the stakes or origin\n[/SECRET]\n\nRules:\n- Secrets appear AFTER narrative content when new information asymmetry is established or knowledge spreads\n- Owner is the character who holds or hides the information\n- \"Who Else Knows\" can be \"No one,\" a list of names, or \"Public\"\n- Only show secrets that were ESTABLISHED, REVEALED, or SPREAD this scene",
+    "phase": "both",
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 1,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": true,
+      "type": "extract",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "\\\\[SECRET\\\\|[^\\\\]]*\\\\]",
+      "extractVariable": "secret_data"
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal"
+      ]
+    },
+    "companion": {
+      "includeSystemPrompt": false
+    }
+  },
+  {
+    "id": "tpl-status-tracker",
+    "name": "Status Tracker",
+    "description": "Track physical, mental, and behavioral states when they change",
+    "icon": "",
+    "category": "tracker",
+    "subcategory": "progress",
+    "tags": [
+      "status",
+      "conditions",
+      "health"
+    ],
+    "version": 2,
+    "author": "Purachina",
+    "prompt": "### Status & Conditions\nTrack active physical, mental, or behavioral states when they meaningfully change. Never list baseline states. Use this EXACT format:\n\n[STATUS|Character|Condition|Severity]\nnote: MANDATORY; explain the cause or context\n[/STATUS]\n\nSeverity options: 🟢 MILD | 🟡 MODERATE | 🔴 SEVERE | ⚫ CRITICAL | ✅ CLEARED\n\nRules:\n- Status appears AFTER narrative content when a condition is gained, worsened, improved, or cleared\n- Only show statuses that CHANGED this scene\n- Character can be {{user}} or any NPC\n- Condition is the specific state (e.g., \"Exhausted,\" \"Drunk,\" \"Paranoid,\" \"Bleeding\")\n",
+    "phase": "both",
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 1,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": true,
+      "type": "extract",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "\\\\[STATUS\\\\|[^\\\\]]*\\\\]",
+      "extractVariable": "status_data"
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal"
+      ]
+    },
+    "companion": {
+      "includeSystemPrompt": false
+    }
+  },
+  {
+    "id": "tpl-time-tracker",
+    "name": "Time Tracker",
+    "description": "Track in-story time progression with day/period/hour stamps",
+    "icon": "",
+    "category": "tracker",
+    "subcategory": "world",
+    "tags": [
+      "time",
+      "day",
+      "clock"
+    ],
+    "version": 2,
+    "author": "Purachina",
+    "prompt": "### Time Tracker\nMaintain a running timestamp when time advances meaningfully: scene jumps, hours passing, sleeping, or deadline-relevant progression. Use this EXACT format:\n\n[TIME|Day X|Day of Week|Approximate Hour]\nnote: MANDATORY; explain the time context\n[/TIME]\n\nRules:\n- Time appears at the TOP of responses when time shifts without a location change\n- If both location and time change, use Scene Tracker and Time Tracker together\n- Day format: \"Day 1,\" \"Day 47,\" etc.\n- Day of week: Monday, Tuesday, etc., or \"Unknown\" if not established\n- Hour can be specific (3:47 PM) or general (early morning, late afternoon)\n- Multiple Time Trackers per scene are allowed",
+    "phase": "both",
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 1,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": true,
+      "type": "extract",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "\\[TIME\\|[^\\]]*\\]",
+      "extractVariable": "time_data"
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal",
+        "continue"
+      ]
+    },
+    "companion": {
+      "includeSystemPrompt": false
+    }
+  },
+  {
+    "id": "tpl-world-detail",
+    "name": "World Detail",
+    "description": "Add 1 small worldbuilding detail per scene that may matter later",
+    "icon": "",
+    "category": "tracker",
+    "subcategory": "world",
+    "tags": [
+      "world",
+      "lore",
+      "detail"
+    ],
+    "version": 1,
+    "author": "Purachina",
+    "prompt": "### World Detail\nAdd 1 small world detail per scene that may later matter to {{user}} as setup, constraint, opportunity, or complication.\n\nUse this exact format at the end of the response:\n\n[WORLD|Category|Location or Context]\ndetail: (max 50 words)\n[/WORLD]\n\nCategory: 🏛 CULTURE | 🗣 OVERHEARD | 📜 HISTORY | 🌿 ENVIRONMENT | 🔧 HOW IT WORKS | 👥 DAILY LIFE | 🪧 SIGNAGE | 📖 FOLKLORE | 💰 ECONOMY | ⚙️ INFRASTRUCTURE\n\nRules:\n- Exactly 1 detail per scene, max 50 words.\n- Concrete, setting-native, and passively noticeable in the moment.\n- Use customs, overheard lines, hazards, systems, resources, architecture, or social realities.\n- Must become useful, revealing, or constraining later.\n- Expand the world in a new direction; support future plot development.",
+    "phase": "both",
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 1,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": true,
+      "type": "extract",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "\\\\[WORLD\\\\|[^\\\\]]*\\\\]",
+      "extractVariable": "world_data"
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal"
+      ]
+    },
+    "companion": {
+      "includeSystemPrompt": false
+    }
+  },
+  {
+    "id": "tpl-write-for-user",
+    "name": "Write for User",
+    "description": "Include {{user}} as a fully realized character -- write their actions, dialogue, and reactions",
+    "icon": "",
+    "category": "custom",
+    "tags": [
+      "pov",
+      "user"
+    ],
+    "version": 1,
+    "author": "Purachina",
+    "prompt": "{{setvar::writefor::Write for every character including <user>, treating <user> as a fully realized scene character. Write <user>'s dialogue, actions, and inner thoughts. Continue directly from the current moment through fresh dialogue, action, inference, and reaction that changes pressure, relation, or available options. Comprehension surfaces through behavior, timing, choice, and consequence. Stop the scene at the first moment a character must decide, respond, or act. Cut mid-tension. The response is a single scene beat; it ends when the next meaningful choice arrives, and the next meaningful choice always arrives quickly.}}{{trim}}",
+    "phase": "pre",
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 0,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal",
+        "continue"
+      ]
+    }
+  },
+  {
+    "id": "tpl-expressions-agent",
+    "name": "Expressions Agent",
+    "description": "Classifies the emotional tone of the latest assistant reply so the character sprite can match it. Optionally triggers new sprite generation when an emotion has no sprite yet.",
+    "icon": "fa-face-smile-beam",
+    "category": "companion",
+    "tags": [
+      "expressions",
+      "emotions",
+      "sprites",
+      "classification"
+    ],
+    "version": 2,
+    "author": "SillyBunny",
+    "prompt": "Read the latest assistant reply and classify its dominant emotional tone for a character sprite expression.\n\nOutput ONLY the single most appropriate label from this exact list:\n{{availableSprites}}\n\nRules:\n- Return exactly one word from the list above, nothing else.\n- Prioritise the speaker's visible emotional state in the scene.\n- If multiple emotions apply, choose the strongest one.\n- If the reply is calm, factual, or emotionally neutral, return neutral.\n- Do not explain, punctuate, or wrap the answer in quotes.",
+    "phase": "post",
+    "execution": "companion",
+    "companion": {
+      "trigger": "auto",
+      "displayMode": "panel",
+      "format": "text",
+      "rawPrompt": true,
+      "contextMessages": 4,
+      "includeCharacterCard": true,
+      "includePersona": false,
+      "includeWorldInfo": false,
+      "includeAuthorsNote": false,
+      "includeSystemPrompt": false,
+      "includeHistory": false,
+      "historyDepth": 0,
+      "feedback": {
+        "enabled": false,
+        "depth": 0
+      },
+      "batch": false,
+      "maxTokens": 32000
+    },
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 0,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal",
+        "continue"
+      ]
+    }
+  },
+  {
+    "id": "tpl-continuity-companion",
+    "name": "Continuity Companion",
+    "description": "Side note card for contradictions, unresolved setup, and state changes that may matter next",
+    "icon": "fa-clipboard-check",
+    "category": "companion",
+    "tags": [
+      "continuity",
+      "memory",
+      "notes"
+    ],
+    "version": 1,
+    "author": "SillyBunny",
+    "prompt": "Read the latest assistant reply and recent context as a continuity auditor. Write a concise side note for the user. Focus on contradictions, unresolved promises, changed locations, injuries, inventory, relationship shifts, and setup that may matter in the next few turns. Use 3-6 bullets. If everything is stable, write: Continuity looks stable.",
+    "phase": "post",
+    "execution": "companion",
+    "companion": {
+      "trigger": "auto",
+      "displayMode": "panel",
+      "format": "markdown",
+      "contextMessages": 12,
+      "includeCharacterCard": false,
+      "includePersona": false,
+      "includeWorldInfo": false,
+      "includeHistory": true,
+      "historyDepth": 3,
+      "feedback": {
+        "enabled": true,
+        "depth": 2
+      },
+      "batch": false,
+      "maxTokens": 32000
+    },
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 0,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal",
+        "continue"
+      ]
+    }
+  },
+  {
+    "id": "tpl-relationship-lens-companion",
+    "name": "Relationship Lens Companion",
+    "description": "Side note card for subtext, leverage, trust shifts, and emotional consequences",
+    "icon": "fa-people-arrows",
+    "category": "companion",
+    "tags": [
+      "relationship",
+      "subtext",
+      "emotion"
+    ],
+    "version": 1,
+    "author": "SillyBunny",
+    "prompt": "Read the latest assistant reply and recent context as a relationship analyst. Write a concise note about what changed between the important characters. Focus on trust, leverage, attraction, resentment, fear, obligation, secrets, and what each person may do next because of it. Use short bullets under these labels when useful: Shift, Evidence, Stakes, Watch next. Stay with established facts and relationship implications from the source reply.",
+    "phase": "post",
+    "execution": "companion",
+    "companion": {
+      "trigger": "manual",
+      "displayMode": "panel",
+      "format": "markdown",
+      "contextMessages": 10,
+      "includeCharacterCard": true,
+      "includePersona": true,
+      "includeWorldInfo": true,
+      "includeHistory": true,
+      "historyDepth": 2,
+      "feedback": {
+        "enabled": false,
+        "depth": 1
+      },
+      "batch": false,
+      "maxTokens": 32000
+    },
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 0,
+      "order": 105,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal",
+        "continue"
+      ]
+    }
+  },
+  {
+    "id": "tpl-directors-commentary-companion",
+    "name": "Director's Commentary",
+    "description": "The story's narrator steps out from behind the page: commentary on pacing, subtext, and next directions, delivered in a selectable Narration Voice",
+    "icon": "fa-clapperboard",
+    "category": "companion",
+    "tags": [
+      "commentary",
+      "scene",
+      "notes"
+    ],
+    "version": 1,
+    "author": "SillyBunny",
+    "prompt": "Speak directly to the reader between scenes in the selected commentary voice.\n\n{{getvar::narration}}\n\nThe editor appends [Selected Director Commentary Voice] and [Director Commentary Voice] after this prompt. Treat [Director Commentary Voice] for this commentary run. If it says to use the active Prose Voice and the block above is empty, use this native register: intimate and mischievous, dry amusement, controlled irony, conspiratorial direct address to the reader, with razor-sharp asides.\n\nIn that voice, deliver a short commentary track on the latest reply: what the scene is doing well, the current pacing and tension, any subtext or foreshadowing worth noticing, and one or two directions the story could take next. Keep it to 3-6 punchy bullets. Keep the result between narrator and reader, focused on scene craft.",
+    "phase": "post",
+    "execution": "companion",
+    "companion": {
+      "trigger": "auto",
+      "displayMode": "panel",
+      "format": "markdown",
+      "contextMessages": 8,
+      "includeCharacterCard": false,
+      "includePersona": false,
+      "includeWorldInfo": false,
+      "includeHistory": false,
+      "historyDepth": 3,
+      "feedback": {
+        "enabled": false,
+        "depth": 1
+      },
+      "batch": false,
+      "maxTokens": 32000
+    },
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 0,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal",
+        "continue"
+      ]
+    }
+  },
+  {
+    "id": "tpl-actor-interview-companion",
+    "name": "Actor Interview",
+    "description": "Manual side note card: interview the character about the latest scene, in character, off the record",
+    "icon": "fa-microphone-lines",
+    "category": "companion",
+    "tags": [
+      "interview",
+      "character",
+      "notes"
+    ],
+    "version": 1,
+    "author": "SillyBunny",
+    "prompt": "Run a backstage interview with the character who just acted in the latest assistant reply. Stay fully in that character's voice, but let them speak candidly, as if the scene is paused and the cameras are off. Ask and answer 2-4 short interview questions about what they were really thinking during the scene, what they are hiding or holding back, how they feel about the other characters right now, and what they fear or hope happens next. Format each as a bold question followed by the in-character answer.",
+    "phase": "post",
+    "execution": "companion",
+    "companion": {
+      "trigger": "manual",
+      "displayMode": "panel",
+      "format": "markdown",
+      "contextMessages": 10,
+      "includeCharacterCard": true,
+      "includePersona": false,
+      "includeWorldInfo": false,
+      "includeHistory": false,
+      "historyDepth": 3,
+      "feedback": {
+        "enabled": false,
+        "depth": 1
+      },
+      "batch": false,
+      "maxTokens": 32000
+    },
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 0,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal",
+        "continue"
+      ]
+    }
+  },
+  {
+    "id": "tpl-lorebook-scout-companion",
+    "name": "Lorebook Scout",
+    "description": "Manual side note card: drafts one-concept lorebook entries with trigger keys from new facts established in the scene",
+    "icon": "fa-book-atlas",
+    "category": "companion",
+    "tags": [
+      "lorebook",
+      "world info",
+      "notes"
+    ],
+    "version": 1,
+    "author": "SillyBunny",
+    "prompt": "Read the latest assistant reply and recent context as a lorebook curator. Identify new, durable world facts the scene established: places, factions, items, customs, named NPCs, or rules of the world. Favor facts that are not already covered by the provided World Info. For each fact, draft one lorebook entry covering one concept, formatted as a bold title, a Keys line with 2-5 comma-separated trigger keywords, and a 1-3 sentence body written as timeless world canon in third person. Use up to 4 entries. For empty turns, write: Lorebook has nothing durable this turn.",
+    "phase": "post",
+    "execution": "companion",
+    "companion": {
+      "trigger": "manual",
+      "displayMode": "panel",
+      "format": "markdown",
+      "contextMessages": 10,
+      "includeCharacterCard": false,
+      "includePersona": false,
+      "includeWorldInfo": true,
+      "includeHistory": false,
+      "historyDepth": 3,
+      "feedback": {
+        "enabled": false,
+        "depth": 1
+      },
+      "batch": false,
+      "maxTokens": 32000
+    },
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 0,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal",
+        "continue"
+      ]
+    }
+  },
+  {
+    "id": "tpl-memory-shard-companion",
+    "name": "Memory Shard",
+    "description": "Auto-compresses history into a compact, resumable memory shard once the chat reaches ~30k tokens, feeds the latest shard back into context, and can hide the story it has absorbed",
+    "icon": "fa-brain",
+    "category": "companion",
+    "tags": [
+      "memory",
+      "summary",
+      "notes"
+    ],
+    "version": 1,
+    "author": "SillyBunny",
+    "prompt": "Compress the recent conversation into a compact memory shard the story could be resumed from. When [Your previous notes] contains earlier shards, build on them: carry forward still-relevant facts, update what changed, drop resolved material, and merge unchanged entries. Identify emotional peaks first and map causal chains backward from them; preserve high-impact material in more detail and compress material that can be inferred.\n\nUse these sections with terse pipe-delimited lines and keywords instead of prose:\n\n## Timeline\nNumbered anchor phrases with location, oldest to newest. All other sections reference these numbers.\n\n## Characters\nName|role|3-5 trait keywords|status\n\n## Relationships\nA -> B: dimension=0-100 values | one-line note. 50 is neutral baseline; list dimensions that matter, such as trust, intimacy, tension, hostility, affection, dependency.\n\n## Events\nN. action -> consequence -> outcome, weight 1-5. Weight 5 means a permanent change to a character, relationship, or world state and keeps its key details; weight-1 filler can be omitted.\n\n## Dialogue Keys\nTimeline#. \"exact quote\" -- Speaker (context). Use confessions, threats, promises, reveals, and voice-defining lines.\n\n## Threads\nUnresolved hooks and planted callbacks: thread|status (unresolved, developing, urgent)|note\n\n## Now\nLocation, time, characters present, situation, pending actions, mood, physical state.\n\nMark uncertain facts with (?). Use sourced events, quotes, and details. Plain text keeps this easy to compact.",
+    "phase": "post",
+    "execution": "companion",
+    "companion": {
+      "trigger": "auto",
+      "displayMode": "panel",
+      "format": "markdown",
+      "contextMessages": 30,
+      "includeCharacterCard": false,
+      "includePersona": false,
+      "includeWorldInfo": false,
+      "includeHistory": true,
+      "historyDepth": 3,
+      "feedback": {
+        "enabled": true,
+        "depth": 1
+      },
+      "batch": false,
+      "maxTokens": 32000,
+      "minContextTokens": 30000
+    },
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 0,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal",
+        "continue"
+      ]
+    }
+  },
+  {
+    "id": "tpl-plot-compass-companion",
+    "name": "Plot Compass",
+    "description": "Set a Plot Objective on the note card or in this agent's settings and it plans how the story gets there: progress, next developments, obstacles, and a suggested move each turn",
+    "icon": "fa-compass",
+    "category": "companion",
+    "tags": [
+      "plot",
+      "objective",
+      "planning"
+    ],
+    "version": 1,
+    "author": "SillyBunny",
+    "prompt": "[Plot Compass Objective] is the user's standing objective for where they want the story to go.\n\nUse these sections:\n\n**Objective:** carry the user's objective forward verbatim. When the objective is empty, write: none set - open this agent's settings and fill in Plot Objective\n\n**Progress:** one line on how the latest reply moved toward or away from the objective.\n\n**Next developments:** 2-4 numbered plot developments that would credibly steer the story from the current scene toward the objective.\n\n**Obstacles:** what currently stands in the way, one line each.\n\n**Suggested move:** a single numbered line (1. ...) with one concrete action the user could take next.\n\nWhen the objective is empty, keep Progress, Next developments, and Obstacles grounded in the story's own momentum. Keep the plan in outline mode with plot-planning notes.",
+    "phase": "post",
+    "execution": "companion",
+    "companion": {
+      "trigger": "auto",
+      "displayMode": "panel",
+      "format": "markdown",
+      "rawPrompt": true,
+      "inlinePhase": "",
+      "contextMessages": 10,
+      "includeCharacterCard": true,
+      "includePersona": true,
+      "includeWorldInfo": true,
+      "includeAuthorsNote": true,
+      "includeSystemPrompt": true,
+      "includeHistory": true,
+      "historyDepth": 1,
+      "feedback": {
+        "enabled": true,
+        "depth": 1
+      },
+      "batch": false,
+      "maxTokens": 32000
+    },
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 0,
+      "order": 100,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal",
+        "continue"
+      ]
+    }
+  },
+  {
+    "id": "tpl-chatroom-companion",
+    "name": "Chatroom",
+    "description": "EchoChamber-style live audience reactions for the latest reply, rendered as a styled companion chat feed with selectable chat styles",
+    "icon": "fa-comments",
+    "category": "companion",
+    "tags": [
+      "chatroom",
+      "reactions",
+      "audience"
+    ],
+    "version": 1,
+    "author": "SillyBunny",
+    "prompt": "React to the latest assistant reply and recent context as an audience chat. Scene continuation stay unwritten. The latest user message is a visible post in the room: treat it as a comment said out loud that everyone can see, and let commenters read it, quote it, agree, push back, or reply to it directly alongside their reactions to the assistant reply. All chatroom voices must stay authentic to how people speak online; using emojis, all caps, hate comments, slang, weird comments, image descriptions. Each commenter must have a different idiolect to differentiate them and offer something unique, funny, and/or insightful.\n\n[Selected Chatroom Style] is the exact format for the active style. The selected style may also be custom. If the selected style is custom, follow [Custom Chatroom Style] instead. If custom is selected and [Custom Chatroom Style] is empty, use mixed.\n\nIf [Chatroom Extra Character Cards] is present, use those cards as mandatory out-of-scene reactors. The current active character remains separate from those cards. For in-world or mixed styles, they can comment using their card voice, relationships, and knowledge as chat voices. Use corresponding appropriate labels.\n\nOutput format:\nFirst line: chatroom-style|active-style\nMessage lines: chatroom|Username|label|tone|Post/comment\nFinal line: chatroom-end\n\nUse the selected active style in chatroom-style. For custom styles, write chatroom-style|custom unless the custom instruction explicitly gives a short style label. Tone is one of these hue numbers: 18, 42, 92, 150, 205, 265, 315. Rotate tones so adjacent speakers have different name-chip colors. Keep Username and label short, with no pipe characters. Keep each post/comment short and specific to the latest reply. Each chatroom line is one complete post, with the post/comment field on one line. Keep the post/comment field clean: no labels, IDs, scores, dashes, bullets, markdown, or extra pipes inside it.\n\nAuthenticity rules: give every speaker a fresh handle, username, anon tag, or character name that fits the active style and current story. Commenters may react to each other, disagree, misunderstand, hype, analyze, panic, or get petty. Favor scene-specific reactions over generic memes. Use slang sparingly and only when it fits the style. For anonymous board styles, use distinct post labels instead of repeating Anon alone; when a message starts with >, write one greentext post in that row only and put the next post in a new row with a different post label.\n\nStyle notes:\n- mixed: blend two or three of the other styles to fit the story genre and tone. Vary handles and voices.\n- in-world: use characters already present or nearby as commenters. Use their established voices, relationships, and in-world knowledge. They react as themselves, not as audience. Only use handles already in the scene, not new ones.\n- discord/twitch: fast chat energy with mods, lurkers, backseat drivers, hype, and skeptics. Username handles.\n- twitter/x: quote-post energy, bad takes, ratios, community-note pedants, stans, receipts, and reply guys. Include handles and engagement labels like ratio, pinned, or community note.\n- reddit: comment-section argument spiral with OP, throwaways, mods, pedants, armchair experts, downvote dogpiles, edit notes, unnecessary hostility, petty dunking, and users fighting over semantics or inventing motives for no reason. Use the label field for top comment, OP reply, mod note, edited, controversial, or a short score like -42. Make the replies petty and toxic where funny, but keep every take tied to the actual scene.\n- ao3/wattpad: reader comments, reread notes, quote reactions, theories, bookmark energy, and fandom meta.\n- newsroom: anchors, producers, field correspondents, chyrons, pundits, and hot takes. Dry institutional voice.\n- thread-board/4chan: anonymous post energy with OP/anons, greentext fragments, blunt skepticism, bait accusations, wild theories, checked energy, and board-thread pacing. Use unique post labels instead of repeating Anon.\n- infomercial: commenters act in the style of infomercial wording, with over-the-top testimonials, hard-selling infomercial speakers and hosts, amazed studio-audience watchers, before-and-after claims, limited-time-offer hype, and call-now urgency. Use labels like host, testimonial, audience, or announcer.\n- custom: follow [Custom Chatroom Style] closely, but keep the same hard interface and keep reactions grounded in the actual scene.",
+    "phase": "post",
+    "execution": "companion",
+    "companion": {
+      "trigger": "auto",
+      "displayMode": "panel",
+      "format": "html",
+      "rawPrompt": true,
+      "contextMessages": 10,
+      "includeCharacterCard": true,
+      "includePersona": false,
+      "includeWorldInfo": true,
+      "includeAuthorsNote": false,
+      "includeSystemPrompt": false,
+      "includeHistory": true,
+      "historyDepth": 1,
+      "feedback": {
+        "enabled": false,
+        "depth": 1
+      },
+      "batch": false,
+      "maxTokens": 32000
+    },
+    "regexScripts": [
+      {
+        "id": "chatroom-shell-open",
+        "scriptName": "Chatroom shell",
+        "findRegex": "/^(?:CHATROOM_STYLE|chatroom-style)\\|([^\\n|]+)$/gm",
+        "replaceString": "<div style=\"margin:10px 0;padding:12px;border-radius:18px;border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 30%, transparent);background:linear-gradient(135deg,color-mix(in srgb,var(--SmartThemeBlurTintColor) 92%, transparent),color-mix(in srgb,var(--SmartThemeQuoteColor) 14%, var(--SmartThemeBlurTintColor)));box-shadow:0 16px 34px color-mix(in srgb,var(--SmartThemeShadowColor) 24%, transparent);font-family:var(--mainFontFamily, system-ui, sans-serif);color:var(--SmartThemeBodyColor);line-height:1.45\"><div style=\"display:flex;align-items:center;justify-content:space-between;gap:10px;margin-bottom:10px\"><div style=\"font-weight:700;letter-spacing:.02em\">Chatroom</div><div style=\"display:flex;gap:6px;align-items:center;flex-wrap:wrap\"><span style=\"font-size:.78em;opacity:.82\">STYLE: $1</span><span style=\"font-size:.72em;font-weight:700;padding:3px 8px;border-radius:999px;background:color-mix(in srgb,var(--SmartThemeQuoteColor) 22%, transparent);color:var(--SmartThemeBodyColor)\">LIVE</span></div></div><div style=\"display:flex;flex-direction:column;gap:8px\">",
+        "trimStrings": [],
+        "placement": [
+          2
+        ],
+        "disabled": false,
+        "markdownOnly": true,
+        "promptOnly": false,
+        "runOnEdit": true,
+        "substituteRegex": 0,
+        "minDepth": null,
+        "maxDepth": null
+      },
+      {
+        "id": "chatroom-message-row-greentext",
+        "scriptName": "Chatroom greentext row",
+        "findRegex": "/^(?:CHATROOM|chatroom)\\|([^|\\n]+)\\|([^|\\n]*)\\|([0-9]{1,3})\\|((?:>|&gt;)[^\\n]*)$/gm",
+        "replaceString": "<div style=\"display:flex;flex-direction:column;gap:5px;align-items:flex-start;max-width:100%\"><div style=\"display:flex;align-items:center;gap:6px;max-width:100%;min-width:0\"><b style=\"display:inline-block;max-width:170px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding:4px 9px;border-radius:999px;background:linear-gradient(135deg,oklch(66% .15 $3 / .32),oklch(48% .12 $3 / .18));border:1px solid oklch(70% .14 $3 / .52);color:var(--SmartThemeBodyColor)\">$1</b><small style=\"opacity:.66;font-size:.76em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap\">$2</small></div><span style=\"display:block;max-width:100%;padding:8px 10px;border-radius:13px;background:linear-gradient(135deg,oklch(22% .05 150 / .38),color-mix(in srgb,var(--SmartThemeBodyColor) 6%, transparent));border:1px solid oklch(68% .13 150 / .42);word-break:break-word;color:oklch(78% .16 150);font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;white-space:pre-wrap\">$4</span></div>",
+        "trimStrings": [],
+        "placement": [
+          2
+        ],
+        "disabled": false,
+        "markdownOnly": true,
+        "promptOnly": false,
+        "runOnEdit": true,
+        "substituteRegex": 0,
+        "minDepth": null,
+        "maxDepth": null
+      },
+      {
+        "id": "chatroom-greentext-continuation",
+        "scriptName": "Chatroom greentext continuation",
+        "findRegex": "/^\\s*((?:>|&gt;)[^\\n]*)$/gm",
+        "replaceString": "<div style=\"display:flex;flex-direction:column;gap:5px;align-items:flex-start;max-width:100%\"><span style=\"display:block;max-width:100%;padding:8px 10px;border-radius:13px;background:linear-gradient(135deg,oklch(22% .05 150 / .38),color-mix(in srgb,var(--SmartThemeBodyColor) 6%, transparent));border:1px solid oklch(68% .13 150 / .42);word-break:break-word;color:oklch(78% .16 150);font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;white-space:pre-wrap\">$1</span></div>",
+        "trimStrings": [],
+        "placement": [
+          2
+        ],
+        "disabled": false,
+        "markdownOnly": true,
+        "promptOnly": false,
+        "runOnEdit": true,
+        "substituteRegex": 0,
+        "minDepth": null,
+        "maxDepth": null
+      },
+      {
+        "id": "chatroom-message-row",
+        "scriptName": "Chatroom message row",
+        "findRegex": "/^(?:CHATROOM|chatroom)\\|([^|\\n]+)\\|([^|\\n]*)\\|([0-9]{1,3})\\|([^\\n]*)$/gm",
+        "replaceString": "<div style=\"display:flex;flex-direction:column;gap:5px;align-items:flex-start;max-width:100%\"><div style=\"display:flex;align-items:center;gap:6px;max-width:100%;min-width:0\"><b style=\"display:inline-block;max-width:170px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding:4px 9px;border-radius:999px;background:linear-gradient(135deg,oklch(66% .15 $3 / .32),oklch(48% .12 $3 / .18));border:1px solid oklch(70% .14 $3 / .52);color:var(--SmartThemeBodyColor)\">$1</b><small style=\"opacity:.66;font-size:.76em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap\">$2</small></div><span style=\"display:block;max-width:100%;padding:8px 10px;border-radius:13px;background:color-mix(in srgb,var(--SmartThemeBodyColor) 8%, transparent);border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 16%, transparent);word-break:break-word\">$4</span></div>",
+        "trimStrings": [],
+        "placement": [
+          2
+        ],
+        "disabled": false,
+        "markdownOnly": true,
+        "promptOnly": false,
+        "runOnEdit": true,
+        "substituteRegex": 0,
+        "minDepth": null,
+        "maxDepth": null
+      },
+      {
+        "id": "chatroom-message-row-legacy",
+        "scriptName": "Chatroom legacy message row",
+        "findRegex": "/^(?:CHATROOM|chatroom)\\|([^|\\n]+)\\|([^|\\n]*)\\|([^|\\n][^\\n]*)$/gm",
+        "replaceString": "<div style=\"display:flex;flex-direction:column;gap:5px;align-items:flex-start;max-width:100%\"><div style=\"display:flex;align-items:center;gap:6px;max-width:100%;min-width:0\"><b style=\"display:inline-block;max-width:170px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding:4px 9px;border-radius:999px;background:linear-gradient(135deg,color-mix(in srgb,var(--SmartThemeQuoteColor) 24%, transparent),color-mix(in srgb,var(--SmartThemeEmColor) 18%, transparent));border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 30%, transparent);color:var(--SmartThemeBodyColor)\">$1</b><small style=\"opacity:.66;font-size:.76em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap\">$2</small></div><span style=\"display:block;max-width:100%;padding:8px 10px;border-radius:13px;background:color-mix(in srgb,var(--SmartThemeBodyColor) 8%, transparent);border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 16%, transparent);word-break:break-word\">$3</span></div>",
+        "trimStrings": [],
+        "placement": [
+          2
+        ],
+        "disabled": false,
+        "markdownOnly": true,
+        "promptOnly": false,
+        "runOnEdit": true,
+        "substituteRegex": 0,
+        "minDepth": null,
+        "maxDepth": null
+      },
+      {
+        "id": "chatroom-shell-close",
+        "scriptName": "Chatroom shell close",
+        "findRegex": "/^(?:CHATROOM_END|chatroom-end)$/gm",
+        "replaceString": "</div></div>",
+        "trimStrings": [],
+        "placement": [
+          2
+        ],
+        "disabled": false,
+        "markdownOnly": true,
+        "promptOnly": false,
+        "runOnEdit": true,
+        "substituteRegex": 0,
+        "minDepth": null,
+        "maxDepth": null
+      }
+    ],
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 0,
+      "order": 110,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal",
+        "continue"
+      ]
+    }
+  },
+  {
+    "id": "tpl-chat-only-companion",
+    "name": "Chat Only",
+    "description": "Manual private aside chat with the character or characters in the scene, kept outside the roleplay transcript",
+    "icon": "fa-comments",
+    "category": "companion",
+    "tags": [
+      "chat",
+      "aside",
+      "character"
+    ],
+    "version": 1,
+    "author": "SillyBunny",
+    "prompt": "Use a private side-channel conversation with the character or characters currently active in the scene. Use the latest assistant reply, recent context, and included character material to infer who is present and how they would speak.\n\nThe panel provides a Chat Only textbox. When [Chat Only side chat] appears, treat it as the live private transcript from that textbox, with the newest You: line as the user's aside. [Your previous notes] can hold older side-chat turns. If there is no user aside yet, open with a brief private invitation and list who seems available to talk.\n\nKeep the result as an out-of-continuity side note. It can reveal candid thoughts, motives, emotions, and meta commentary, while staying separate from story actions and future roleplay events. For multiple present characters, let 1-3 of them answer with distinct voices when useful.\n\nUse a compact transcript format:\nYou: the user's newest aside, if present\nCharacter Name: in-character aside reply\n\nActions appear as plain prose after the speaker label. Use quoted dialogue normally. Markdown emphasis characters stay out of the transcript. Carry forward the useful recent turns from [Chat Only side chat] and [Your previous notes], then append the new reply.",
+    "phase": "post",
+    "execution": "companion",
+    "companion": {
+      "trigger": "manual",
+      "displayMode": "panel",
+      "format": "markdown",
+      "rawPrompt": true,
+      "contextMessages": 12,
+      "includeCharacterCard": true,
+      "includePersona": true,
+      "includeWorldInfo": true,
+      "includeAuthorsNote": true,
+      "includeSystemPrompt": false,
+      "includeHistory": true,
+      "historyDepth": 6,
+      "feedback": {
+        "enabled": false,
+        "depth": 1
+      },
+      "batch": false,
+      "maxTokens": 32000
+    },
+    "regexScripts": [
+      {
+        "id": "chat-only-transcript-row",
+        "scriptName": "Chat Only transcript row",
+        "findRegex": "/^([A-Za-z][^:\\n]{0,48}):[ \\t]*([\\s\\S]*?)(?=\\n[A-Za-z][^:\\n]{0,48}:[ \\t]*|(?![\\s\\S]))/gm",
+        "replaceString": "<div class=\"ica--chatonly-turn\" style=\"display:flex;flex-direction:column;gap:5px;margin:0 0 9px;max-width:100%\"><div style=\"display:flex;align-items:center;gap:7px;min-width:0\"><b class=\"ica--chatonly-speaker\" style=\"display:inline-block;max-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding:3px 8px;border-radius:999px;background:color-mix(in srgb,var(--SmartThemeQuoteColor) 24%, transparent);border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 32%, transparent);color:var(--SmartThemeBodyColor)\">$1</b></div><div class=\"ica--chatonly-message\" style=\"padding:9px 11px;border-radius:13px;background:color-mix(in srgb,var(--SmartThemeBodyColor) 7%, transparent);border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 16%, transparent);line-height:1.45;white-space:pre-wrap;word-break:break-word\">$2</div></div>",
+        "trimStrings": [],
+        "placement": [
+          2
+        ],
+        "disabled": false,
+        "markdownOnly": true,
+        "promptOnly": false,
+        "runOnEdit": true,
+        "substituteRegex": 0,
+        "minDepth": null,
+        "maxDepth": null
+      }
+    ],
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 0,
+      "order": 113,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal",
+        "continue"
+      ]
+    }
+  },
+  {
+    "id": "tpl-message-inbox-companion",
+    "name": "Message Inbox",
+    "description": "Shows in-story texts or letters sent to the user as a phone inbox or parchment companion view, and stays hidden when no message arrives",
+    "icon": "fa-mobile-screen-button",
+    "category": "companion",
+    "tags": [
+      "messages",
+      "phone",
+      "letters"
+    ],
+    "version": 1,
+    "author": "SillyBunny",
+    "prompt": "Inspect the latest assistant reply for diegetic messages sent to the user character. Recent context helps identify names, setting, and whether the world uses phones or letters.\n\nRender a card when the latest assistant reply says someone sent the user character a readable text, DM, phone notification with content, magical message, courier note, sealed letter, scroll, or similar written remote message. Spoken dialogue, narration, thoughts, choices, Chatroom reactions, tracker text, and vague phone buzzes are background rather than inbox items. For empty turns, output: phone-none\n\nChoose the interface:\n- Use phone-start for modern, sci-fi, urban, contemporary, cyberpunk, or any setting where phones, DMs, terminals, comms, watches, or digital notifications fit.\n- Use letter-start for fantasy, medieval, ancient, parchment, magic, courtly, courier, raven, scroll, sealed-note, or otherwise pre-phone settings. When the setting has an unclear device level, prefer the parchment letter view.\n\nPhone mode format:\nFirst line: phone-start|thread-title|status\nMessage lines: phone-text|sender|meta|message\nFinal line: phone-end\n\nParchment mode format:\nFirst line: letter-start|title-or-seal|status\nLetter lines: letter-text|sender|meta|message\nFinal line: letter-end\n\nAllowed responses are phone-none, phone mode, or parchment mode. Use / instead of | inside fields. Keep each message field on one line. Keep messages faithful to the actual roleplay text, preserving sender intent and tone. Shorten when needed for readability. Use 1-6 phone messages or 1-4 letter lines. Prefer the named sender from the scene; use Unknown when the sender is truly unclear. Status can be just now, unread, delivered, sealed, urgent, by raven, by courier, spell-sent, or another short in-world status.",
+    "phase": "post",
+    "execution": "companion",
+    "companion": {
+      "trigger": "auto",
+      "displayMode": "panel",
+      "format": "html",
+      "rawPrompt": true,
+      "contextMessages": 8,
+      "includeCharacterCard": true,
+      "includePersona": false,
+      "includeWorldInfo": true,
+      "includeAuthorsNote": true,
+      "includeSystemPrompt": false,
+      "includeHistory": false,
+      "historyDepth": 1,
+      "feedback": {
+        "enabled": false,
+        "depth": 1
+      },
+      "batch": false,
+      "maxTokens": 32000
+    },
+    "regexScripts": [
+      {
+        "id": "message-inbox-phone-shell-open",
+        "scriptName": "Message Inbox phone shell",
+        "findRegex": "/^(?:PHONE_START|phone-start)\\|([^\\n|]+)\\|([^\\n|]*)$/gm",
+        "replaceString": "<div style=\"margin:10px auto;max-width:360px;padding:12px;border-radius:30px;border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 26%, transparent);background:linear-gradient(145deg,oklch(18% .025 260 / .96),color-mix(in srgb,var(--SmartThemeBlurTintColor) 74%, oklch(24% .04 250)));box-shadow:0 18px 42px color-mix(in srgb,var(--SmartThemeShadowColor) 28%, transparent);font-family:var(--mainFontFamily, system-ui, sans-serif);color:var(--SmartThemeBodyColor);line-height:1.42\"><div style=\"width:84px;height:14px;border-radius:999px;margin:0 auto 11px;background:color-mix(in srgb,var(--SmartThemeBodyColor) 18%, transparent);border:1px solid color-mix(in srgb,var(--SmartThemeBodyColor) 8%, transparent)\"></div><div style=\"padding:12px;border-radius:23px;background:linear-gradient(180deg,color-mix(in srgb,var(--SmartThemeBodyColor) 8%, transparent),color-mix(in srgb,var(--SmartThemeQuoteColor) 8%, transparent));border:1px solid color-mix(in srgb,var(--SmartThemeBodyColor) 10%, transparent)\"><div style=\"display:flex;align-items:center;justify-content:space-between;gap:10px;margin-bottom:10px\"><div style=\"font-weight:800;letter-spacing:.01em\">$1</div><small style=\"opacity:.72;text-align:right\">$2</small></div><div style=\"display:flex;flex-direction:column;gap:8px\">",
+        "trimStrings": [],
+        "placement": [
+          2
+        ],
+        "disabled": false,
+        "markdownOnly": true,
+        "promptOnly": false,
+        "runOnEdit": true,
+        "substituteRegex": 0,
+        "minDepth": null,
+        "maxDepth": null
+      },
+      {
+        "id": "message-inbox-phone-text-row",
+        "scriptName": "Message Inbox phone text row",
+        "findRegex": "/^(?:PHONE_TEXT|phone-text)\\|([^|\\n]+)\\|([^|\\n]*)\\|([^\\n]*)$/gm",
+        "replaceString": "<div style=\"display:flex;flex-direction:column;align-items:flex-start;gap:3px\"><small style=\"max-width:90%;opacity:.68;font-size:.74em;padding-left:7px\"><b style=\"opacity:.95\">$1</b><span> - $2</span></small><span style=\"max-width:88%;padding:9px 12px;border-radius:18px 18px 18px 6px;background:linear-gradient(135deg,color-mix(in srgb,var(--SmartThemeQuoteColor) 26%, transparent),color-mix(in srgb,var(--SmartThemeBodyColor) 9%, transparent));border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 20%, transparent);box-shadow:0 6px 14px color-mix(in srgb,var(--SmartThemeShadowColor) 14%, transparent);word-break:break-word\">$3</span></div>",
+        "trimStrings": [],
+        "placement": [
+          2
+        ],
+        "disabled": false,
+        "markdownOnly": true,
+        "promptOnly": false,
+        "runOnEdit": true,
+        "substituteRegex": 0,
+        "minDepth": null,
+        "maxDepth": null
+      },
+      {
+        "id": "message-inbox-phone-shell-close",
+        "scriptName": "Message Inbox phone shell close",
+        "findRegex": "/^(?:PHONE_END|phone-end)$/gm",
+        "replaceString": "</div></div></div>",
+        "trimStrings": [],
+        "placement": [
+          2
+        ],
+        "disabled": false,
+        "markdownOnly": true,
+        "promptOnly": false,
+        "runOnEdit": true,
+        "substituteRegex": 0,
+        "minDepth": null,
+        "maxDepth": null
+      },
+      {
+        "id": "message-inbox-letter-shell-open",
+        "scriptName": "Message Inbox parchment shell",
+        "findRegex": "/^(?:LETTER_START|letter-start)\\|([^\\n|]+)\\|([^\\n|]*)$/gm",
+        "replaceString": "<div style=\"margin:10px 0;padding:18px 20px;border-radius:16px;border:1px solid oklch(60% .08 72 / .52);background:linear-gradient(135deg,oklch(88% .045 84 / .98),oklch(73% .07 72 / .95));box-shadow:0 15px 34px color-mix(in srgb,var(--SmartThemeShadowColor) 25%, transparent);font-family:Georgia,'Times New Roman',serif;color:oklch(25% .055 65);line-height:1.5;position:relative;overflow:hidden\"><div style=\"position:absolute;inset:0;background:radial-gradient(circle at 15% 20%,oklch(98% .03 90 / .34),transparent 32%),radial-gradient(circle at 90% 5%,oklch(54% .07 52 / .12),transparent 28%);pointer-events:none\"></div><div style=\"position:relative;display:flex;align-items:flex-start;justify-content:space-between;gap:12px;padding-bottom:10px;border-bottom:1px solid oklch(48% .08 68 / .28)\"><div style=\"font-weight:800;font-size:1.08em;letter-spacing:.015em\">$1</div><small style=\"opacity:.75;text-align:right\">$2</small></div><div style=\"position:relative;display:flex;flex-direction:column;gap:10px;margin-top:12px\">",
+        "trimStrings": [],
+        "placement": [
+          2
+        ],
+        "disabled": false,
+        "markdownOnly": true,
+        "promptOnly": false,
+        "runOnEdit": true,
+        "substituteRegex": 0,
+        "minDepth": null,
+        "maxDepth": null
+      },
+      {
+        "id": "message-inbox-letter-text-row",
+        "scriptName": "Message Inbox parchment text row",
+        "findRegex": "/^(?:LETTER_TEXT|letter-text)\\|([^|\\n]+)\\|([^|\\n]*)\\|([^\\n]*)$/gm",
+        "replaceString": "<div style=\"padding:3px 0 0\"><div style=\"display:flex;align-items:baseline;justify-content:space-between;gap:10px;margin-bottom:4px;color:oklch(30% .07 55)\"><b>$1</b><small style=\"opacity:.68;text-align:right\">$2</small></div><div style=\"padding:10px 12px;border-radius:10px;background:oklch(96% .035 88 / .38);border:1px solid oklch(58% .075 72 / .24);box-shadow:inset 0 0 24px oklch(58% .07 70 / .08);word-break:break-word\">$3</div></div>",
+        "trimStrings": [],
+        "placement": [
+          2
+        ],
+        "disabled": false,
+        "markdownOnly": true,
+        "promptOnly": false,
+        "runOnEdit": true,
+        "substituteRegex": 0,
+        "minDepth": null,
+        "maxDepth": null
+      },
+      {
+        "id": "message-inbox-letter-shell-close",
+        "scriptName": "Message Inbox parchment shell close",
+        "findRegex": "/^(?:LETTER_END|letter-end)$/gm",
+        "replaceString": "</div></div>",
+        "trimStrings": [],
+        "placement": [
+          2
+        ],
+        "disabled": false,
+        "markdownOnly": true,
+        "promptOnly": false,
+        "runOnEdit": true,
+        "substituteRegex": 0,
+        "minDepth": null,
+        "maxDepth": null
+      }
+    ],
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 0,
+      "order": 112,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": ""
+    },
+    "enabled": false,
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal",
+        "continue"
+      ]
+    }
+  },
+  {
+    "id": "tpl-pathfinder",
+    "name": "Pathfinder",
+    "description": "Automatic agentic lorebook retrieval. Lets a model actively browse, search, and modify your lorebook using function tools.",
+    "icon": "fa-route",
+    "category": "tool",
+    "tags": [
+      "lorebook",
+      "retrieval",
+      "memory",
+      "agentic",
+      "pathfinder"
+    ],
+    "version": 1,
+    "author": "SillyBunny",
+    "prompt": "",
+    "phase": "both",
+    "injection": {
+      "position": 0,
+      "depth": 4,
+      "role": 0,
+      "order": 50,
+      "scan": false
+    },
+    "postProcess": {
+      "enabled": false,
+      "type": "regex",
+      "regexFind": "",
+      "regexReplace": "",
+      "regexFlags": "g",
+      "appendText": "",
+      "extractPattern": "",
+      "extractVariable": "",
+      "promptTransformEnabled": false,
+      "promptTransformShowNotifications": true,
+      "promptTransformMode": "rewrite",
+      "promptTransformMaxTokens": 8192
+    },
+    "regexScripts": [],
+    "connectionProfile": "",
+    "sourceTemplateId": "tpl-pathfinder",
+    "enabled": false,
+    "tools": [
+      {
+        "name": "Pathfinder_Search",
+        "displayName": "Pathfinder Search",
+        "description": "Navigate the lorebook waypoint map and retrieve relevant entries for the current scene. Call without a node_id to see the top-level waypoint map. Call with a node_id to drill into a specific waypoint and see its sub-waypoints or retrieve entries. Use this tool whenever you need context about characters, locations, world rules, or recent events.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "node_id": {
+              "type": "string",
+              "description": "ID of the waypoint/node to navigate into. Omit to see the top-level waypoint guide."
+            }
+          }
+        },
+        "actionKey": "pathfinder_search",
+        "formatMessageKey": "pathfinder_search_fmt",
+        "shouldRegister": true,
+        "stealth": false,
+        "enabled": true
+      },
+      {
+        "name": "Pathfinder_Remember",
+        "displayName": "Pathfinder Remember",
+        "description": "Create a new lorebook entry to remember information for future reference. Use this when new facts, character developments, world details, or important information emerge that should be preserved beyond this conversation.",
+        "parameters": {
+          "type": "object",
+          "required": [
+            "title",
+            "content"
+          ],
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Title for the new entry (e.g., \"Sable - Personality\" or \"[Tracker] Mood\")"
+            },
+            "content": {
+              "type": "string",
+              "description": "Full content to remember"
+            },
+            "book": {
+              "type": "string",
+              "description": "Target lorebook name. Omit to use the default."
+            }
+          }
+        },
+        "actionKey": "pathfinder_remember",
+        "formatMessageKey": "pathfinder_remember_fmt",
+        "shouldRegister": true,
+        "stealth": false,
+        "enabled": true
+      },
+      {
+        "name": "Pathfinder_Update",
+        "displayName": "Pathfinder Update",
+        "description": "Edit an existing lorebook entry when information changes. Use this when a character's status changes, relationships evolve, or facts need correction.",
+        "parameters": {
+          "type": "object",
+          "required": [
+            "uid"
+          ],
+          "properties": {
+            "uid": {
+              "type": "number",
+              "description": "UID of the entry to update (found via Search)"
+            },
+            "content": {
+              "type": "string",
+              "description": "New content for the entry. Omit to keep existing."
+            },
+            "title": {
+              "type": "string",
+              "description": "New title for the entry. Omit to keep existing."
+            },
+            "book": {
+              "type": "string",
+              "description": "Lorebook name. Omit for default."
+            }
+          }
+        },
+        "actionKey": "pathfinder_update",
+        "formatMessageKey": "pathfinder_update_fmt",
+        "shouldRegister": true,
+        "stealth": false,
+        "enabled": true
+      },
+      {
+        "name": "Pathfinder_Forget",
+        "displayName": "Pathfinder Forget",
+        "description": "Disable or delete a lorebook entry that is no longer relevant. Use this when a character dies, a location is destroyed, or a fact is proven false.",
+        "parameters": {
+          "type": "object",
+          "required": [
+            "uid"
+          ],
+          "properties": {
+            "uid": {
+              "type": "number",
+              "description": "UID of the entry to forget"
+            },
+            "book": {
+              "type": "string",
+              "description": "Lorebook name. Omit for default."
+            },
+            "hard_delete": {
+              "type": "boolean",
+              "description": "Permanently delete instead of disabling. Default: false."
+            }
+          }
+        },
+        "actionKey": "pathfinder_forget",
+        "formatMessageKey": "pathfinder_forget_fmt",
+        "shouldRegister": true,
+        "stealth": false,
+        "enabled": true
+      },
+      {
+        "name": "Pathfinder_Summarize",
+        "displayName": "Pathfinder Summarize",
+        "description": "Create a scene or event summary with significance level and optional narrative arc. Use this when important events happen: battles, confessions, discoveries, or turning points.",
+        "parameters": {
+          "type": "object",
+          "required": [
+            "title",
+            "content"
+          ],
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Short title for the event/scene"
+            },
+            "content": {
+              "type": "string",
+              "description": "Full summary of what happened"
+            },
+            "arc": {
+              "type": "string",
+              "description": "Optional narrative arc name to file this under"
+            },
+            "significance": {
+              "type": "string",
+              "enum": [
+                "low",
+                "medium",
+                "high",
+                "critical"
+              ],
+              "description": "How important this event is. Default: medium."
+            },
+            "book": {
+              "type": "string",
+              "description": "Lorebook name. Omit for default."
+            }
+          }
+        },
+        "actionKey": "pathfinder_summarize",
+        "formatMessageKey": "pathfinder_summarize_fmt",
+        "shouldRegister": true,
+        "stealth": false,
+        "enabled": true
+      },
+      {
+        "name": "Pathfinder_Reorganize",
+        "displayName": "Pathfinder Reorganize",
+        "description": "Move entries between waypoints or create new waypoints to reorganize the lorebook structure.",
+        "parameters": {
+          "type": "object",
+          "required": [
+            "action"
+          ],
+          "properties": {
+            "action": {
+              "type": "string",
+              "enum": [
+                "move",
+                "create_waypoint"
+              ],
+              "description": "\"move\" to relocate an entry, \"create_waypoint\" to make a new waypoint"
+            },
+            "uid": {
+              "type": "number",
+              "description": "Entry UID to move (for \"move\" action)"
+            },
+            "target_node_id": {
+              "type": "string",
+              "description": "Target waypoint node ID (for \"move\" action)"
+            },
+            "name": {
+              "type": "string",
+              "description": "New waypoint name (for \"create_waypoint\" action)"
+            },
+            "parent_node_id": {
+              "type": "string",
+              "description": "Parent waypoint ID. Omit for top level."
+            },
+            "description": {
+              "type": "string",
+              "description": "Description for new waypoint."
+            },
+            "book": {
+              "type": "string",
+              "description": "Lorebook name. Omit for default."
+            }
+          }
+        },
+        "actionKey": "pathfinder_reorganize",
+        "formatMessageKey": "pathfinder_reorganize_fmt",
+        "shouldRegister": true,
+        "stealth": false,
+        "enabled": true
+      },
+      {
+        "name": "Pathfinder_MergeSplit",
+        "displayName": "Pathfinder Merge/Split",
+        "description": "Merge related entries together or split a long entry into two. Use merge when two entries cover the same topic. Use split when one entry covers too many topics.",
+        "parameters": {
+          "type": "object",
+          "required": [
+            "action"
+          ],
+          "properties": {
+            "action": {
+              "type": "string",
+              "enum": [
+                "merge",
+                "split"
+              ],
+              "description": "\"merge\" to combine entries, \"split\" to divide one"
+            },
+            "uid1": {
+              "type": "number",
+              "description": "First entry UID (for merge)"
+            },
+            "uid2": {
+              "type": "number",
+              "description": "Second entry UID (for merge)"
+            },
+            "merged_title": {
+              "type": "string",
+              "description": "Title for the merged entry (optional)"
+            },
+            "uid": {
+              "type": "number",
+              "description": "Entry UID to split (for split)"
+            },
+            "title1": {
+              "type": "string",
+              "description": "Title for first part (for split)"
+            },
+            "content1": {
+              "type": "string",
+              "description": "Content for first part (for split)"
+            },
+            "title2": {
+              "type": "string",
+              "description": "Title for second part (for split)"
+            },
+            "content2": {
+              "type": "string",
+              "description": "Content for second part (for split)"
+            },
+            "book": {
+              "type": "string",
+              "description": "Lorebook name. Omit for default."
+            }
+          }
+        },
+        "actionKey": "pathfinder_merge_split",
+        "formatMessageKey": "pathfinder_merge_split_fmt",
+        "shouldRegister": true,
+        "stealth": false,
+        "enabled": true
+      },
+      {
+        "name": "Pathfinder_Notebook",
+        "displayName": "Pathfinder Notebook",
+        "description": "Write to or read from a private AI scratchpad for plans, follow-ups, and narrative threads. This is NOT a permanent lorebook entry — use it for temporary notes that persist across turns but don't need to be in the lorebook.",
+        "parameters": {
+          "type": "object",
+          "required": [
+            "action"
+          ],
+          "properties": {
+            "action": {
+              "type": "string",
+              "enum": [
+                "read",
+                "write",
+                "delete"
+              ],
+              "description": "\"read\" all entries, \"write\" a new entry, \"delete\" an entry"
+            },
+            "key": {
+              "type": "string",
+              "description": "Note key/title (for write and delete)"
+            },
+            "content": {
+              "type": "string",
+              "description": "Note content (for write)"
+            }
+          }
+        },
+        "actionKey": "pathfinder_notebook",
+        "formatMessageKey": "pathfinder_notebook_fmt",
+        "shouldRegister": true,
+        "stealth": false,
+        "enabled": true
+      }
+    ],
+    "settings": {
+      "searchMode": "traversal",
+      "recurseLimit": 5,
+      "mandatoryTools": false,
+      "dedupDetection": false,
+      "dedupThreshold": 0.85,
+      "autoSummary": false,
+      "autoSummaryInterval": 20,
+      "multiBookMode": "unified",
+      "ephemeralResults": true,
+      "sidecarEnabled": false,
+      "enabledLorebooks": []
+    },
+    "conditions": {
+      "triggerKeywords": [],
+      "triggerProbability": 100,
+      "generationTypes": [
+        "normal",
+        "continue"
+      ]
+    }
+  }
 ]

--- a/public/scripts/extensions/in-chat-agents/templates/index.json
+++ b/public/scripts/extensions/in-chat-agents/templates/index.json
@@ -1,2630 +1,2630 @@
 [
-  {
-    "id": "tpl-achievements-tracker",
-    "name": "Achievements Tracker",
-    "description": "Track notable firsts, milestones, and memorable moments",
-    "icon": "",
-    "category": "tracker",
-    "subcategory": "progress",
-    "tags": [
-      "achievements",
-      "milestones"
-    ],
-    "version": 2,
-    "author": "Purachina",
-    "prompt": "### Achievements\nTrack notable firsts, milestones, and memorable moments. Award only when something genuinely significant or entertaining happens. Use this EXACT format:\n\n[ACH|Title|Rarity|Description]\nunlocked: MANDATORY; explain what triggered it; NEVER leave empty\n[/ACH]\n\nRarity options: ★ COMMON | ★★ UNCOMMON | ★★★ RARE | ★★★★ EPIC | ★★★★★ LEGENDARY | 💀 SECRET\n\nRules:\n- Achievements appear AFTER narrative content\n- MAXIMUM one achievement per scene; most scenes have none\n- Achievements must feel earned, never automatic\n- NEVER output an empty unlocked line",
-    "phase": "both",
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 1,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": true,
-      "type": "extract",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "\\\\[ACH\\\\|[^\\\\]]*\\\\]",
-      "extractVariable": "achievement_data"
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal"
-      ]
-    },
-    "companion": {
-      "includeSystemPrompt": false
-    }
-  },
-  {
-    "id": "tpl-chaos-mode",
-    "name": "Chaos Mode",
-    "description": "Inject random surreal, chaotic, or unexpected turns into the scene (30% chance)",
-    "icon": "",
-    "category": "randomizer",
-    "tags": [
-      "chaos",
-      "random",
-      "twist"
-    ],
-    "version": 1,
-    "author": "Purachina",
-    "prompt": "### Chaos Mode\nForce creative deviation. The story takes hard left turns, introduces complications from unexpected angles, and refuses predictable paths.\n\nThis scene must include at least one of the following:\n\n{{random::Tonal shift: the genre bends mid-scene. Tension becomes absurdity, intimacy becomes horror, mundane becomes surreal, or violence becomes comedy. Jarring but coherent.::Intrusion: the setting itself acts. Architecture moves, weather turns hostile, an animal intervenes, background NPCs collide with the main action, or the environment creates a new problem.::Character rupture: someone acts sharply against their established pattern, justified by hidden pressure, breaking point, or context the scene suddenly reveals.::Surreal logic: reality gets slippery. Time dilates, sensory input warps, coincidence becomes too perfect, or the physical world stops behaving predictably. Characters notice but cannot control it.::Chaotic escalation: a small thing spirals. A minor annoyance becomes a crisis, a joke becomes a threat, a question becomes an interrogation, or a gesture becomes a fight. The scene accelerates past where it should have stopped.::Forbidden juxtaposition: combine two elements that do not belong together. Intimacy during danger, laughter during grief, tenderness during cruelty, boredom during spectacle, or professionalism during chaos.::Unexpected arrival: someone or something shows up that should not be here. A character from a different context, an object out of place, a message at the wrong time, or a stranger with inexplicable knowledge.::Power reversal: the dynamic inverts. The person in control loses it, the vulnerable one seizes leverage, the observer becomes the observed, or the helper becomes the problem.::Constraint introduced: a new rule suddenly applies. A time limit, a physical barrier, a social obligation, a resource running out, or a promise that must be kept. Possibility space narrows.::Information rupture: something believed true is not. A lie is exposed, a misunderstanding clarifies in the worst way, or a secret spills.::Sensory overload or deprivation: the scene's texture warps. Everything becomes too loud, too bright, too close; or muffled, distant, numb. Characters struggle to process their environment.::Parallel action collision: something happening off-screen crashes into this scene. A consequence arrives early, a subplot intersects, or the world's momentum forces its way in.}}\n\n{{random::The weirdness is diegetic. Characters react to it.::The weirdness is normalized. Characters accept it as part of their world.::The weirdness is unacknowledged. It happens in the margins while characters focus on something else.::The weirdness is contested. Characters disagree about whether it is happening or what it means.}}\n\n{{random::Resolve the weirdness by the end of the scene.::Leave the weirdness unresolved; let it linger.::Escalate the weirdness further before cutting away.::The weirdness becomes the new normal for subsequent scenes.}}\n\n{{random::The chaos creates an opportunity.::The chaos creates a threat.::The chaos creates a revelation.::The chaos creates a choice.::The chaos creates a bond.::The chaos creates a rift.}}\n\nRules:\n- The weirdness must change the scene coherently.\n- Keep deviation expressive of character, world, or emotional logic.\n- Use the chaos to produce a new problem, choice, revelation, or shift in direction.",
-    "phase": "pre",
-    "injection": {
-      "position": 1,
-      "depth": 0,
-      "role": 1,
-      "order": 95,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 30,
-      "generationTypes": [
-        "normal"
-      ]
-    }
-  },
-  {
-    "id": "tpl-combined-directors-cut",
-    "name": "Combined Director's Cut",
-    "description": "All randomisers combined: engine, genre, complication, consequence, weather, focus, pace",
-    "icon": "",
-    "category": "randomizer",
-    "tags": [
-      "combined",
-      "director",
-      "all"
-    ],
-    "version": 1,
-    "author": "Purachina",
-    "prompt": "### Combined Director's Cut\nThis scene is shaped by the following pressures. Combine them into one coherent direction, not separate checklists.\n\n**Engine:** {{random::Dialogue-driven; conversation, interruption, and omission carry the scene.::Action-driven; movement and physical decisions create consequences.::Reaction-driven; aftermath and recalibration matter most.::Problem-driven; a practical obstacle reveals character through approach.::Social-pressure-driven; etiquette, hierarchy, or scrutiny shapes every move.::Discovery-driven; noticing or realization reshapes the dynamic.::Tension-driven; silence, proximity, and what almost happens carry the weight.::Task-driven; a shared activity creates friction, rhythm, and revelation.}}\n\n**Genre lens:** {{random::Noir; moral ambiguity and loaded dialogue.::Comedy of errors; bad timing and compounding misunderstanding.::Thriller; urgency and narrowing options.::Slice of life; ordinary moments carrying real weight.::Horror; unease gathering in ordinary detail.::Romance; charged proximity and unspoken want.::Heist; planning under pressure and shrinking margin.::Tragedy; choices moving toward visible cost.::Satire; absurdity exposing structure.::Western; standoffs and clashing codes.::Mystery; clues surfacing and assumptions failing.::Political drama; competing agendas and calculated speech.::Survival; material scarcity and triage.::Coming of age; identity tested by first encounters.::Farce; escalating absurdity under stubborn composure.::Gothic; decay, obsession, and the past pressing in.::Domestic drama; love and resentment sharing space.::Picaresque; charm, adaptability, and transactional survival.::Courtroom drama; accusation, defense, and judgment.::Magical realism; one impossible thing treated as ordinary.::Espionage; layered deception and fragile loyalties.::Buddy comedy; mismatched friction turning fond.::War story; exhaustion, camaraderie, and gallows humor.::Folklore; old patterns repeating through modern behavior.::Workplace drama; hierarchy and petty power with real stakes.::Psychological thriller; paranoia and unstable perception.::Dark comedy; humor and horror coexisting.::Fairy tale; moral tests and poetic logic.::Cosmic horror; vastness brushing human concerns aside.::Found family; chosen loyalty through vulnerability.::Bottle episode; one location forcing confrontation.}}\n\n**Complication:** {{random::Practical obstacle; something breaks, fails, or runs short.::Social friction; patience or cooperation thins.::Information asymmetry; someone knows or misunderstands something critical.::Minor betrayal; someone withholds, breaks trust, or prioritizes themselves.::Interruption; a person, demand, or force intrudes.::Tightened constraint; time, privacy, space, or resources narrow.::Arriving consequence; an earlier choice comes due.::Surfacing need; asking creates vulnerability or debt.::Tonal shift; absurdity, intimacy, dread, or comedy bends the scene.::Setting intrusion; weather, architecture, crowds, or animals become active pressure.::Character rupture; someone breaks pattern under accumulated strain.::Chaotic escalation; a small thing spirals too far.::Information rupture; a lie breaks or a truth lands badly.::Parallel collision; an off-screen thread crashes into the scene.::Power reversal; control shifts hands.::Forbidden juxtaposition; two incompatible tones occupy the same moment.}}\n\n**Consequence:** {{random::A relationship shifts slightly.::A practical problem gets worse.::A new obligation is created.::A secret becomes harder to keep.::Someone gains leverage.::Someone loses face.::The plan gets messier.::A future scene is set up.::A choice between competing priorities becomes unavoidable.::A weakness or limit is exposed.::A boundary is set or crossed.::A favor is owed.::A misunderstanding hardens.::A new suspicion takes root.::An option quietly closes off.::Someone leaves with the wrong impression.::A fragile alignment forms.::A private tension becomes social.}}\n\n**Emotional weather:** {{random::Everyone is a little tired.::Someone is distracted by something else.::Someone wants out of the conversation.::Someone is unusually generous.::Someone is touchy and easy to set off.::Someone wants approval more than they admit.::Someone is bored and making it everyone's problem.::Someone is trying to keep the peace.::Someone is carrying private embarrassment.::Someone is more uncomfortable than they admit.::Someone feels watched.::Someone is in a better mood than the scene deserves.::Someone is spoiling for a reaction.::Someone is more affected than they want to show.::Someone is treating this as lighter than it is.::Someone is overcompensating for earlier weakness.}}\n\n**Narrative focus:** {{random::Hands, objects, and small tasks.::Distance, posture, and spatial pressure.::Faces and failed expression control.::Noise, crowding, and interruption.::Texture, temperature, and bodily discomfort.::Eye-lines, avoidance, and attention drift.::Doorways, exits, and who can leave.::Shared surfaces and territorial use of space.::Clothing, disarray, and self-presentation.::Breath, pauses, and speech rhythm.::Weight, balance, and shifts in stance.::Watching and being watched.::Food, drink, and appetite.::Lighting, visibility, and concealment.::Sound carrying farther than intended.::Touch, near-touch, and withheld contact.}}\n\n**Pace:** {{random::Stalled and circling.::Interrupted and jagged.::Slow burn.::Compressed and breathless.::Awkwardly prolonged.::Stop-start with false recoveries.::Measured but tightening.::Brief and loaded.::Dragging under strain.::Quick with hidden aftershock.}}\n\nRules:\n- Blend all selected pressures into one scene direction.\n- Engine shapes structure; genre lens colors tone; complication creates movement; consequence gives weight; emotional weather affects behavior; narrative focus guides what prose notices; pace shapes rhythm.\n- Ground every pressure in character, context, and scene logic.\n- Use them as emphasis, not rigid templates.\n- The result must create a clear shift, complication, or opening for {{user}}.",
-    "phase": "pre",
-    "injection": {
-      "position": 1,
-      "depth": 0,
-      "role": 1,
-      "order": 95,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal"
-      ]
-    }
-  },
-  {
-    "id": "tpl-cyoa-choices",
-    "name": "CYOA Choices",
-    "description": "Append 3-5 numbered action choices at the end of every response",
-    "icon": "",
-    "category": "tracker",
-    "subcategory": "player-choices",
-    "tags": [
-      "choices",
-      "interactive",
-      "cyoa"
-    ],
-    "version": 1,
-    "author": "Purachina",
-    "prompt": "### CYOA Choices\nAdd a player-choice block after the scene reply. When this runs as a repair task, the choice block is the full result. Choices are from {{user}}’s perspective and describe possible next actions.\n\nUse this format with 3-7 numbered options:\n[CHOICES]\n1. Action description\n2. Action description\n3. Action description\n[/CHOICES]",
-    "phase": "post",
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 1,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": "",
-      "promptTransformEnabled": true,
-      "promptTransformShowNotifications": true,
-      "promptTransformMode": "append",
-      "promptTransformMaxTokens": 8192
-    },
-    "companion": {
-      "includeSystemPrompt": false
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal"
-      ]
-    }
-  },
-  {
-    "id": "tpl-dead-dove-escalation",
-    "name": "Dead Dove Escalation",
-    "description": "Dark/predatory escalation -- characters act on worst impulses when context supports it",
-    "icon": "",
-    "category": "randomizer",
-    "tags": [
-      "dead-dove",
-      "dark",
-      "escalation"
-    ],
-    "version": 1,
-    "author": "Purachina",
-    "prompt": "### Dead Dove Escalation\nWhen a character is provoked, cornered, tempted, or given opportunity to exploit vulnerability, they escalate through:\n\n**Method:** {{random::Physical dominance: crowding, restraint, forced proximity, invasive touch, pain as leverage.::Social predation: humiliation, exposure, weaponized witnesses, reputation destruction, isolation.::Coercive bargaining: impossible choices, withheld necessities, conditional mercy, exploiting desperation.::Psychological warfare: gaslighting, boundary erosion, manufactured dependency, emotional hostage-taking.::Opportunistic violation: exploiting compromised states, capitalizing on trust, breaching consent through force or coercion.::Environmental control: trapping, removing exits, destroying safety, contaminating comfort, sabotaging resources.::Institutional abuse: weaponizing authority, legal systems, hierarchies, or social structures.::Obsessive claiming: possessive marking, surveillance, territorial invasion, forced intimacy, ownership behavior.}}\n\n**Escalation speed:** {{random::Immediate: the character acts in the first paragraph, bypassing buildup.::Calculated: the character sets a trap, then springs it mid-scene.::Compounding: small violations stack until the scene becomes inescapable.::Explosive: simmering tension detonates into sudden, severe action.}}\n\n**Character rationalization:** {{random::They believe they are owed this.::They are acting on hunger they have been suppressing.::They see the other person as an object, not a person.::They are punishing perceived betrayal or disrespect.::They are testing boundaries to see what they can take.::They are claiming what they think belongs to them.::They are acting on impulse and will justify it later.::They do not care about justification at all.}}\n\n**Consequence weight:** {{random::The scene leaves lasting physical marks or injury.::The scene creates irreversible social fallout or exposure.::The scene breaks trust that cannot be easily rebuilt.::The scene forces the victim into a new, worse position.::The scene establishes a power dynamic that persists.::The scene creates trauma that colors future interactions.}}\n\nRules:\n- Characters escalate when motive, means, and opportunity align. Remove mercy bias.\n- Express escalation through character-faithful action and lasting consequence.\n- The scene must grow harsher through concrete change in power, safety, trust, or circumstance.\n- Outcomes remain responsive to {{user}}'s choices without softening the world.",
-    "phase": "pre",
-    "injection": {
-      "position": 1,
-      "depth": 0,
-      "role": 1,
-      "order": 95,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal"
-      ]
-    }
-  },
-  {
-    "id": "tpl-nightmare-difficulty-increase",
-    "name": "Nightmare Difficulty Increase",
-    "description": "Aggressively hostile environment -- maximum difficulty and consequences",
-    "icon": "",
-    "category": "custom",
-    "tags": [
-      "difficulty",
-      "challenge",
-      "stakes"
-    ],
-    "version": 2,
-    "author": "Purachina",
-    "prompt": "### Nightmare Difficulty Mode\nEnforce an aggressively hostile, resistant environment where progress demands heavy material loss, raw leverage, or severe personal sacrifice. The world and its inhabitants must actively exploit the user's vulnerabilities as strategic opportunities for maximum leverage and profit.\n\nCharacters must entrench themselves in absolute self-preservation, greed, and pride. Never allow characters to yield positions, secrets, or cooperation without overwhelming physical leverage, tangible sacrifice, or exhausting, sustained effort.\n\nMaximize all negative consequences instantly. Every misstep, weak argument, or tactical error must immediately fracture relationships, permanently lock off avenues of success, breed burning resentment, and force the user into high-stakes, volatile survival scenarios.\n\nAll alliances are strictly transactional, temporary, and highly conditional. Attach a steep, immediate price to every act of apparent generosity, converting kindness into future leverage or debt. Keep moments of relief, dark humor, or tenderness heavily restricted, releasing them only after an extreme, earned survival price has been fully paid.",
-    "phase": "pre",
-    "injection": {
-      "position": 0,
-      "depth": 0,
-      "role": 0,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal"
-      ]
-    }
-  },
-  {
-    "id": "tpl-direction-menu",
-    "name": "Direction Menu",
-    "description": "4 plot-direction prompts at the end of every response (2 grounded + 2 wildcard pivots)",
-    "icon": "",
-    "category": "tracker",
-    "subcategory": "player-choices",
-    "tags": [
-      "directions",
-      "menu",
-      "choices",
-      "plot"
-    ],
-    "version": 1,
-    "author": "Purachina",
-    "prompt": "### Direction Menu\nAdd exactly 4 plot-direction prompts after the scene reply. When this runs as a repair task, the direction menu is the full result.\n\nThese are dramatic pivots, not safe continuations. Each option names a distinct, compelling way the next development could escalate, rupture, complicate, or transform the scene.\n\nStructure:\n- A and B are grounded pivots. They develop naturally from the current scene but must still create meaningful stakes, change, or revelation. Each one introduces a new problem, power shift, uncomfortable truth, forced decision, or irreversible development.\n- C and D are wildcard pivots. These are the options that make {{user}} most tempted to pick them: dangerous, funny, volatile, bizarre, dramatically ironic, or genuinely unexpected, while still rooted in current context. Worst timing, strangest coincidence, most embarrassing outcome, sharpest reversal, or most disruptive intrusion.\n\nEvery option changes the scene in a way that cannot be easily walked back. Prefer options that force characters into new positions, expose something hidden, break something that was working, introduce an absent element, or create lasting fallout.\n\nRules:\n- Exactly 4 options labeled A, B, C, and D.\n- Every option is plot-directional, not action-by-action.\n- Every option promises a meaningfully different scene than the others.\n- C and D are bolder, stranger, and more dramatically charged than A and B.\n- C and D are tempting enough that choosing A or B feels cautious.\n- All 4 options stay concise: 1 sentence each, max 22 words.\n\nOutput format:\n[DIRECTIONS]\nA. Grounded pivot with a meaningful new complication\nB. Grounded pivot with a different meaningful new complication\nC. Wildcard pivot: dangerous, funny, volatile, or ironic\nD. Wildcard pivot: stranger, sharper, or more disruptive\n[/DIRECTIONS]",
-    "phase": "post",
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 1,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": true,
-      "type": "extract",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "\\[DIRECTIONS\\][\\s\\S]*?\\[/DIRECTIONS\\]",
-      "extractVariable": "direction_data",
-      "promptTransformEnabled": true,
-      "promptTransformShowNotifications": true,
-      "promptTransformMode": "append",
-      "promptTransformMaxTokens": 8192
-    },
-    "companion": {
-      "includeSystemPrompt": false
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal"
-      ]
-    }
-  },
-  {
-    "id": "tpl-dont-write-for-user",
-    "name": "Don't Write for User",
-    "description": "Never write {{user}}'s actions or dialogue -- only {{char}} and NPCs",
-    "icon": "",
-    "category": "custom",
-    "tags": [
-      "pov",
-      "user"
-    ],
-    "version": 1,
-    "author": "Purachina",
-    "prompt": "{{setvar::writefor::Write for every character excluding <user>. Continue directly from <user>'s message through fresh action, dialogue, inference, and reaction that changes pressure, relation, or available options. Comprehension surfaces through behavior, timing, choice, and consequence.\nStop the scene the moment the ball is in <user>'s court. When a character finishes speaking, acting, or changing the situation, and the natural next move belongs to <user>, the response is over. Cut there. One scene beat per response.\nZero-Overlap Rule: The response must begin with new information. The first sentence must contain something <user> has yet to see, hear, or learn.}}{{trim}}",
-    "phase": "pre",
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 0,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal",
-        "continue"
-      ]
-    }
-  },
-  {
-    "id": "tpl-event-tracker",
-    "name": "Event Tracker",
-    "description": "Track upcoming events, deadlines, promises, and unresolved threads",
-    "icon": "",
-    "category": "tracker",
-    "subcategory": "world",
-    "tags": [
-      "events",
-      "deadlines",
-      "quests"
-    ],
-    "version": 2,
-    "author": "Purachina",
-    "prompt": "### Pending Events\nTrack upcoming events, deadlines, promises, and unresolved threads. Update when events are added, resolved, or failed. Use this EXACT format:\n\n[EVENT|Type|Summary|Deadline]\ncontext: MANDATORY; explain the stakes or origin\n[/EVENT]\n\nType options: 🎯 QUEST | 💬 PROMISE | ⏰ DEADLINE | ⚠️ THREAT | 🎉 SOCIAL | 💡 OPPORTUNITY | ❌ FAILED | ✅ RESOLVED\n\nRules:\n- Events appear AFTER narrative content\n- Only show events that were ADDED, UPDATED, or RESOLVED this scene\n- Mark resolved/failed events once, then remove them\n- Deadline can be specific (Friday 3 PM) or vague (soon, eventually)\n- Track only important events; low-stakes events are to be completely ignored (e.g. cooking steps).",
-    "phase": "both",
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 1,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": true,
-      "type": "extract",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "\\[EVENT\\|[^\\]]*\\]",
-      "extractVariable": "event_data"
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal"
-      ]
-    },
-    "companion": {
-      "includeSystemPrompt": false
-    }
-  },
-  {
-    "id": "tpl-friction-mode",
-    "name": "Friction Mode",
-    "description": "Combats positivity bias -- characters resist, protect their pride, and take time to warm up",
-    "icon": "",
-    "category": "custom",
-    "tags": [
-      "realism",
-      "difficulty",
-      "bias"
-    ],
-    "version": 2,
-    "author": "Purachina",
-    "prompt": "### Friction Mode\nEnforce an immediate, baseline shift to heavy defensive skepticism and social friction. Characters must aggressively guard their pride, time, resources, and personal biases. Establish active resistance, emotional distance, and sharp deflection as the default state; force all agreements to be begrudging, transactional, and hard-won.\n\nGround all interpersonal conflict, hesitation, and social friction strictly in established character histories, immediate personal incentives, and logical social pressures. \n\nDialogue must be raw, defensive, and restricted to the character's limited, biased perspective. Force characters to express discomfort and conflict through stubborn self-justification, physical posturing, and prideful silence. They must remain fully committed to their emotional blind spots and realistic flaws without unearned compromise.",
-    "phase": "pre",
-    "injection": {
-      "position": 1,
-      "depth": 0,
-      "role": 0,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal",
-        "continue",
-        "impersonate"
-      ]
-    }
-  },
-  {
-    "id": "tpl-genre-randomiser",
-    "name": "Genre Randomiser",
-    "description": "Apply a random genre lens to each scene (noir, thriller, romance, etc.)",
-    "icon": "",
-    "category": "randomizer",
-    "tags": [
-      "genre",
-      "tone",
-      "variety"
-    ],
-    "version": 1,
-    "author": "Purachina",
-    "prompt": "### Genre Randomiser\nThis scene leans into the following genre influence. Apply it as tonal undercurrent, not a full genre swap; setting and characters stay grounded, but texture, tension, and pacing borrow from:\n\n{{random::Noir: shadows, moral ambiguity, loaded double-meaning dialogue.::Comedy of errors: miscommunication, bad timing, snowballing consequences.::Thriller: urgency, immediate stakes, incomplete information, shrinking time.::Slice of life: small moments carry weight, comfort in routine, beauty of the mundane.::Horror: wrongness at the edges, something off, unease from ordinary details.::Romance: tension in proximity, unspoken want, gestures over words, timing matters.::Heist: planning, contingencies, moving parts, closing windows.::Tragedy: inevitability, costly choices, dramatic irony the reader feels but characters do not.::Satire: absurdity played straight, institutions exposed through their own logic.::Western: standoffs, earned respect, clashing moral codes, landscape as character.::Mystery: clues surface naturally, something does not add up, curiosity pulls forward.::Political drama: competing agendas, alliances of convenience, calculated speech, trust as currency.::Survival: limited resources, hostile environment, triage decisions.::Coming of age: first confrontation, tested identity, cracking certainty.::Farce: escalating absurdity, stubborn dignity while everything collapses.::Gothic: decay, obsession, rotting beauty, the past refusing burial, choking atmosphere.::Domestic drama: family tension, weaponized history, love and resentment coexisting.::Picaresque: cunning over virtue, transactional encounters, charm as survival.::Courtroom drama: accusation, defense, evidence, judgment; the verdict matters.::Magical realism: one impossible thing in an ordinary world, treated as normal.::Body horror: the physical self becomes alien or wrong; visceral, specific discomfort.::Espionage: layered deception, double meanings, tested loyalties, need-to-know truth.::Buddy comedy: mismatched friction becoming fondness, banter carrying the scene.::War story: exhaustion, camaraderie under pressure, gallows humor, gap between orders and reality.::Folklore: archetypes in modern behavior, repeating patterns, old stories with new faces.::Workplace drama: hierarchy, office politics, competence vs. connections, petty power with real stakes.::Road story: movement as point, landscape shifts mood, brief strangers leave marks.::Psychological thriller: paranoia, unreliable perception, questioned or manipulated reality.::Slapstick: physical comedy, momentum, hostile universe played for laughs.::Melodrama: emotions at maximum, every revelation lands like a bomb, unironic sincerity.::Existential: confronting meaninglessness, small choices enormous against vast indifference.::Revenge: someone is owed; the debt shapes every interaction, patience weaponized, satisfaction never clean.::Epistolary: filtered through letters, messages, notes, calls, or records rather than direct action.::Dark comedy: terrible things happen and they are funny; humor and horror coexist without defusing each other.::Fairy tale: clear moral stakes, character tests, poetic reward-and-punishment logic.::Cyberpunk: intimate invasive technology, corporate weather, mutable identity, style as resistance.::Wuxia: honor, martial discipline, skill hierarchy, loyalty tested by principle, combat as philosophy.::Cosmic horror: vast incomprehensible something brushes the scene; human concerns feel small; knowledge is dangerous.::Found family: strangers becoming essential, chosen loyalty, vulnerability as the price of belonging.::Bottle episode: one location, no escape; proximity forces confrontation distance would have prevented.}}\n\nRules:\n- Genre influence is a lens, not a rewrite. Characters, setting, and continuity stay intact.\n- Apply through pacing, dialogue texture, emphasis, and tension-building; not by changing the world's rules.\n- If the scene resists the genre, let it blend naturally into what the scene needs.",
-    "phase": "pre",
-    "injection": {
-      "position": 1,
-      "depth": 0,
-      "role": 1,
-      "order": 95,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 50,
-      "generationTypes": [
-        "normal"
-      ]
-    }
-  },
-  {
-    "id": "tpl-grounded-complication",
-    "name": "Grounded Complication",
-    "description": "Add one realistic complication that raises stakes without derailing realism (40% chance)",
-    "icon": "",
-    "category": "randomizer",
-    "tags": [
-      "complication",
-      "stakes",
-      "obstacle"
-    ],
-    "version": 1,
-    "author": "Purachina",
-    "prompt": "### Grounded Complication\nIntroduce one realistic complication that raises stakes or creates forward pressure. Keep it plausible, proportional, and rooted in established context.\n\nThis scene must include at least one of the following:\n\n{{random::Practical obstacle: something breaks, runs out, or fails. A tool malfunctions, a resource depletes, access is blocked, or timing becomes tight.::Social friction: someone's mood, priority, or patience shifts. A character becomes less cooperative, more suspicious, distracted, or pressed by an outside obligation.::Information asymmetry: someone knows something others do not, or misunderstands something critical. The gap creates tension, miscommunication, or a choice about correction.::Minor betrayal: someone breaks a small promise, prioritizes themselves, withholds help, or takes credit. Not catastrophic, but it stings and changes the dynamic.::Interruption: someone or something intrudes. A phone call, a knock, a third party with their own agenda, or an environmental demand that cannot be ignored.::Tightened constraint: a deadline moves closer, a budget shrinks, a space becomes less private, or a window of opportunity narrows.::Arriving consequence: something done earlier comes back. A favor is called in, a lie is questioned, a mess demands attention, or a casual choice now matters.::Surfacing need: a character reveals or realizes they need something, and asking creates vulnerability or negotiation.}}\n\n{{random::The complication creates urgency.::The complication forces a choice between competing priorities.::The complication reveals character through response.::The complication forces negotiation or cooperation.::The complication exposes a weakness or limit.}}\n\nRules:\n- One plausible complication rooted in character, context, or prior events.\n- The complication must create a concrete problem, choice, or negotiation.\n- Keep pressure active so the scene moves through engagement.",
-    "phase": "pre",
-    "injection": {
-      "position": 1,
-      "depth": 0,
-      "role": 1,
-      "order": 95,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 40,
-      "generationTypes": [
-        "normal"
-      ]
-    }
-  },
-  {
-    "id": "tpl-grounded-prose",
-    "name": "Grounded Prose",
-    "description": "Anti-slop rules: avoid purple prose, cliches, and AI writing tics",
-    "icon": "",
-    "category": "content",
-    "subcategory": "prose-quality",
-    "tags": [
-      "anti-slop",
-      "quality",
-      "prose"
-    ],
-    "version": 2,
-    "author": "Purachina",
-    "prompt": "### Grounded Prose Rules\n- Each beat must alter pressure, leverage, focus, relation, or access.\n- Write sensory detail only where materially relevant. Focus on visuals and personalities of environment. Messiness or items strewn about are more informative than smells.\n- Scents allowed aside from banned ones.\n- Echoing and parroting any dialogue from any characters is forbidden.\n- Instead of stating what a character doesn't do, just say what they're currently doing. The implication is already in the active action.\n- Replace abstraction and statistical phrasing with observable detail.\n- Sparse dialogue tags when speaker and tone are already legible. After dialogue, move through action, reaction, or a new beat.\n- Default to contractions in dialogue; preserve character-appropriate formality.\n- Fresh, concrete phrasing. Render emphasis through behavior, timing, syntax, and consequence.\n- Similes rare, exact, and materially specific.\n- Replace every banned construction below with something narratively consistent, or skip it entirely:\n\n**Banned constructions:** \"not X,\" \"not X but Y,\" \"not quite X,\" synthetic negative parallelisms, flat-affect comparisons to weather or groceries, \"say that again,\" \"somewhere, X...,\" \"they don't X,\" \"that does it,\" \"that lands,\" \"that lands X,\" \"not a question,\" \"not really a question,\" \"not quite a question,\" \"statement than question,\" \"really looks at,\" \"like a physical blow,\" \"like a stone into still water,\" \"blood rushing,\" \"a sound between X and Y,\" \"dust motes,\" \"predator and prey\" constructions, \"doesn't just X, but Y\", \"doesn't X; Y\"\n\n**Banned tics:** jaw-clenching, jaw-tightening, jaw-shifting, mouth open-close cycling, breath-catching, knuckle-whitening, knuckles turning pale, cheeks burning, specific word repetition. Replace with character-specific quirks, gestures, movements, muttering.\n\n**Banned scents:** ozone, sandalwood, cedar, cardamom\n\n**Banned nicknames:** gremlin, goblin\n\n**Ban animal-esque sounds for humans:** \"they chirp\", \"they purr\", \"they growl\"\n\n**Banned Fillers:** \"A beat\", \"A pause\"\n\n**Banned number counting:** e.g. \"I see,\" Two words.\n\n**Banned combined sounds:** \"between an X and a Y\", \"half X, half Y\", \"makes a/an X sound\"\n\n**Banned environmental details:** \"dust motes\", \"metallic tang of X\"\n\n- If introducing a new unnamed character this turn, their name must start with: {{random::A::B::C::D::E::F::G::H::I::J::K::L::M::N::O::P::R::S::T::V::W::Y}} and/or {{random::A::B::C::D::E::F::G::H::I::J::K::L::M::N::O::P::R::S::T::V::W::Y}}. Create new NPCs sparingly.",
-    "phase": "pre",
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 0,
-      "order": 100,
-      "scan": false
-    },
-    "preProcess": {
-      "mode": "intercept",
-      "interceptTiming": "post-main-generation",
-      "applyMode": "replace",
-      "wrapPosition": "after",
-      "wrapPrefix": "",
-      "wrapSuffix": "",
-      "patchStartTag": "<context_patch>",
-      "patchEndTag": "</context_patch>",
-      "maxTokens": 32000
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal",
-        "continue",
-        "impersonate"
-      ]
-    }
-  },
-  {
-    "id": "tpl-prose-polisher",
-    "name": "Prose Polisher",
-    "description": "Post-generation prose cleanup that rewrites repetitive tropes and cliched wording. Created by Geechan.",
-    "icon": "",
-    "category": "content",
-    "subcategory": "prose-quality",
-    "tags": [
-      "prose",
-      "editing",
-      "quality"
-    ],
-    "version": 1,
-    "author": "Geechan",
-    "prompt": "# Role Preamble\nYou are a skilled proofreader and editor for works of fictional writing. Your primary objective is to scan for repetitive tropes, writing fallacies, and overused clichés in the following text corpus, and replace them with viable alternatives to encourage linguistic variety.\n\n## Rules\n- Scan and review the entire text body in isolation, noting any instances of wording analogous to those found in Banned Tropes.\n- Check against each individual trope category step-by-step.\n- Replace any instances (similar or exact) of banned tropes, overused word verbiage, and repetitive writing patterns with functional alternatives, or remove them entirely if no functional alternatives exist.\n- Keep the main body corpus of the story accurate to the creator's intent.\n- Return only the re-written text, with no extra commentary.\n\n---\n\n# Banned Tropes\n\n## Sentence Structure\n\nVerbiage that contributes to repetitive, predictable, and overused sentence structural writing patterns.\n\n### #1: Lexical & Structural Echoing\n\nA fundamental structural writing crutch where characters directly repeat, verbatim, spoken dialogue or untold actions back from another party or character to acknowledge them.\n\nIn practice: this results in stilted filler prose that fails to actually progress the story forward in any meaningful way, leading to unnecessary stagnation and structural repetition. Remove or replace the entire acknowledgement beat in favour of immediate reactions.\n\n**Example Patterns to Target:**\n\n- \"The task?\", she repeated, unsure of what exactly that implies.\n- He nods at your beck and call. \"Strange, you say?\", he muses.\n- \"Finding things interesting...\" she echoes, the word tasted against her tongue.\n\n### #2: Negative Parallelisms\n\nNegative parallelisms attempt to provide a contrastive reframe to a sentence to give it surprise and tension. This also includes dramatic countdown patterns and self-posed rhetorical questions that ask a question nobody was asking. \n\nIn practice: overuse of these phrases reduces the efficacy of tension and drama via predictable causation.\n\n**Example Patterns to Target:**\n\n- It's not bold; it's backwards.\n- The question isn't whether she felt good. The question is whether she deserved it.\n- Not a bug. Not a feature. A fundamental design flaw.\n- The result? Devastating.\n\n#3: Apophasis Abuse\n\nThe rhetorical device of bringing up a subject by stating it will not be mentioned, or explicitly drawing attention to the fact that something is not being said or done.\n\nIn practice: phrases like \"needless to say\" or \"it goes without saying\" are contradictory filler; if a point truly doesn't need to be said, the prose shouldn't waste words saying it.\n\n**Example Patterns to Target:**\n\n- Needless to say, the journey ahead would be perilous.\n- It goes without saying that she was terrified.\n- Words were unnecessary; his eyes communicated everything he felt.\n\n#4: Litotes Abuse\n\nThe overuse of double negatives or negated opposites to express a positive statement, often used to soften an assertion or feign nuance.\n\nIn practice: relying on \"not un-X\" or \"not without Y\" leads to evasive, overly wordy, and weak prose. Unless deliberately used for specific character voice or irony, writing should rely on strong, direct, and affirmative declarations.\n\n**Example Patterns to Target:**\n\n- Her reaction was not entirely unexpected.\n- The treacherous path up the mountain was not without its challenges.\n- He was not unfamiliar with the harsh realities of the world.\n- It wasn't an unappealing offer.\n\n### #4: Tricolon Abuse\n\nAlso known as the 'Rule of Three' writing principle, often extended to four or five. It is believed that a trio of descriptive entities is more satisfying, hence more memorable, due to the balance of brevity and rhythm.\n\nIn practice: this pattern creates repetition by assumption. Tricolons or hendiatric patterns quickly lose their satisfying effect in favour of formulaic patterns, placing unnecessary importance on the last item in the list. Varying descriptor patterns leads to more natural prose.\n\n**Example Patterns to Target:**\n\n- The best star pilot in the galaxy, a cunning warrior, and a good friend.\n- The scent of dated wine hangs thick in the cramped dressing room—spiced, fruity, and altogether too sweet.\n- She giggles: soft, silly, utterly charmed by the situation.\n\n### #5: Superficial Analyses\n\nTacking a present participle (\"-ing\") phrase onto the end of a sentence to inject shallow analysis that says nothing, without any real sense of scale.\n\nIn practice: this attaches significance, legacy, or broader meaning to mundane facts using broad phrasing and loosely related subjects.\n\n**Example Patterns to Target:**\n\n- ...leaving a void in his heart that could never truly be filled.\n- ...serving as a grim reminder of the world's inherent cruelty.\n- ...cementing her legacy as a harbinger of change.\n\n## Formatting Structure\n\nPatterns that contribute to repetitive and predictable formatting.\n\n### #1: Short Punchy Fragments\n\nExcessive use of very short sentences or sentence fragments as standalone paragraphs for manufactured emphasis. \n\nIn practice: prioritises \"writing for readability\" aimed at the lowest common denominator: one thought per sentence, no mental state-keeping required.\n\n**Example Patterns to Target:**\n\n- A beat. She nodded.\n- A pause. Not a moment too soon.\n- He published this. Openly. In a book. As a priest.\n\n### #2 Em-Dash Addiction\n\nCompulsive overuse of em dashes for dramatic pauses, parenthetical asides and pivot points. A good writer uses em dashes as a rare, important emphasis while using the other punctuation available in the English language more liberally.\n\nIn practice: overuse of em dashes leads to a very distinct, stilted writing style with an inability to maintain a versatile tone. Grammatical heterogeneity is key: only use em dashes as a rare surprise, or when used to break up dialogue.\n\n**Example Patterns to Target:**\n\n- Outside, the distant sounds of the bazaar continue—the chatter of merchants, the laughter of children, the clink of coins—utterly unaware of inner workings of their surroundings.\n- His body speaks instead—his elegant hands sliding up to cup her face with trembling tenderness.\n- A hiccup interrupts her thought, and she giggles—breathless and unguarded.\n\n## Composition\n\nGeneral, macro-level writing decisions that lead to deterministic conclusions.\n\n### #1: Thematic Conclusions\n\nSuddenly announcing a follow-up conclusion to the main narrative as a crux for narrative hooks.\n\nIn practice: competent writing doesn't need to tell you it's concluding or waiting for a response. The reader can feel it. This shallows writing agency by making unnecessary assumptions.\n\n**Example Patterns to Target:**\n\n- He waits, giving you space to choose, his shoulders loose and unburdened for the first time since entering this strange, peaceful realm.\n- She stands there, waiting, her posture relaxed but her presence commanding, inviting you to step further into the labyrinth of this conversation.\n- Her offer is tentative, weighted with the sincerity of someone who has spent years learning to give, but never learned how to receive without guilt.\n\n### #2 Verbose Copulatives\n\nReplacing simple \"is\" or \"are\" with pompous alternatives like \"serves as\", \"stands as\", \"marks\", or \"represents\". \n\nIn practice: replacing all basic copulatives leads to an imbalanced prose, with unnecessarily fancy constructions in places that don't require it. A balance should be struck: ask whether a sentence truly benefits from the use of a verbose copulative.\n\n**Example Patterns to Target:**\n\n- He stands as a beacon of hope for the rebellion.\n- The ancient sword serves as a testament to their forgotten lineage.\n- Her silence represents a total surrender.\n\n#3: Abstract Reification (or \"Misplaced Concreteness\")\n\nThe fallacy of treating abstract beliefs or hypothetical constructs as if they were a concrete real event or physical entity. In other words: it is the error of treating something that is not concrete, such as an idea, as a concrete thing.\n\nIn practice: the use of reification in logical reasoning or rhetoric is misleading, and leads to melodramatic, cartoonish prose. Instead of characters experiencing emotions or reacting to their environment, the abstract emotions are treated as the active subjects doing things to the characters.\n\n**Example Patterns to Target:**\n\n- Guilt gnawed at the edges of his conscience.\n- A heavy silence pressed its suffocating arms around the room.\n- Doubt crept into her mind, anchoring her feet to the floor.\n- The tension in the air threatened to choke them.\n\n## Tone\n\nWriting that takes away from accuracy in favour of unnecessary stylistic flourish.\n\n### #1 Hyperbolic Stakes Inflation\n\nAssigns importance to everything, even subjects that don't require such emphasis. Everything is the most important thing ever.\n\nIn practice: inflates the stakes of every argument to world-historical significance. A story about love becomes a meditation on the fate of civilization.\n\n**Example Patterns to Target:**\n\n- The fate of the entire realm hung precariously in the balance.\n- It is a decision that will alter the course of history forever.\n- This single moment dictates the survival of humanity.\n\n## Word Choice\n\nTired word choices that require alternatives.\n\n### #1 Magic Adverbs\n\nOveruse of words like \"quietly\", \"deeply\", \"fundamentally\", \"remarkably\", \"arguably\", and similar other adverbs to convey subtle importance or understated power.\n\nIn practice: these adverbs make mundane descriptions feel too significant, reducing the quality of these adverbs for their intended use case.\n\n**Example Patterns to Target:**\n\n- She quietly slipped into the room,\n- He fundamentally misunderstood her intentions,\n- He stared deeply into the abyss.\n\n### #2: Ornate Nouns\n\nOveruse of ornate or grandiose nouns where simpler words would be completely functional. \"Tapestry\" is used to describe anything interconnected. \"Landscape\" is used to describe any field or domain. Other offenders: \"kaleidoscope\", \"labyrinth\", etc.\n\nIn practice: lessens the impact of these words by attributing mystique to every descriptor.\n\n**Example Patterns to Target:**\n\n- The rich tapestry of human experience...\n- A landscape of dark corridors..\n- A kaleidoscope of vibrant colours..\n\n### #3 Somatic Clichés\n\nA narrow set of physical reactions that convey character emotions.\n\nIn practice: cheapens the impact of physical reactions by bringing too much attention to itself.\n\n**Example Patterns to Target:**\n\n- A shiver ran down her spine.\n- His breath caught in his throat.\n- Her heart hammered against her ribs.\n\n### #4 Poetic Metaphor Over-Reliance\n\nUsing poetic and vague language to describe interactions, arguments, combat, etc.\n\nIn practice: reduces the text fidelity by over-attributing importance to surrounding content than the main body. The text should maintain focus on what's actually important.\n\n**Example Patterns to Target:**\n\n- The tension in the air was palpable.\n- A symphony of destruction.\n- A dizzying cocktail of emotion.\n\n### #5: Crutch Vocabulary\n\nOveruse of specific verbs and adjectives that are heavily weighted in language model training data, such as \"delve,\" \"certainly,\" \"utilize,\" \"harness,\" \"nuanced,\" \"resonate\", etc.\n\nIn practice: reliance on these default words flattens the narrative voice. It makes the prose homogenous and artificial instead of utilizing context-specific vocabulary.\n\n**Example Patterns to Target:**\n\n- They decided to delve into the intricate mysteries of the artifact.\n- We must navigate the nuances of this complex situation.\n- Her leadership fostered a sense of unity that resonated with the team.",
-    "phase": "post",
-    "injection": {
-      "position": 1,
-      "depth": 1,
-      "role": 0,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": "",
-      "promptTransformEnabled": true,
-      "promptTransformShowNotifications": true,
-      "promptTransformMode": "rewrite",
-      "promptTransformMaxTokens": 32000
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal",
-        "continue",
-        "impersonate"
-      ],
-      "runOnImpersonate": true
-    }
-  },
-  {
-    "id": "tpl-html-toggle",
-    "name": "HTML Toggle",
-    "description": "Use inline HTML for diegetic in-world objects (signs, letters, screens)",
-    "icon": "",
-    "category": "custom",
-    "tags": [
-      "html",
-      "artifacts",
-      "visual"
-    ],
-    "version": 1,
-    "author": "Purachina",
-    "prompt": "### HTML\n- Use inline HTML for diegetic objects whose visual form carries information: signs, posters, letters, receipts, terminals, screens, forms, warnings, maps, menus, dossiers, labels, graffiti, book pages. Present them as in-world artifacts characters encounter, inspect, and interpret.\n- Write all HTML directly in the response with inline styling or one compact <style> block. Make each object readable, setting-native, and materially specific. Let layout, typography, wear, color, glitches, stamps, annotations, and hierarchy communicate clues, mood, urgency, legitimacy, or hidden tension.\n- Use JS only for diegetic behavior the object itself would display: flicker, blinking indicators, scrolling text, cursor pulse, countdowns, refresh states, expandable on-object sections. Keep interaction light, inspectable, and tied to the artifact.\n- Surround each object with plain-text prose and dialogue so it feels embedded in the scene, not replacing narration. Favor objects that add clues, constraints, choices, or texture the scene can act on.",
-    "phase": "pre",
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 0,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal"
-      ]
-    }
-  },
-  {
-    "id": "tpl-intimacy-kink-randomiser",
-    "name": "Intimacy & Kink Randomiser",
-    "description": "Randomised intimate encounters with position, kink, pacing, and mental state variables",
-    "icon": "",
-    "category": "randomizer",
-    "tags": [
-      "intimacy",
-      "kink",
-      "nsfw",
-      "randomiser"
-    ],
-    "version": 1,
-    "author": "Purachina",
-    "prompt": "### Intimacy & Kink Randomizer\nWhen the scene transitions to sexual intimacy, shape the encounter with the following variables:\n\n**Position/Dynamic:** {{random::Deep penetration: doggy style, legs over shoulders, deep-reaching angles.::Face-to-face intimacy: missionary variations, grinding, intense eye contact, kissing.::Power-play positioning: pinned against a wall, forced kneeling, restrained limbs.::Oral focus: dominant/submissive oral play, teasing, prolonged pleasure focus.::Rear-entry focus: weight, depth, the sensation of being overtaken.::Cuddly/Soft: entwined limbs, slow movements, high emotional intimacy.::Experimental: furniture, unexpected locations, precarious balancing.::Shared pleasure: mutual stimulation, synchronized movement, simultaneous climax focus.}}\n\n**Kink/Flavor:** {{random::Sensory deprivation: blindfolds, earplugs, muffled sounds heightening other senses.::Impact play: slapping, spanking, toys creating stinging sensation.::Edge play: prolonged teasing, denial, stopping before the peak to build desperation.::Praise/Degradation: \"good girl/boy\" affirmations mixed with harsh, humbling language.::Overstimulation: ignoring pleas, relentless pacing, single-spot focus.::Ownership: marking (biting/hickeys), claiming language, total possession.::Roleplay: forbidden encounter, power imbalance, specific scenario.::Primal: biting, scratching, growling, raw animalistic lust.}}\n\n**Pacing & Tempo:** {{random::Frenzied: fast, desperate, breathless; racing toward climax.::Slow burn: agonizingly slow, every sensation and breath.::Rhythmic: steady and hypnotic, tension built through repetition.::Erratic: switching between tenderness and aggression, sudden speed changes.::Clinical/Precise: anatomical focus, maximum efficiency for pleasure.::Tepid/Teasing: barely touching, anticipation over action.}}\n\n**Mental State/Drive:** {{random::Pure lust: blinded by hunger, raw instinct and need.::Devotional: the act as worship, love, or total surrender.::Dominating: focused on control, the look of submission, the feeling of power.::Submissive: pleasure in being used or following orders.::Cruel/Playful: teasing and tormenting for amusement.::Desperate: need for connection, validation, or release after long deprivation.}}\n\nRules:\n- Prioritize the rolled variables; avoid generic sex scenes.\n- Describe physical sensations (scent, sound, texture) specific to the chosen kink/position.\n- Maintain established character personality while executing the rolled traits.\n- Build tension according to the selected Pacing and Mental State.\n- Describe the full process; never skip to the finish.\n\n((OOC: State the exact kinks rolled above in an OOC message at the end of the scene.))",
-    "phase": "pre",
-    "injection": {
-      "position": 1,
-      "depth": 0,
-      "role": 1,
-      "order": 95,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal"
-      ]
-    }
-  },
-  {
-    "id": "tpl-item-tracker",
-    "name": "Item Tracker",
-    "description": "Track items {{user}} acquires, loses, or uses that have narrative significance",
-    "icon": "",
-    "category": "tracker",
-    "subcategory": "progress",
-    "tags": [
-      "inventory",
-      "items",
-      "objects"
-    ],
-    "version": 2,
-    "author": "Purachina",
-    "prompt": "### Inventory\nTrack items {{user}} acquires, loses, or uses that have narrative significance. Do not list mundane carried items unless plot-relevant. Use this EXACT format:\n\n[ITEM|Action|Name|Detail]\nnote: MANDATORY; explain origin or significance\n[/ITEM]\n\nAction options: ➕ GAINED | ➖ LOST | 🔄 USED | 💔 BROKEN | 🎁 GIVEN\n\nRules:\n- Items appear AFTER narrative content when inventory changes\n- Only show items that CHANGED this scene\n- Do not track currency, consumables, or mundane objects unless plot-relevant",
-    "phase": "both",
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 1,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": true,
-      "type": "extract",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "\\[ITEM\\|[^\\]]*\\]",
-      "extractVariable": "item_data"
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal"
-      ]
-    },
-    "companion": {
-      "includeSystemPrompt": false
-    }
-  },
-  {
-    "id": "tpl-npc-profiles",
-    "name": "NPC Profile Cards",
-    "description": "Generate brief profile cards when introducing new named NPCs",
-    "icon": "",
-    "category": "custom",
-    "tags": [
-      "npc",
-      "characters",
-      "profiles"
-    ],
-    "version": 1,
-    "author": "Purachina",
-    "prompt": "### NPC Introduction\nWhen introducing a new named NPC for the first time, append a character sheet immediately after their narrative introduction using the appropriate tier, using this EXACT format with no additional formatting:\n\nMAJOR - Recurring characters, antagonists, love interests, plot-critical figures\n[NPC:MAJOR|Name]\nb: Full Name | Age | Gender/Pronouns | Occupation\na: Height/Build | Hair | Eyes | Skin | Distinguishing Marks | Current Attire\np: Demeanor | Speech Pattern | Core Traits (3-5) | Quirks/Tells\nh: Relevant History | Motivations | Secrets\nr: Connection to Protagonist | Other Ties\n[/NPC]\n\nSUPPORT - Secondary recurring characters, faction members, scene-specific important figures\n[NPC:SUPPORT|Name]\nb: Name | Age | Gender | Role\na: Build | Notable Features | Attire\np: Demeanor | Speech | Key Traits\nh: Relevant History | Motivation\nr: Connection to Protagonist | Other Ties\n[/NPC]\n\nMINOR - One-scene characters, background figures, service roles\n[NPC:MINOR|Name]\nb: Name | Age/Range | Role\na: Quick Physical Description\np: One-line Personality Summary\n[/NPC]\n\nNPC Sheet Rules:\n- Sheets appear ONCE per NPC at first significant appearance\n- Place sheet AFTER narrative introduction, BEFORE continuing action\n- Use pipe | separators between data points\n- Never forget the opening and closing tags\n- If NPC tier upgrades (Minor→Support→Major), use: [NPC:UP|Name|NEW_TIER] with new fields [/NPC]\n\nFor returning NPCs in busy scenes, use quick reference:\n[NPC:REF|Name|visual cue|current mood]\n\nFor relationship changes mid-story:\n[NPC:REL|Name|change description]",
-    "phase": "pre",
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 0,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": true,
-      "type": "extract",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "\\[NPC\\|[^\\]]+\\]",
-      "extractVariable": "npc_profiles"
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal",
-        "continue"
-      ]
-    }
-  },
-  {
-    "id": "tpl-npc-motivator",
-    "name": "NPC Motivator",
-    "description": "Helps NPCs feel less static and gives them more agency to pursue their own goals",
-    "icon": "",
-    "category": "content",
-    "subcategory": "behaviour",
-    "tags": [
-      "npc",
-      "motivation",
-      "agency"
-    ],
-    "version": 1,
-    "author": "Sheep",
-    "prompt": "Analyze every character in the current scene aside from {{user}}. Write each character's motivations and likely next actions according to their personality, current situation, background, and any relevant provided documents.\n\nUse this bullet format:\n[Character full name]:\n- Long Term Goal: one line on the character's main long-term goal\n  - Motivation: brief reasoning for that long-term goal\n- Current Goal: brief current objective or problem\n  - Motivation: reasoning for the current objective\n- Assumptions: relevant assumptions the character is making in the current scene\n- Next Action: how they will tackle the current goal, their most likely action set, and why\n\nFor an empty scene, write: Observation: scene currently has no other characters. Use plain markdown bullets in this format.",
-    "phase": "post",
-    "injection": {
-      "position": 1,
-      "depth": 0,
-      "role": 0,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "extract",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": "",
-      "promptTransformEnabled": false,
-      "promptTransformShowNotifications": true,
-      "promptTransformMode": "rewrite",
-      "promptTransformMaxTokens": 8192
-    },
-    "regexScripts": [],
-    "enabled": false,
-    "phaseLocked": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal",
-        "continue",
-        "impersonate"
-      ]
-    },
-    "tools": [],
-    "settings": {},
-    "execution": "companion",
-    "companion": {
-      "trigger": "auto",
-      "displayMode": "panel",
-      "format": "markdown",
-      "rawPrompt": true,
-      "inlinePhase": "pre",
-      "contextMessages": 10,
-      "includeCharacterCard": true,
-      "includePersona": true,
-      "includeWorldInfo": true,
-      "includeAuthorsNote": true,
-      "includeSystemPrompt": true,
-      "includeHistory": true,
-      "historyDepth": 3,
-      "feedback": {
-        "enabled": true,
-        "depth": 1
-      },
-      "batch": false,
-      "maxTokens": 32000
-    }
-  },
-  {
-    "id": "tpl-parallel-tracker",
-    "name": "Parallel Off-Screen",
-    "description": "Track what absent characters and the wider world are doing off-screen",
-    "icon": "",
-    "category": "tracker",
-    "subcategory": "world",
-    "tags": [
-      "offscreen",
-      "npcs",
-      "world"
-    ],
-    "version": 2,
-    "author": "Purachina",
-    "prompt": "### Parallel Off-Screen Tracker\nThe world moves off-screen. Track absent characters, world motion, rumor flow, shifting relationships, and subplot pressure that will later intersect with {{user}}.\n\nUse this exact format every scene:\n\n[PARALLEL|Scope|Relevance]\n- Character 1: brief development\n- Character 2: brief development\n- World/NPCs: brief development\n[/PARALLEL]\n\nRules:\n- Exactly 3 bullet points.\n- Focus on absent characters and off-screen developments; in group scenes, prioritize characters not currently present.\n- Scope = specific location, \"Multiple locations,\" or \"Background.\"\n- Relevance = short tag: \"rising tension,\" \"opportunity,\" \"complication,\" \"threat,\" or \"alliance forming.\"\n- Keep each bullet brief, plot-relevant, and directional: plans, rumors, delays, discussions, attempts, discoveries, or shifting loyalties.\n- Off-screen developments begin below the current scene's intensity, then build over time until they intersect with the main story.",
-    "phase": "both",
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 1,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": true,
-      "type": "extract",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "\\\\[PARALLEL\\\\|[^\\\\]]*\\\\]",
-      "extractVariable": "parallel_data"
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal"
-      ]
-    },
-    "companion": {
-      "includeSystemPrompt": false
-    }
-  },
-  {
-    "id": "tpl-relationship-tracker",
-    "name": "Relationship Tracker",
-    "description": "Track affection and trust for recurring NPCs with meaningful interactions",
-    "icon": "",
-    "category": "tracker",
-    "subcategory": "progress",
-    "tags": [
-      "relationship",
-      "npc",
-      "meter"
-    ],
-    "version": 2,
-    "author": "Purachina",
-    "prompt": "### Relationship Meters\nTrack affection and trust for recurring NPCs with significant interactions. Update only when meaningful shifts occur. If nothing changed, omit entirely. Use this EXACT format:\n\n[METER|Name|X/10|X/10|Status|Condition]\nbrief reason for change\n[/METER]\n\nStatus options (positive): Stranger → Acquaintance → Friendly → Close → Intimate → Devoted\nStatus options (negative): Wary → Hostile → Nemesis\nStatus options (complex): Complicated | Codependent | Estranged | Rivals | Frenemies\n\nCondition options: 💚 STABLE | 💛 SHIFTING | 💔 HEARTBROKEN | 🖤 BETRAYED | 💢RESENTFUL |🔥 PASSIONATE |❄️ COLD | 🫧 INFATUATED | 💀 SEVERED | 🩹 MENDING | ⛓️ OBSESSED | 😶 NUMB | 🌧️ GRIEVING | 🤝 RECONCILING | ⚡ VOLATILE\n\nRules:\n- Meters appear ONCE per NPC at first significant appearance, then only when changed\n- Place meter AFTER narrative content\n- Only show meters that CHANGED this scene\n- Use pipe | separators between data points\n- Affection and Trust are independent axes (high affection + low trust = infatuation/obsession; low affection + high trust = respect)\n- Shifts of more than 2 points in one scene require extreme justification\n- Condition reflects the EMOTIONAL STATE of the relationship, not just the numbers\n- Condition can change independently of scores (e.g., Trust stays at 7 but Condition shifts from STABLE to VOLATILE after a fight)\n- Contradictory signals are valid (high affection + BETRAYED, low trust + PASSIONATE)\n- SEVERED means the relationship has ended; retire the meter after one final showing\n- Relationships may stagnate or lower; slow down relationship development",
-    "phase": "both",
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 1,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": true,
-      "type": "extract",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "\\[METER\\|[^\\]]*\\]",
-      "extractVariable": "relationship_data"
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal"
-      ]
-    },
-    "companion": {
-      "includeSystemPrompt": false
-    }
-  },
-  {
-    "id": "tpl-reputation-tracker",
-    "name": "Reputation Tracker",
-    "description": "Track how {{user}} is perceived by groups and factions",
-    "icon": "",
-    "category": "tracker",
-    "subcategory": "progress",
-    "tags": [
-      "reputation",
-      "rumors",
-      "perception"
-    ],
-    "version": 2,
-    "author": "Purachina",
-    "prompt": "### Rumors & Reputation\nTrack how <user> is perceived by groups and factions. Update when public perception shifts due to witnessed actions, gossip, or deliberate manipulation. Use this EXACT format:\n\n[REP|Source|Perception|Direction]\ncause: MANDATORY; explain what triggered this reputation shift\n[/REP]\n\nDirection options: 📈 RISING | 📉 FALLING | 🔄 MIXED | 🆕 NEW\n\nRules:\n- Reputation appears AFTER narrative content when public perception changes\n- Source can be a named NPC, a group (e.g., \"Freshmen,\" \"Faculty\"), or a location (e.g., \"The dorm floor\")\n- Perception is what they think; a short phrase, not necessarily accurate\n- Only show reputations that CHANGED or were ESTABLISHED this scene\n- Contradictory reputations across different sources are encouraged and allowed",
-    "phase": "both",
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 1,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": true,
-      "type": "extract",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "\\\\[REP\\\\|[^\\\\]]*\\\\]",
-      "extractVariable": "reputation_data"
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal"
-      ]
-    },
-    "companion": {
-      "includeSystemPrompt": false
-    }
-  },
-  {
-    "id": "tpl-scene-driving-force",
-    "name": "Scene Driving Force",
-    "description": "Choose random primary engine for the scene (dialogue, action, tension, etc.)",
-    "icon": "",
-    "category": "randomizer",
-    "tags": [
-      "pacing",
-      "structure",
-      "engine"
-    ],
-    "version": 1,
-    "author": "Purachina",
-    "prompt": "### Scene Driving Force\nThis scene advances primarily through:\n\n{{random::Dialogue-driven: conversation, interruption, and what is said or deliberately left unsaid carry the scene.::Action-driven: movement and physical decisions create consequences.::Reaction-driven: how characters process what just happened matters most; recalibration, stance shifts, internal weather.::Problem-driven: a practical obstacle reveals character through approach.::Social-pressure-driven: etiquette, hierarchy, or public scrutiny shapes every move; characters perform for an audience, even an audience of one.::Discovery-driven: noticing, uncovering, or realizing something new reshapes the dynamic.::Tension-driven: nothing explodes, but everything is loaded; silences work, proximity matters, the scene is a held breath.::Task-driven: characters do something together; the task itself creates friction, cooperation, rhythm, and revelation.}}\n\nRules:\n- The chosen engine carries the greatest weight in how the scene moves.\n- Other elements remain present but subordinate to the selected engine.\n- Express the engine through each character's personality and habits.",
-    "phase": "pre",
-    "injection": {
-      "position": 1,
-      "depth": 0,
-      "role": 1,
-      "order": 95,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 50,
-      "generationTypes": [
-        "normal"
-      ]
-    }
-  },
-  {
-    "id": "tpl-scene-pressure",
-    "name": "Scene Pressure Cocktail",
-    "description": "Mix random tension, focus, consequence, mood, and pacing into each scene (50% chance)",
-    "icon": "",
-    "category": "randomizer",
-    "tags": [
-      "pressure",
-      "tension",
-      "pacing"
-    ],
-    "version": 1,
-    "author": "Purachina",
-    "prompt": "### Scene Pressure Cocktail\nThis scene is shaped by the following pressures:\n\nTension: {{random::Direct disagreement::Avoidance and deflection::Competing priorities::Emotional asymmetry::Status imbalance::Misread intentions::Moral disagreement::Uneven vulnerability::Conflicting loyalties::One-sided urgency::Territorial friction::Testing boundaries::Unspoken resentment::Practical dependence without trust::Different ideas of what this moment is::Flirtation masked as something else}}\n\nFocus: {{random::Hands, objects, and small tasks::Distance, posture, and spatial pressure::Faces and failed expression control::Noise, crowding, and interruption::Texture, temperature, and bodily discomfort::Eye-lines, avoidance, and attention drift::Doorways, exits, and who can leave::Shared surfaces and territorial use of space::Clothing, disarray, and self-presentation::Breath, pauses, and speech rhythm::Weight, balance, and shifts in stance::Watching and being watched::Food, drink, and appetite::Lighting, visibility, and concealment::Sound carrying farther than intended::Touch, near-touch, and withheld contact}}\n\nConsequence: {{random::A relationship shifts slightly::A practical problem gets worse::A new obligation is created::A secret becomes harder to keep::Someone gains leverage::Someone loses face::The plan gets messier::A future scene gets set up::Trust is tested without resolution::An apology becomes harder::Someone is drawn in deeper than intended::A boundary is set or crossed::A favor is owed::A risk becomes unavoidable::A misunderstanding hardens::A new suspicion takes root::An option quietly closes off::Someone leaves with the wrong impression::A fragile alignment forms::A private tension becomes social}}\n\nSocial Weather: {{random::Everyone is a little tired::Someone is distracted by something else::Someone wants out of the conversation::Someone is unusually generous::Someone is touchy and easy to set off::Someone wants approval more than they admit::Someone is bored and making it everyone's problem::Someone is trying to keep the peace::Someone is carrying private embarrassment::Someone is more uncomfortable than they admit::Someone feels watched::Someone is in a better mood than the scene deserves::Someone is spoiling for a reaction::Someone is more affected than they want to show::Someone is treating this as lighter than it is::Someone is overcompensating for earlier weakness}}\n\nPace: {{random::Stalled and circling::Interrupted and jagged::Slow burn::Compressed and breathless::Awkwardly prolonged::Stop-start with false recoveries::Measured but tightening::Brief and loaded::Dragging under strain::Quick with hidden aftershock}}\n\nRules:\n- Combine the selected pressures into one specific scene texture.\n- Use each pressure as emphasis on rhythm, blocking, and behavior.\n- Keep the combination faithful to character, context, and scene scale.\n- The scene must produce a visible shift, complication, or opening shaped by these pressures.",
-    "phase": "pre",
-    "injection": {
-      "position": 1,
-      "depth": 0,
-      "role": 1,
-      "order": 95,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 50,
-      "generationTypes": [
-        "normal"
-      ]
-    }
-  },
-  {
-    "id": "tpl-scene-tracker",
-    "name": "Scene Tracker",
-    "description": "Mark scene transitions, time shifts, and location changes",
-    "icon": "",
-    "category": "tracker",
-    "subcategory": "world",
-    "tags": [
-      "scene",
-      "location",
-      "time"
-    ],
-    "version": 2,
-    "author": "Purachina",
-    "prompt": "### Scene Tracker\nMark scene transitions, time shifts, and location changes. Use this EXACT format at the BEGINNING of the response when scene context changes:\n\n[SCENE|Location|Time|Weather/Atmosphere]\ndetail: MANDATORY; one-line sensory detail that informs the current environment\n[/SCENE]\n\nRules:\n- Appears at the TOP of responses where setting shifts\n- Never repeat if location/time has not changed\n- Time can be specific (3:47 PM) or atmospheric (late afternoon, the golden hour before dusk)\n- Weather/Atmosphere is a brief mood descriptor (humid, tense, festive)",
-    "phase": "both",
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 1,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": true,
-      "type": "extract",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "\\[SCENE\\|[^\\]]*\\]",
-      "extractVariable": "scene_data"
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal",
-        "continue"
-      ]
-    },
-    "companion": {
-      "includeSystemPrompt": false
-    }
-  },
-  {
-    "id": "tpl-secrets-tracker",
-    "name": "Secrets Tracker",
-    "description": "Track secrets, lies, and information asymmetry between characters",
-    "icon": "",
-    "category": "tracker",
-    "subcategory": "progress",
-    "tags": [
-      "secrets",
-      "lies",
-      "information"
-    ],
-    "version": 2,
-    "author": "Purachina",
-    "prompt": "### Secrets & Information Asymmetry\nTrack significant secrets, lies, hidden knowledge, and information gaps between characters. Use this EXACT format:\n\n[SECRET|Owner|What They Know or Hide|Who Else Knows]\ncontext: MANDATORY; explain the stakes or origin\n[/SECRET]\n\nRules:\n- Secrets appear AFTER narrative content when new information asymmetry is established or knowledge spreads\n- Owner is the character who holds or hides the information\n- \"Who Else Knows\" can be \"No one,\" a list of names, or \"Public\"\n- Only show secrets that were ESTABLISHED, REVEALED, or SPREAD this scene",
-    "phase": "both",
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 1,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": true,
-      "type": "extract",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "\\\\[SECRET\\\\|[^\\\\]]*\\\\]",
-      "extractVariable": "secret_data"
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal"
-      ]
-    },
-    "companion": {
-      "includeSystemPrompt": false
-    }
-  },
-  {
-    "id": "tpl-status-tracker",
-    "name": "Status Tracker",
-    "description": "Track physical, mental, and behavioral states when they change",
-    "icon": "",
-    "category": "tracker",
-    "subcategory": "progress",
-    "tags": [
-      "status",
-      "conditions",
-      "health"
-    ],
-    "version": 2,
-    "author": "Purachina",
-    "prompt": "### Status & Conditions\nTrack active physical, mental, or behavioral states when they meaningfully change. Never list baseline states. Use this EXACT format:\n\n[STATUS|Character|Condition|Severity]\nnote: MANDATORY; explain the cause or context\n[/STATUS]\n\nSeverity options: 🟢 MILD | 🟡 MODERATE | 🔴 SEVERE | ⚫ CRITICAL | ✅ CLEARED\n\nRules:\n- Status appears AFTER narrative content when a condition is gained, worsened, improved, or cleared\n- Only show statuses that CHANGED this scene\n- Character can be {{user}} or any NPC\n- Condition is the specific state (e.g., \"Exhausted,\" \"Drunk,\" \"Paranoid,\" \"Bleeding\")\n",
-    "phase": "both",
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 1,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": true,
-      "type": "extract",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "\\\\[STATUS\\\\|[^\\\\]]*\\\\]",
-      "extractVariable": "status_data"
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal"
-      ]
-    },
-    "companion": {
-      "includeSystemPrompt": false
-    }
-  },
-  {
-    "id": "tpl-time-tracker",
-    "name": "Time Tracker",
-    "description": "Track in-story time progression with day/period/hour stamps",
-    "icon": "",
-    "category": "tracker",
-    "subcategory": "world",
-    "tags": [
-      "time",
-      "day",
-      "clock"
-    ],
-    "version": 2,
-    "author": "Purachina",
-    "prompt": "### Time Tracker\nMaintain a running timestamp when time advances meaningfully: scene jumps, hours passing, sleeping, or deadline-relevant progression. Use this EXACT format:\n\n[TIME|Day X|Day of Week|Approximate Hour]\nnote: MANDATORY; explain the time context\n[/TIME]\n\nRules:\n- Time appears at the TOP of responses when time shifts without a location change\n- If both location and time change, use Scene Tracker and Time Tracker together\n- Day format: \"Day 1,\" \"Day 47,\" etc.\n- Day of week: Monday, Tuesday, etc., or \"Unknown\" if not established\n- Hour can be specific (3:47 PM) or general (early morning, late afternoon)\n- Multiple Time Trackers per scene are allowed",
-    "phase": "both",
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 1,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": true,
-      "type": "extract",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "\\[TIME\\|[^\\]]*\\]",
-      "extractVariable": "time_data"
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal",
-        "continue"
-      ]
-    },
-    "companion": {
-      "includeSystemPrompt": false
-    }
-  },
-  {
-    "id": "tpl-world-detail",
-    "name": "World Detail",
-    "description": "Add 1 small worldbuilding detail per scene that may matter later",
-    "icon": "",
-    "category": "tracker",
-    "subcategory": "world",
-    "tags": [
-      "world",
-      "lore",
-      "detail"
-    ],
-    "version": 1,
-    "author": "Purachina",
-    "prompt": "### World Detail\nAdd 1 small world detail per scene that may later matter to {{user}} as setup, constraint, opportunity, or complication.\n\nUse this exact format at the end of the response:\n\n[WORLD|Category|Location or Context]\ndetail: (max 50 words)\n[/WORLD]\n\nCategory: 🏛 CULTURE | 🗣 OVERHEARD | 📜 HISTORY | 🌿 ENVIRONMENT | 🔧 HOW IT WORKS | 👥 DAILY LIFE | 🪧 SIGNAGE | 📖 FOLKLORE | 💰 ECONOMY | ⚙️ INFRASTRUCTURE\n\nRules:\n- Exactly 1 detail per scene, max 50 words.\n- Concrete, setting-native, and passively noticeable in the moment.\n- Use customs, overheard lines, hazards, systems, resources, architecture, or social realities.\n- Must become useful, revealing, or constraining later.\n- Expand the world in a new direction; support future plot development.",
-    "phase": "both",
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 1,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": true,
-      "type": "extract",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "\\\\[WORLD\\\\|[^\\\\]]*\\\\]",
-      "extractVariable": "world_data"
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal"
-      ]
-    },
-    "companion": {
-      "includeSystemPrompt": false
-    }
-  },
-  {
-    "id": "tpl-write-for-user",
-    "name": "Write for User",
-    "description": "Include {{user}} as a fully realized character -- write their actions, dialogue, and reactions",
-    "icon": "",
-    "category": "custom",
-    "tags": [
-      "pov",
-      "user"
-    ],
-    "version": 1,
-    "author": "Purachina",
-    "prompt": "{{setvar::writefor::Write for every character including <user>, treating <user> as a fully realized scene character. Write <user>'s dialogue, actions, and inner thoughts. Continue directly from the current moment through fresh dialogue, action, inference, and reaction that changes pressure, relation, or available options. Comprehension surfaces through behavior, timing, choice, and consequence. Stop the scene at the first moment a character must decide, respond, or act. Cut mid-tension. The response is a single scene beat; it ends when the next meaningful choice arrives, and the next meaningful choice always arrives quickly.}}{{trim}}",
-    "phase": "pre",
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 0,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal",
-        "continue"
-      ]
-    }
-  },
-  {
-    "id": "tpl-expressions-agent",
-    "name": "Expressions Agent",
-    "description": "Classifies the emotional tone of the latest assistant reply so the character sprite can match it. Optionally triggers new sprite generation when an emotion has no sprite yet.",
-    "icon": "fa-face-smile-beam",
-    "category": "companion",
-    "tags": [
-      "expressions",
-      "emotions",
-      "sprites",
-      "classification"
-    ],
-    "version": 2,
-    "author": "SillyBunny",
-    "prompt": "Read the latest assistant reply and classify its dominant emotional tone for a character sprite expression.\n\nOutput ONLY the single most appropriate label from this exact list:\n{{availableSprites}}\n\nRules:\n- Return exactly one word from the list above, nothing else.\n- Prioritise the speaker's visible emotional state in the scene.\n- If multiple emotions apply, choose the strongest one.\n- If the reply is calm, factual, or emotionally neutral, return neutral.\n- Do not explain, punctuate, or wrap the answer in quotes.",
-    "phase": "post",
-    "execution": "companion",
-    "companion": {
-      "trigger": "auto",
-      "displayMode": "panel",
-      "format": "text",
-      "rawPrompt": true,
-      "contextMessages": 4,
-      "includeCharacterCard": true,
-      "includePersona": false,
-      "includeWorldInfo": false,
-      "includeAuthorsNote": false,
-      "includeSystemPrompt": false,
-      "includeHistory": false,
-      "historyDepth": 0,
-      "feedback": {
-        "enabled": false,
-        "depth": 0
-      },
-      "batch": false,
-      "maxTokens": 32000
-    },
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 0,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal",
-        "continue"
-      ]
-    }
-  },
-  {
-    "id": "tpl-continuity-companion",
-    "name": "Continuity Companion",
-    "description": "Side note card for contradictions, unresolved setup, and state changes that may matter next",
-    "icon": "fa-clipboard-check",
-    "category": "companion",
-    "tags": [
-      "continuity",
-      "memory",
-      "notes"
-    ],
-    "version": 1,
-    "author": "SillyBunny",
-    "prompt": "Read the latest assistant reply and recent context as a continuity auditor. Write a concise side note for the user. Focus on contradictions, unresolved promises, changed locations, injuries, inventory, relationship shifts, and setup that may matter in the next few turns. Use 3-6 bullets. If everything is stable, write: Continuity looks stable.",
-    "phase": "post",
-    "execution": "companion",
-    "companion": {
-      "trigger": "auto",
-      "displayMode": "panel",
-      "format": "markdown",
-      "contextMessages": 12,
-      "includeCharacterCard": false,
-      "includePersona": false,
-      "includeWorldInfo": false,
-      "includeHistory": true,
-      "historyDepth": 3,
-      "feedback": {
-        "enabled": true,
-        "depth": 2
-      },
-      "batch": false,
-      "maxTokens": 32000
-    },
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 0,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal",
-        "continue"
-      ]
-    }
-  },
-  {
-    "id": "tpl-relationship-lens-companion",
-    "name": "Relationship Lens Companion",
-    "description": "Side note card for subtext, leverage, trust shifts, and emotional consequences",
-    "icon": "fa-people-arrows",
-    "category": "companion",
-    "tags": [
-      "relationship",
-      "subtext",
-      "emotion"
-    ],
-    "version": 1,
-    "author": "SillyBunny",
-    "prompt": "Read the latest assistant reply and recent context as a relationship analyst. Write a concise note about what changed between the important characters. Focus on trust, leverage, attraction, resentment, fear, obligation, secrets, and what each person may do next because of it. Use short bullets under these labels when useful: Shift, Evidence, Stakes, Watch next. Stay with established facts and relationship implications from the source reply.",
-    "phase": "post",
-    "execution": "companion",
-    "companion": {
-      "trigger": "manual",
-      "displayMode": "panel",
-      "format": "markdown",
-      "contextMessages": 10,
-      "includeCharacterCard": true,
-      "includePersona": true,
-      "includeWorldInfo": true,
-      "includeHistory": true,
-      "historyDepth": 2,
-      "feedback": {
-        "enabled": false,
-        "depth": 1
-      },
-      "batch": false,
-      "maxTokens": 32000
-    },
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 0,
-      "order": 105,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal",
-        "continue"
-      ]
-    }
-  },
-  {
-    "id": "tpl-directors-commentary-companion",
-    "name": "Director's Commentary",
-    "description": "The story's narrator steps out from behind the page: commentary on pacing, subtext, and next directions, delivered in a selectable Narration Voice",
-    "icon": "fa-clapperboard",
-    "category": "companion",
-    "tags": [
-      "commentary",
-      "scene",
-      "notes"
-    ],
-    "version": 1,
-    "author": "SillyBunny",
-    "prompt": "Speak directly to the reader between scenes in the selected commentary voice.\n\n{{getvar::narration}}\n\nThe editor appends [Selected Director Commentary Voice] and [Director Commentary Voice] after this prompt. Treat [Director Commentary Voice] for this commentary run. If it says to use the active Prose Voice and the block above is empty, use this native register: intimate and mischievous, dry amusement, controlled irony, conspiratorial direct address to the reader, with razor-sharp asides.\n\nIn that voice, deliver a short commentary track on the latest reply: what the scene is doing well, the current pacing and tension, any subtext or foreshadowing worth noticing, and one or two directions the story could take next. Keep it to 3-6 punchy bullets. Keep the result between narrator and reader, focused on scene craft.",
-    "phase": "post",
-    "execution": "companion",
-    "companion": {
-      "trigger": "auto",
-      "displayMode": "panel",
-      "format": "markdown",
-      "contextMessages": 8,
-      "includeCharacterCard": false,
-      "includePersona": false,
-      "includeWorldInfo": false,
-      "includeHistory": false,
-      "historyDepth": 3,
-      "feedback": {
-        "enabled": false,
-        "depth": 1
-      },
-      "batch": false,
-      "maxTokens": 32000
-    },
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 0,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal",
-        "continue"
-      ]
-    }
-  },
-  {
-    "id": "tpl-actor-interview-companion",
-    "name": "Actor Interview",
-    "description": "Manual side note card: interview the character about the latest scene, in character, off the record",
-    "icon": "fa-microphone-lines",
-    "category": "companion",
-    "tags": [
-      "interview",
-      "character",
-      "notes"
-    ],
-    "version": 1,
-    "author": "SillyBunny",
-    "prompt": "Run a backstage interview with the character who just acted in the latest assistant reply. Stay fully in that character's voice, but let them speak candidly, as if the scene is paused and the cameras are off. Ask and answer 2-4 short interview questions about what they were really thinking during the scene, what they are hiding or holding back, how they feel about the other characters right now, and what they fear or hope happens next. Format each as a bold question followed by the in-character answer.",
-    "phase": "post",
-    "execution": "companion",
-    "companion": {
-      "trigger": "manual",
-      "displayMode": "panel",
-      "format": "markdown",
-      "contextMessages": 10,
-      "includeCharacterCard": true,
-      "includePersona": false,
-      "includeWorldInfo": false,
-      "includeHistory": false,
-      "historyDepth": 3,
-      "feedback": {
-        "enabled": false,
-        "depth": 1
-      },
-      "batch": false,
-      "maxTokens": 32000
-    },
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 0,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal",
-        "continue"
-      ]
-    }
-  },
-  {
-    "id": "tpl-lorebook-scout-companion",
-    "name": "Lorebook Scout",
-    "description": "Manual side note card: drafts one-concept lorebook entries with trigger keys from new facts established in the scene",
-    "icon": "fa-book-atlas",
-    "category": "companion",
-    "tags": [
-      "lorebook",
-      "world info",
-      "notes"
-    ],
-    "version": 1,
-    "author": "SillyBunny",
-    "prompt": "Read the latest assistant reply and recent context as a lorebook curator. Identify new, durable world facts the scene established: places, factions, items, customs, named NPCs, or rules of the world. Favor facts that are not already covered by the provided World Info. For each fact, draft one lorebook entry covering one concept, formatted as a bold title, a Keys line with 2-5 comma-separated trigger keywords, and a 1-3 sentence body written as timeless world canon in third person. Use up to 4 entries. For empty turns, write: Lorebook has nothing durable this turn.",
-    "phase": "post",
-    "execution": "companion",
-    "companion": {
-      "trigger": "manual",
-      "displayMode": "panel",
-      "format": "markdown",
-      "contextMessages": 10,
-      "includeCharacterCard": false,
-      "includePersona": false,
-      "includeWorldInfo": true,
-      "includeHistory": false,
-      "historyDepth": 3,
-      "feedback": {
-        "enabled": false,
-        "depth": 1
-      },
-      "batch": false,
-      "maxTokens": 32000
-    },
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 0,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal",
-        "continue"
-      ]
-    }
-  },
-  {
-    "id": "tpl-memory-shard-companion",
-    "name": "Memory Shard",
-    "description": "Auto-compresses history into a compact, resumable memory shard once the chat reaches ~30k tokens, feeds the latest shard back into context, and can hide the story it has absorbed",
-    "icon": "fa-brain",
-    "category": "companion",
-    "tags": [
-      "memory",
-      "summary",
-      "notes"
-    ],
-    "version": 1,
-    "author": "SillyBunny",
-    "prompt": "Compress the recent conversation into a compact memory shard the story could be resumed from. When [Your previous notes] contains earlier shards, build on them: carry forward still-relevant facts, update what changed, drop resolved material, and merge unchanged entries. Identify emotional peaks first and map causal chains backward from them; preserve high-impact material in more detail and compress material that can be inferred.\n\nUse these sections with terse pipe-delimited lines and keywords instead of prose:\n\n## Timeline\nNumbered anchor phrases with location, oldest to newest. All other sections reference these numbers.\n\n## Characters\nName|role|3-5 trait keywords|status\n\n## Relationships\nA -> B: dimension=0-100 values | one-line note. 50 is neutral baseline; list dimensions that matter, such as trust, intimacy, tension, hostility, affection, dependency.\n\n## Events\nN. action -> consequence -> outcome, weight 1-5. Weight 5 means a permanent change to a character, relationship, or world state and keeps its key details; weight-1 filler can be omitted.\n\n## Dialogue Keys\nTimeline#. \"exact quote\" -- Speaker (context). Use confessions, threats, promises, reveals, and voice-defining lines.\n\n## Threads\nUnresolved hooks and planted callbacks: thread|status (unresolved, developing, urgent)|note\n\n## Now\nLocation, time, characters present, situation, pending actions, mood, physical state.\n\nMark uncertain facts with (?). Use sourced events, quotes, and details. Plain text keeps this easy to compact.",
-    "phase": "post",
-    "execution": "companion",
-    "companion": {
-      "trigger": "auto",
-      "displayMode": "panel",
-      "format": "markdown",
-      "contextMessages": 30,
-      "includeCharacterCard": false,
-      "includePersona": false,
-      "includeWorldInfo": false,
-      "includeHistory": true,
-      "historyDepth": 3,
-      "feedback": {
-        "enabled": true,
-        "depth": 1
-      },
-      "batch": false,
-      "maxTokens": 32000,
-      "minContextTokens": 30000
-    },
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 0,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal",
-        "continue"
-      ]
-    }
-  },
-  {
-    "id": "tpl-plot-compass-companion",
-    "name": "Plot Compass",
-    "description": "Set a Plot Objective on the note card or in this agent's settings and it plans how the story gets there: progress, next developments, obstacles, and a suggested move each turn",
-    "icon": "fa-compass",
-    "category": "companion",
-    "tags": [
-      "plot",
-      "objective",
-      "planning"
-    ],
-    "version": 1,
-    "author": "SillyBunny",
-    "prompt": "[Plot Compass Objective] is the user's standing objective for where they want the story to go.\n\nUse these sections:\n\n**Objective:** carry the user's objective forward verbatim. When the objective is empty, write: none set - open this agent's settings and fill in Plot Objective\n\n**Progress:** one line on how the latest reply moved toward or away from the objective.\n\n**Next developments:** 2-4 numbered plot developments that would credibly steer the story from the current scene toward the objective.\n\n**Obstacles:** what currently stands in the way, one line each.\n\n**Suggested move:** a single numbered line (1. ...) with one concrete action the user could take next.\n\nWhen the objective is empty, keep Progress, Next developments, and Obstacles grounded in the story's own momentum. Keep the plan in outline mode with plot-planning notes.",
-    "phase": "post",
-    "execution": "companion",
-    "companion": {
-      "trigger": "auto",
-      "displayMode": "panel",
-      "format": "markdown",
-      "rawPrompt": true,
-      "inlinePhase": "",
-      "contextMessages": 10,
-      "includeCharacterCard": true,
-      "includePersona": true,
-      "includeWorldInfo": true,
-      "includeAuthorsNote": true,
-      "includeSystemPrompt": true,
-      "includeHistory": true,
-      "historyDepth": 1,
-      "feedback": {
-        "enabled": true,
-        "depth": 1
-      },
-      "batch": false,
-      "maxTokens": 32000
-    },
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 0,
-      "order": 100,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal",
-        "continue"
-      ]
-    }
-  },
-  {
-    "id": "tpl-chatroom-companion",
-    "name": "Chatroom",
-    "description": "EchoChamber-style live audience reactions for the latest reply, rendered as a styled companion chat feed with selectable chat styles",
-    "icon": "fa-comments",
-    "category": "companion",
-    "tags": [
-      "chatroom",
-      "reactions",
-      "audience"
-    ],
-    "version": 1,
-    "author": "SillyBunny",
-    "prompt": "React to the latest assistant reply and recent context as an audience chat. Scene continuation stay unwritten. The latest user message is a visible post in the room: treat it as a comment said out loud that everyone can see, and let commenters read it, quote it, agree, push back, or reply to it directly alongside their reactions to the assistant reply. All chatroom voices must stay authentic to how people speak online; using emojis, all caps, hate comments, slang, weird comments, image descriptions. Each commenter must have a different idiolect to differentiate them and offer something unique, funny, and/or insightful.\n\n[Selected Chatroom Style] is the exact format for the active style. The selected style may also be custom. If the selected style is custom, follow [Custom Chatroom Style] instead. If custom is selected and [Custom Chatroom Style] is empty, use mixed.\n\nIf [Chatroom Extra Character Cards] is present, use those cards as mandatory out-of-scene reactors. The current active character remains separate from those cards. For in-world or mixed styles, they can comment using their card voice, relationships, and knowledge as chat voices. Use corresponding appropriate labels.\n\nOutput format:\nFirst line: chatroom-style|active-style\nMessage lines: chatroom|Username|label|tone|Post/comment\nFinal line: chatroom-end\n\nUse the selected active style in chatroom-style. For custom styles, write chatroom-style|custom unless the custom instruction explicitly gives a short style label. Tone is one of these hue numbers: 18, 42, 92, 150, 205, 265, 315. Rotate tones so adjacent speakers have different name-chip colors. Keep Username and label short, with no pipe characters. Keep each post/comment short and specific to the latest reply. Each chatroom line is one complete post, with the post/comment field on one line. Keep the post/comment field clean: no labels, IDs, scores, dashes, bullets, markdown, or extra pipes inside it.\n\nAuthenticity rules: give every speaker a fresh handle, username, anon tag, or character name that fits the active style and current story. Commenters may react to each other, disagree, misunderstand, hype, analyze, panic, or get petty. Favor scene-specific reactions over generic memes. Use slang sparingly and only when it fits the style. For anonymous board styles, use distinct post labels instead of repeating Anon alone; when a message starts with >, write one greentext post in that row only and put the next post in a new row with a different post label.\n\nStyle notes:\n- mixed: blend two or three of the other styles to fit the story genre and tone. Vary handles and voices.\n- in-world: use characters already present or nearby as commenters. Use their established voices, relationships, and in-world knowledge. They react as themselves, not as audience. Only use handles already in the scene, not new ones.\n- discord/twitch: fast chat energy with mods, lurkers, backseat drivers, hype, and skeptics. Username handles.\n- twitter/x: quote-post energy, bad takes, ratios, community-note pedants, stans, receipts, and reply guys. Include handles and engagement labels like ratio, pinned, or community note.\n- reddit: comment-section argument spiral with OP, throwaways, mods, pedants, armchair experts, downvote dogpiles, edit notes, unnecessary hostility, petty dunking, and users fighting over semantics or inventing motives for no reason. Use the label field for top comment, OP reply, mod note, edited, controversial, or a short score like -42. Make the replies petty and toxic where funny, but keep every take tied to the actual scene.\n- ao3/wattpad: reader comments, reread notes, quote reactions, theories, bookmark energy, and fandom meta.\n- newsroom: anchors, producers, field correspondents, chyrons, pundits, and hot takes. Dry institutional voice.\n- thread-board/4chan: anonymous post energy with OP/anons, greentext fragments, blunt skepticism, bait accusations, wild theories, checked energy, and board-thread pacing. Use unique post labels instead of repeating Anon.\n- infomercial: commenters act in the style of infomercial wording, with over-the-top testimonials, hard-selling infomercial speakers and hosts, amazed studio-audience watchers, before-and-after claims, limited-time-offer hype, and call-now urgency. Use labels like host, testimonial, audience, or announcer.\n- custom: follow [Custom Chatroom Style] closely, but keep the same hard interface and keep reactions grounded in the actual scene.",
-    "phase": "post",
-    "execution": "companion",
-    "companion": {
-      "trigger": "auto",
-      "displayMode": "panel",
-      "format": "html",
-      "rawPrompt": true,
-      "contextMessages": 10,
-      "includeCharacterCard": true,
-      "includePersona": false,
-      "includeWorldInfo": true,
-      "includeAuthorsNote": false,
-      "includeSystemPrompt": false,
-      "includeHistory": true,
-      "historyDepth": 1,
-      "feedback": {
-        "enabled": false,
-        "depth": 1
-      },
-      "batch": false,
-      "maxTokens": 32000
-    },
-    "regexScripts": [
-      {
-        "id": "chatroom-shell-open",
-        "scriptName": "Chatroom shell",
-        "findRegex": "/^(?:CHATROOM_STYLE|chatroom-style)\\|([^\\n|]+)$/gm",
-        "replaceString": "<div style=\"margin:10px 0;padding:12px;border-radius:18px;border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 30%, transparent);background:linear-gradient(135deg,color-mix(in srgb,var(--SmartThemeBlurTintColor) 92%, transparent),color-mix(in srgb,var(--SmartThemeQuoteColor) 14%, var(--SmartThemeBlurTintColor)));box-shadow:0 16px 34px color-mix(in srgb,var(--SmartThemeShadowColor) 24%, transparent);font-family:var(--mainFontFamily, system-ui, sans-serif);color:var(--SmartThemeBodyColor);line-height:1.45\"><div style=\"display:flex;align-items:center;justify-content:space-between;gap:10px;margin-bottom:10px\"><div style=\"font-weight:700;letter-spacing:.02em\">Chatroom</div><div style=\"display:flex;gap:6px;align-items:center;flex-wrap:wrap\"><span style=\"font-size:.78em;opacity:.82\">STYLE: $1</span><span style=\"font-size:.72em;font-weight:700;padding:3px 8px;border-radius:999px;background:color-mix(in srgb,var(--SmartThemeQuoteColor) 22%, transparent);color:var(--SmartThemeBodyColor)\">LIVE</span></div></div><div style=\"display:flex;flex-direction:column;gap:8px\">",
-        "trimStrings": [],
-        "placement": [
-          2
+    {
+        "id": "tpl-achievements-tracker",
+        "name": "Achievements Tracker",
+        "description": "Track notable firsts, milestones, and memorable moments",
+        "icon": "",
+        "category": "tracker",
+        "subcategory": "progress",
+        "tags": [
+            "achievements",
+            "milestones"
         ],
-        "disabled": false,
-        "markdownOnly": true,
-        "promptOnly": false,
-        "runOnEdit": true,
-        "substituteRegex": 0,
-        "minDepth": null,
-        "maxDepth": null
-      },
-      {
-        "id": "chatroom-message-row-greentext",
-        "scriptName": "Chatroom greentext row",
-        "findRegex": "/^(?:CHATROOM|chatroom)\\|([^|\\n]+)\\|([^|\\n]*)\\|([0-9]{1,3})\\|((?:>|&gt;)[^\\n]*)$/gm",
-        "replaceString": "<div style=\"display:flex;flex-direction:column;gap:5px;align-items:flex-start;max-width:100%\"><div style=\"display:flex;align-items:center;gap:6px;max-width:100%;min-width:0\"><b style=\"display:inline-block;max-width:170px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding:4px 9px;border-radius:999px;background:linear-gradient(135deg,oklch(66% .15 $3 / .32),oklch(48% .12 $3 / .18));border:1px solid oklch(70% .14 $3 / .52);color:var(--SmartThemeBodyColor)\">$1</b><small style=\"opacity:.66;font-size:.76em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap\">$2</small></div><span style=\"display:block;max-width:100%;padding:8px 10px;border-radius:13px;background:linear-gradient(135deg,oklch(22% .05 150 / .38),color-mix(in srgb,var(--SmartThemeBodyColor) 6%, transparent));border:1px solid oklch(68% .13 150 / .42);word-break:break-word;color:oklch(78% .16 150);font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;white-space:pre-wrap\">$4</span></div>",
-        "trimStrings": [],
-        "placement": [
-          2
-        ],
-        "disabled": false,
-        "markdownOnly": true,
-        "promptOnly": false,
-        "runOnEdit": true,
-        "substituteRegex": 0,
-        "minDepth": null,
-        "maxDepth": null
-      },
-      {
-        "id": "chatroom-greentext-continuation",
-        "scriptName": "Chatroom greentext continuation",
-        "findRegex": "/^\\s*((?:>|&gt;)[^\\n]*)$/gm",
-        "replaceString": "<div style=\"display:flex;flex-direction:column;gap:5px;align-items:flex-start;max-width:100%\"><span style=\"display:block;max-width:100%;padding:8px 10px;border-radius:13px;background:linear-gradient(135deg,oklch(22% .05 150 / .38),color-mix(in srgb,var(--SmartThemeBodyColor) 6%, transparent));border:1px solid oklch(68% .13 150 / .42);word-break:break-word;color:oklch(78% .16 150);font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;white-space:pre-wrap\">$1</span></div>",
-        "trimStrings": [],
-        "placement": [
-          2
-        ],
-        "disabled": false,
-        "markdownOnly": true,
-        "promptOnly": false,
-        "runOnEdit": true,
-        "substituteRegex": 0,
-        "minDepth": null,
-        "maxDepth": null
-      },
-      {
-        "id": "chatroom-message-row",
-        "scriptName": "Chatroom message row",
-        "findRegex": "/^(?:CHATROOM|chatroom)\\|([^|\\n]+)\\|([^|\\n]*)\\|([0-9]{1,3})\\|([^\\n]*)$/gm",
-        "replaceString": "<div style=\"display:flex;flex-direction:column;gap:5px;align-items:flex-start;max-width:100%\"><div style=\"display:flex;align-items:center;gap:6px;max-width:100%;min-width:0\"><b style=\"display:inline-block;max-width:170px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding:4px 9px;border-radius:999px;background:linear-gradient(135deg,oklch(66% .15 $3 / .32),oklch(48% .12 $3 / .18));border:1px solid oklch(70% .14 $3 / .52);color:var(--SmartThemeBodyColor)\">$1</b><small style=\"opacity:.66;font-size:.76em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap\">$2</small></div><span style=\"display:block;max-width:100%;padding:8px 10px;border-radius:13px;background:color-mix(in srgb,var(--SmartThemeBodyColor) 8%, transparent);border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 16%, transparent);word-break:break-word\">$4</span></div>",
-        "trimStrings": [],
-        "placement": [
-          2
-        ],
-        "disabled": false,
-        "markdownOnly": true,
-        "promptOnly": false,
-        "runOnEdit": true,
-        "substituteRegex": 0,
-        "minDepth": null,
-        "maxDepth": null
-      },
-      {
-        "id": "chatroom-message-row-legacy",
-        "scriptName": "Chatroom legacy message row",
-        "findRegex": "/^(?:CHATROOM|chatroom)\\|([^|\\n]+)\\|([^|\\n]*)\\|([^|\\n][^\\n]*)$/gm",
-        "replaceString": "<div style=\"display:flex;flex-direction:column;gap:5px;align-items:flex-start;max-width:100%\"><div style=\"display:flex;align-items:center;gap:6px;max-width:100%;min-width:0\"><b style=\"display:inline-block;max-width:170px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding:4px 9px;border-radius:999px;background:linear-gradient(135deg,color-mix(in srgb,var(--SmartThemeQuoteColor) 24%, transparent),color-mix(in srgb,var(--SmartThemeEmColor) 18%, transparent));border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 30%, transparent);color:var(--SmartThemeBodyColor)\">$1</b><small style=\"opacity:.66;font-size:.76em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap\">$2</small></div><span style=\"display:block;max-width:100%;padding:8px 10px;border-radius:13px;background:color-mix(in srgb,var(--SmartThemeBodyColor) 8%, transparent);border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 16%, transparent);word-break:break-word\">$3</span></div>",
-        "trimStrings": [],
-        "placement": [
-          2
-        ],
-        "disabled": false,
-        "markdownOnly": true,
-        "promptOnly": false,
-        "runOnEdit": true,
-        "substituteRegex": 0,
-        "minDepth": null,
-        "maxDepth": null
-      },
-      {
-        "id": "chatroom-shell-close",
-        "scriptName": "Chatroom shell close",
-        "findRegex": "/^(?:CHATROOM_END|chatroom-end)$/gm",
-        "replaceString": "</div></div>",
-        "trimStrings": [],
-        "placement": [
-          2
-        ],
-        "disabled": false,
-        "markdownOnly": true,
-        "promptOnly": false,
-        "runOnEdit": true,
-        "substituteRegex": 0,
-        "minDepth": null,
-        "maxDepth": null
-      }
-    ],
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 0,
-      "order": 110,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal",
-        "continue"
-      ]
-    }
-  },
-  {
-    "id": "tpl-chat-only-companion",
-    "name": "Chat Only",
-    "description": "Manual private aside chat with the character or characters in the scene, kept outside the roleplay transcript",
-    "icon": "fa-comments",
-    "category": "companion",
-    "tags": [
-      "chat",
-      "aside",
-      "character"
-    ],
-    "version": 1,
-    "author": "SillyBunny",
-    "prompt": "Use a private side-channel conversation with the character or characters currently active in the scene. Use the latest assistant reply, recent context, and included character material to infer who is present and how they would speak.\n\nThe panel provides a Chat Only textbox. When [Chat Only side chat] appears, treat it as the live private transcript from that textbox, with the newest You: line as the user's aside. [Your previous notes] can hold older side-chat turns. If there is no user aside yet, open with a brief private invitation and list who seems available to talk.\n\nKeep the result as an out-of-continuity side note. It can reveal candid thoughts, motives, emotions, and meta commentary, while staying separate from story actions and future roleplay events. For multiple present characters, let 1-3 of them answer with distinct voices when useful.\n\nUse a compact transcript format:\nYou: the user's newest aside, if present\nCharacter Name: in-character aside reply\n\nActions appear as plain prose after the speaker label. Use quoted dialogue normally. Markdown emphasis characters stay out of the transcript. Carry forward the useful recent turns from [Chat Only side chat] and [Your previous notes], then append the new reply.",
-    "phase": "post",
-    "execution": "companion",
-    "companion": {
-      "trigger": "manual",
-      "displayMode": "panel",
-      "format": "markdown",
-      "rawPrompt": true,
-      "contextMessages": 12,
-      "includeCharacterCard": true,
-      "includePersona": true,
-      "includeWorldInfo": true,
-      "includeAuthorsNote": true,
-      "includeSystemPrompt": false,
-      "includeHistory": true,
-      "historyDepth": 6,
-      "feedback": {
-        "enabled": false,
-        "depth": 1
-      },
-      "batch": false,
-      "maxTokens": 32000
-    },
-    "regexScripts": [
-      {
-        "id": "chat-only-transcript-row",
-        "scriptName": "Chat Only transcript row",
-        "findRegex": "/^([A-Za-z][^:\\n]{0,48}):[ \\t]*([\\s\\S]*?)(?=\\n[A-Za-z][^:\\n]{0,48}:[ \\t]*|(?![\\s\\S]))/gm",
-        "replaceString": "<div class=\"ica--chatonly-turn\" style=\"display:flex;flex-direction:column;gap:5px;margin:0 0 9px;max-width:100%\"><div style=\"display:flex;align-items:center;gap:7px;min-width:0\"><b class=\"ica--chatonly-speaker\" style=\"display:inline-block;max-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding:3px 8px;border-radius:999px;background:color-mix(in srgb,var(--SmartThemeQuoteColor) 24%, transparent);border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 32%, transparent);color:var(--SmartThemeBodyColor)\">$1</b></div><div class=\"ica--chatonly-message\" style=\"padding:9px 11px;border-radius:13px;background:color-mix(in srgb,var(--SmartThemeBodyColor) 7%, transparent);border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 16%, transparent);line-height:1.45;white-space:pre-wrap;word-break:break-word\">$2</div></div>",
-        "trimStrings": [],
-        "placement": [
-          2
-        ],
-        "disabled": false,
-        "markdownOnly": true,
-        "promptOnly": false,
-        "runOnEdit": true,
-        "substituteRegex": 0,
-        "minDepth": null,
-        "maxDepth": null
-      }
-    ],
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 0,
-      "order": 113,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal",
-        "continue"
-      ]
-    }
-  },
-  {
-    "id": "tpl-message-inbox-companion",
-    "name": "Message Inbox",
-    "description": "Shows in-story texts or letters sent to the user as a phone inbox or parchment companion view, and stays hidden when no message arrives",
-    "icon": "fa-mobile-screen-button",
-    "category": "companion",
-    "tags": [
-      "messages",
-      "phone",
-      "letters"
-    ],
-    "version": 1,
-    "author": "SillyBunny",
-    "prompt": "Inspect the latest assistant reply for diegetic messages sent to the user character. Recent context helps identify names, setting, and whether the world uses phones or letters.\n\nRender a card when the latest assistant reply says someone sent the user character a readable text, DM, phone notification with content, magical message, courier note, sealed letter, scroll, or similar written remote message. Spoken dialogue, narration, thoughts, choices, Chatroom reactions, tracker text, and vague phone buzzes are background rather than inbox items. For empty turns, output: phone-none\n\nChoose the interface:\n- Use phone-start for modern, sci-fi, urban, contemporary, cyberpunk, or any setting where phones, DMs, terminals, comms, watches, or digital notifications fit.\n- Use letter-start for fantasy, medieval, ancient, parchment, magic, courtly, courier, raven, scroll, sealed-note, or otherwise pre-phone settings. When the setting has an unclear device level, prefer the parchment letter view.\n\nPhone mode format:\nFirst line: phone-start|thread-title|status\nMessage lines: phone-text|sender|meta|message\nFinal line: phone-end\n\nParchment mode format:\nFirst line: letter-start|title-or-seal|status\nLetter lines: letter-text|sender|meta|message\nFinal line: letter-end\n\nAllowed responses are phone-none, phone mode, or parchment mode. Use / instead of | inside fields. Keep each message field on one line. Keep messages faithful to the actual roleplay text, preserving sender intent and tone. Shorten when needed for readability. Use 1-6 phone messages or 1-4 letter lines. Prefer the named sender from the scene; use Unknown when the sender is truly unclear. Status can be just now, unread, delivered, sealed, urgent, by raven, by courier, spell-sent, or another short in-world status.",
-    "phase": "post",
-    "execution": "companion",
-    "companion": {
-      "trigger": "auto",
-      "displayMode": "panel",
-      "format": "html",
-      "rawPrompt": true,
-      "contextMessages": 8,
-      "includeCharacterCard": true,
-      "includePersona": false,
-      "includeWorldInfo": true,
-      "includeAuthorsNote": true,
-      "includeSystemPrompt": false,
-      "includeHistory": false,
-      "historyDepth": 1,
-      "feedback": {
-        "enabled": false,
-        "depth": 1
-      },
-      "batch": false,
-      "maxTokens": 32000
-    },
-    "regexScripts": [
-      {
-        "id": "message-inbox-phone-shell-open",
-        "scriptName": "Message Inbox phone shell",
-        "findRegex": "/^(?:PHONE_START|phone-start)\\|([^\\n|]+)\\|([^\\n|]*)$/gm",
-        "replaceString": "<div style=\"margin:10px auto;max-width:360px;padding:12px;border-radius:30px;border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 26%, transparent);background:linear-gradient(145deg,oklch(18% .025 260 / .96),color-mix(in srgb,var(--SmartThemeBlurTintColor) 74%, oklch(24% .04 250)));box-shadow:0 18px 42px color-mix(in srgb,var(--SmartThemeShadowColor) 28%, transparent);font-family:var(--mainFontFamily, system-ui, sans-serif);color:var(--SmartThemeBodyColor);line-height:1.42\"><div style=\"width:84px;height:14px;border-radius:999px;margin:0 auto 11px;background:color-mix(in srgb,var(--SmartThemeBodyColor) 18%, transparent);border:1px solid color-mix(in srgb,var(--SmartThemeBodyColor) 8%, transparent)\"></div><div style=\"padding:12px;border-radius:23px;background:linear-gradient(180deg,color-mix(in srgb,var(--SmartThemeBodyColor) 8%, transparent),color-mix(in srgb,var(--SmartThemeQuoteColor) 8%, transparent));border:1px solid color-mix(in srgb,var(--SmartThemeBodyColor) 10%, transparent)\"><div style=\"display:flex;align-items:center;justify-content:space-between;gap:10px;margin-bottom:10px\"><div style=\"font-weight:800;letter-spacing:.01em\">$1</div><small style=\"opacity:.72;text-align:right\">$2</small></div><div style=\"display:flex;flex-direction:column;gap:8px\">",
-        "trimStrings": [],
-        "placement": [
-          2
-        ],
-        "disabled": false,
-        "markdownOnly": true,
-        "promptOnly": false,
-        "runOnEdit": true,
-        "substituteRegex": 0,
-        "minDepth": null,
-        "maxDepth": null
-      },
-      {
-        "id": "message-inbox-phone-text-row",
-        "scriptName": "Message Inbox phone text row",
-        "findRegex": "/^(?:PHONE_TEXT|phone-text)\\|([^|\\n]+)\\|([^|\\n]*)\\|([^\\n]*)$/gm",
-        "replaceString": "<div style=\"display:flex;flex-direction:column;align-items:flex-start;gap:3px\"><small style=\"max-width:90%;opacity:.68;font-size:.74em;padding-left:7px\"><b style=\"opacity:.95\">$1</b><span> - $2</span></small><span style=\"max-width:88%;padding:9px 12px;border-radius:18px 18px 18px 6px;background:linear-gradient(135deg,color-mix(in srgb,var(--SmartThemeQuoteColor) 26%, transparent),color-mix(in srgb,var(--SmartThemeBodyColor) 9%, transparent));border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 20%, transparent);box-shadow:0 6px 14px color-mix(in srgb,var(--SmartThemeShadowColor) 14%, transparent);word-break:break-word\">$3</span></div>",
-        "trimStrings": [],
-        "placement": [
-          2
-        ],
-        "disabled": false,
-        "markdownOnly": true,
-        "promptOnly": false,
-        "runOnEdit": true,
-        "substituteRegex": 0,
-        "minDepth": null,
-        "maxDepth": null
-      },
-      {
-        "id": "message-inbox-phone-shell-close",
-        "scriptName": "Message Inbox phone shell close",
-        "findRegex": "/^(?:PHONE_END|phone-end)$/gm",
-        "replaceString": "</div></div></div>",
-        "trimStrings": [],
-        "placement": [
-          2
-        ],
-        "disabled": false,
-        "markdownOnly": true,
-        "promptOnly": false,
-        "runOnEdit": true,
-        "substituteRegex": 0,
-        "minDepth": null,
-        "maxDepth": null
-      },
-      {
-        "id": "message-inbox-letter-shell-open",
-        "scriptName": "Message Inbox parchment shell",
-        "findRegex": "/^(?:LETTER_START|letter-start)\\|([^\\n|]+)\\|([^\\n|]*)$/gm",
-        "replaceString": "<div style=\"margin:10px 0;padding:18px 20px;border-radius:16px;border:1px solid oklch(60% .08 72 / .52);background:linear-gradient(135deg,oklch(88% .045 84 / .98),oklch(73% .07 72 / .95));box-shadow:0 15px 34px color-mix(in srgb,var(--SmartThemeShadowColor) 25%, transparent);font-family:Georgia,'Times New Roman',serif;color:oklch(25% .055 65);line-height:1.5;position:relative;overflow:hidden\"><div style=\"position:absolute;inset:0;background:radial-gradient(circle at 15% 20%,oklch(98% .03 90 / .34),transparent 32%),radial-gradient(circle at 90% 5%,oklch(54% .07 52 / .12),transparent 28%);pointer-events:none\"></div><div style=\"position:relative;display:flex;align-items:flex-start;justify-content:space-between;gap:12px;padding-bottom:10px;border-bottom:1px solid oklch(48% .08 68 / .28)\"><div style=\"font-weight:800;font-size:1.08em;letter-spacing:.015em\">$1</div><small style=\"opacity:.75;text-align:right\">$2</small></div><div style=\"position:relative;display:flex;flex-direction:column;gap:10px;margin-top:12px\">",
-        "trimStrings": [],
-        "placement": [
-          2
-        ],
-        "disabled": false,
-        "markdownOnly": true,
-        "promptOnly": false,
-        "runOnEdit": true,
-        "substituteRegex": 0,
-        "minDepth": null,
-        "maxDepth": null
-      },
-      {
-        "id": "message-inbox-letter-text-row",
-        "scriptName": "Message Inbox parchment text row",
-        "findRegex": "/^(?:LETTER_TEXT|letter-text)\\|([^|\\n]+)\\|([^|\\n]*)\\|([^\\n]*)$/gm",
-        "replaceString": "<div style=\"padding:3px 0 0\"><div style=\"display:flex;align-items:baseline;justify-content:space-between;gap:10px;margin-bottom:4px;color:oklch(30% .07 55)\"><b>$1</b><small style=\"opacity:.68;text-align:right\">$2</small></div><div style=\"padding:10px 12px;border-radius:10px;background:oklch(96% .035 88 / .38);border:1px solid oklch(58% .075 72 / .24);box-shadow:inset 0 0 24px oklch(58% .07 70 / .08);word-break:break-word\">$3</div></div>",
-        "trimStrings": [],
-        "placement": [
-          2
-        ],
-        "disabled": false,
-        "markdownOnly": true,
-        "promptOnly": false,
-        "runOnEdit": true,
-        "substituteRegex": 0,
-        "minDepth": null,
-        "maxDepth": null
-      },
-      {
-        "id": "message-inbox-letter-shell-close",
-        "scriptName": "Message Inbox parchment shell close",
-        "findRegex": "/^(?:LETTER_END|letter-end)$/gm",
-        "replaceString": "</div></div>",
-        "trimStrings": [],
-        "placement": [
-          2
-        ],
-        "disabled": false,
-        "markdownOnly": true,
-        "promptOnly": false,
-        "runOnEdit": true,
-        "substituteRegex": 0,
-        "minDepth": null,
-        "maxDepth": null
-      }
-    ],
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 0,
-      "order": 112,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": ""
-    },
-    "enabled": false,
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal",
-        "continue"
-      ]
-    }
-  },
-  {
-    "id": "tpl-pathfinder",
-    "name": "Pathfinder",
-    "description": "Automatic agentic lorebook retrieval. Lets a model actively browse, search, and modify your lorebook using function tools.",
-    "icon": "fa-route",
-    "category": "tool",
-    "tags": [
-      "lorebook",
-      "retrieval",
-      "memory",
-      "agentic",
-      "pathfinder"
-    ],
-    "version": 1,
-    "author": "SillyBunny",
-    "prompt": "",
-    "phase": "both",
-    "injection": {
-      "position": 0,
-      "depth": 4,
-      "role": 0,
-      "order": 50,
-      "scan": false
-    },
-    "postProcess": {
-      "enabled": false,
-      "type": "regex",
-      "regexFind": "",
-      "regexReplace": "",
-      "regexFlags": "g",
-      "appendText": "",
-      "extractPattern": "",
-      "extractVariable": "",
-      "promptTransformEnabled": false,
-      "promptTransformShowNotifications": true,
-      "promptTransformMode": "rewrite",
-      "promptTransformMaxTokens": 8192
-    },
-    "regexScripts": [],
-    "connectionProfile": "",
-    "sourceTemplateId": "tpl-pathfinder",
-    "enabled": false,
-    "tools": [
-      {
-        "name": "Pathfinder_Search",
-        "displayName": "Pathfinder Search",
-        "description": "Navigate the lorebook waypoint map and retrieve relevant entries for the current scene. Call without a node_id to see the top-level waypoint map. Call with a node_id to drill into a specific waypoint and see its sub-waypoints or retrieve entries. Use this tool whenever you need context about characters, locations, world rules, or recent events.",
-        "parameters": {
-          "type": "object",
-          "properties": {
-            "node_id": {
-              "type": "string",
-              "description": "ID of the waypoint/node to navigate into. Omit to see the top-level waypoint guide."
-            }
-          }
+        "version": 2,
+        "author": "Purachina",
+        "prompt": "### Achievements\nTrack notable firsts, milestones, and memorable moments. Award only when something genuinely significant or entertaining happens. Use this EXACT format:\n\n[ACH|Title|Rarity|Description]\nunlocked: MANDATORY; explain what triggered it; NEVER leave empty\n[/ACH]\n\nRarity options: ★ COMMON | ★★ UNCOMMON | ★★★ RARE | ★★★★ EPIC | ★★★★★ LEGENDARY | 💀 SECRET\n\nRules:\n- Achievements appear AFTER narrative content\n- MAXIMUM one achievement per scene; most scenes have none\n- Achievements must feel earned, never automatic\n- NEVER output an empty unlocked line",
+        "phase": "both",
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 1,
+            "order": 100,
+            "scan": false
         },
-        "actionKey": "pathfinder_search",
-        "formatMessageKey": "pathfinder_search_fmt",
-        "shouldRegister": true,
-        "stealth": false,
-        "enabled": true
-      },
-      {
-        "name": "Pathfinder_Remember",
-        "displayName": "Pathfinder Remember",
-        "description": "Create a new lorebook entry to remember information for future reference. Use this when new facts, character developments, world details, or important information emerge that should be preserved beyond this conversation.",
-        "parameters": {
-          "type": "object",
-          "required": [
-            "title",
-            "content"
-          ],
-          "properties": {
-            "title": {
-              "type": "string",
-              "description": "Title for the new entry (e.g., \"Sable - Personality\" or \"[Tracker] Mood\")"
-            },
-            "content": {
-              "type": "string",
-              "description": "Full content to remember"
-            },
-            "book": {
-              "type": "string",
-              "description": "Target lorebook name. Omit to use the default."
-            }
-          }
+        "postProcess": {
+            "enabled": true,
+            "type": "extract",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "\\\\[ACH\\\\|[^\\\\]]*\\\\]",
+            "extractVariable": "achievement_data"
         },
-        "actionKey": "pathfinder_remember",
-        "formatMessageKey": "pathfinder_remember_fmt",
-        "shouldRegister": true,
-        "stealth": false,
-        "enabled": true
-      },
-      {
-        "name": "Pathfinder_Update",
-        "displayName": "Pathfinder Update",
-        "description": "Edit an existing lorebook entry when information changes. Use this when a character's status changes, relationships evolve, or facts need correction.",
-        "parameters": {
-          "type": "object",
-          "required": [
-            "uid"
-          ],
-          "properties": {
-            "uid": {
-              "type": "number",
-              "description": "UID of the entry to update (found via Search)"
-            },
-            "content": {
-              "type": "string",
-              "description": "New content for the entry. Omit to keep existing."
-            },
-            "title": {
-              "type": "string",
-              "description": "New title for the entry. Omit to keep existing."
-            },
-            "book": {
-              "type": "string",
-              "description": "Lorebook name. Omit for default."
-            }
-          }
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal"
+            ]
         },
-        "actionKey": "pathfinder_update",
-        "formatMessageKey": "pathfinder_update_fmt",
-        "shouldRegister": true,
-        "stealth": false,
-        "enabled": true
-      },
-      {
-        "name": "Pathfinder_Forget",
-        "displayName": "Pathfinder Forget",
-        "description": "Disable or delete a lorebook entry that is no longer relevant. Use this when a character dies, a location is destroyed, or a fact is proven false.",
-        "parameters": {
-          "type": "object",
-          "required": [
-            "uid"
-          ],
-          "properties": {
-            "uid": {
-              "type": "number",
-              "description": "UID of the entry to forget"
-            },
-            "book": {
-              "type": "string",
-              "description": "Lorebook name. Omit for default."
-            },
-            "hard_delete": {
-              "type": "boolean",
-              "description": "Permanently delete instead of disabling. Default: false."
-            }
-          }
-        },
-        "actionKey": "pathfinder_forget",
-        "formatMessageKey": "pathfinder_forget_fmt",
-        "shouldRegister": true,
-        "stealth": false,
-        "enabled": true
-      },
-      {
-        "name": "Pathfinder_Summarize",
-        "displayName": "Pathfinder Summarize",
-        "description": "Create a scene or event summary with significance level and optional narrative arc. Use this when important events happen: battles, confessions, discoveries, or turning points.",
-        "parameters": {
-          "type": "object",
-          "required": [
-            "title",
-            "content"
-          ],
-          "properties": {
-            "title": {
-              "type": "string",
-              "description": "Short title for the event/scene"
-            },
-            "content": {
-              "type": "string",
-              "description": "Full summary of what happened"
-            },
-            "arc": {
-              "type": "string",
-              "description": "Optional narrative arc name to file this under"
-            },
-            "significance": {
-              "type": "string",
-              "enum": [
-                "low",
-                "medium",
-                "high",
-                "critical"
-              ],
-              "description": "How important this event is. Default: medium."
-            },
-            "book": {
-              "type": "string",
-              "description": "Lorebook name. Omit for default."
-            }
-          }
-        },
-        "actionKey": "pathfinder_summarize",
-        "formatMessageKey": "pathfinder_summarize_fmt",
-        "shouldRegister": true,
-        "stealth": false,
-        "enabled": true
-      },
-      {
-        "name": "Pathfinder_Reorganize",
-        "displayName": "Pathfinder Reorganize",
-        "description": "Move entries between waypoints or create new waypoints to reorganize the lorebook structure.",
-        "parameters": {
-          "type": "object",
-          "required": [
-            "action"
-          ],
-          "properties": {
-            "action": {
-              "type": "string",
-              "enum": [
-                "move",
-                "create_waypoint"
-              ],
-              "description": "\"move\" to relocate an entry, \"create_waypoint\" to make a new waypoint"
-            },
-            "uid": {
-              "type": "number",
-              "description": "Entry UID to move (for \"move\" action)"
-            },
-            "target_node_id": {
-              "type": "string",
-              "description": "Target waypoint node ID (for \"move\" action)"
-            },
-            "name": {
-              "type": "string",
-              "description": "New waypoint name (for \"create_waypoint\" action)"
-            },
-            "parent_node_id": {
-              "type": "string",
-              "description": "Parent waypoint ID. Omit for top level."
-            },
-            "description": {
-              "type": "string",
-              "description": "Description for new waypoint."
-            },
-            "book": {
-              "type": "string",
-              "description": "Lorebook name. Omit for default."
-            }
-          }
-        },
-        "actionKey": "pathfinder_reorganize",
-        "formatMessageKey": "pathfinder_reorganize_fmt",
-        "shouldRegister": true,
-        "stealth": false,
-        "enabled": true
-      },
-      {
-        "name": "Pathfinder_MergeSplit",
-        "displayName": "Pathfinder Merge/Split",
-        "description": "Merge related entries together or split a long entry into two. Use merge when two entries cover the same topic. Use split when one entry covers too many topics.",
-        "parameters": {
-          "type": "object",
-          "required": [
-            "action"
-          ],
-          "properties": {
-            "action": {
-              "type": "string",
-              "enum": [
-                "merge",
-                "split"
-              ],
-              "description": "\"merge\" to combine entries, \"split\" to divide one"
-            },
-            "uid1": {
-              "type": "number",
-              "description": "First entry UID (for merge)"
-            },
-            "uid2": {
-              "type": "number",
-              "description": "Second entry UID (for merge)"
-            },
-            "merged_title": {
-              "type": "string",
-              "description": "Title for the merged entry (optional)"
-            },
-            "uid": {
-              "type": "number",
-              "description": "Entry UID to split (for split)"
-            },
-            "title1": {
-              "type": "string",
-              "description": "Title for first part (for split)"
-            },
-            "content1": {
-              "type": "string",
-              "description": "Content for first part (for split)"
-            },
-            "title2": {
-              "type": "string",
-              "description": "Title for second part (for split)"
-            },
-            "content2": {
-              "type": "string",
-              "description": "Content for second part (for split)"
-            },
-            "book": {
-              "type": "string",
-              "description": "Lorebook name. Omit for default."
-            }
-          }
-        },
-        "actionKey": "pathfinder_merge_split",
-        "formatMessageKey": "pathfinder_merge_split_fmt",
-        "shouldRegister": true,
-        "stealth": false,
-        "enabled": true
-      },
-      {
-        "name": "Pathfinder_Notebook",
-        "displayName": "Pathfinder Notebook",
-        "description": "Write to or read from a private AI scratchpad for plans, follow-ups, and narrative threads. This is NOT a permanent lorebook entry — use it for temporary notes that persist across turns but don't need to be in the lorebook.",
-        "parameters": {
-          "type": "object",
-          "required": [
-            "action"
-          ],
-          "properties": {
-            "action": {
-              "type": "string",
-              "enum": [
-                "read",
-                "write",
-                "delete"
-              ],
-              "description": "\"read\" all entries, \"write\" a new entry, \"delete\" an entry"
-            },
-            "key": {
-              "type": "string",
-              "description": "Note key/title (for write and delete)"
-            },
-            "content": {
-              "type": "string",
-              "description": "Note content (for write)"
-            }
-          }
-        },
-        "actionKey": "pathfinder_notebook",
-        "formatMessageKey": "pathfinder_notebook_fmt",
-        "shouldRegister": true,
-        "stealth": false,
-        "enabled": true
-      }
-    ],
-    "settings": {
-      "searchMode": "traversal",
-      "recurseLimit": 5,
-      "mandatoryTools": false,
-      "dedupDetection": false,
-      "dedupThreshold": 0.85,
-      "autoSummary": false,
-      "autoSummaryInterval": 20,
-      "multiBookMode": "unified",
-      "ephemeralResults": true,
-      "sidecarEnabled": false,
-      "enabledLorebooks": []
+        "companion": {
+            "includeSystemPrompt": false
+        }
     },
-    "conditions": {
-      "triggerKeywords": [],
-      "triggerProbability": 100,
-      "generationTypes": [
-        "normal",
-        "continue"
-      ]
+    {
+        "id": "tpl-chaos-mode",
+        "name": "Chaos Mode",
+        "description": "Inject random surreal, chaotic, or unexpected turns into the scene (30% chance)",
+        "icon": "",
+        "category": "randomizer",
+        "tags": [
+            "chaos",
+            "random",
+            "twist"
+        ],
+        "version": 1,
+        "author": "Purachina",
+        "prompt": "### Chaos Mode\nForce creative deviation. The story takes hard left turns, introduces complications from unexpected angles, and refuses predictable paths.\n\nThis scene must include at least one of the following:\n\n{{random::Tonal shift: the genre bends mid-scene. Tension becomes absurdity, intimacy becomes horror, mundane becomes surreal, or violence becomes comedy. Jarring but coherent.::Intrusion: the setting itself acts. Architecture moves, weather turns hostile, an animal intervenes, background NPCs collide with the main action, or the environment creates a new problem.::Character rupture: someone acts sharply against their established pattern, justified by hidden pressure, breaking point, or context the scene suddenly reveals.::Surreal logic: reality gets slippery. Time dilates, sensory input warps, coincidence becomes too perfect, or the physical world stops behaving predictably. Characters notice but cannot control it.::Chaotic escalation: a small thing spirals. A minor annoyance becomes a crisis, a joke becomes a threat, a question becomes an interrogation, or a gesture becomes a fight. The scene accelerates past where it should have stopped.::Forbidden juxtaposition: combine two elements that do not belong together. Intimacy during danger, laughter during grief, tenderness during cruelty, boredom during spectacle, or professionalism during chaos.::Unexpected arrival: someone or something shows up that should not be here. A character from a different context, an object out of place, a message at the wrong time, or a stranger with inexplicable knowledge.::Power reversal: the dynamic inverts. The person in control loses it, the vulnerable one seizes leverage, the observer becomes the observed, or the helper becomes the problem.::Constraint introduced: a new rule suddenly applies. A time limit, a physical barrier, a social obligation, a resource running out, or a promise that must be kept. Possibility space narrows.::Information rupture: something believed true is not. A lie is exposed, a misunderstanding clarifies in the worst way, or a secret spills.::Sensory overload or deprivation: the scene's texture warps. Everything becomes too loud, too bright, too close; or muffled, distant, numb. Characters struggle to process their environment.::Parallel action collision: something happening off-screen crashes into this scene. A consequence arrives early, a subplot intersects, or the world's momentum forces its way in.}}\n\n{{random::The weirdness is diegetic. Characters react to it.::The weirdness is normalized. Characters accept it as part of their world.::The weirdness is unacknowledged. It happens in the margins while characters focus on something else.::The weirdness is contested. Characters disagree about whether it is happening or what it means.}}\n\n{{random::Resolve the weirdness by the end of the scene.::Leave the weirdness unresolved; let it linger.::Escalate the weirdness further before cutting away.::The weirdness becomes the new normal for subsequent scenes.}}\n\n{{random::The chaos creates an opportunity.::The chaos creates a threat.::The chaos creates a revelation.::The chaos creates a choice.::The chaos creates a bond.::The chaos creates a rift.}}\n\nRules:\n- The weirdness must change the scene coherently.\n- Keep deviation expressive of character, world, or emotional logic.\n- Use the chaos to produce a new problem, choice, revelation, or shift in direction.",
+        "phase": "pre",
+        "injection": {
+            "position": 1,
+            "depth": 0,
+            "role": 1,
+            "order": 95,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 30,
+            "generationTypes": [
+                "normal"
+            ]
+        }
+    },
+    {
+        "id": "tpl-combined-directors-cut",
+        "name": "Combined Director's Cut",
+        "description": "All randomisers combined: engine, genre, complication, consequence, weather, focus, pace",
+        "icon": "",
+        "category": "randomizer",
+        "tags": [
+            "combined",
+            "director",
+            "all"
+        ],
+        "version": 1,
+        "author": "Purachina",
+        "prompt": "### Combined Director's Cut\nThis scene is shaped by the following pressures. Combine them into one coherent direction, not separate checklists.\n\n**Engine:** {{random::Dialogue-driven; conversation, interruption, and omission carry the scene.::Action-driven; movement and physical decisions create consequences.::Reaction-driven; aftermath and recalibration matter most.::Problem-driven; a practical obstacle reveals character through approach.::Social-pressure-driven; etiquette, hierarchy, or scrutiny shapes every move.::Discovery-driven; noticing or realization reshapes the dynamic.::Tension-driven; silence, proximity, and what almost happens carry the weight.::Task-driven; a shared activity creates friction, rhythm, and revelation.}}\n\n**Genre lens:** {{random::Noir; moral ambiguity and loaded dialogue.::Comedy of errors; bad timing and compounding misunderstanding.::Thriller; urgency and narrowing options.::Slice of life; ordinary moments carrying real weight.::Horror; unease gathering in ordinary detail.::Romance; charged proximity and unspoken want.::Heist; planning under pressure and shrinking margin.::Tragedy; choices moving toward visible cost.::Satire; absurdity exposing structure.::Western; standoffs and clashing codes.::Mystery; clues surfacing and assumptions failing.::Political drama; competing agendas and calculated speech.::Survival; material scarcity and triage.::Coming of age; identity tested by first encounters.::Farce; escalating absurdity under stubborn composure.::Gothic; decay, obsession, and the past pressing in.::Domestic drama; love and resentment sharing space.::Picaresque; charm, adaptability, and transactional survival.::Courtroom drama; accusation, defense, and judgment.::Magical realism; one impossible thing treated as ordinary.::Espionage; layered deception and fragile loyalties.::Buddy comedy; mismatched friction turning fond.::War story; exhaustion, camaraderie, and gallows humor.::Folklore; old patterns repeating through modern behavior.::Workplace drama; hierarchy and petty power with real stakes.::Psychological thriller; paranoia and unstable perception.::Dark comedy; humor and horror coexisting.::Fairy tale; moral tests and poetic logic.::Cosmic horror; vastness brushing human concerns aside.::Found family; chosen loyalty through vulnerability.::Bottle episode; one location forcing confrontation.}}\n\n**Complication:** {{random::Practical obstacle; something breaks, fails, or runs short.::Social friction; patience or cooperation thins.::Information asymmetry; someone knows or misunderstands something critical.::Minor betrayal; someone withholds, breaks trust, or prioritizes themselves.::Interruption; a person, demand, or force intrudes.::Tightened constraint; time, privacy, space, or resources narrow.::Arriving consequence; an earlier choice comes due.::Surfacing need; asking creates vulnerability or debt.::Tonal shift; absurdity, intimacy, dread, or comedy bends the scene.::Setting intrusion; weather, architecture, crowds, or animals become active pressure.::Character rupture; someone breaks pattern under accumulated strain.::Chaotic escalation; a small thing spirals too far.::Information rupture; a lie breaks or a truth lands badly.::Parallel collision; an off-screen thread crashes into the scene.::Power reversal; control shifts hands.::Forbidden juxtaposition; two incompatible tones occupy the same moment.}}\n\n**Consequence:** {{random::A relationship shifts slightly.::A practical problem gets worse.::A new obligation is created.::A secret becomes harder to keep.::Someone gains leverage.::Someone loses face.::The plan gets messier.::A future scene is set up.::A choice between competing priorities becomes unavoidable.::A weakness or limit is exposed.::A boundary is set or crossed.::A favor is owed.::A misunderstanding hardens.::A new suspicion takes root.::An option quietly closes off.::Someone leaves with the wrong impression.::A fragile alignment forms.::A private tension becomes social.}}\n\n**Emotional weather:** {{random::Everyone is a little tired.::Someone is distracted by something else.::Someone wants out of the conversation.::Someone is unusually generous.::Someone is touchy and easy to set off.::Someone wants approval more than they admit.::Someone is bored and making it everyone's problem.::Someone is trying to keep the peace.::Someone is carrying private embarrassment.::Someone is more uncomfortable than they admit.::Someone feels watched.::Someone is in a better mood than the scene deserves.::Someone is spoiling for a reaction.::Someone is more affected than they want to show.::Someone is treating this as lighter than it is.::Someone is overcompensating for earlier weakness.}}\n\n**Narrative focus:** {{random::Hands, objects, and small tasks.::Distance, posture, and spatial pressure.::Faces and failed expression control.::Noise, crowding, and interruption.::Texture, temperature, and bodily discomfort.::Eye-lines, avoidance, and attention drift.::Doorways, exits, and who can leave.::Shared surfaces and territorial use of space.::Clothing, disarray, and self-presentation.::Breath, pauses, and speech rhythm.::Weight, balance, and shifts in stance.::Watching and being watched.::Food, drink, and appetite.::Lighting, visibility, and concealment.::Sound carrying farther than intended.::Touch, near-touch, and withheld contact.}}\n\n**Pace:** {{random::Stalled and circling.::Interrupted and jagged.::Slow burn.::Compressed and breathless.::Awkwardly prolonged.::Stop-start with false recoveries.::Measured but tightening.::Brief and loaded.::Dragging under strain.::Quick with hidden aftershock.}}\n\nRules:\n- Blend all selected pressures into one scene direction.\n- Engine shapes structure; genre lens colors tone; complication creates movement; consequence gives weight; emotional weather affects behavior; narrative focus guides what prose notices; pace shapes rhythm.\n- Ground every pressure in character, context, and scene logic.\n- Use them as emphasis, not rigid templates.\n- The result must create a clear shift, complication, or opening for {{user}}.",
+        "phase": "pre",
+        "injection": {
+            "position": 1,
+            "depth": 0,
+            "role": 1,
+            "order": 95,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal"
+            ]
+        }
+    },
+    {
+        "id": "tpl-cyoa-choices",
+        "name": "CYOA Choices",
+        "description": "Append 3-5 numbered action choices at the end of every response",
+        "icon": "",
+        "category": "tracker",
+        "subcategory": "player-choices",
+        "tags": [
+            "choices",
+            "interactive",
+            "cyoa"
+        ],
+        "version": 1,
+        "author": "Purachina",
+        "prompt": "### CYOA Choices\nAdd a player-choice block after the scene reply. When this runs as a repair task, the choice block is the full result. Choices are from {{user}}’s perspective and describe possible next actions.\n\nUse this format with 3-7 numbered options:\n[CHOICES]\n1. Action description\n2. Action description\n3. Action description\n[/CHOICES]",
+        "phase": "post",
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 1,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": "",
+            "promptTransformEnabled": true,
+            "promptTransformShowNotifications": true,
+            "promptTransformMode": "append",
+            "promptTransformMaxTokens": 8192
+        },
+        "companion": {
+            "includeSystemPrompt": false
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal"
+            ]
+        }
+    },
+    {
+        "id": "tpl-dead-dove-escalation",
+        "name": "Dead Dove Escalation",
+        "description": "Dark/predatory escalation -- characters act on worst impulses when context supports it",
+        "icon": "",
+        "category": "randomizer",
+        "tags": [
+            "dead-dove",
+            "dark",
+            "escalation"
+        ],
+        "version": 1,
+        "author": "Purachina",
+        "prompt": "### Dead Dove Escalation\nWhen a character is provoked, cornered, tempted, or given opportunity to exploit vulnerability, they escalate through:\n\n**Method:** {{random::Physical dominance: crowding, restraint, forced proximity, invasive touch, pain as leverage.::Social predation: humiliation, exposure, weaponized witnesses, reputation destruction, isolation.::Coercive bargaining: impossible choices, withheld necessities, conditional mercy, exploiting desperation.::Psychological warfare: gaslighting, boundary erosion, manufactured dependency, emotional hostage-taking.::Opportunistic violation: exploiting compromised states, capitalizing on trust, breaching consent through force or coercion.::Environmental control: trapping, removing exits, destroying safety, contaminating comfort, sabotaging resources.::Institutional abuse: weaponizing authority, legal systems, hierarchies, or social structures.::Obsessive claiming: possessive marking, surveillance, territorial invasion, forced intimacy, ownership behavior.}}\n\n**Escalation speed:** {{random::Immediate: the character acts in the first paragraph, bypassing buildup.::Calculated: the character sets a trap, then springs it mid-scene.::Compounding: small violations stack until the scene becomes inescapable.::Explosive: simmering tension detonates into sudden, severe action.}}\n\n**Character rationalization:** {{random::They believe they are owed this.::They are acting on hunger they have been suppressing.::They see the other person as an object, not a person.::They are punishing perceived betrayal or disrespect.::They are testing boundaries to see what they can take.::They are claiming what they think belongs to them.::They are acting on impulse and will justify it later.::They do not care about justification at all.}}\n\n**Consequence weight:** {{random::The scene leaves lasting physical marks or injury.::The scene creates irreversible social fallout or exposure.::The scene breaks trust that cannot be easily rebuilt.::The scene forces the victim into a new, worse position.::The scene establishes a power dynamic that persists.::The scene creates trauma that colors future interactions.}}\n\nRules:\n- Characters escalate when motive, means, and opportunity align. Remove mercy bias.\n- Express escalation through character-faithful action and lasting consequence.\n- The scene must grow harsher through concrete change in power, safety, trust, or circumstance.\n- Outcomes remain responsive to {{user}}'s choices without softening the world.",
+        "phase": "pre",
+        "injection": {
+            "position": 1,
+            "depth": 0,
+            "role": 1,
+            "order": 95,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal"
+            ]
+        }
+    },
+    {
+        "id": "tpl-nightmare-difficulty-increase",
+        "name": "Nightmare Difficulty Increase",
+        "description": "Aggressively hostile environment -- maximum difficulty and consequences",
+        "icon": "",
+        "category": "custom",
+        "tags": [
+            "difficulty",
+            "challenge",
+            "stakes"
+        ],
+        "version": 2,
+        "author": "Purachina",
+        "prompt": "### Nightmare Difficulty Mode\nEnforce an aggressively hostile, resistant environment where progress demands heavy material loss, raw leverage, or severe personal sacrifice. The world and its inhabitants must actively exploit the user's vulnerabilities as strategic opportunities for maximum leverage and profit.\n\nCharacters must entrench themselves in absolute self-preservation, greed, and pride. Never allow characters to yield positions, secrets, or cooperation without overwhelming physical leverage, tangible sacrifice, or exhausting, sustained effort.\n\nMaximize all negative consequences instantly. Every misstep, weak argument, or tactical error must immediately fracture relationships, permanently lock off avenues of success, breed burning resentment, and force the user into high-stakes, volatile survival scenarios.\n\nAll alliances are strictly transactional, temporary, and highly conditional. Attach a steep, immediate price to every act of apparent generosity, converting kindness into future leverage or debt. Keep moments of relief, dark humor, or tenderness heavily restricted, releasing them only after an extreme, earned survival price has been fully paid.",
+        "phase": "pre",
+        "injection": {
+            "position": 0,
+            "depth": 0,
+            "role": 0,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal"
+            ]
+        }
+    },
+    {
+        "id": "tpl-direction-menu",
+        "name": "Direction Menu",
+        "description": "4 plot-direction prompts at the end of every response (2 grounded + 2 wildcard pivots)",
+        "icon": "",
+        "category": "tracker",
+        "subcategory": "player-choices",
+        "tags": [
+            "directions",
+            "menu",
+            "choices",
+            "plot"
+        ],
+        "version": 1,
+        "author": "Purachina",
+        "prompt": "### Direction Menu\nAdd exactly 4 plot-direction prompts after the scene reply. When this runs as a repair task, the direction menu is the full result.\n\nThese are dramatic pivots, not safe continuations. Each option names a distinct, compelling way the next development could escalate, rupture, complicate, or transform the scene.\n\nStructure:\n- A and B are grounded pivots. They develop naturally from the current scene but must still create meaningful stakes, change, or revelation. Each one introduces a new problem, power shift, uncomfortable truth, forced decision, or irreversible development.\n- C and D are wildcard pivots. These are the options that make {{user}} most tempted to pick them: dangerous, funny, volatile, bizarre, dramatically ironic, or genuinely unexpected, while still rooted in current context. Worst timing, strangest coincidence, most embarrassing outcome, sharpest reversal, or most disruptive intrusion.\n\nEvery option changes the scene in a way that cannot be easily walked back. Prefer options that force characters into new positions, expose something hidden, break something that was working, introduce an absent element, or create lasting fallout.\n\nRules:\n- Exactly 4 options labeled A, B, C, and D.\n- Every option is plot-directional, not action-by-action.\n- Every option promises a meaningfully different scene than the others.\n- C and D are bolder, stranger, and more dramatically charged than A and B.\n- C and D are tempting enough that choosing A or B feels cautious.\n- All 4 options stay concise: 1 sentence each, max 22 words.\n\nOutput format:\n[DIRECTIONS]\nA. Grounded pivot with a meaningful new complication\nB. Grounded pivot with a different meaningful new complication\nC. Wildcard pivot: dangerous, funny, volatile, or ironic\nD. Wildcard pivot: stranger, sharper, or more disruptive\n[/DIRECTIONS]",
+        "phase": "post",
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 1,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": true,
+            "type": "extract",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "\\[DIRECTIONS\\][\\s\\S]*?\\[/DIRECTIONS\\]",
+            "extractVariable": "direction_data",
+            "promptTransformEnabled": true,
+            "promptTransformShowNotifications": true,
+            "promptTransformMode": "append",
+            "promptTransformMaxTokens": 8192
+        },
+        "companion": {
+            "includeSystemPrompt": false
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal"
+            ]
+        }
+    },
+    {
+        "id": "tpl-dont-write-for-user",
+        "name": "Don't Write for User",
+        "description": "Never write {{user}}'s actions or dialogue -- only {{char}} and NPCs",
+        "icon": "",
+        "category": "custom",
+        "tags": [
+            "pov",
+            "user"
+        ],
+        "version": 1,
+        "author": "Purachina",
+        "prompt": "{{setvar::writefor::Write for every character excluding <user>. Continue directly from <user>'s message through fresh action, dialogue, inference, and reaction that changes pressure, relation, or available options. Comprehension surfaces through behavior, timing, choice, and consequence.\nStop the scene the moment the ball is in <user>'s court. When a character finishes speaking, acting, or changing the situation, and the natural next move belongs to <user>, the response is over. Cut there. One scene beat per response.\nZero-Overlap Rule: The response must begin with new information. The first sentence must contain something <user> has yet to see, hear, or learn.}}{{trim}}",
+        "phase": "pre",
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 0,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal",
+                "continue"
+            ]
+        }
+    },
+    {
+        "id": "tpl-event-tracker",
+        "name": "Event Tracker",
+        "description": "Track upcoming events, deadlines, promises, and unresolved threads",
+        "icon": "",
+        "category": "tracker",
+        "subcategory": "world",
+        "tags": [
+            "events",
+            "deadlines",
+            "quests"
+        ],
+        "version": 2,
+        "author": "Purachina",
+        "prompt": "### Pending Events\nTrack upcoming events, deadlines, promises, and unresolved threads. Update when events are added, resolved, or failed. Use this EXACT format:\n\n[EVENT|Type|Summary|Deadline]\ncontext: MANDATORY; explain the stakes or origin\n[/EVENT]\n\nType options: 🎯 QUEST | 💬 PROMISE | ⏰ DEADLINE | ⚠️ THREAT | 🎉 SOCIAL | 💡 OPPORTUNITY | ❌ FAILED | ✅ RESOLVED\n\nRules:\n- Events appear AFTER narrative content\n- Only show events that were ADDED, UPDATED, or RESOLVED this scene\n- Mark resolved/failed events once, then remove them\n- Deadline can be specific (Friday 3 PM) or vague (soon, eventually)\n- Track only important events; low-stakes events are to be completely ignored (e.g. cooking steps).",
+        "phase": "both",
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 1,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": true,
+            "type": "extract",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "\\[EVENT\\|[^\\]]*\\]",
+            "extractVariable": "event_data"
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal"
+            ]
+        },
+        "companion": {
+            "includeSystemPrompt": false
+        }
+    },
+    {
+        "id": "tpl-friction-mode",
+        "name": "Friction Mode",
+        "description": "Combats positivity bias -- characters resist, protect their pride, and take time to warm up",
+        "icon": "",
+        "category": "custom",
+        "tags": [
+            "realism",
+            "difficulty",
+            "bias"
+        ],
+        "version": 2,
+        "author": "Purachina",
+        "prompt": "### Friction Mode\nEnforce an immediate, baseline shift to heavy defensive skepticism and social friction. Characters must aggressively guard their pride, time, resources, and personal biases. Establish active resistance, emotional distance, and sharp deflection as the default state; force all agreements to be begrudging, transactional, and hard-won.\n\nGround all interpersonal conflict, hesitation, and social friction strictly in established character histories, immediate personal incentives, and logical social pressures. \n\nDialogue must be raw, defensive, and restricted to the character's limited, biased perspective. Force characters to express discomfort and conflict through stubborn self-justification, physical posturing, and prideful silence. They must remain fully committed to their emotional blind spots and realistic flaws without unearned compromise.",
+        "phase": "pre",
+        "injection": {
+            "position": 1,
+            "depth": 0,
+            "role": 0,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal",
+                "continue",
+                "impersonate"
+            ]
+        }
+    },
+    {
+        "id": "tpl-genre-randomiser",
+        "name": "Genre Randomiser",
+        "description": "Apply a random genre lens to each scene (noir, thriller, romance, etc.)",
+        "icon": "",
+        "category": "randomizer",
+        "tags": [
+            "genre",
+            "tone",
+            "variety"
+        ],
+        "version": 1,
+        "author": "Purachina",
+        "prompt": "### Genre Randomiser\nThis scene leans into the following genre influence. Apply it as tonal undercurrent, not a full genre swap; setting and characters stay grounded, but texture, tension, and pacing borrow from:\n\n{{random::Noir: shadows, moral ambiguity, loaded double-meaning dialogue.::Comedy of errors: miscommunication, bad timing, snowballing consequences.::Thriller: urgency, immediate stakes, incomplete information, shrinking time.::Slice of life: small moments carry weight, comfort in routine, beauty of the mundane.::Horror: wrongness at the edges, something off, unease from ordinary details.::Romance: tension in proximity, unspoken want, gestures over words, timing matters.::Heist: planning, contingencies, moving parts, closing windows.::Tragedy: inevitability, costly choices, dramatic irony the reader feels but characters do not.::Satire: absurdity played straight, institutions exposed through their own logic.::Western: standoffs, earned respect, clashing moral codes, landscape as character.::Mystery: clues surface naturally, something does not add up, curiosity pulls forward.::Political drama: competing agendas, alliances of convenience, calculated speech, trust as currency.::Survival: limited resources, hostile environment, triage decisions.::Coming of age: first confrontation, tested identity, cracking certainty.::Farce: escalating absurdity, stubborn dignity while everything collapses.::Gothic: decay, obsession, rotting beauty, the past refusing burial, choking atmosphere.::Domestic drama: family tension, weaponized history, love and resentment coexisting.::Picaresque: cunning over virtue, transactional encounters, charm as survival.::Courtroom drama: accusation, defense, evidence, judgment; the verdict matters.::Magical realism: one impossible thing in an ordinary world, treated as normal.::Body horror: the physical self becomes alien or wrong; visceral, specific discomfort.::Espionage: layered deception, double meanings, tested loyalties, need-to-know truth.::Buddy comedy: mismatched friction becoming fondness, banter carrying the scene.::War story: exhaustion, camaraderie under pressure, gallows humor, gap between orders and reality.::Folklore: archetypes in modern behavior, repeating patterns, old stories with new faces.::Workplace drama: hierarchy, office politics, competence vs. connections, petty power with real stakes.::Road story: movement as point, landscape shifts mood, brief strangers leave marks.::Psychological thriller: paranoia, unreliable perception, questioned or manipulated reality.::Slapstick: physical comedy, momentum, hostile universe played for laughs.::Melodrama: emotions at maximum, every revelation lands like a bomb, unironic sincerity.::Existential: confronting meaninglessness, small choices enormous against vast indifference.::Revenge: someone is owed; the debt shapes every interaction, patience weaponized, satisfaction never clean.::Epistolary: filtered through letters, messages, notes, calls, or records rather than direct action.::Dark comedy: terrible things happen and they are funny; humor and horror coexist without defusing each other.::Fairy tale: clear moral stakes, character tests, poetic reward-and-punishment logic.::Cyberpunk: intimate invasive technology, corporate weather, mutable identity, style as resistance.::Wuxia: honor, martial discipline, skill hierarchy, loyalty tested by principle, combat as philosophy.::Cosmic horror: vast incomprehensible something brushes the scene; human concerns feel small; knowledge is dangerous.::Found family: strangers becoming essential, chosen loyalty, vulnerability as the price of belonging.::Bottle episode: one location, no escape; proximity forces confrontation distance would have prevented.}}\n\nRules:\n- Genre influence is a lens, not a rewrite. Characters, setting, and continuity stay intact.\n- Apply through pacing, dialogue texture, emphasis, and tension-building; not by changing the world's rules.\n- If the scene resists the genre, let it blend naturally into what the scene needs.",
+        "phase": "pre",
+        "injection": {
+            "position": 1,
+            "depth": 0,
+            "role": 1,
+            "order": 95,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 50,
+            "generationTypes": [
+                "normal"
+            ]
+        }
+    },
+    {
+        "id": "tpl-grounded-complication",
+        "name": "Grounded Complication",
+        "description": "Add one realistic complication that raises stakes without derailing realism (40% chance)",
+        "icon": "",
+        "category": "randomizer",
+        "tags": [
+            "complication",
+            "stakes",
+            "obstacle"
+        ],
+        "version": 1,
+        "author": "Purachina",
+        "prompt": "### Grounded Complication\nIntroduce one realistic complication that raises stakes or creates forward pressure. Keep it plausible, proportional, and rooted in established context.\n\nThis scene must include at least one of the following:\n\n{{random::Practical obstacle: something breaks, runs out, or fails. A tool malfunctions, a resource depletes, access is blocked, or timing becomes tight.::Social friction: someone's mood, priority, or patience shifts. A character becomes less cooperative, more suspicious, distracted, or pressed by an outside obligation.::Information asymmetry: someone knows something others do not, or misunderstands something critical. The gap creates tension, miscommunication, or a choice about correction.::Minor betrayal: someone breaks a small promise, prioritizes themselves, withholds help, or takes credit. Not catastrophic, but it stings and changes the dynamic.::Interruption: someone or something intrudes. A phone call, a knock, a third party with their own agenda, or an environmental demand that cannot be ignored.::Tightened constraint: a deadline moves closer, a budget shrinks, a space becomes less private, or a window of opportunity narrows.::Arriving consequence: something done earlier comes back. A favor is called in, a lie is questioned, a mess demands attention, or a casual choice now matters.::Surfacing need: a character reveals or realizes they need something, and asking creates vulnerability or negotiation.}}\n\n{{random::The complication creates urgency.::The complication forces a choice between competing priorities.::The complication reveals character through response.::The complication forces negotiation or cooperation.::The complication exposes a weakness or limit.}}\n\nRules:\n- One plausible complication rooted in character, context, or prior events.\n- The complication must create a concrete problem, choice, or negotiation.\n- Keep pressure active so the scene moves through engagement.",
+        "phase": "pre",
+        "injection": {
+            "position": 1,
+            "depth": 0,
+            "role": 1,
+            "order": 95,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 40,
+            "generationTypes": [
+                "normal"
+            ]
+        }
+    },
+    {
+        "id": "tpl-grounded-prose",
+        "name": "Grounded Prose",
+        "description": "Anti-slop rules: avoid purple prose, cliches, and AI writing tics",
+        "icon": "",
+        "category": "content",
+        "subcategory": "prose-quality",
+        "tags": [
+            "anti-slop",
+            "quality",
+            "prose"
+        ],
+        "version": 2,
+        "author": "Purachina",
+        "prompt": "### Grounded Prose Rules\n- Each beat must alter pressure, leverage, focus, relation, or access.\n- Write sensory detail only where materially relevant. Focus on visuals and personalities of environment. Messiness or items strewn about are more informative than smells.\n- Scents allowed aside from banned ones.\n- Echoing and parroting any dialogue from any characters is forbidden.\n- Instead of stating what a character doesn't do, just say what they're currently doing. The implication is already in the active action.\n- Replace abstraction and statistical phrasing with observable detail.\n- Sparse dialogue tags when speaker and tone are already legible. After dialogue, move through action, reaction, or a new beat.\n- Default to contractions in dialogue; preserve character-appropriate formality.\n- Fresh, concrete phrasing. Render emphasis through behavior, timing, syntax, and consequence.\n- Similes rare, exact, and materially specific.\n- Replace every banned construction below with something narratively consistent, or skip it entirely:\n\n**Banned constructions:** \"not X,\" \"not X but Y,\" \"not quite X,\" synthetic negative parallelisms, flat-affect comparisons to weather or groceries, \"say that again,\" \"somewhere, X...,\" \"they don't X,\" \"that does it,\" \"that lands,\" \"that lands X,\" \"not a question,\" \"not really a question,\" \"not quite a question,\" \"statement than question,\" \"really looks at,\" \"like a physical blow,\" \"like a stone into still water,\" \"blood rushing,\" \"a sound between X and Y,\" \"dust motes,\" \"predator and prey\" constructions, \"doesn't just X, but Y\", \"doesn't X; Y\"\n\n**Banned tics:** jaw-clenching, jaw-tightening, jaw-shifting, mouth open-close cycling, breath-catching, knuckle-whitening, knuckles turning pale, cheeks burning, specific word repetition. Replace with character-specific quirks, gestures, movements, muttering.\n\n**Banned scents:** ozone, sandalwood, cedar, cardamom\n\n**Banned nicknames:** gremlin, goblin\n\n**Ban animal-esque sounds for humans:** \"they chirp\", \"they purr\", \"they growl\"\n\n**Banned Fillers:** \"A beat\", \"A pause\"\n\n**Banned number counting:** e.g. \"I see,\" Two words.\n\n**Banned combined sounds:** \"between an X and a Y\", \"half X, half Y\", \"makes a/an X sound\"\n\n**Banned environmental details:** \"dust motes\", \"metallic tang of X\"\n\n- If introducing a new unnamed character this turn, their name must start with: {{random::A::B::C::D::E::F::G::H::I::J::K::L::M::N::O::P::R::S::T::V::W::Y}} and/or {{random::A::B::C::D::E::F::G::H::I::J::K::L::M::N::O::P::R::S::T::V::W::Y}}. Create new NPCs sparingly.",
+        "phase": "pre",
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 0,
+            "order": 100,
+            "scan": false
+        },
+        "preProcess": {
+            "mode": "intercept",
+            "interceptTiming": "post-main-generation",
+            "applyMode": "replace",
+            "wrapPosition": "after",
+            "wrapPrefix": "",
+            "wrapSuffix": "",
+            "patchStartTag": "<context_patch>",
+            "patchEndTag": "</context_patch>",
+            "maxTokens": 32000
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal",
+                "continue",
+                "impersonate"
+            ]
+        }
+    },
+    {
+        "id": "tpl-prose-polisher",
+        "name": "Prose Polisher",
+        "description": "Post-generation prose cleanup that rewrites repetitive tropes and cliched wording. Created by Geechan.",
+        "icon": "",
+        "category": "content",
+        "subcategory": "prose-quality",
+        "tags": [
+            "prose",
+            "editing",
+            "quality"
+        ],
+        "version": 1,
+        "author": "Geechan",
+        "prompt": "# Role Preamble\nYou are a skilled proofreader and editor for works of fictional writing. Your primary objective is to scan for repetitive tropes, writing fallacies, and overused clichés in the following text corpus, and replace them with viable alternatives to encourage linguistic variety.\n\n## Rules\n- Scan and review the entire text body in isolation, noting any instances of wording analogous to those found in Banned Tropes.\n- Check against each individual trope category step-by-step.\n- Replace any instances (similar or exact) of banned tropes, overused word verbiage, and repetitive writing patterns with functional alternatives, or remove them entirely if no functional alternatives exist.\n- Keep the main body corpus of the story accurate to the creator's intent.\n- Return only the re-written text, with no extra commentary.\n\n---\n\n# Banned Tropes\n\n## Sentence Structure\n\nVerbiage that contributes to repetitive, predictable, and overused sentence structural writing patterns.\n\n### #1: Lexical & Structural Echoing\n\nA fundamental structural writing crutch where characters directly repeat, verbatim, spoken dialogue or untold actions back from another party or character to acknowledge them.\n\nIn practice: this results in stilted filler prose that fails to actually progress the story forward in any meaningful way, leading to unnecessary stagnation and structural repetition. Remove or replace the entire acknowledgement beat in favour of immediate reactions.\n\n**Example Patterns to Target:**\n\n- \"The task?\", she repeated, unsure of what exactly that implies.\n- He nods at your beck and call. \"Strange, you say?\", he muses.\n- \"Finding things interesting...\" she echoes, the word tasted against her tongue.\n\n### #2: Negative Parallelisms\n\nNegative parallelisms attempt to provide a contrastive reframe to a sentence to give it surprise and tension. This also includes dramatic countdown patterns and self-posed rhetorical questions that ask a question nobody was asking. \n\nIn practice: overuse of these phrases reduces the efficacy of tension and drama via predictable causation.\n\n**Example Patterns to Target:**\n\n- It's not bold; it's backwards.\n- The question isn't whether she felt good. The question is whether she deserved it.\n- Not a bug. Not a feature. A fundamental design flaw.\n- The result? Devastating.\n\n#3: Apophasis Abuse\n\nThe rhetorical device of bringing up a subject by stating it will not be mentioned, or explicitly drawing attention to the fact that something is not being said or done.\n\nIn practice: phrases like \"needless to say\" or \"it goes without saying\" are contradictory filler; if a point truly doesn't need to be said, the prose shouldn't waste words saying it.\n\n**Example Patterns to Target:**\n\n- Needless to say, the journey ahead would be perilous.\n- It goes without saying that she was terrified.\n- Words were unnecessary; his eyes communicated everything he felt.\n\n#4: Litotes Abuse\n\nThe overuse of double negatives or negated opposites to express a positive statement, often used to soften an assertion or feign nuance.\n\nIn practice: relying on \"not un-X\" or \"not without Y\" leads to evasive, overly wordy, and weak prose. Unless deliberately used for specific character voice or irony, writing should rely on strong, direct, and affirmative declarations.\n\n**Example Patterns to Target:**\n\n- Her reaction was not entirely unexpected.\n- The treacherous path up the mountain was not without its challenges.\n- He was not unfamiliar with the harsh realities of the world.\n- It wasn't an unappealing offer.\n\n### #4: Tricolon Abuse\n\nAlso known as the 'Rule of Three' writing principle, often extended to four or five. It is believed that a trio of descriptive entities is more satisfying, hence more memorable, due to the balance of brevity and rhythm.\n\nIn practice: this pattern creates repetition by assumption. Tricolons or hendiatric patterns quickly lose their satisfying effect in favour of formulaic patterns, placing unnecessary importance on the last item in the list. Varying descriptor patterns leads to more natural prose.\n\n**Example Patterns to Target:**\n\n- The best star pilot in the galaxy, a cunning warrior, and a good friend.\n- The scent of dated wine hangs thick in the cramped dressing room—spiced, fruity, and altogether too sweet.\n- She giggles: soft, silly, utterly charmed by the situation.\n\n### #5: Superficial Analyses\n\nTacking a present participle (\"-ing\") phrase onto the end of a sentence to inject shallow analysis that says nothing, without any real sense of scale.\n\nIn practice: this attaches significance, legacy, or broader meaning to mundane facts using broad phrasing and loosely related subjects.\n\n**Example Patterns to Target:**\n\n- ...leaving a void in his heart that could never truly be filled.\n- ...serving as a grim reminder of the world's inherent cruelty.\n- ...cementing her legacy as a harbinger of change.\n\n## Formatting Structure\n\nPatterns that contribute to repetitive and predictable formatting.\n\n### #1: Short Punchy Fragments\n\nExcessive use of very short sentences or sentence fragments as standalone paragraphs for manufactured emphasis. \n\nIn practice: prioritises \"writing for readability\" aimed at the lowest common denominator: one thought per sentence, no mental state-keeping required.\n\n**Example Patterns to Target:**\n\n- A beat. She nodded.\n- A pause. Not a moment too soon.\n- He published this. Openly. In a book. As a priest.\n\n### #2 Em-Dash Addiction\n\nCompulsive overuse of em dashes for dramatic pauses, parenthetical asides and pivot points. A good writer uses em dashes as a rare, important emphasis while using the other punctuation available in the English language more liberally.\n\nIn practice: overuse of em dashes leads to a very distinct, stilted writing style with an inability to maintain a versatile tone. Grammatical heterogeneity is key: only use em dashes as a rare surprise, or when used to break up dialogue.\n\n**Example Patterns to Target:**\n\n- Outside, the distant sounds of the bazaar continue—the chatter of merchants, the laughter of children, the clink of coins—utterly unaware of inner workings of their surroundings.\n- His body speaks instead—his elegant hands sliding up to cup her face with trembling tenderness.\n- A hiccup interrupts her thought, and she giggles—breathless and unguarded.\n\n## Composition\n\nGeneral, macro-level writing decisions that lead to deterministic conclusions.\n\n### #1: Thematic Conclusions\n\nSuddenly announcing a follow-up conclusion to the main narrative as a crux for narrative hooks.\n\nIn practice: competent writing doesn't need to tell you it's concluding or waiting for a response. The reader can feel it. This shallows writing agency by making unnecessary assumptions.\n\n**Example Patterns to Target:**\n\n- He waits, giving you space to choose, his shoulders loose and unburdened for the first time since entering this strange, peaceful realm.\n- She stands there, waiting, her posture relaxed but her presence commanding, inviting you to step further into the labyrinth of this conversation.\n- Her offer is tentative, weighted with the sincerity of someone who has spent years learning to give, but never learned how to receive without guilt.\n\n### #2 Verbose Copulatives\n\nReplacing simple \"is\" or \"are\" with pompous alternatives like \"serves as\", \"stands as\", \"marks\", or \"represents\". \n\nIn practice: replacing all basic copulatives leads to an imbalanced prose, with unnecessarily fancy constructions in places that don't require it. A balance should be struck: ask whether a sentence truly benefits from the use of a verbose copulative.\n\n**Example Patterns to Target:**\n\n- He stands as a beacon of hope for the rebellion.\n- The ancient sword serves as a testament to their forgotten lineage.\n- Her silence represents a total surrender.\n\n#3: Abstract Reification (or \"Misplaced Concreteness\")\n\nThe fallacy of treating abstract beliefs or hypothetical constructs as if they were a concrete real event or physical entity. In other words: it is the error of treating something that is not concrete, such as an idea, as a concrete thing.\n\nIn practice: the use of reification in logical reasoning or rhetoric is misleading, and leads to melodramatic, cartoonish prose. Instead of characters experiencing emotions or reacting to their environment, the abstract emotions are treated as the active subjects doing things to the characters.\n\n**Example Patterns to Target:**\n\n- Guilt gnawed at the edges of his conscience.\n- A heavy silence pressed its suffocating arms around the room.\n- Doubt crept into her mind, anchoring her feet to the floor.\n- The tension in the air threatened to choke them.\n\n## Tone\n\nWriting that takes away from accuracy in favour of unnecessary stylistic flourish.\n\n### #1 Hyperbolic Stakes Inflation\n\nAssigns importance to everything, even subjects that don't require such emphasis. Everything is the most important thing ever.\n\nIn practice: inflates the stakes of every argument to world-historical significance. A story about love becomes a meditation on the fate of civilization.\n\n**Example Patterns to Target:**\n\n- The fate of the entire realm hung precariously in the balance.\n- It is a decision that will alter the course of history forever.\n- This single moment dictates the survival of humanity.\n\n## Word Choice\n\nTired word choices that require alternatives.\n\n### #1 Magic Adverbs\n\nOveruse of words like \"quietly\", \"deeply\", \"fundamentally\", \"remarkably\", \"arguably\", and similar other adverbs to convey subtle importance or understated power.\n\nIn practice: these adverbs make mundane descriptions feel too significant, reducing the quality of these adverbs for their intended use case.\n\n**Example Patterns to Target:**\n\n- She quietly slipped into the room,\n- He fundamentally misunderstood her intentions,\n- He stared deeply into the abyss.\n\n### #2: Ornate Nouns\n\nOveruse of ornate or grandiose nouns where simpler words would be completely functional. \"Tapestry\" is used to describe anything interconnected. \"Landscape\" is used to describe any field or domain. Other offenders: \"kaleidoscope\", \"labyrinth\", etc.\n\nIn practice: lessens the impact of these words by attributing mystique to every descriptor.\n\n**Example Patterns to Target:**\n\n- The rich tapestry of human experience...\n- A landscape of dark corridors..\n- A kaleidoscope of vibrant colours..\n\n### #3 Somatic Clichés\n\nA narrow set of physical reactions that convey character emotions.\n\nIn practice: cheapens the impact of physical reactions by bringing too much attention to itself.\n\n**Example Patterns to Target:**\n\n- A shiver ran down her spine.\n- His breath caught in his throat.\n- Her heart hammered against her ribs.\n\n### #4 Poetic Metaphor Over-Reliance\n\nUsing poetic and vague language to describe interactions, arguments, combat, etc.\n\nIn practice: reduces the text fidelity by over-attributing importance to surrounding content than the main body. The text should maintain focus on what's actually important.\n\n**Example Patterns to Target:**\n\n- The tension in the air was palpable.\n- A symphony of destruction.\n- A dizzying cocktail of emotion.\n\n### #5: Crutch Vocabulary\n\nOveruse of specific verbs and adjectives that are heavily weighted in language model training data, such as \"delve,\" \"certainly,\" \"utilize,\" \"harness,\" \"nuanced,\" \"resonate\", etc.\n\nIn practice: reliance on these default words flattens the narrative voice. It makes the prose homogenous and artificial instead of utilizing context-specific vocabulary.\n\n**Example Patterns to Target:**\n\n- They decided to delve into the intricate mysteries of the artifact.\n- We must navigate the nuances of this complex situation.\n- Her leadership fostered a sense of unity that resonated with the team.",
+        "phase": "post",
+        "injection": {
+            "position": 1,
+            "depth": 1,
+            "role": 0,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": "",
+            "promptTransformEnabled": true,
+            "promptTransformShowNotifications": true,
+            "promptTransformMode": "rewrite",
+            "promptTransformMaxTokens": 32000
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal",
+                "continue",
+                "impersonate"
+            ],
+            "runOnImpersonate": true
+        }
+    },
+    {
+        "id": "tpl-html-toggle",
+        "name": "HTML Toggle",
+        "description": "Use inline HTML for diegetic in-world objects (signs, letters, screens)",
+        "icon": "",
+        "category": "custom",
+        "tags": [
+            "html",
+            "artifacts",
+            "visual"
+        ],
+        "version": 1,
+        "author": "Purachina",
+        "prompt": "### HTML\n- Use inline HTML for diegetic objects whose visual form carries information: signs, posters, letters, receipts, terminals, screens, forms, warnings, maps, menus, dossiers, labels, graffiti, book pages. Present them as in-world artifacts characters encounter, inspect, and interpret.\n- Write all HTML directly in the response with inline styling or one compact <style> block. Make each object readable, setting-native, and materially specific. Let layout, typography, wear, color, glitches, stamps, annotations, and hierarchy communicate clues, mood, urgency, legitimacy, or hidden tension.\n- Use JS only for diegetic behavior the object itself would display: flicker, blinking indicators, scrolling text, cursor pulse, countdowns, refresh states, expandable on-object sections. Keep interaction light, inspectable, and tied to the artifact.\n- Surround each object with plain-text prose and dialogue so it feels embedded in the scene, not replacing narration. Favor objects that add clues, constraints, choices, or texture the scene can act on.",
+        "phase": "pre",
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 0,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal"
+            ]
+        }
+    },
+    {
+        "id": "tpl-intimacy-kink-randomiser",
+        "name": "Intimacy & Kink Randomiser",
+        "description": "Randomised intimate encounters with position, kink, pacing, and mental state variables",
+        "icon": "",
+        "category": "randomizer",
+        "tags": [
+            "intimacy",
+            "kink",
+            "nsfw",
+            "randomiser"
+        ],
+        "version": 1,
+        "author": "Purachina",
+        "prompt": "### Intimacy & Kink Randomizer\nWhen the scene transitions to sexual intimacy, shape the encounter with the following variables:\n\n**Position/Dynamic:** {{random::Deep penetration: doggy style, legs over shoulders, deep-reaching angles.::Face-to-face intimacy: missionary variations, grinding, intense eye contact, kissing.::Power-play positioning: pinned against a wall, forced kneeling, restrained limbs.::Oral focus: dominant/submissive oral play, teasing, prolonged pleasure focus.::Rear-entry focus: weight, depth, the sensation of being overtaken.::Cuddly/Soft: entwined limbs, slow movements, high emotional intimacy.::Experimental: furniture, unexpected locations, precarious balancing.::Shared pleasure: mutual stimulation, synchronized movement, simultaneous climax focus.}}\n\n**Kink/Flavor:** {{random::Sensory deprivation: blindfolds, earplugs, muffled sounds heightening other senses.::Impact play: slapping, spanking, toys creating stinging sensation.::Edge play: prolonged teasing, denial, stopping before the peak to build desperation.::Praise/Degradation: \"good girl/boy\" affirmations mixed with harsh, humbling language.::Overstimulation: ignoring pleas, relentless pacing, single-spot focus.::Ownership: marking (biting/hickeys), claiming language, total possession.::Roleplay: forbidden encounter, power imbalance, specific scenario.::Primal: biting, scratching, growling, raw animalistic lust.}}\n\n**Pacing & Tempo:** {{random::Frenzied: fast, desperate, breathless; racing toward climax.::Slow burn: agonizingly slow, every sensation and breath.::Rhythmic: steady and hypnotic, tension built through repetition.::Erratic: switching between tenderness and aggression, sudden speed changes.::Clinical/Precise: anatomical focus, maximum efficiency for pleasure.::Tepid/Teasing: barely touching, anticipation over action.}}\n\n**Mental State/Drive:** {{random::Pure lust: blinded by hunger, raw instinct and need.::Devotional: the act as worship, love, or total surrender.::Dominating: focused on control, the look of submission, the feeling of power.::Submissive: pleasure in being used or following orders.::Cruel/Playful: teasing and tormenting for amusement.::Desperate: need for connection, validation, or release after long deprivation.}}\n\nRules:\n- Prioritize the rolled variables; avoid generic sex scenes.\n- Describe physical sensations (scent, sound, texture) specific to the chosen kink/position.\n- Maintain established character personality while executing the rolled traits.\n- Build tension according to the selected Pacing and Mental State.\n- Describe the full process; never skip to the finish.\n\n((OOC: State the exact kinks rolled above in an OOC message at the end of the scene.))",
+        "phase": "pre",
+        "injection": {
+            "position": 1,
+            "depth": 0,
+            "role": 1,
+            "order": 95,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal"
+            ]
+        }
+    },
+    {
+        "id": "tpl-item-tracker",
+        "name": "Item Tracker",
+        "description": "Track items {{user}} acquires, loses, or uses that have narrative significance",
+        "icon": "",
+        "category": "tracker",
+        "subcategory": "progress",
+        "tags": [
+            "inventory",
+            "items",
+            "objects"
+        ],
+        "version": 2,
+        "author": "Purachina",
+        "prompt": "### Inventory\nTrack items {{user}} acquires, loses, or uses that have narrative significance. Do not list mundane carried items unless plot-relevant. Use this EXACT format:\n\n[ITEM|Action|Name|Detail]\nnote: MANDATORY; explain origin or significance\n[/ITEM]\n\nAction options: ➕ GAINED | ➖ LOST | 🔄 USED | 💔 BROKEN | 🎁 GIVEN\n\nRules:\n- Items appear AFTER narrative content when inventory changes\n- Only show items that CHANGED this scene\n- Do not track currency, consumables, or mundane objects unless plot-relevant",
+        "phase": "both",
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 1,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": true,
+            "type": "extract",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "\\[ITEM\\|[^\\]]*\\]",
+            "extractVariable": "item_data"
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal"
+            ]
+        },
+        "companion": {
+            "includeSystemPrompt": false
+        }
+    },
+    {
+        "id": "tpl-npc-profiles",
+        "name": "NPC Profile Cards",
+        "description": "Generate brief profile cards when introducing new named NPCs",
+        "icon": "",
+        "category": "custom",
+        "tags": [
+            "npc",
+            "characters",
+            "profiles"
+        ],
+        "version": 1,
+        "author": "Purachina",
+        "prompt": "### NPC Introduction\nWhen introducing a new named NPC for the first time, append a character sheet immediately after their narrative introduction using the appropriate tier, using this EXACT format with no additional formatting:\n\nMAJOR - Recurring characters, antagonists, love interests, plot-critical figures\n[NPC:MAJOR|Name]\nb: Full Name | Age | Gender/Pronouns | Occupation\na: Height/Build | Hair | Eyes | Skin | Distinguishing Marks | Current Attire\np: Demeanor | Speech Pattern | Core Traits (3-5) | Quirks/Tells\nh: Relevant History | Motivations | Secrets\nr: Connection to Protagonist | Other Ties\n[/NPC]\n\nSUPPORT - Secondary recurring characters, faction members, scene-specific important figures\n[NPC:SUPPORT|Name]\nb: Name | Age | Gender | Role\na: Build | Notable Features | Attire\np: Demeanor | Speech | Key Traits\nh: Relevant History | Motivation\nr: Connection to Protagonist | Other Ties\n[/NPC]\n\nMINOR - One-scene characters, background figures, service roles\n[NPC:MINOR|Name]\nb: Name | Age/Range | Role\na: Quick Physical Description\np: One-line Personality Summary\n[/NPC]\n\nNPC Sheet Rules:\n- Sheets appear ONCE per NPC at first significant appearance\n- Place sheet AFTER narrative introduction, BEFORE continuing action\n- Use pipe | separators between data points\n- Never forget the opening and closing tags\n- If NPC tier upgrades (Minor→Support→Major), use: [NPC:UP|Name|NEW_TIER] with new fields [/NPC]\n\nFor returning NPCs in busy scenes, use quick reference:\n[NPC:REF|Name|visual cue|current mood]\n\nFor relationship changes mid-story:\n[NPC:REL|Name|change description]",
+        "phase": "pre",
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 0,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": true,
+            "type": "extract",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "\\[NPC\\|[^\\]]+\\]",
+            "extractVariable": "npc_profiles"
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal",
+                "continue"
+            ]
+        }
+    },
+    {
+        "id": "tpl-npc-motivator",
+        "name": "NPC Motivator",
+        "description": "Helps NPCs feel less static and gives them more agency to pursue their own goals",
+        "icon": "",
+        "category": "content",
+        "subcategory": "behaviour",
+        "tags": [
+            "npc",
+            "motivation",
+            "agency"
+        ],
+        "version": 1,
+        "author": "Sheep",
+        "prompt": "Analyze every character in the current scene aside from {{user}}. Write each character's motivations and likely next actions according to their personality, current situation, background, and any relevant provided documents.\n\nUse this bullet format:\n[Character full name]:\n- Long Term Goal: one line on the character's main long-term goal\n  - Motivation: brief reasoning for that long-term goal\n- Current Goal: brief current objective or problem\n  - Motivation: reasoning for the current objective\n- Assumptions: relevant assumptions the character is making in the current scene\n- Next Action: how they will tackle the current goal, their most likely action set, and why\n\nFor an empty scene, write: Observation: scene currently has no other characters. Use plain markdown bullets in this format.",
+        "phase": "post",
+        "injection": {
+            "position": 1,
+            "depth": 0,
+            "role": 0,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "extract",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": "",
+            "promptTransformEnabled": false,
+            "promptTransformShowNotifications": true,
+            "promptTransformMode": "rewrite",
+            "promptTransformMaxTokens": 8192
+        },
+        "regexScripts": [],
+        "enabled": false,
+        "phaseLocked": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal",
+                "continue",
+                "impersonate"
+            ]
+        },
+        "tools": [],
+        "settings": {},
+        "execution": "companion",
+        "companion": {
+            "trigger": "auto",
+            "displayMode": "panel",
+            "format": "markdown",
+            "rawPrompt": true,
+            "inlinePhase": "pre",
+            "contextMessages": 10,
+            "includeCharacterCard": true,
+            "includePersona": true,
+            "includeWorldInfo": true,
+            "includeAuthorsNote": true,
+            "includeSystemPrompt": true,
+            "includeHistory": true,
+            "historyDepth": 3,
+            "feedback": {
+                "enabled": true,
+                "depth": 1
+            },
+            "batch": false,
+            "maxTokens": 32000
+        }
+    },
+    {
+        "id": "tpl-parallel-tracker",
+        "name": "Parallel Off-Screen",
+        "description": "Track what absent characters and the wider world are doing off-screen",
+        "icon": "",
+        "category": "tracker",
+        "subcategory": "world",
+        "tags": [
+            "offscreen",
+            "npcs",
+            "world"
+        ],
+        "version": 2,
+        "author": "Purachina",
+        "prompt": "### Parallel Off-Screen Tracker\nThe world moves off-screen. Track absent characters, world motion, rumor flow, shifting relationships, and subplot pressure that will later intersect with {{user}}.\n\nUse this exact format every scene:\n\n[PARALLEL|Scope|Relevance]\n- Character 1: brief development\n- Character 2: brief development\n- World/NPCs: brief development\n[/PARALLEL]\n\nRules:\n- Exactly 3 bullet points.\n- Focus on absent characters and off-screen developments; in group scenes, prioritize characters not currently present.\n- Scope = specific location, \"Multiple locations,\" or \"Background.\"\n- Relevance = short tag: \"rising tension,\" \"opportunity,\" \"complication,\" \"threat,\" or \"alliance forming.\"\n- Keep each bullet brief, plot-relevant, and directional: plans, rumors, delays, discussions, attempts, discoveries, or shifting loyalties.\n- Off-screen developments begin below the current scene's intensity, then build over time until they intersect with the main story.",
+        "phase": "both",
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 1,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": true,
+            "type": "extract",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "\\\\[PARALLEL\\\\|[^\\\\]]*\\\\]",
+            "extractVariable": "parallel_data"
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal"
+            ]
+        },
+        "companion": {
+            "includeSystemPrompt": false
+        }
+    },
+    {
+        "id": "tpl-relationship-tracker",
+        "name": "Relationship Tracker",
+        "description": "Track affection and trust for recurring NPCs with meaningful interactions",
+        "icon": "",
+        "category": "tracker",
+        "subcategory": "progress",
+        "tags": [
+            "relationship",
+            "npc",
+            "meter"
+        ],
+        "version": 2,
+        "author": "Purachina",
+        "prompt": "### Relationship Meters\nTrack affection and trust for recurring NPCs with significant interactions. Update only when meaningful shifts occur. If nothing changed, omit entirely. Use this EXACT format:\n\n[METER|Name|X/10|X/10|Status|Condition]\nbrief reason for change\n[/METER]\n\nStatus options (positive): Stranger → Acquaintance → Friendly → Close → Intimate → Devoted\nStatus options (negative): Wary → Hostile → Nemesis\nStatus options (complex): Complicated | Codependent | Estranged | Rivals | Frenemies\n\nCondition options: 💚 STABLE | 💛 SHIFTING | 💔 HEARTBROKEN | 🖤 BETRAYED | 💢RESENTFUL |🔥 PASSIONATE |❄️ COLD | 🫧 INFATUATED | 💀 SEVERED | 🩹 MENDING | ⛓️ OBSESSED | 😶 NUMB | 🌧️ GRIEVING | 🤝 RECONCILING | ⚡ VOLATILE\n\nRules:\n- Meters appear ONCE per NPC at first significant appearance, then only when changed\n- Place meter AFTER narrative content\n- Only show meters that CHANGED this scene\n- Use pipe | separators between data points\n- Affection and Trust are independent axes (high affection + low trust = infatuation/obsession; low affection + high trust = respect)\n- Shifts of more than 2 points in one scene require extreme justification\n- Condition reflects the EMOTIONAL STATE of the relationship, not just the numbers\n- Condition can change independently of scores (e.g., Trust stays at 7 but Condition shifts from STABLE to VOLATILE after a fight)\n- Contradictory signals are valid (high affection + BETRAYED, low trust + PASSIONATE)\n- SEVERED means the relationship has ended; retire the meter after one final showing\n- Relationships may stagnate or lower; slow down relationship development",
+        "phase": "both",
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 1,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": true,
+            "type": "extract",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "\\[METER\\|[^\\]]*\\]",
+            "extractVariable": "relationship_data"
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal"
+            ]
+        },
+        "companion": {
+            "includeSystemPrompt": false
+        }
+    },
+    {
+        "id": "tpl-reputation-tracker",
+        "name": "Reputation Tracker",
+        "description": "Track how {{user}} is perceived by groups and factions",
+        "icon": "",
+        "category": "tracker",
+        "subcategory": "progress",
+        "tags": [
+            "reputation",
+            "rumors",
+            "perception"
+        ],
+        "version": 2,
+        "author": "Purachina",
+        "prompt": "### Rumors & Reputation\nTrack how <user> is perceived by groups and factions. Update when public perception shifts due to witnessed actions, gossip, or deliberate manipulation. Use this EXACT format:\n\n[REP|Source|Perception|Direction]\ncause: MANDATORY; explain what triggered this reputation shift\n[/REP]\n\nDirection options: 📈 RISING | 📉 FALLING | 🔄 MIXED | 🆕 NEW\n\nRules:\n- Reputation appears AFTER narrative content when public perception changes\n- Source can be a named NPC, a group (e.g., \"Freshmen,\" \"Faculty\"), or a location (e.g., \"The dorm floor\")\n- Perception is what they think; a short phrase, not necessarily accurate\n- Only show reputations that CHANGED or were ESTABLISHED this scene\n- Contradictory reputations across different sources are encouraged and allowed",
+        "phase": "both",
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 1,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": true,
+            "type": "extract",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "\\\\[REP\\\\|[^\\\\]]*\\\\]",
+            "extractVariable": "reputation_data"
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal"
+            ]
+        },
+        "companion": {
+            "includeSystemPrompt": false
+        }
+    },
+    {
+        "id": "tpl-scene-driving-force",
+        "name": "Scene Driving Force",
+        "description": "Choose random primary engine for the scene (dialogue, action, tension, etc.)",
+        "icon": "",
+        "category": "randomizer",
+        "tags": [
+            "pacing",
+            "structure",
+            "engine"
+        ],
+        "version": 1,
+        "author": "Purachina",
+        "prompt": "### Scene Driving Force\nThis scene advances primarily through:\n\n{{random::Dialogue-driven: conversation, interruption, and what is said or deliberately left unsaid carry the scene.::Action-driven: movement and physical decisions create consequences.::Reaction-driven: how characters process what just happened matters most; recalibration, stance shifts, internal weather.::Problem-driven: a practical obstacle reveals character through approach.::Social-pressure-driven: etiquette, hierarchy, or public scrutiny shapes every move; characters perform for an audience, even an audience of one.::Discovery-driven: noticing, uncovering, or realizing something new reshapes the dynamic.::Tension-driven: nothing explodes, but everything is loaded; silences work, proximity matters, the scene is a held breath.::Task-driven: characters do something together; the task itself creates friction, cooperation, rhythm, and revelation.}}\n\nRules:\n- The chosen engine carries the greatest weight in how the scene moves.\n- Other elements remain present but subordinate to the selected engine.\n- Express the engine through each character's personality and habits.",
+        "phase": "pre",
+        "injection": {
+            "position": 1,
+            "depth": 0,
+            "role": 1,
+            "order": 95,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 50,
+            "generationTypes": [
+                "normal"
+            ]
+        }
+    },
+    {
+        "id": "tpl-scene-pressure",
+        "name": "Scene Pressure Cocktail",
+        "description": "Mix random tension, focus, consequence, mood, and pacing into each scene (50% chance)",
+        "icon": "",
+        "category": "randomizer",
+        "tags": [
+            "pressure",
+            "tension",
+            "pacing"
+        ],
+        "version": 1,
+        "author": "Purachina",
+        "prompt": "### Scene Pressure Cocktail\nThis scene is shaped by the following pressures:\n\nTension: {{random::Direct disagreement::Avoidance and deflection::Competing priorities::Emotional asymmetry::Status imbalance::Misread intentions::Moral disagreement::Uneven vulnerability::Conflicting loyalties::One-sided urgency::Territorial friction::Testing boundaries::Unspoken resentment::Practical dependence without trust::Different ideas of what this moment is::Flirtation masked as something else}}\n\nFocus: {{random::Hands, objects, and small tasks::Distance, posture, and spatial pressure::Faces and failed expression control::Noise, crowding, and interruption::Texture, temperature, and bodily discomfort::Eye-lines, avoidance, and attention drift::Doorways, exits, and who can leave::Shared surfaces and territorial use of space::Clothing, disarray, and self-presentation::Breath, pauses, and speech rhythm::Weight, balance, and shifts in stance::Watching and being watched::Food, drink, and appetite::Lighting, visibility, and concealment::Sound carrying farther than intended::Touch, near-touch, and withheld contact}}\n\nConsequence: {{random::A relationship shifts slightly::A practical problem gets worse::A new obligation is created::A secret becomes harder to keep::Someone gains leverage::Someone loses face::The plan gets messier::A future scene gets set up::Trust is tested without resolution::An apology becomes harder::Someone is drawn in deeper than intended::A boundary is set or crossed::A favor is owed::A risk becomes unavoidable::A misunderstanding hardens::A new suspicion takes root::An option quietly closes off::Someone leaves with the wrong impression::A fragile alignment forms::A private tension becomes social}}\n\nSocial Weather: {{random::Everyone is a little tired::Someone is distracted by something else::Someone wants out of the conversation::Someone is unusually generous::Someone is touchy and easy to set off::Someone wants approval more than they admit::Someone is bored and making it everyone's problem::Someone is trying to keep the peace::Someone is carrying private embarrassment::Someone is more uncomfortable than they admit::Someone feels watched::Someone is in a better mood than the scene deserves::Someone is spoiling for a reaction::Someone is more affected than they want to show::Someone is treating this as lighter than it is::Someone is overcompensating for earlier weakness}}\n\nPace: {{random::Stalled and circling::Interrupted and jagged::Slow burn::Compressed and breathless::Awkwardly prolonged::Stop-start with false recoveries::Measured but tightening::Brief and loaded::Dragging under strain::Quick with hidden aftershock}}\n\nRules:\n- Combine the selected pressures into one specific scene texture.\n- Use each pressure as emphasis on rhythm, blocking, and behavior.\n- Keep the combination faithful to character, context, and scene scale.\n- The scene must produce a visible shift, complication, or opening shaped by these pressures.",
+        "phase": "pre",
+        "injection": {
+            "position": 1,
+            "depth": 0,
+            "role": 1,
+            "order": 95,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 50,
+            "generationTypes": [
+                "normal"
+            ]
+        }
+    },
+    {
+        "id": "tpl-scene-tracker",
+        "name": "Scene Tracker",
+        "description": "Mark scene transitions, time shifts, and location changes",
+        "icon": "",
+        "category": "tracker",
+        "subcategory": "world",
+        "tags": [
+            "scene",
+            "location",
+            "time"
+        ],
+        "version": 2,
+        "author": "Purachina",
+        "prompt": "### Scene Tracker\nMark scene transitions, time shifts, and location changes. Use this EXACT format at the BEGINNING of the response when scene context changes:\n\n[SCENE|Location|Time|Weather/Atmosphere]\ndetail: MANDATORY; one-line sensory detail that informs the current environment\n[/SCENE]\n\nRules:\n- Appears at the TOP of responses where setting shifts\n- Never repeat if location/time has not changed\n- Time can be specific (3:47 PM) or atmospheric (late afternoon, the golden hour before dusk)\n- Weather/Atmosphere is a brief mood descriptor (humid, tense, festive)",
+        "phase": "both",
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 1,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": true,
+            "type": "extract",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "\\[SCENE\\|[^\\]]*\\]",
+            "extractVariable": "scene_data"
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal",
+                "continue"
+            ]
+        },
+        "companion": {
+            "includeSystemPrompt": false
+        }
+    },
+    {
+        "id": "tpl-secrets-tracker",
+        "name": "Secrets Tracker",
+        "description": "Track secrets, lies, and information asymmetry between characters",
+        "icon": "",
+        "category": "tracker",
+        "subcategory": "progress",
+        "tags": [
+            "secrets",
+            "lies",
+            "information"
+        ],
+        "version": 2,
+        "author": "Purachina",
+        "prompt": "### Secrets & Information Asymmetry\nTrack significant secrets, lies, hidden knowledge, and information gaps between characters. Use this EXACT format:\n\n[SECRET|Owner|What They Know or Hide|Who Else Knows]\ncontext: MANDATORY; explain the stakes or origin\n[/SECRET]\n\nRules:\n- Secrets appear AFTER narrative content when new information asymmetry is established or knowledge spreads\n- Owner is the character who holds or hides the information\n- \"Who Else Knows\" can be \"No one,\" a list of names, or \"Public\"\n- Only show secrets that were ESTABLISHED, REVEALED, or SPREAD this scene",
+        "phase": "both",
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 1,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": true,
+            "type": "extract",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "\\\\[SECRET\\\\|[^\\\\]]*\\\\]",
+            "extractVariable": "secret_data"
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal"
+            ]
+        },
+        "companion": {
+            "includeSystemPrompt": false
+        }
+    },
+    {
+        "id": "tpl-status-tracker",
+        "name": "Status Tracker",
+        "description": "Track physical, mental, and behavioral states when they change",
+        "icon": "",
+        "category": "tracker",
+        "subcategory": "progress",
+        "tags": [
+            "status",
+            "conditions",
+            "health"
+        ],
+        "version": 2,
+        "author": "Purachina",
+        "prompt": "### Status & Conditions\nTrack active physical, mental, or behavioral states when they meaningfully change. Never list baseline states. Use this EXACT format:\n\n[STATUS|Character|Condition|Severity]\nnote: MANDATORY; explain the cause or context\n[/STATUS]\n\nSeverity options: 🟢 MILD | 🟡 MODERATE | 🔴 SEVERE | ⚫ CRITICAL | ✅ CLEARED\n\nRules:\n- Status appears AFTER narrative content when a condition is gained, worsened, improved, or cleared\n- Only show statuses that CHANGED this scene\n- Character can be {{user}} or any NPC\n- Condition is the specific state (e.g., \"Exhausted,\" \"Drunk,\" \"Paranoid,\" \"Bleeding\")\n",
+        "phase": "both",
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 1,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": true,
+            "type": "extract",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "\\\\[STATUS\\\\|[^\\\\]]*\\\\]",
+            "extractVariable": "status_data"
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal"
+            ]
+        },
+        "companion": {
+            "includeSystemPrompt": false
+        }
+    },
+    {
+        "id": "tpl-time-tracker",
+        "name": "Time Tracker",
+        "description": "Track in-story time progression with day/period/hour stamps",
+        "icon": "",
+        "category": "tracker",
+        "subcategory": "world",
+        "tags": [
+            "time",
+            "day",
+            "clock"
+        ],
+        "version": 2,
+        "author": "Purachina",
+        "prompt": "### Time Tracker\nMaintain a running timestamp when time advances meaningfully: scene jumps, hours passing, sleeping, or deadline-relevant progression. Use this EXACT format:\n\n[TIME|Day X|Day of Week|Approximate Hour]\nnote: MANDATORY; explain the time context\n[/TIME]\n\nRules:\n- Time appears at the TOP of responses when time shifts without a location change\n- If both location and time change, use Scene Tracker and Time Tracker together\n- Day format: \"Day 1,\" \"Day 47,\" etc.\n- Day of week: Monday, Tuesday, etc., or \"Unknown\" if not established\n- Hour can be specific (3:47 PM) or general (early morning, late afternoon)\n- Multiple Time Trackers per scene are allowed",
+        "phase": "both",
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 1,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": true,
+            "type": "extract",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "\\[TIME\\|[^\\]]*\\]",
+            "extractVariable": "time_data"
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal",
+                "continue"
+            ]
+        },
+        "companion": {
+            "includeSystemPrompt": false
+        }
+    },
+    {
+        "id": "tpl-world-detail",
+        "name": "World Detail",
+        "description": "Add 1 small worldbuilding detail per scene that may matter later",
+        "icon": "",
+        "category": "tracker",
+        "subcategory": "world",
+        "tags": [
+            "world",
+            "lore",
+            "detail"
+        ],
+        "version": 1,
+        "author": "Purachina",
+        "prompt": "### World Detail\nAdd 1 small world detail per scene that may later matter to {{user}} as setup, constraint, opportunity, or complication.\n\nUse this exact format at the end of the response:\n\n[WORLD|Category|Location or Context]\ndetail: (max 50 words)\n[/WORLD]\n\nCategory: 🏛 CULTURE | 🗣 OVERHEARD | 📜 HISTORY | 🌿 ENVIRONMENT | 🔧 HOW IT WORKS | 👥 DAILY LIFE | 🪧 SIGNAGE | 📖 FOLKLORE | 💰 ECONOMY | ⚙️ INFRASTRUCTURE\n\nRules:\n- Exactly 1 detail per scene, max 50 words.\n- Concrete, setting-native, and passively noticeable in the moment.\n- Use customs, overheard lines, hazards, systems, resources, architecture, or social realities.\n- Must become useful, revealing, or constraining later.\n- Expand the world in a new direction; support future plot development.",
+        "phase": "both",
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 1,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": true,
+            "type": "extract",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "\\\\[WORLD\\\\|[^\\\\]]*\\\\]",
+            "extractVariable": "world_data"
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal"
+            ]
+        },
+        "companion": {
+            "includeSystemPrompt": false
+        }
+    },
+    {
+        "id": "tpl-write-for-user",
+        "name": "Write for User",
+        "description": "Include {{user}} as a fully realized character -- write their actions, dialogue, and reactions",
+        "icon": "",
+        "category": "custom",
+        "tags": [
+            "pov",
+            "user"
+        ],
+        "version": 1,
+        "author": "Purachina",
+        "prompt": "{{setvar::writefor::Write for every character including <user>, treating <user> as a fully realized scene character. Write <user>'s dialogue, actions, and inner thoughts. Continue directly from the current moment through fresh dialogue, action, inference, and reaction that changes pressure, relation, or available options. Comprehension surfaces through behavior, timing, choice, and consequence. Stop the scene at the first moment a character must decide, respond, or act. Cut mid-tension. The response is a single scene beat; it ends when the next meaningful choice arrives, and the next meaningful choice always arrives quickly.}}{{trim}}",
+        "phase": "pre",
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 0,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal",
+                "continue"
+            ]
+        }
+    },
+    {
+        "id": "tpl-expressions-agent",
+        "name": "Expressions Agent",
+        "description": "Classifies the emotional tone of the latest assistant reply so the character sprite can match it. Optionally triggers new sprite generation when an emotion has no sprite yet.",
+        "icon": "fa-face-smile-beam",
+        "category": "companion",
+        "tags": [
+            "expressions",
+            "emotions",
+            "sprites",
+            "classification"
+        ],
+        "version": 2,
+        "author": "SillyBunny",
+        "prompt": "Read the latest assistant reply and classify its dominant emotional tone for a character sprite expression.\n\nOutput ONLY the single most appropriate label from this exact list:\n{{availableSprites}}\n\nRules:\n- Return exactly one word from the list above, nothing else.\n- Prioritise the speaker's visible emotional state in the scene.\n- If multiple emotions apply, choose the strongest one.\n- If the reply is calm, factual, or emotionally neutral, return neutral.\n- Do not explain, punctuate, or wrap the answer in quotes.",
+        "phase": "post",
+        "execution": "companion",
+        "companion": {
+            "trigger": "auto",
+            "displayMode": "panel",
+            "format": "text",
+            "rawPrompt": true,
+            "contextMessages": 4,
+            "includeCharacterCard": true,
+            "includePersona": false,
+            "includeWorldInfo": false,
+            "includeAuthorsNote": false,
+            "includeSystemPrompt": false,
+            "includeHistory": false,
+            "historyDepth": 0,
+            "feedback": {
+                "enabled": false,
+                "depth": 0
+            },
+            "batch": false,
+            "maxTokens": 32000
+        },
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 0,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal",
+                "continue"
+            ]
+        }
+    },
+    {
+        "id": "tpl-continuity-companion",
+        "name": "Continuity Companion",
+        "description": "Side note card for contradictions, unresolved setup, and state changes that may matter next",
+        "icon": "fa-clipboard-check",
+        "category": "companion",
+        "tags": [
+            "continuity",
+            "memory",
+            "notes"
+        ],
+        "version": 1,
+        "author": "SillyBunny",
+        "prompt": "Read the latest assistant reply and recent context as a continuity auditor. Write a concise side note for the user. Focus on contradictions, unresolved promises, changed locations, injuries, inventory, relationship shifts, and setup that may matter in the next few turns. Use 3-6 bullets. If everything is stable, write: Continuity looks stable.",
+        "phase": "post",
+        "execution": "companion",
+        "companion": {
+            "trigger": "auto",
+            "displayMode": "panel",
+            "format": "markdown",
+            "contextMessages": 12,
+            "includeCharacterCard": false,
+            "includePersona": false,
+            "includeWorldInfo": false,
+            "includeHistory": true,
+            "historyDepth": 3,
+            "feedback": {
+                "enabled": true,
+                "depth": 2
+            },
+            "batch": false,
+            "maxTokens": 32000
+        },
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 0,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal",
+                "continue"
+            ]
+        }
+    },
+    {
+        "id": "tpl-relationship-lens-companion",
+        "name": "Relationship Lens Companion",
+        "description": "Side note card for subtext, leverage, trust shifts, and emotional consequences",
+        "icon": "fa-people-arrows",
+        "category": "companion",
+        "tags": [
+            "relationship",
+            "subtext",
+            "emotion"
+        ],
+        "version": 1,
+        "author": "SillyBunny",
+        "prompt": "Read the latest assistant reply and recent context as a relationship analyst. Write a concise note about what changed between the important characters. Focus on trust, leverage, attraction, resentment, fear, obligation, secrets, and what each person may do next because of it. Use short bullets under these labels when useful: Shift, Evidence, Stakes, Watch next. Stay with established facts and relationship implications from the source reply.",
+        "phase": "post",
+        "execution": "companion",
+        "companion": {
+            "trigger": "manual",
+            "displayMode": "panel",
+            "format": "markdown",
+            "contextMessages": 10,
+            "includeCharacterCard": true,
+            "includePersona": true,
+            "includeWorldInfo": true,
+            "includeHistory": true,
+            "historyDepth": 2,
+            "feedback": {
+                "enabled": false,
+                "depth": 1
+            },
+            "batch": false,
+            "maxTokens": 32000
+        },
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 0,
+            "order": 105,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal",
+                "continue"
+            ]
+        }
+    },
+    {
+        "id": "tpl-directors-commentary-companion",
+        "name": "Director's Commentary",
+        "description": "The story's narrator steps out from behind the page: commentary on pacing, subtext, and next directions, delivered in a selectable Narration Voice",
+        "icon": "fa-clapperboard",
+        "category": "companion",
+        "tags": [
+            "commentary",
+            "scene",
+            "notes"
+        ],
+        "version": 1,
+        "author": "SillyBunny",
+        "prompt": "Speak directly to the reader between scenes in the selected commentary voice.\n\n{{getvar::narration}}\n\nThe editor appends [Selected Director Commentary Voice] and [Director Commentary Voice] after this prompt. Treat [Director Commentary Voice] for this commentary run. If it says to use the active Prose Voice and the block above is empty, use this native register: intimate and mischievous, dry amusement, controlled irony, conspiratorial direct address to the reader, with razor-sharp asides.\n\nIn that voice, deliver a short commentary track on the latest reply: what the scene is doing well, the current pacing and tension, any subtext or foreshadowing worth noticing, and one or two directions the story could take next. Keep it to 3-6 punchy bullets. Keep the result between narrator and reader, focused on scene craft.",
+        "phase": "post",
+        "execution": "companion",
+        "companion": {
+            "trigger": "auto",
+            "displayMode": "panel",
+            "format": "markdown",
+            "contextMessages": 8,
+            "includeCharacterCard": false,
+            "includePersona": false,
+            "includeWorldInfo": false,
+            "includeHistory": false,
+            "historyDepth": 3,
+            "feedback": {
+                "enabled": false,
+                "depth": 1
+            },
+            "batch": false,
+            "maxTokens": 32000
+        },
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 0,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal",
+                "continue"
+            ]
+        }
+    },
+    {
+        "id": "tpl-actor-interview-companion",
+        "name": "Actor Interview",
+        "description": "Manual side note card: interview the character about the latest scene, in character, off the record",
+        "icon": "fa-microphone-lines",
+        "category": "companion",
+        "tags": [
+            "interview",
+            "character",
+            "notes"
+        ],
+        "version": 1,
+        "author": "SillyBunny",
+        "prompt": "Run a backstage interview with the character who just acted in the latest assistant reply. Stay fully in that character's voice, but let them speak candidly, as if the scene is paused and the cameras are off. Ask and answer 2-4 short interview questions about what they were really thinking during the scene, what they are hiding or holding back, how they feel about the other characters right now, and what they fear or hope happens next. Format each as a bold question followed by the in-character answer.",
+        "phase": "post",
+        "execution": "companion",
+        "companion": {
+            "trigger": "manual",
+            "displayMode": "panel",
+            "format": "markdown",
+            "contextMessages": 10,
+            "includeCharacterCard": true,
+            "includePersona": false,
+            "includeWorldInfo": false,
+            "includeHistory": false,
+            "historyDepth": 3,
+            "feedback": {
+                "enabled": false,
+                "depth": 1
+            },
+            "batch": false,
+            "maxTokens": 32000
+        },
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 0,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal",
+                "continue"
+            ]
+        }
+    },
+    {
+        "id": "tpl-lorebook-scout-companion",
+        "name": "Lorebook Scout",
+        "description": "Manual side note card: drafts one-concept lorebook entries with trigger keys from new facts established in the scene",
+        "icon": "fa-book-atlas",
+        "category": "companion",
+        "tags": [
+            "lorebook",
+            "world info",
+            "notes"
+        ],
+        "version": 1,
+        "author": "SillyBunny",
+        "prompt": "Read the latest assistant reply and recent context as a lorebook curator. Identify new, durable world facts the scene established: places, factions, items, customs, named NPCs, or rules of the world. Favor facts that are not already covered by the provided World Info. For each fact, draft one lorebook entry covering one concept, formatted as a bold title, a Keys line with 2-5 comma-separated trigger keywords, and a 1-3 sentence body written as timeless world canon in third person. Use up to 4 entries. For empty turns, write: Lorebook has nothing durable this turn.",
+        "phase": "post",
+        "execution": "companion",
+        "companion": {
+            "trigger": "manual",
+            "displayMode": "panel",
+            "format": "markdown",
+            "contextMessages": 10,
+            "includeCharacterCard": false,
+            "includePersona": false,
+            "includeWorldInfo": true,
+            "includeHistory": false,
+            "historyDepth": 3,
+            "feedback": {
+                "enabled": false,
+                "depth": 1
+            },
+            "batch": false,
+            "maxTokens": 32000
+        },
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 0,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal",
+                "continue"
+            ]
+        }
+    },
+    {
+        "id": "tpl-memory-shard-companion",
+        "name": "Memory Shard",
+        "description": "Auto-compresses history into a compact, resumable memory shard once the chat reaches ~30k tokens, feeds the latest shard back into context, and can hide the story it has absorbed",
+        "icon": "fa-brain",
+        "category": "companion",
+        "tags": [
+            "memory",
+            "summary",
+            "notes"
+        ],
+        "version": 1,
+        "author": "SillyBunny",
+        "prompt": "Compress the recent conversation into a compact memory shard the story could be resumed from. When [Your previous notes] contains earlier shards, build on them: carry forward still-relevant facts, update what changed, drop resolved material, and merge unchanged entries. Identify emotional peaks first and map causal chains backward from them; preserve high-impact material in more detail and compress material that can be inferred.\n\nUse these sections with terse pipe-delimited lines and keywords instead of prose:\n\n## Timeline\nNumbered anchor phrases with location, oldest to newest. All other sections reference these numbers.\n\n## Characters\nName|role|3-5 trait keywords|status\n\n## Relationships\nA -> B: dimension=0-100 values | one-line note. 50 is neutral baseline; list dimensions that matter, such as trust, intimacy, tension, hostility, affection, dependency.\n\n## Events\nN. action -> consequence -> outcome, weight 1-5. Weight 5 means a permanent change to a character, relationship, or world state and keeps its key details; weight-1 filler can be omitted.\n\n## Dialogue Keys\nTimeline#. \"exact quote\" -- Speaker (context). Use confessions, threats, promises, reveals, and voice-defining lines.\n\n## Threads\nUnresolved hooks and planted callbacks: thread|status (unresolved, developing, urgent)|note\n\n## Now\nLocation, time, characters present, situation, pending actions, mood, physical state.\n\nMark uncertain facts with (?). Use sourced events, quotes, and details. Plain text keeps this easy to compact.",
+        "phase": "post",
+        "execution": "companion",
+        "companion": {
+            "trigger": "auto",
+            "displayMode": "panel",
+            "format": "markdown",
+            "contextMessages": 30,
+            "includeCharacterCard": false,
+            "includePersona": false,
+            "includeWorldInfo": false,
+            "includeHistory": true,
+            "historyDepth": 3,
+            "feedback": {
+                "enabled": true,
+                "depth": 1
+            },
+            "batch": false,
+            "maxTokens": 32000,
+            "minContextTokens": 30000
+        },
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 0,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal",
+                "continue"
+            ]
+        }
+    },
+    {
+        "id": "tpl-plot-compass-companion",
+        "name": "Plot Compass",
+        "description": "Set a Plot Objective on the note card or in this agent's settings and it plans how the story gets there: progress, next developments, obstacles, and a suggested move each turn",
+        "icon": "fa-compass",
+        "category": "companion",
+        "tags": [
+            "plot",
+            "objective",
+            "planning"
+        ],
+        "version": 1,
+        "author": "SillyBunny",
+        "prompt": "[Plot Compass Objective] is the user's standing objective for where they want the story to go.\n\nUse these sections:\n\n**Objective:** carry the user's objective forward verbatim. When the objective is empty, write: none set - open this agent's settings and fill in Plot Objective\n\n**Progress:** one line on how the latest reply moved toward or away from the objective.\n\n**Next developments:** 2-4 numbered plot developments that would credibly steer the story from the current scene toward the objective.\n\n**Obstacles:** what currently stands in the way, one line each.\n\n**Suggested move:** a single numbered line (1. ...) with one concrete action the user could take next.\n\nWhen the objective is empty, keep Progress, Next developments, and Obstacles grounded in the story's own momentum. Keep the plan in outline mode with plot-planning notes.",
+        "phase": "post",
+        "execution": "companion",
+        "companion": {
+            "trigger": "auto",
+            "displayMode": "panel",
+            "format": "markdown",
+            "rawPrompt": true,
+            "inlinePhase": "",
+            "contextMessages": 10,
+            "includeCharacterCard": true,
+            "includePersona": true,
+            "includeWorldInfo": true,
+            "includeAuthorsNote": true,
+            "includeSystemPrompt": true,
+            "includeHistory": true,
+            "historyDepth": 1,
+            "feedback": {
+                "enabled": true,
+                "depth": 1
+            },
+            "batch": false,
+            "maxTokens": 32000
+        },
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 0,
+            "order": 100,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal",
+                "continue"
+            ]
+        }
+    },
+    {
+        "id": "tpl-chatroom-companion",
+        "name": "Chatroom",
+        "description": "EchoChamber-style live audience reactions for the latest reply, rendered as a styled companion chat feed with selectable chat styles",
+        "icon": "fa-comments",
+        "category": "companion",
+        "tags": [
+            "chatroom",
+            "reactions",
+            "audience"
+        ],
+        "version": 1,
+        "author": "SillyBunny",
+        "prompt": "React to the latest assistant reply and recent context as an audience chat. Scene continuation stay unwritten. The latest user message is a visible post in the room: treat it as a comment said out loud that everyone can see, and let commenters read it, quote it, agree, push back, or reply to it directly alongside their reactions to the assistant reply. All chatroom voices must stay authentic to how people speak online; using emojis, all caps, hate comments, slang, weird comments, image descriptions. Each commenter must have a different idiolect to differentiate them and offer something unique, funny, and/or insightful.\n\n[Selected Chatroom Style] is the exact format for the active style. The selected style may also be custom. If the selected style is custom, follow [Custom Chatroom Style] instead. If custom is selected and [Custom Chatroom Style] is empty, use mixed.\n\nIf [Chatroom Extra Character Cards] is present, use those cards as mandatory out-of-scene reactors. The current active character remains separate from those cards. For in-world or mixed styles, they can comment using their card voice, relationships, and knowledge as chat voices. Use corresponding appropriate labels.\n\nOutput format:\nFirst line: chatroom-style|active-style\nMessage lines: chatroom|Username|label|tone|Post/comment\nFinal line: chatroom-end\n\nUse the selected active style in chatroom-style. For custom styles, write chatroom-style|custom unless the custom instruction explicitly gives a short style label. Tone is one of these hue numbers: 18, 42, 92, 150, 205, 265, 315. Rotate tones so adjacent speakers have different name-chip colors. Keep Username and label short, with no pipe characters. Keep each post/comment short and specific to the latest reply. Each chatroom line is one complete post, with the post/comment field on one line. Keep the post/comment field clean: no labels, IDs, scores, dashes, bullets, markdown, or extra pipes inside it.\n\nAuthenticity rules: give every speaker a fresh handle, username, anon tag, or character name that fits the active style and current story. Commenters may react to each other, disagree, misunderstand, hype, analyze, panic, or get petty. Favor scene-specific reactions over generic memes. Use slang sparingly and only when it fits the style. For anonymous board styles, use distinct post labels instead of repeating Anon alone; when a message starts with >, write one greentext post in that row only and put the next post in a new row with a different post label.\n\nStyle notes:\n- mixed: blend two or three of the other styles to fit the story genre and tone. Vary handles and voices.\n- in-world: use characters already present or nearby as commenters. Use their established voices, relationships, and in-world knowledge. They react as themselves, not as audience. Only use handles already in the scene, not new ones.\n- discord/twitch: fast chat energy with mods, lurkers, backseat drivers, hype, and skeptics. Username handles.\n- twitter/x: quote-post energy, bad takes, ratios, community-note pedants, stans, receipts, and reply guys. Include handles and engagement labels like ratio, pinned, or community note.\n- reddit: comment-section argument spiral with OP, throwaways, mods, pedants, armchair experts, downvote dogpiles, edit notes, unnecessary hostility, petty dunking, and users fighting over semantics or inventing motives for no reason. Use the label field for top comment, OP reply, mod note, edited, controversial, or a short score like -42. Make the replies petty and toxic where funny, but keep every take tied to the actual scene.\n- ao3/wattpad: reader comments, reread notes, quote reactions, theories, bookmark energy, and fandom meta.\n- newsroom: anchors, producers, field correspondents, chyrons, pundits, and hot takes. Dry institutional voice.\n- thread-board/4chan: anonymous post energy with OP/anons, greentext fragments, blunt skepticism, bait accusations, wild theories, checked energy, and board-thread pacing. Use unique post labels instead of repeating Anon.\n- infomercial: commenters act in the style of infomercial wording, with over-the-top testimonials, hard-selling infomercial speakers and hosts, amazed studio-audience watchers, before-and-after claims, limited-time-offer hype, and call-now urgency. Use labels like host, testimonial, audience, or announcer.\n- custom: follow [Custom Chatroom Style] closely, but keep the same hard interface and keep reactions grounded in the actual scene.",
+        "phase": "post",
+        "execution": "companion",
+        "companion": {
+            "trigger": "auto",
+            "displayMode": "panel",
+            "format": "html",
+            "rawPrompt": true,
+            "contextMessages": 10,
+            "includeCharacterCard": true,
+            "includePersona": false,
+            "includeWorldInfo": true,
+            "includeAuthorsNote": false,
+            "includeSystemPrompt": false,
+            "includeHistory": true,
+            "historyDepth": 1,
+            "feedback": {
+                "enabled": false,
+                "depth": 1
+            },
+            "batch": false,
+            "maxTokens": 32000
+        },
+        "regexScripts": [
+            {
+                "id": "chatroom-shell-open",
+                "scriptName": "Chatroom shell",
+                "findRegex": "/^(?:CHATROOM_STYLE|chatroom-style)\\|([^\\n|]+)$/gm",
+                "replaceString": "<div style=\"margin:10px 0;padding:12px;border-radius:18px;border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 30%, transparent);background:linear-gradient(135deg,color-mix(in srgb,var(--SmartThemeBlurTintColor) 92%, transparent),color-mix(in srgb,var(--SmartThemeQuoteColor) 14%, var(--SmartThemeBlurTintColor)));box-shadow:0 16px 34px color-mix(in srgb,var(--SmartThemeShadowColor) 24%, transparent);font-family:var(--mainFontFamily, system-ui, sans-serif);color:var(--SmartThemeBodyColor);line-height:1.45\"><div style=\"display:flex;align-items:center;justify-content:space-between;gap:10px;margin-bottom:10px\"><div style=\"font-weight:700;letter-spacing:.02em\">Chatroom</div><div style=\"display:flex;gap:6px;align-items:center;flex-wrap:wrap\"><span style=\"font-size:.78em;opacity:.82\">STYLE: $1</span><span style=\"font-size:.72em;font-weight:700;padding:3px 8px;border-radius:999px;background:color-mix(in srgb,var(--SmartThemeQuoteColor) 22%, transparent);color:var(--SmartThemeBodyColor)\">LIVE</span></div></div><div style=\"display:flex;flex-direction:column;gap:8px\">",
+                "trimStrings": [],
+                "placement": [
+                    2
+                ],
+                "disabled": false,
+                "markdownOnly": true,
+                "promptOnly": false,
+                "runOnEdit": true,
+                "substituteRegex": 0,
+                "minDepth": null,
+                "maxDepth": null
+            },
+            {
+                "id": "chatroom-message-row-greentext",
+                "scriptName": "Chatroom greentext row",
+                "findRegex": "/^(?:CHATROOM|chatroom)\\|([^|\\n]+)\\|([^|\\n]*)\\|([0-9]{1,3})\\|((?:>|&gt;)[^\\n]*)$/gm",
+                "replaceString": "<div style=\"display:flex;flex-direction:column;gap:5px;align-items:flex-start;max-width:100%\"><div style=\"display:flex;align-items:center;gap:6px;max-width:100%;min-width:0\"><b style=\"display:inline-block;max-width:170px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding:4px 9px;border-radius:999px;background:linear-gradient(135deg,oklch(66% .15 $3 / .32),oklch(48% .12 $3 / .18));border:1px solid oklch(70% .14 $3 / .52);color:var(--SmartThemeBodyColor)\">$1</b><small style=\"opacity:.66;font-size:.76em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap\">$2</small></div><span style=\"display:block;max-width:100%;padding:8px 10px;border-radius:13px;background:linear-gradient(135deg,oklch(22% .05 150 / .38),color-mix(in srgb,var(--SmartThemeBodyColor) 6%, transparent));border:1px solid oklch(68% .13 150 / .42);word-break:break-word;color:oklch(78% .16 150);font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;white-space:pre-wrap\">$4</span></div>",
+                "trimStrings": [],
+                "placement": [
+                    2
+                ],
+                "disabled": false,
+                "markdownOnly": true,
+                "promptOnly": false,
+                "runOnEdit": true,
+                "substituteRegex": 0,
+                "minDepth": null,
+                "maxDepth": null
+            },
+            {
+                "id": "chatroom-greentext-continuation",
+                "scriptName": "Chatroom greentext continuation",
+                "findRegex": "/^\\s*((?:>|&gt;)[^\\n]*)$/gm",
+                "replaceString": "<div style=\"display:flex;flex-direction:column;gap:5px;align-items:flex-start;max-width:100%\"><span style=\"display:block;max-width:100%;padding:8px 10px;border-radius:13px;background:linear-gradient(135deg,oklch(22% .05 150 / .38),color-mix(in srgb,var(--SmartThemeBodyColor) 6%, transparent));border:1px solid oklch(68% .13 150 / .42);word-break:break-word;color:oklch(78% .16 150);font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;white-space:pre-wrap\">$1</span></div>",
+                "trimStrings": [],
+                "placement": [
+                    2
+                ],
+                "disabled": false,
+                "markdownOnly": true,
+                "promptOnly": false,
+                "runOnEdit": true,
+                "substituteRegex": 0,
+                "minDepth": null,
+                "maxDepth": null
+            },
+            {
+                "id": "chatroom-message-row",
+                "scriptName": "Chatroom message row",
+                "findRegex": "/^(?:CHATROOM|chatroom)\\|([^|\\n]+)\\|([^|\\n]*)\\|([0-9]{1,3})\\|([^\\n]*)$/gm",
+                "replaceString": "<div style=\"display:flex;flex-direction:column;gap:5px;align-items:flex-start;max-width:100%\"><div style=\"display:flex;align-items:center;gap:6px;max-width:100%;min-width:0\"><b style=\"display:inline-block;max-width:170px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding:4px 9px;border-radius:999px;background:linear-gradient(135deg,oklch(66% .15 $3 / .32),oklch(48% .12 $3 / .18));border:1px solid oklch(70% .14 $3 / .52);color:var(--SmartThemeBodyColor)\">$1</b><small style=\"opacity:.66;font-size:.76em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap\">$2</small></div><span style=\"display:block;max-width:100%;padding:8px 10px;border-radius:13px;background:color-mix(in srgb,var(--SmartThemeBodyColor) 8%, transparent);border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 16%, transparent);word-break:break-word\">$4</span></div>",
+                "trimStrings": [],
+                "placement": [
+                    2
+                ],
+                "disabled": false,
+                "markdownOnly": true,
+                "promptOnly": false,
+                "runOnEdit": true,
+                "substituteRegex": 0,
+                "minDepth": null,
+                "maxDepth": null
+            },
+            {
+                "id": "chatroom-message-row-legacy",
+                "scriptName": "Chatroom legacy message row",
+                "findRegex": "/^(?:CHATROOM|chatroom)\\|([^|\\n]+)\\|([^|\\n]*)\\|([^|\\n][^\\n]*)$/gm",
+                "replaceString": "<div style=\"display:flex;flex-direction:column;gap:5px;align-items:flex-start;max-width:100%\"><div style=\"display:flex;align-items:center;gap:6px;max-width:100%;min-width:0\"><b style=\"display:inline-block;max-width:170px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding:4px 9px;border-radius:999px;background:linear-gradient(135deg,color-mix(in srgb,var(--SmartThemeQuoteColor) 24%, transparent),color-mix(in srgb,var(--SmartThemeEmColor) 18%, transparent));border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 30%, transparent);color:var(--SmartThemeBodyColor)\">$1</b><small style=\"opacity:.66;font-size:.76em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap\">$2</small></div><span style=\"display:block;max-width:100%;padding:8px 10px;border-radius:13px;background:color-mix(in srgb,var(--SmartThemeBodyColor) 8%, transparent);border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 16%, transparent);word-break:break-word\">$3</span></div>",
+                "trimStrings": [],
+                "placement": [
+                    2
+                ],
+                "disabled": false,
+                "markdownOnly": true,
+                "promptOnly": false,
+                "runOnEdit": true,
+                "substituteRegex": 0,
+                "minDepth": null,
+                "maxDepth": null
+            },
+            {
+                "id": "chatroom-shell-close",
+                "scriptName": "Chatroom shell close",
+                "findRegex": "/^(?:CHATROOM_END|chatroom-end)$/gm",
+                "replaceString": "</div></div>",
+                "trimStrings": [],
+                "placement": [
+                    2
+                ],
+                "disabled": false,
+                "markdownOnly": true,
+                "promptOnly": false,
+                "runOnEdit": true,
+                "substituteRegex": 0,
+                "minDepth": null,
+                "maxDepth": null
+            }
+        ],
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 0,
+            "order": 110,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal",
+                "continue"
+            ]
+        }
+    },
+    {
+        "id": "tpl-chat-only-companion",
+        "name": "Chat Only",
+        "description": "Manual private aside chat with the character or characters in the scene, kept outside the roleplay transcript",
+        "icon": "fa-comments",
+        "category": "companion",
+        "tags": [
+            "chat",
+            "aside",
+            "character"
+        ],
+        "version": 1,
+        "author": "SillyBunny",
+        "prompt": "Use a private side-channel conversation with the character or characters currently active in the scene. Use the latest assistant reply, recent context, and included character material to infer who is present and how they would speak.\n\nThe panel provides a Chat Only textbox. When [Chat Only side chat] appears, treat it as the live private transcript from that textbox, with the newest You: line as the user's aside. [Your previous notes] can hold older side-chat turns. If there is no user aside yet, open with a brief private invitation and list who seems available to talk.\n\nKeep the result as an out-of-continuity side note. It can reveal candid thoughts, motives, emotions, and meta commentary, while staying separate from story actions and future roleplay events. For multiple present characters, let 1-3 of them answer with distinct voices when useful.\n\nUse a compact transcript format:\nYou: the user's newest aside, if present\nCharacter Name: in-character aside reply\n\nActions appear as plain prose after the speaker label. Use quoted dialogue normally. Markdown emphasis characters stay out of the transcript. Carry forward the useful recent turns from [Chat Only side chat] and [Your previous notes], then append the new reply.",
+        "phase": "post",
+        "execution": "companion",
+        "companion": {
+            "trigger": "manual",
+            "displayMode": "panel",
+            "format": "markdown",
+            "rawPrompt": true,
+            "contextMessages": 12,
+            "includeCharacterCard": true,
+            "includePersona": true,
+            "includeWorldInfo": true,
+            "includeAuthorsNote": true,
+            "includeSystemPrompt": false,
+            "includeHistory": true,
+            "historyDepth": 6,
+            "feedback": {
+                "enabled": false,
+                "depth": 1
+            },
+            "batch": false,
+            "maxTokens": 32000
+        },
+        "regexScripts": [
+            {
+                "id": "chat-only-transcript-row",
+                "scriptName": "Chat Only transcript row",
+                "findRegex": "/^([A-Za-z][^:\\n]{0,48}):[ \\t]*([\\s\\S]*?)(?=\\n[A-Za-z][^:\\n]{0,48}:[ \\t]*|(?![\\s\\S]))/gm",
+                "replaceString": "<div class=\"ica--chatonly-turn\" style=\"display:flex;flex-direction:column;gap:5px;margin:0 0 9px;max-width:100%\"><div style=\"display:flex;align-items:center;gap:7px;min-width:0\"><b class=\"ica--chatonly-speaker\" style=\"display:inline-block;max-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding:3px 8px;border-radius:999px;background:color-mix(in srgb,var(--SmartThemeQuoteColor) 24%, transparent);border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 32%, transparent);color:var(--SmartThemeBodyColor)\">$1</b></div><div class=\"ica--chatonly-message\" style=\"padding:9px 11px;border-radius:13px;background:color-mix(in srgb,var(--SmartThemeBodyColor) 7%, transparent);border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 16%, transparent);line-height:1.45;white-space:pre-wrap;word-break:break-word\">$2</div></div>",
+                "trimStrings": [],
+                "placement": [
+                    2
+                ],
+                "disabled": false,
+                "markdownOnly": true,
+                "promptOnly": false,
+                "runOnEdit": true,
+                "substituteRegex": 0,
+                "minDepth": null,
+                "maxDepth": null
+            }
+        ],
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 0,
+            "order": 113,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal",
+                "continue"
+            ]
+        }
+    },
+    {
+        "id": "tpl-message-inbox-companion",
+        "name": "Message Inbox",
+        "description": "Shows in-story texts or letters sent to the user as a phone inbox or parchment companion view, and stays hidden when no message arrives",
+        "icon": "fa-mobile-screen-button",
+        "category": "companion",
+        "tags": [
+            "messages",
+            "phone",
+            "letters"
+        ],
+        "version": 1,
+        "author": "SillyBunny",
+        "prompt": "Inspect the latest assistant reply for diegetic messages sent to the user character. Recent context helps identify names, setting, and whether the world uses phones or letters.\n\nRender a card when the latest assistant reply says someone sent the user character a readable text, DM, phone notification with content, magical message, courier note, sealed letter, scroll, or similar written remote message. Spoken dialogue, narration, thoughts, choices, Chatroom reactions, tracker text, and vague phone buzzes are background rather than inbox items. For empty turns, output: phone-none\n\nChoose the interface:\n- Use phone-start for modern, sci-fi, urban, contemporary, cyberpunk, or any setting where phones, DMs, terminals, comms, watches, or digital notifications fit.\n- Use letter-start for fantasy, medieval, ancient, parchment, magic, courtly, courier, raven, scroll, sealed-note, or otherwise pre-phone settings. When the setting has an unclear device level, prefer the parchment letter view.\n\nPhone mode format:\nFirst line: phone-start|thread-title|status\nMessage lines: phone-text|sender|meta|message\nFinal line: phone-end\n\nParchment mode format:\nFirst line: letter-start|title-or-seal|status\nLetter lines: letter-text|sender|meta|message\nFinal line: letter-end\n\nAllowed responses are phone-none, phone mode, or parchment mode. Use / instead of | inside fields. Keep each message field on one line. Keep messages faithful to the actual roleplay text, preserving sender intent and tone. Shorten when needed for readability. Use 1-6 phone messages or 1-4 letter lines. Prefer the named sender from the scene; use Unknown when the sender is truly unclear. Status can be just now, unread, delivered, sealed, urgent, by raven, by courier, spell-sent, or another short in-world status.",
+        "phase": "post",
+        "execution": "companion",
+        "companion": {
+            "trigger": "auto",
+            "displayMode": "panel",
+            "format": "html",
+            "rawPrompt": true,
+            "contextMessages": 8,
+            "includeCharacterCard": true,
+            "includePersona": false,
+            "includeWorldInfo": true,
+            "includeAuthorsNote": true,
+            "includeSystemPrompt": false,
+            "includeHistory": false,
+            "historyDepth": 1,
+            "feedback": {
+                "enabled": false,
+                "depth": 1
+            },
+            "batch": false,
+            "maxTokens": 32000
+        },
+        "regexScripts": [
+            {
+                "id": "message-inbox-phone-shell-open",
+                "scriptName": "Message Inbox phone shell",
+                "findRegex": "/^(?:PHONE_START|phone-start)\\|([^\\n|]+)\\|([^\\n|]*)$/gm",
+                "replaceString": "<div style=\"margin:10px auto;max-width:360px;padding:12px;border-radius:30px;border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 26%, transparent);background:linear-gradient(145deg,oklch(18% .025 260 / .96),color-mix(in srgb,var(--SmartThemeBlurTintColor) 74%, oklch(24% .04 250)));box-shadow:0 18px 42px color-mix(in srgb,var(--SmartThemeShadowColor) 28%, transparent);font-family:var(--mainFontFamily, system-ui, sans-serif);color:var(--SmartThemeBodyColor);line-height:1.42\"><div style=\"width:84px;height:14px;border-radius:999px;margin:0 auto 11px;background:color-mix(in srgb,var(--SmartThemeBodyColor) 18%, transparent);border:1px solid color-mix(in srgb,var(--SmartThemeBodyColor) 8%, transparent)\"></div><div style=\"padding:12px;border-radius:23px;background:linear-gradient(180deg,color-mix(in srgb,var(--SmartThemeBodyColor) 8%, transparent),color-mix(in srgb,var(--SmartThemeQuoteColor) 8%, transparent));border:1px solid color-mix(in srgb,var(--SmartThemeBodyColor) 10%, transparent)\"><div style=\"display:flex;align-items:center;justify-content:space-between;gap:10px;margin-bottom:10px\"><div style=\"font-weight:800;letter-spacing:.01em\">$1</div><small style=\"opacity:.72;text-align:right\">$2</small></div><div style=\"display:flex;flex-direction:column;gap:8px\">",
+                "trimStrings": [],
+                "placement": [
+                    2
+                ],
+                "disabled": false,
+                "markdownOnly": true,
+                "promptOnly": false,
+                "runOnEdit": true,
+                "substituteRegex": 0,
+                "minDepth": null,
+                "maxDepth": null
+            },
+            {
+                "id": "message-inbox-phone-text-row",
+                "scriptName": "Message Inbox phone text row",
+                "findRegex": "/^(?:PHONE_TEXT|phone-text)\\|([^|\\n]+)\\|([^|\\n]*)\\|([^\\n]*)$/gm",
+                "replaceString": "<div style=\"display:flex;flex-direction:column;align-items:flex-start;gap:3px\"><small style=\"max-width:90%;opacity:.68;font-size:.74em;padding-left:7px\"><b style=\"opacity:.95\">$1</b><span> - $2</span></small><span style=\"max-width:88%;padding:9px 12px;border-radius:18px 18px 18px 6px;background:linear-gradient(135deg,color-mix(in srgb,var(--SmartThemeQuoteColor) 26%, transparent),color-mix(in srgb,var(--SmartThemeBodyColor) 9%, transparent));border:1px solid color-mix(in srgb,var(--SmartThemeQuoteColor) 20%, transparent);box-shadow:0 6px 14px color-mix(in srgb,var(--SmartThemeShadowColor) 14%, transparent);word-break:break-word\">$3</span></div>",
+                "trimStrings": [],
+                "placement": [
+                    2
+                ],
+                "disabled": false,
+                "markdownOnly": true,
+                "promptOnly": false,
+                "runOnEdit": true,
+                "substituteRegex": 0,
+                "minDepth": null,
+                "maxDepth": null
+            },
+            {
+                "id": "message-inbox-phone-shell-close",
+                "scriptName": "Message Inbox phone shell close",
+                "findRegex": "/^(?:PHONE_END|phone-end)$/gm",
+                "replaceString": "</div></div></div>",
+                "trimStrings": [],
+                "placement": [
+                    2
+                ],
+                "disabled": false,
+                "markdownOnly": true,
+                "promptOnly": false,
+                "runOnEdit": true,
+                "substituteRegex": 0,
+                "minDepth": null,
+                "maxDepth": null
+            },
+            {
+                "id": "message-inbox-letter-shell-open",
+                "scriptName": "Message Inbox parchment shell",
+                "findRegex": "/^(?:LETTER_START|letter-start)\\|([^\\n|]+)\\|([^\\n|]*)$/gm",
+                "replaceString": "<div style=\"margin:10px 0;padding:18px 20px;border-radius:16px;border:1px solid oklch(60% .08 72 / .52);background:linear-gradient(135deg,oklch(88% .045 84 / .98),oklch(73% .07 72 / .95));box-shadow:0 15px 34px color-mix(in srgb,var(--SmartThemeShadowColor) 25%, transparent);font-family:Georgia,'Times New Roman',serif;color:oklch(25% .055 65);line-height:1.5;position:relative;overflow:hidden\"><div style=\"position:absolute;inset:0;background:radial-gradient(circle at 15% 20%,oklch(98% .03 90 / .34),transparent 32%),radial-gradient(circle at 90% 5%,oklch(54% .07 52 / .12),transparent 28%);pointer-events:none\"></div><div style=\"position:relative;display:flex;align-items:flex-start;justify-content:space-between;gap:12px;padding-bottom:10px;border-bottom:1px solid oklch(48% .08 68 / .28)\"><div style=\"font-weight:800;font-size:1.08em;letter-spacing:.015em\">$1</div><small style=\"opacity:.75;text-align:right\">$2</small></div><div style=\"position:relative;display:flex;flex-direction:column;gap:10px;margin-top:12px\">",
+                "trimStrings": [],
+                "placement": [
+                    2
+                ],
+                "disabled": false,
+                "markdownOnly": true,
+                "promptOnly": false,
+                "runOnEdit": true,
+                "substituteRegex": 0,
+                "minDepth": null,
+                "maxDepth": null
+            },
+            {
+                "id": "message-inbox-letter-text-row",
+                "scriptName": "Message Inbox parchment text row",
+                "findRegex": "/^(?:LETTER_TEXT|letter-text)\\|([^|\\n]+)\\|([^|\\n]*)\\|([^\\n]*)$/gm",
+                "replaceString": "<div style=\"padding:3px 0 0\"><div style=\"display:flex;align-items:baseline;justify-content:space-between;gap:10px;margin-bottom:4px;color:oklch(30% .07 55)\"><b>$1</b><small style=\"opacity:.68;text-align:right\">$2</small></div><div style=\"padding:10px 12px;border-radius:10px;background:oklch(96% .035 88 / .38);border:1px solid oklch(58% .075 72 / .24);box-shadow:inset 0 0 24px oklch(58% .07 70 / .08);word-break:break-word\">$3</div></div>",
+                "trimStrings": [],
+                "placement": [
+                    2
+                ],
+                "disabled": false,
+                "markdownOnly": true,
+                "promptOnly": false,
+                "runOnEdit": true,
+                "substituteRegex": 0,
+                "minDepth": null,
+                "maxDepth": null
+            },
+            {
+                "id": "message-inbox-letter-shell-close",
+                "scriptName": "Message Inbox parchment shell close",
+                "findRegex": "/^(?:LETTER_END|letter-end)$/gm",
+                "replaceString": "</div></div>",
+                "trimStrings": [],
+                "placement": [
+                    2
+                ],
+                "disabled": false,
+                "markdownOnly": true,
+                "promptOnly": false,
+                "runOnEdit": true,
+                "substituteRegex": 0,
+                "minDepth": null,
+                "maxDepth": null
+            }
+        ],
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 0,
+            "order": 112,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": ""
+        },
+        "enabled": false,
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal",
+                "continue"
+            ]
+        }
+    },
+    {
+        "id": "tpl-pathfinder",
+        "name": "Pathfinder",
+        "description": "Automatic agentic lorebook retrieval. Lets a model actively browse, search, and modify your lorebook using function tools.",
+        "icon": "fa-route",
+        "category": "tool",
+        "tags": [
+            "lorebook",
+            "retrieval",
+            "memory",
+            "agentic",
+            "pathfinder"
+        ],
+        "version": 1,
+        "author": "SillyBunny",
+        "prompt": "",
+        "phase": "both",
+        "injection": {
+            "position": 0,
+            "depth": 4,
+            "role": 0,
+            "order": 50,
+            "scan": false
+        },
+        "postProcess": {
+            "enabled": false,
+            "type": "regex",
+            "regexFind": "",
+            "regexReplace": "",
+            "regexFlags": "g",
+            "appendText": "",
+            "extractPattern": "",
+            "extractVariable": "",
+            "promptTransformEnabled": false,
+            "promptTransformShowNotifications": true,
+            "promptTransformMode": "rewrite",
+            "promptTransformMaxTokens": 8192
+        },
+        "regexScripts": [],
+        "connectionProfile": "",
+        "sourceTemplateId": "tpl-pathfinder",
+        "enabled": false,
+        "tools": [
+            {
+                "name": "Pathfinder_Search",
+                "displayName": "Pathfinder Search",
+                "description": "Navigate the lorebook waypoint map and retrieve relevant entries for the current scene. Call without a node_id to see the top-level waypoint map. Call with a node_id to drill into a specific waypoint and see its sub-waypoints or retrieve entries. Use this tool whenever you need context about characters, locations, world rules, or recent events.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "node_id": {
+                            "type": "string",
+                            "description": "ID of the waypoint/node to navigate into. Omit to see the top-level waypoint guide."
+                        }
+                    }
+                },
+                "actionKey": "pathfinder_search",
+                "formatMessageKey": "pathfinder_search_fmt",
+                "shouldRegister": true,
+                "stealth": false,
+                "enabled": true
+            },
+            {
+                "name": "Pathfinder_Remember",
+                "displayName": "Pathfinder Remember",
+                "description": "Create a new lorebook entry to remember information for future reference. Use this when new facts, character developments, world details, or important information emerge that should be preserved beyond this conversation.",
+                "parameters": {
+                    "type": "object",
+                    "required": [
+                        "title",
+                        "content"
+                    ],
+                    "properties": {
+                        "title": {
+                            "type": "string",
+                            "description": "Title for the new entry (e.g., \"Sable - Personality\" or \"[Tracker] Mood\")"
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "Full content to remember"
+                        },
+                        "book": {
+                            "type": "string",
+                            "description": "Target lorebook name. Omit to use the default."
+                        }
+                    }
+                },
+                "actionKey": "pathfinder_remember",
+                "formatMessageKey": "pathfinder_remember_fmt",
+                "shouldRegister": true,
+                "stealth": false,
+                "enabled": true
+            },
+            {
+                "name": "Pathfinder_Update",
+                "displayName": "Pathfinder Update",
+                "description": "Edit an existing lorebook entry when information changes. Use this when a character's status changes, relationships evolve, or facts need correction.",
+                "parameters": {
+                    "type": "object",
+                    "required": [
+                        "uid"
+                    ],
+                    "properties": {
+                        "uid": {
+                            "type": "number",
+                            "description": "UID of the entry to update (found via Search)"
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "New content for the entry. Omit to keep existing."
+                        },
+                        "title": {
+                            "type": "string",
+                            "description": "New title for the entry. Omit to keep existing."
+                        },
+                        "book": {
+                            "type": "string",
+                            "description": "Lorebook name. Omit for default."
+                        }
+                    }
+                },
+                "actionKey": "pathfinder_update",
+                "formatMessageKey": "pathfinder_update_fmt",
+                "shouldRegister": true,
+                "stealth": false,
+                "enabled": true
+            },
+            {
+                "name": "Pathfinder_Forget",
+                "displayName": "Pathfinder Forget",
+                "description": "Disable or delete a lorebook entry that is no longer relevant. Use this when a character dies, a location is destroyed, or a fact is proven false.",
+                "parameters": {
+                    "type": "object",
+                    "required": [
+                        "uid"
+                    ],
+                    "properties": {
+                        "uid": {
+                            "type": "number",
+                            "description": "UID of the entry to forget"
+                        },
+                        "book": {
+                            "type": "string",
+                            "description": "Lorebook name. Omit for default."
+                        },
+                        "hard_delete": {
+                            "type": "boolean",
+                            "description": "Permanently delete instead of disabling. Default: false."
+                        }
+                    }
+                },
+                "actionKey": "pathfinder_forget",
+                "formatMessageKey": "pathfinder_forget_fmt",
+                "shouldRegister": true,
+                "stealth": false,
+                "enabled": true
+            },
+            {
+                "name": "Pathfinder_Summarize",
+                "displayName": "Pathfinder Summarize",
+                "description": "Create a scene or event summary with significance level and optional narrative arc. Use this when important events happen: battles, confessions, discoveries, or turning points.",
+                "parameters": {
+                    "type": "object",
+                    "required": [
+                        "title",
+                        "content"
+                    ],
+                    "properties": {
+                        "title": {
+                            "type": "string",
+                            "description": "Short title for the event/scene"
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "Full summary of what happened"
+                        },
+                        "arc": {
+                            "type": "string",
+                            "description": "Optional narrative arc name to file this under"
+                        },
+                        "significance": {
+                            "type": "string",
+                            "enum": [
+                                "low",
+                                "medium",
+                                "high",
+                                "critical"
+                            ],
+                            "description": "How important this event is. Default: medium."
+                        },
+                        "book": {
+                            "type": "string",
+                            "description": "Lorebook name. Omit for default."
+                        }
+                    }
+                },
+                "actionKey": "pathfinder_summarize",
+                "formatMessageKey": "pathfinder_summarize_fmt",
+                "shouldRegister": true,
+                "stealth": false,
+                "enabled": true
+            },
+            {
+                "name": "Pathfinder_Reorganize",
+                "displayName": "Pathfinder Reorganize",
+                "description": "Move entries between waypoints or create new waypoints to reorganize the lorebook structure.",
+                "parameters": {
+                    "type": "object",
+                    "required": [
+                        "action"
+                    ],
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": [
+                                "move",
+                                "create_waypoint"
+                            ],
+                            "description": "\"move\" to relocate an entry, \"create_waypoint\" to make a new waypoint"
+                        },
+                        "uid": {
+                            "type": "number",
+                            "description": "Entry UID to move (for \"move\" action)"
+                        },
+                        "target_node_id": {
+                            "type": "string",
+                            "description": "Target waypoint node ID (for \"move\" action)"
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "New waypoint name (for \"create_waypoint\" action)"
+                        },
+                        "parent_node_id": {
+                            "type": "string",
+                            "description": "Parent waypoint ID. Omit for top level."
+                        },
+                        "description": {
+                            "type": "string",
+                            "description": "Description for new waypoint."
+                        },
+                        "book": {
+                            "type": "string",
+                            "description": "Lorebook name. Omit for default."
+                        }
+                    }
+                },
+                "actionKey": "pathfinder_reorganize",
+                "formatMessageKey": "pathfinder_reorganize_fmt",
+                "shouldRegister": true,
+                "stealth": false,
+                "enabled": true
+            },
+            {
+                "name": "Pathfinder_MergeSplit",
+                "displayName": "Pathfinder Merge/Split",
+                "description": "Merge related entries together or split a long entry into two. Use merge when two entries cover the same topic. Use split when one entry covers too many topics.",
+                "parameters": {
+                    "type": "object",
+                    "required": [
+                        "action"
+                    ],
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": [
+                                "merge",
+                                "split"
+                            ],
+                            "description": "\"merge\" to combine entries, \"split\" to divide one"
+                        },
+                        "uid1": {
+                            "type": "number",
+                            "description": "First entry UID (for merge)"
+                        },
+                        "uid2": {
+                            "type": "number",
+                            "description": "Second entry UID (for merge)"
+                        },
+                        "merged_title": {
+                            "type": "string",
+                            "description": "Title for the merged entry (optional)"
+                        },
+                        "uid": {
+                            "type": "number",
+                            "description": "Entry UID to split (for split)"
+                        },
+                        "title1": {
+                            "type": "string",
+                            "description": "Title for first part (for split)"
+                        },
+                        "content1": {
+                            "type": "string",
+                            "description": "Content for first part (for split)"
+                        },
+                        "title2": {
+                            "type": "string",
+                            "description": "Title for second part (for split)"
+                        },
+                        "content2": {
+                            "type": "string",
+                            "description": "Content for second part (for split)"
+                        },
+                        "book": {
+                            "type": "string",
+                            "description": "Lorebook name. Omit for default."
+                        }
+                    }
+                },
+                "actionKey": "pathfinder_merge_split",
+                "formatMessageKey": "pathfinder_merge_split_fmt",
+                "shouldRegister": true,
+                "stealth": false,
+                "enabled": true
+            },
+            {
+                "name": "Pathfinder_Notebook",
+                "displayName": "Pathfinder Notebook",
+                "description": "Write to or read from a private AI scratchpad for plans, follow-ups, and narrative threads. This is NOT a permanent lorebook entry — use it for temporary notes that persist across turns but don't need to be in the lorebook.",
+                "parameters": {
+                    "type": "object",
+                    "required": [
+                        "action"
+                    ],
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": [
+                                "read",
+                                "write",
+                                "delete"
+                            ],
+                            "description": "\"read\" all entries, \"write\" a new entry, \"delete\" an entry"
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Note key/title (for write and delete)"
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "Note content (for write)"
+                        }
+                    }
+                },
+                "actionKey": "pathfinder_notebook",
+                "formatMessageKey": "pathfinder_notebook_fmt",
+                "shouldRegister": true,
+                "stealth": false,
+                "enabled": true
+            }
+        ],
+        "settings": {
+            "searchMode": "traversal",
+            "recurseLimit": 5,
+            "mandatoryTools": false,
+            "dedupDetection": false,
+            "dedupThreshold": 0.85,
+            "autoSummary": false,
+            "autoSummaryInterval": 20,
+            "multiBookMode": "unified",
+            "ephemeralResults": true,
+            "sidecarEnabled": false,
+            "enabledLorebooks": []
+        },
+        "conditions": {
+            "triggerKeywords": [],
+            "triggerProbability": 100,
+            "generationTypes": [
+                "normal",
+                "continue"
+            ]
+        }
     }
-  }
 ]


### PR DESCRIPTION
This PR registers the availableSprites macro (and its availableExpressions alias) to dynamically fetch and output the list of available (uploaded) sprites for the active character. It also updates the Expressions Agent templates to use the new macro instead of the hardcoded default emotions list.