### PR TITLE
fix: re-apply model sampling profile after preset changes

### DIFF
--- a/public/scripts/openai-preset-utils.js
+++ b/public/scripts/openai-preset-utils.js
@@ -80,6 +80,115 @@ export function buildChatCompletionSamplingSettingsSnapshot(settings, settingsMa
     return structuredClone(snapshot);
 }
 
+const OPENAI_SAMPLING_PROFILE_SOURCE = 'openai';
+const OPENAI_SAMPLING_PROFILE_SOURCES = new Set([
+    'openai',
+    'openai_responses',
+    'azure_openai',
+]);
+const OPENAI_MODEL_PROVIDER_SEGMENTS = new Set([
+    'openai',
+    'openai-responses',
+    'azure-openai',
+]);
+
+function normalizeSamplingProfileSource(source) {
+    return String(source ?? '').trim().toLowerCase();
+}
+
+function normalizeSamplingProfileModel(model) {
+    return String(model ?? '')
+        .trim()
+        .toLowerCase()
+        .replace(/\\/g, '/')
+        .replace(/:+/g, '/')
+        .replace(/[\s_]+/g, '-')
+        .replace(/\/+/g, '/')
+        .replace(/-+/g, '-')
+        .replace(/^[-/]+|[-/]+$/g, '');
+}
+
+function stripOpenAIModelProviderPrefix(model) {
+    let normalizedModel = normalizeSamplingProfileModel(model).replace(/^(?:models\/)+/, '');
+    const slashSegments = normalizedModel.split('/');
+    const openAiSegmentIndex = slashSegments.findIndex(segment => OPENAI_MODEL_PROVIDER_SEGMENTS.has(segment));
+
+    if (openAiSegmentIndex >= 0 && slashSegments[openAiSegmentIndex + 1]) {
+        return slashSegments.slice(openAiSegmentIndex + 1).join('-');
+    }
+
+    return normalizedModel.replace(/^(?:openai|openai-responses|azure-openai)[-/]+/, '');
+}
+
+function normalizeOpenAIModelForSamplingProfile(model) {
+    let normalizedModel = stripOpenAIModelProviderPrefix(model)
+        .replace(/^chatgpt(?=\d)/, 'chatgpt-')
+        .replace(/^chatgpt-/, 'gpt-')
+        .replace(/^gpt(?=\d)/, 'gpt-')
+        .replace(/^(o[134])(?=[a-z])/, '$1-');
+
+    normalizedModel = normalizedModel
+        .replace(/-(?:\d{4}-\d{2}-\d{2}|\d{8})$/, '')
+        .replace(/-latest$/, '');
+
+    return normalizedModel;
+}
+
+function isOpenAIModelForSamplingProfile(model) {
+    const normalizedModel = normalizeSamplingProfileModel(model);
+    const normalizedOpenAIModel = normalizeOpenAIModelForSamplingProfile(model);
+
+    return Boolean(normalizedOpenAIModel) && (
+        normalizedModel.split('/').some(segment => OPENAI_MODEL_PROVIDER_SEGMENTS.has(segment))
+        || /^(?:gpt(?:-|\d)|codex(?:-|$)|omni(?:-|$)|o[134](?:-|\d|$))/.test(normalizedOpenAIModel)
+    );
+}
+
+/**
+ * Builds a canonical key for model sampling profiles.
+ *
+ * @param {string} source Chat Completion source
+ * @param {string} model Chat Completion model
+ * @returns {string|null} Canonical model sampling profile key
+ */
+export function buildChatCompletionSamplingProfileKey(source, model) {
+    const normalizedSource = normalizeSamplingProfileSource(source);
+    const normalizedModel = normalizeSamplingProfileModel(model);
+
+    if (!normalizedSource || !normalizedModel) {
+        return null;
+    }
+
+    const isOpenAIProfile = OPENAI_SAMPLING_PROFILE_SOURCES.has(normalizedSource)
+        || (normalizedSource === 'custom' && isOpenAIModelForSamplingProfile(normalizedModel));
+
+    const profileSource = isOpenAIProfile ? OPENAI_SAMPLING_PROFILE_SOURCE : normalizedSource;
+    const profileModel = isOpenAIProfile ? normalizeOpenAIModelForSamplingProfile(normalizedModel) : normalizedModel;
+
+    if (!profileModel) {
+        return null;
+    }
+
+    return `${profileSource}:${profileModel}`;
+}
+
+/**
+ * Lists profile keys to try when loading/clearing model sampling profiles.
+ * The legacy exact key keeps saved profiles from earlier SillyBunny builds usable.
+ *
+ * @param {string} source Chat Completion source
+ * @param {string} model Chat Completion model
+ * @returns {string[]} Canonical key followed by legacy fallback keys
+ */
+export function getChatCompletionSamplingProfileLookupKeys(source, model) {
+    const legacyKey = source && model ? `${source}:${model}` : null;
+
+    return [
+        buildChatCompletionSamplingProfileKey(source, model),
+        legacyKey,
+    ].filter((key, index, keys) => key && keys.indexOf(key) === index);
+}
+
 /**
  * Returns whether OpenAI preset saves should include provider/model/API fields.
  *

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -88,8 +88,10 @@ import { hasTextOrArrayPayload, shouldRetainContextAtDepth, stripHtmlTagsFromCon
 import { checkPostInterceptChatBudget, shouldCheckPostInterceptChatBudget } from './openai-prompt-budget.js';
 import {
     buildChatCompletionPresetForSave,
+    buildChatCompletionSamplingProfileKey,
     buildChatCompletionSamplingSettingsSnapshot,
     buildReverseProxyPresetForSave,
+    getChatCompletionSamplingProfileLookupKeys,
     normalizeReverseProxyPreset,
     shouldIncludeSamplingFieldsInPreset,
 } from './openai-preset-utils.js';
@@ -6687,7 +6689,37 @@ function getModelSamplingProfileKey() {
     if (!source || !model) {
         return null;
     }
-    return `${source}:${model}`;
+    return buildChatCompletionSamplingProfileKey(source, model);
+}
+
+function getModelSamplingProfileKeys() {
+    const source = oai_settings.chat_completion_source;
+    const model = getChatCompletionModel();
+    if (!source || !model) {
+        return [];
+    }
+    return getChatCompletionSamplingProfileLookupKeys(source, model);
+}
+
+function getModelSamplingProfileMatch() {
+    const profileKeys = getModelSamplingProfileKeys();
+    const profiles = oai_settings.model_sampling_profiles;
+
+    if (!profileKeys.length || !profiles) {
+        return null;
+    }
+
+    for (const profileKey of profileKeys) {
+        if (Object.hasOwn(profiles, profileKey)) {
+            return {
+                canonicalKey: profileKeys[0],
+                profileKey,
+                profile: profiles[profileKey],
+            };
+        }
+    }
+
+    return null;
 }
 
 function getSamplingSettingsSnapshot() {
@@ -6730,20 +6762,31 @@ function saveSamplingProfileForCurrentModel() {
         toastr.warning(t`No model is currently selected.`, t`Cannot save sampling profile`);
         return;
     }
+    oai_settings.model_sampling_profiles ??= {};
     oai_settings.model_sampling_profiles[profileKey] = getSamplingSettingsSnapshot();
+    for (const lookupKey of getModelSamplingProfileKeys()) {
+        if (lookupKey !== profileKey) {
+            delete oai_settings.model_sampling_profiles[lookupKey];
+        }
+    }
     saveSettingsDebounced();
     const modelLabel = getChatCompletionModel();
     toastr.success(t`Saved sampling settings for ${modelLabel}.`, t`Model sampling profile saved`);
 }
 
 function clearSamplingProfileForCurrentModel() {
-    const profileKey = getModelSamplingProfileKey();
-    if (!profileKey) {
+    const profileKeys = getModelSamplingProfileKeys();
+    if (!profileKeys.length) {
         toastr.warning(t`No model is currently selected.`, t`Cannot clear sampling profile`);
         return;
     }
-    if (oai_settings.model_sampling_profiles?.[profileKey]) {
-        delete oai_settings.model_sampling_profiles[profileKey];
+    const profiles = oai_settings.model_sampling_profiles;
+    const deletedKeys = profileKeys.filter(profileKey => profiles && Object.hasOwn(profiles, profileKey));
+
+    if (deletedKeys.length) {
+        for (const profileKey of deletedKeys) {
+            delete profiles[profileKey];
+        }
         saveSettingsDebounced();
         const modelLabel = getChatCompletionModel();
         toastr.info(t`Cleared sampling profile for ${modelLabel}.`, t`Model sampling profile removed`);
@@ -6757,15 +6800,15 @@ function maybeApplyModelSamplingProfile() {
     if (!oai_settings.model_sampling_profiles_enabled) {
         return;
     }
-    const profileKey = getModelSamplingProfileKey();
-    if (!profileKey) {
+    const profileMatch = getModelSamplingProfileMatch();
+    if (!profileMatch) {
         return;
     }
-    const profile = oai_settings.model_sampling_profiles?.[profileKey];
-    if (!profile) {
-        return;
+    applySamplingSettings(profileMatch.profile);
+    if (profileMatch.profileKey !== profileMatch.canonicalKey) {
+        oai_settings.model_sampling_profiles[profileMatch.canonicalKey] = structuredClone(profileMatch.profile);
+        saveSettingsDebounced();
     }
-    applySamplingSettings(profile);
     // SillyBunny: Removed constant "Model sampling profile loaded" toast to reduce UI noise
 }
 
@@ -7535,6 +7578,13 @@ function onSettingsPresetChange() {
         updateOpenAISettingsGroupVisibility();
         scheduleOpenAIUiRefresh();
         $('#openai_logit_bias_preset').trigger('change');
+
+        // SillyBunny: re-assert the per-model sampling profile after a preset has
+        // written its sampling values, so a bound model profile always wins over
+        // the (Default/char) preset — the core promise of "decouple sampling from
+        // preset". Without this, starting a new chat or switching to a backend
+        // with a saved sampling profile silently reverts to the preset's sampling.
+        maybeApplyModelSamplingProfile();
 
         await saveSettings();
         await eventSource.emit(event_types.OAI_PRESET_CHANGED_AFTER);

--- a/tests/openai-preset-utils.test.js
+++ b/tests/openai-preset-utils.test.js
@@ -2,9 +2,11 @@ import { describe, expect, test } from '@jest/globals';
 import {
     buildChatCompletionPreset,
     buildChatCompletionPresetForSave,
+    buildChatCompletionSamplingProfileKey,
     buildChatCompletionSamplingSettingsSnapshot,
     buildReverseProxyPresetForSave,
     getChatCompletionConnectionPresetKeys,
+    getChatCompletionSamplingProfileLookupKeys,
     getChatCompletionSamplingPresetKeys,
     getChatCompletionSamplingSettingsKeys,
     normalizeReverseProxyPreset,
@@ -257,5 +259,63 @@ describe('Chat Completion preset utilities', () => {
             assistant_prefill: '',
             prompts: [{ identifier: 'main', content: 'Prompt after edit' }],
         });
+    });
+});
+
+describe('Chat Completion sampling profile keys', () => {
+    test('builds canonical keys for native OpenAI models', () => {
+        expect(buildChatCompletionSamplingProfileKey('openai', 'gpt-4o')).toBe('openai:gpt-4o');
+        expect(buildChatCompletionSamplingProfileKey('openai', 'gpt-4-turbo')).toBe('openai:gpt-4-turbo');
+        expect(buildChatCompletionSamplingProfileKey('openai', 'o1-preview')).toBe('openai:o1-preview');
+        expect(buildChatCompletionSamplingProfileKey('openai_responses', 'gpt-4o')).toBe('openai:gpt-4o');
+        expect(buildChatCompletionSamplingProfileKey('azure_openai', 'gpt-4')).toBe('openai:gpt-4');
+    });
+
+    test('shares canonical keys for OpenAI Custom models', () => {
+        expect(buildChatCompletionSamplingProfileKey('custom', 'openai/gpt-4o')).toBe('openai:gpt-4o');
+        expect(buildChatCompletionSamplingProfileKey('custom', 'models/openai/gpt-4-turbo')).toBe('openai:gpt-4-turbo');
+        expect(buildChatCompletionSamplingProfileKey('custom', 'chatgpt-4o-latest')).toBe('openai:gpt-4o');
+        expect(buildChatCompletionSamplingProfileKey('custom', 'o1-preview-2024-08-01')).toBe('openai:o1-preview');
+    });
+
+    test('normalizes model separators and case in canonical keys', () => {
+        expect(buildChatCompletionSamplingProfileKey('openai', 'GPT-4O')).toBe('openai:gpt-4o');
+        expect(buildChatCompletionSamplingProfileKey('custom', 'openai\\gpt-4')).toBe('openai:gpt-4');
+        expect(buildChatCompletionSamplingProfileKey('custom', 'openai:gpt-4-turbo')).toBe('openai:gpt-4-turbo');
+    });
+
+    test('isolates unknown custom models with normalized keys', () => {
+        expect(buildChatCompletionSamplingProfileKey('custom', 'my-local-model')).toBe('custom:my-local-model');
+        expect(buildChatCompletionSamplingProfileKey('custom', 'llama-3.1')).toBe('custom:llama-3.1');
+        expect(buildChatCompletionSamplingProfileKey('custom', 'MyLocalModel')).toBe('custom:mylocalmodel');
+    });
+
+    test('includes legacy exact key in lookup keys', () => {
+        const keys = getChatCompletionSamplingProfileLookupKeys('openai', 'gpt-4o');
+        expect(keys).toContain('openai:gpt-4o');
+        expect(keys[0]).toBe('openai:gpt-4o');
+    });
+
+    test('includes legacy key for OpenAI Custom models', () => {
+        const keys = getChatCompletionSamplingProfileLookupKeys('custom', 'openai/gpt-4o');
+        expect(keys[0]).toBe('openai:gpt-4o');
+        expect(keys).toContain('custom:openai/gpt-4o');
+    });
+
+    test('deduplicates canonical and legacy keys when identical', () => {
+        const keys = getChatCompletionSamplingProfileLookupKeys('custom', 'my-model');
+        expect(keys).toEqual(['custom:my-model']);
+    });
+
+    test('returns null for missing source or model', () => {
+        expect(buildChatCompletionSamplingProfileKey('', 'gpt-4o')).toBeNull();
+        expect(buildChatCompletionSamplingProfileKey('openai', '')).toBeNull();
+        expect(buildChatCompletionSamplingProfileKey(null, 'gpt-4o')).toBeNull();
+        expect(buildChatCompletionSamplingProfileKey('openai', null)).toBeNull();
+    });
+
+    test('returns empty array for missing source or model', () => {
+        expect(getChatCompletionSamplingProfileLookupKeys('', 'gpt-4o')).toEqual([]);
+        expect(getChatCompletionSamplingProfileLookupKeys('openai', '')).toEqual([]);
     });
 });


### PR DESCRIPTION
## Problem

Starting a new chat forces the Default Preset's sampling values to apply. The same happens when switching to a backend that has a saved model sampling profile — the preset's sampling silently wins over the model-bound profile.

## Root cause

The **decouple sampling from preset** feature (#470) lets a per-model sampling profile override preset sampling values, but `maybeApplyModelSamplingProfile()` was only invoked from `onModelChange()` — never after a preset was applied. Since `bind_preset_to_sampling` defaults to `true`, every preset application overwrote the sampling fields with the preset's values, and nothing re-asserted the model-bound profile afterward.

Both reported symptoms share this single preset-application path:
- **New chat** → `autoSelectPreset` (`CHAT_CHANGED` in `preset-manager.js:1514`) → `selectPreset` → `change` event → `onSettingsPresetChange` → preset sampling wins → bug.
- **Backend switch** → connection-manager runs `/preset` then `/model`; hooking the preset change guarantees model-profile precedence regardless of command ordering/races (defense-in-depth).

A second, related gap: saved OpenAI profiles weren't being matched when the backend reported a prefixed model id (e.g. `openai/gpt-4o`, `chatgpt-4o-latest`, `o1-preview-2024-08-01`). The legacy exact-match key `${source}:${model}` couldn't reconcile these variants, so even when `maybeApplyModelSamplingProfile` did run, it couldn't find the profile.

## Fix

Two cohesive changes that together make the model sampling profile actually win:

1. **Re-apply after preset change** (`public/scripts/openai.js`): call `maybeApplyModelSamplingProfile()` at the end of `onSettingsPresetChange`'s field-application block, just before the single `await saveSettings()`. This lets the subsequent save persist the corrected sampling values and the emitted `OAI_PRESET_CHANGED_AFTER` / `PRESET_CHANGED` events reflect the final state. No loop risk — sampling-field input handlers only queue `saveSettingsDebounced` and don't re-trigger the preset change.

2. **Model-key normalization** (`public/scripts/openai-preset-utils.js`, folded in): canonical keys collapse `openai/gpt-4o` ↔ `gpt-4o`, `chatgpt-4o-latest` → `gpt-4o`, strip date suffixes (`o1-preview-2024-08-01` → `o1-preview`); legacy exact keys are kept as a fallback so existing saved profiles keep working, and matched legacy keys auto-migrate to canonical form on load.

Both changes are needed end-to-end: key normalization makes a saved profile discoverable, and the preset-change hook makes it actually take precedence.

## Verification

- ✅ `npm run lint` (root ESLint) — clean
- ✅ `npm run test:unit --prefix tests` — 9 new tests added (1199→1208 passing); the 6 failing suites / 26 failing tests are pre-existing on clean `staging` (unrelated `in-chat-agents` / `mobile-shell` / `conversation-settings-keys` module-resolution issues around `MAX_AGENT_MAX_TOKENS`) and identical on baseline.

## Notes

- Self-contained in `openai.js` + `openai-preset-utils.js` with an inline `// SillyBunny:` divergence comment per CONTRIBUTING.
- No new persistent structures — reuses existing `model_sampling_profiles` state; legacy keys auto-migrate in place.
- AI-assisted per the CONTRIBUTING AI disclaimer.