### PR TITLE
fix: harden model sampling profile detection

### DIFF
--- a/public/scripts/openai-preset-utils.js
+++ b/public/scripts/openai-preset-utils.js
@@ -80,6 +80,115 @@ export function buildChatCompletionSamplingSettingsSnapshot(settings, settingsMa
     return structuredClone(snapshot);
 }
 
+const OPENAI_SAMPLING_PROFILE_SOURCE = 'openai';
+const OPENAI_SAMPLING_PROFILE_SOURCES = new Set([
+    'openai',
+    'openai_responses',
+    'azure_openai',
+]);
+const OPENAI_MODEL_PROVIDER_SEGMENTS = new Set([
+    'openai',
+    'openai-responses',
+    'azure-openai',
+]);
+
+function normalizeSamplingProfileSource(source) {
+    return String(source ?? '').trim().toLowerCase();
+}
+
+function normalizeSamplingProfileModel(model) {
+    return String(model ?? '')
+        .trim()
+        .toLowerCase()
+        .replace(/\\/g, '/')
+        .replace(/:+/g, '/')
+        .replace(/[\s_]+/g, '-')
+        .replace(/\/+/g, '/')
+        .replace(/-+/g, '-')
+        .replace(/^[-/]+|[-/]+$/g, '');
+}
+
+function stripOpenAIModelProviderPrefix(model) {
+    let normalizedModel = normalizeSamplingProfileModel(model).replace(/^(?:models\/)+/, '');
+    const slashSegments = normalizedModel.split('/');
+    const openAiSegmentIndex = slashSegments.findIndex(segment => OPENAI_MODEL_PROVIDER_SEGMENTS.has(segment));
+
+    if (openAiSegmentIndex >= 0 && slashSegments[openAiSegmentIndex + 1]) {
+        return slashSegments.slice(openAiSegmentIndex + 1).join('-');
+    }
+
+    return normalizedModel.replace(/^(?:openai|openai-responses|azure-openai)[-/]+/, '');
+}
+
+function normalizeOpenAIModelForSamplingProfile(model) {
+    let normalizedModel = stripOpenAIModelProviderPrefix(model)
+        .replace(/^chatgpt(?=\d)/, 'chatgpt-')
+        .replace(/^chatgpt-/, 'gpt-')
+        .replace(/^gpt(?=\d)/, 'gpt-')
+        .replace(/^(o[134])(?=[a-z])/, '$1-');
+
+    normalizedModel = normalizedModel
+        .replace(/-(?:\d{4}-\d{2}-\d{2}|\d{8})$/, '')
+        .replace(/-latest$/, '');
+
+    return normalizedModel;
+}
+
+function isOpenAIModelForSamplingProfile(model) {
+    const normalizedModel = normalizeSamplingProfileModel(model);
+    const normalizedOpenAIModel = normalizeOpenAIModelForSamplingProfile(model);
+
+    return Boolean(normalizedOpenAIModel) && (
+        normalizedModel.split('/').some(segment => OPENAI_MODEL_PROVIDER_SEGMENTS.has(segment))
+        || /^(?:gpt(?:-|\d)|codex(?:-|$)|omni(?:-|$)|o[134](?:-|\d|$))/.test(normalizedOpenAIModel)
+    );
+}
+
+/**
+ * Builds a canonical key for model sampling profiles.
+ *
+ * @param {string} source Chat Completion source
+ * @param {string} model Chat Completion model
+ * @returns {string|null} Canonical model sampling profile key
+ */
+export function buildChatCompletionSamplingProfileKey(source, model) {
+    const normalizedSource = normalizeSamplingProfileSource(source);
+    const normalizedModel = normalizeSamplingProfileModel(model);
+
+    if (!normalizedSource || !normalizedModel) {
+        return null;
+    }
+
+    const isOpenAIProfile = OPENAI_SAMPLING_PROFILE_SOURCES.has(normalizedSource)
+        || (normalizedSource === 'custom' && isOpenAIModelForSamplingProfile(normalizedModel));
+
+    const profileSource = isOpenAIProfile ? OPENAI_SAMPLING_PROFILE_SOURCE : normalizedSource;
+    const profileModel = isOpenAIProfile ? normalizeOpenAIModelForSamplingProfile(normalizedModel) : normalizedModel;
+
+    if (!profileModel) {
+        return null;
+    }
+
+    return `${profileSource}:${profileModel}`;
+}
+
+/**
+ * Lists profile keys to try when loading/clearing model sampling profiles.
+ * The legacy exact key keeps saved profiles from earlier SillyBunny builds usable.
+ *
+ * @param {string} source Chat Completion source
+ * @param {string} model Chat Completion model
+ * @returns {string[]} Canonical key followed by legacy fallback keys
+ */
+export function getChatCompletionSamplingProfileLookupKeys(source, model) {
+    const legacyKey = source && model ? `${source}:${model}` : null;
+
+    return [
+        buildChatCompletionSamplingProfileKey(source, model),
+        legacyKey,
+    ].filter((key, index, keys) => key && keys.indexOf(key) === index);
+}
+
 /**
  * Returns whether OpenAI preset saves should include provider/model/API fields.
  *

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -88,8 +88,10 @@ import { hasTextOrArrayPayload, shouldRetainContextAtDepth, stripHtmlTagsFromCon
 import { checkPostInterceptChatBudget, shouldCheckPostInterceptChatBudget } from './openai-prompt-budget.js';
 import {
     buildChatCompletionPresetForSave,
+    buildChatCompletionSamplingProfileKey,
     buildChatCompletionSamplingSettingsSnapshot,
     buildReverseProxyPresetForSave,
+    getChatCompletionSamplingProfileLookupKeys,
     normalizeReverseProxyPreset,
     shouldIncludeSamplingFieldsInPreset,
 } from './openai-preset-utils.js';
@@ -6687,7 +6689,37 @@ function getModelSamplingProfileKey() {
     if (!source || !model) {
         return null;
     }
-    return `${source}:${model}`;
+    return buildChatCompletionSamplingProfileKey(source, model);
+}
+
+function getModelSamplingProfileKeys() {
+    const source = oai_settings.chat_completion_source;
+    const model = getChatCompletionModel();
+    if (!source || !model) {
+        return [];
+    }
+    return getChatCompletionSamplingProfileLookupKeys(source, model);
+}
+
+function getModelSamplingProfileMatch() {
+    const profileKeys = getModelSamplingProfileKeys();
+    const profiles = oai_settings.model_sampling_profiles;
+
+    if (!profileKeys.length || !profiles) {
+        return null;
+    }
+
+    for (const profileKey of profileKeys) {
+        if (Object.hasOwn(profiles, profileKey)) {
+            return {
+                canonicalKey: profileKeys[0],
+                profileKey,
+                profile: profiles[profileKey],
+            };
+        }
+    }
+
+    return null;
 }
 
 function getSamplingSettingsSnapshot() {
@@ -6730,20 +6762,31 @@ function saveSamplingProfileForCurrentModel() {
         toastr.warning(t`No model is currently selected.`, t`Cannot save sampling profile`);
         return;
     }
+    oai_settings.model_sampling_profiles ??= {};
     oai_settings.model_sampling_profiles[profileKey] = getSamplingSettingsSnapshot();
+    for (const lookupKey of getModelSamplingProfileKeys()) {
+        if (lookupKey !== profileKey) {
+            delete oai_settings.model_sampling_profiles[lookupKey];
+        }
+    }
     saveSettingsDebounced();
     const modelLabel = getChatCompletionModel();
     toastr.success(t`Saved sampling settings for ${modelLabel}.`, t`Model sampling profile saved`);
 }
 
 function clearSamplingProfileForCurrentModel() {
-    const profileKey = getModelSamplingProfileKey();
-    if (!profileKey) {
+    const profileKeys = getModelSamplingProfileKeys();
+    if (!profileKeys.length) {
         toastr.warning(t`No model is currently selected.`, t`Cannot clear sampling profile`);
         return;
     }
-    if (oai_settings.model_sampling_profiles?.[profileKey]) {
-        delete oai_settings.model_sampling_profiles[profileKey];
+    const profiles = oai_settings.model_sampling_profiles;
+    const deletedKeys = profileKeys.filter(profileKey => profiles && Object.hasOwn(profiles, profileKey));
+
+    if (deletedKeys.length) {
+        for (const profileKey of deletedKeys) {
+            delete profiles[profileKey];
+        }
         saveSettingsDebounced();
         const modelLabel = getChatCompletionModel();
         toastr.info(t`Cleared sampling profile for ${modelLabel}.`, t`Model sampling profile removed`);
@@ -6757,15 +6800,15 @@ function maybeApplyModelSamplingProfile() {
     if (!oai_settings.model_sampling_profiles_enabled) {
         return;
     }
-    const profileKey = getModelSamplingProfileKey();
-    if (!profileKey) {
+    const profileMatch = getModelSamplingProfileMatch();
+    if (!profileMatch) {
         return;
     }
-    const profile = oai_settings.model_sampling_profiles?.[profileKey];
-    if (!profile) {
-        return;
+    applySamplingSettings(profileMatch.profile);
+    if (profileMatch.profileKey !== profileMatch.canonicalKey) {
+        oai_settings.model_sampling_profiles[profileMatch.canonicalKey] = structuredClone(profileMatch.profile);
+        saveSettingsDebounced();
     }
-    applySamplingSettings(profile);
     // SillyBunny: Removed constant "Model sampling profile loaded" toast to reduce UI noise
 }
 

--- a/tests/openai-preset-utils.test.js
+++ b/tests/openai-preset-utils.test.js
@@ -2,9 +2,11 @@ import { describe, expect, test } from '@jest/globals';
 import {
     buildChatCompletionPreset,
     buildChatCompletionPresetForSave,
+    buildChatCompletionSamplingProfileKey,
     buildChatCompletionSamplingSettingsSnapshot,
     buildReverseProxyPresetForSave,
     getChatCompletionConnectionPresetKeys,
+    getChatCompletionSamplingProfileLookupKeys,
     getChatCompletionSamplingPresetKeys,
     getChatCompletionSamplingSettingsKeys,
     normalizeReverseProxyPreset,
@@ -257,5 +259,63 @@ describe('Chat Completion preset utilities', () => {
             assistant_prefill: '',
             prompts: [{ identifier: 'main', content: 'Prompt after edit' }],
         });
+    });
+});
+
+describe('Chat Completion sampling profile keys', () => {
+    test('builds canonical keys for native OpenAI models', () => {
+        expect(buildChatCompletionSamplingProfileKey('openai', 'gpt-4o')).toBe('openai:gpt-4o');
+        expect(buildChatCompletionSamplingProfileKey('openai', 'gpt-4-turbo')).toBe('openai:gpt-4-turbo');
+        expect(buildChatCompletionSamplingProfileKey('openai', 'o1-preview')).toBe('openai:o1-preview');
+        expect(buildChatCompletionSamplingProfileKey('openai_responses', 'gpt-4o')).toBe('openai:gpt-4o');
+        expect(buildChatCompletionSamplingProfileKey('azure_openai', 'gpt-4')).toBe('openai:gpt-4');
+    });
+
+    test('shares canonical keys for OpenAI Custom models', () => {
+        expect(buildChatCompletionSamplingProfileKey('custom', 'openai/gpt-4o')).toBe('openai:gpt-4o');
+        expect(buildChatCompletionSamplingProfileKey('custom', 'models/openai/gpt-4-turbo')).toBe('openai:gpt-4-turbo');
+        expect(buildChatCompletionSamplingProfileKey('custom', 'chatgpt-4o-latest')).toBe('openai:gpt-4o');
+        expect(buildChatCompletionSamplingProfileKey('custom', 'o1-preview-2024-08-01')).toBe('openai:o1-preview');
+    });
+
+    test('normalizes model separators and case in canonical keys', () => {
+        expect(buildChatCompletionSamplingProfileKey('openai', 'GPT-4O')).toBe('openai:gpt-4o');
+        expect(buildChatCompletionSamplingProfileKey('custom', 'openai\\gpt-4')).toBe('openai:gpt-4');
+        expect(buildChatCompletionSamplingProfileKey('custom', 'openai:gpt-4-turbo')).toBe('openai:gpt-4-turbo');
+    });
+
+    test('isolates unknown custom models with normalized keys', () => {
+        expect(buildChatCompletionSamplingProfileKey('custom', 'my-local-model')).toBe('custom:my-local-model');
+        expect(buildChatCompletionSamplingProfileKey('custom', 'llama-3.1')).toBe('custom:llama-3.1');
+        expect(buildChatCompletionSamplingProfileKey('custom', 'MyLocalModel')).toBe('custom:mylocalmodel');
+    });
+
+    test('includes legacy exact key in lookup keys', () => {
+        const keys = getChatCompletionSamplingProfileLookupKeys('openai', 'gpt-4o');
+        expect(keys).toContain('openai:gpt-4o');
+        expect(keys[0]).toBe('openai:gpt-4o');
+    });
+
+    test('includes legacy key for OpenAI Custom models', () => {
+        const keys = getChatCompletionSamplingProfileLookupKeys('custom', 'openai/gpt-4o');
+        expect(keys[0]).toBe('openai:gpt-4o');
+        expect(keys).toContain('custom:openai/gpt-4o');
+    });
+
+    test('deduplicates canonical and legacy keys when identical', () => {
+        const keys = getChatCompletionSamplingProfileLookupKeys('custom', 'my-model');
+        expect(keys).toEqual(['custom:my-model']);
+    });
+
+    test('returns null for missing source or model', () => {
+        expect(buildChatCompletionSamplingProfileKey('', 'gpt-4o')).toBeNull();
+        expect(buildChatCompletionSamplingProfileKey('openai', '')).toBeNull();
+        expect(buildChatCompletionSamplingProfileKey(null, 'gpt-4o')).toBeNull();
+        expect(buildChatCompletionSamplingProfileKey('openai', null)).toBeNull();
+    });
+
+    test('returns empty array for missing source or model', () => {
+        expect(getChatCompletionSamplingProfileLookupKeys('', 'gpt-4o')).toEqual([]);
+        expect(getChatCompletionSamplingProfileLookupKeys('openai', '')).toEqual([]);
     });
 });


### PR DESCRIPTION
## Summary

Hardens the sampling preset system so it detects models by family rather than exact name, especially for OpenAI Custom models. This allows OpenAI Custom endpoints using OpenAI-family model IDs to share the same sampling profile as native OpenAI.

## Changes

- **Canonical profile keys**: `buildChatCompletionSamplingProfileKey()` normalizes OpenAI-family model IDs so `openai:gpt-4o`, `custom:openai/gpt-4o`, and `custom:chatgpt-4o-latest` all map to the same canonical key `openai:gpt-4o`
- **Legacy fallback**: `getChatCompletionSamplingProfileLookupKeys()` includes the old exact key `{source}:{model}` so previously saved profiles without canonical normalization continue to work
- **Automatic migration**: When a legacy profile is loaded, it is copied to the canonical key and saved via `saveSettingsDebounced`, so aliases share it going forward
- **Save deletes stale aliases**: Saving a profile writes the canonical key and removes duplicate legacy keys for the current model
- **Model family detection**: Recognizes OpenAI models under `custom` source via provider-segment detection and model ID pattern matching for `gpt-*`, `codex-*`, `omni-*`, `o1/o3/o4-*`
- **Unknown custom models stay isolated**: Non-OpenAI custom models get their own normalized custom keys (e.g. `custom:my-local-model`)
- Date-suffix stripping handles `o1-preview-2024-08-01` style versioned IDs

## Testing

Added 9 new test cases in `openai-preset-utils.test.js` covering:
- Canonical keys for native OpenAI models (openai, openai_responses, azure_openai)
- Shared canonical keys for OpenAI Custom models
- Separator and case normalization
- Unknown custom model isolation
- Legacy exact-key lookup and deduplication
- Null/empty source or model handling

All 33 sampling profile tests pass.

## Files changed

- `public/scripts/openai-preset-utils.js` — new `buildChatCompletionSamplingProfileKey` and `getChatCompletionSamplingProfileLookupKeys` exports
- `public/scripts/openai.js` — wired save/clear/apply to use canonical lookup with legacy migration
- `tests/openai-preset-utils.test.js` — new sampling profile key tests
