### PR TITLE
fix: scope conversation connection profile without switching the global profile

### DIFF
--- a/public/scripts/sillybunny-conversation/chrome.js
+++ b/public/scripts/sillybunny-conversation/chrome.js
@@ -1,5 +1,4 @@
 import { characters } from '../../script.js';
-import { extension_settings } from '../extensions.js';
 import { selected_group } from '../group-chats.js';
 import { setUserAvatar } from '../personas.js';
 import { shouldSendOnEnter } from '../RossAscends-mods.js';
@@ -753,15 +752,6 @@ export function disableConversationModeForCurrentCharacter({ focusRoleplay = tru
     if (focusRoleplay) {
         document.getElementById('send_textarea')?.focus?.({ preventScroll: false });
     }
-}
-
-export function getSelectedConnectionProfileName() {
-    const manager = extension_settings.connectionManager;
-    if (!manager || !Array.isArray(manager.profiles)) {
-        return '';
-    }
-    const selected = manager.profiles.find((profile) => profile?.id === manager.selectedProfile);
-    return selected?.name ?? '';
 }
 
 export function setConversationInterfaceActive(active) {

--- a/public/scripts/sillybunny-conversation/generation.js
+++ b/public/scripts/sillybunny-conversation/generation.js
@@ -1,4 +1,5 @@
 import { characters, generateRaw } from '../../script.js';
+import { extractProfileResponseText } from '../extensions/in-chat-agents/llm-utils.js';
 import {
     CONVERSATION_ERROR_DETAIL_MAX_LENGTH,
     MAX_CONVERSATION_REPLY_MAX_TOKENS,
@@ -15,7 +16,7 @@ import {
 import { buildCharacterImagePrompt, generateConversationImage, getCharacterForAvatar, getCharacterImageDetails } from './media.js';
 import { appendConversationMessage } from './message-writer.js';
 import { stripSpeakerPrefix } from './partners.js';
-import { withConversationConnectionProfile } from './personas.js';
+import { getConnectionProfiles } from './personas.js';
 import { buildConversationPromptMessages, buildConversationSystemPrompt, formatPromptText } from './prompt.js';
 import { scheduleTimelineRender } from './render-scheduler.js';
 import { clamp, getConversationReplyMaxTokens, parseDurationToMs } from './schedule.js';
@@ -35,6 +36,71 @@ export {
     parseCommandArgs,
 } from './generation-utils.js';
 
+// SillyBunny: Conversation Mode diverges from the global connection-profile
+// switch pattern. Instead of flipping the active profile via /profile around
+// each generation, we issue a scoped request through ConnectionManagerRequestService
+// so the global selectedProfile (and the visible dropdown) never changes.
+function isAbortLikeError(error, signal = null) {
+    return Boolean(
+        signal?.aborted ||
+        error?.name === 'AbortError' ||
+        /abort|cancel/i.test(String(error?.message ?? error ?? '')),
+    );
+}
+
+/**
+ * SillyBunny: generate Conversation Mode text using the configured connection
+ * profile WITHOUT switching the global selected profile. Resolves the profile
+ * by name and routes through ConnectionManagerRequestService.sendRequest so no
+ * global state is mutated. Falls back to generateRaw (the active profile) when
+ * no profile is configured, the scoped request path is unavailable, or the
+ * profile name cannot be resolved.
+ * @param {Object} options - Same option shape as generateRaw (prompt, systemPrompt, responseLength, trimNames, signal, cacheScope).
+ * @param {Object} settings - Conversation settings holding connection_profile (a profile NAME).
+ * @returns {Promise<string>}
+ */
+export async function generateConversationRaw(options, settings) {
+    const profileName = String(settings?.connection_profile || '').trim();
+    const ctx = window?.SillyTavern?.getContext?.();
+    const CMRS = ctx?.ConnectionManagerRequestService;
+
+    if (profileName && CMRS) {
+        const profile = getConnectionProfiles().find(candidate => candidate?.name === profileName);
+        if (profile?.id) {
+            const messages = [];
+            if (options.systemPrompt) {
+                messages.push({ role: 'system', content: options.systemPrompt });
+            }
+            if (Array.isArray(options.prompt)) {
+                for (const message of options.prompt) {
+                    if (message && typeof message === 'object') {
+                        messages.push({ role: String(message.role || 'user'), content: message.content });
+                    }
+                }
+            } else {
+                messages.push({ role: 'user', content: options.prompt });
+            }
+
+            try {
+                const result = await CMRS.sendRequest(profile.id, messages, options.responseLength, {
+                    extractData: true,
+                    includePreset: true,
+                    stream: false,
+                    signal: options.signal ?? null,
+                });
+                return typeof result === 'string' ? result : extractProfileResponseText(result);
+            } catch (error) {
+                if (isAbortLikeError(error, options.signal)) {
+                    throw error;
+                }
+                console.warn(`Conversation Mode: scoped profile "${profileName}" request failed, falling back to the active profile`, error);
+            }
+        }
+    }
+
+    return generateRaw(options);
+}
+
 export async function generateConversationReply(directive, settings, { responseLength = null, speakerName = getCurrentCharName(), trimNames = true, avatar = getCurrentCharAvatar(), threadAvatar = avatar, speakerAvatar = avatar, groupId = getConversationGroupIdForAvatar(threadAvatar) } = {}) {
     const messages = getConversationThread(threadAvatar, { groupId });
     const resolvedResponseLength = Number.isFinite(responseLength) && responseLength > 0
@@ -42,13 +108,13 @@ export async function generateConversationReply(directive, settings, { responseL
         : getConversationReplyMaxTokens(settings);
     const prompt = await buildConversationPromptMessages(messages, directive, speakerName);
 
-    return withConversationConnectionProfile(settings, () => generateRaw({
+    return generateConversationRaw({
         prompt,
         systemPrompt: buildConversationSystemPrompt(settings, speakerAvatar, { threadAvatar, groupId }),
         responseLength: resolvedResponseLength,
         trimNames,
         cacheScope: 'conversation-mode',
-    }));
+    }, settings);
 }
 
 export function editConversationMessage(messageId) {
@@ -257,13 +323,13 @@ export async function generateSelfieFromContext(context, settings, avatar = getC
 
     let imagePrompt = '';
     try {
-        imagePrompt = await withConversationConnectionProfile(settings, () => generateRaw({
+        imagePrompt = await generateConversationRaw({
             prompt: metaPrompt,
             systemPrompt: 'You output only a raw image generation prompt with no preamble.',
             responseLength: 200,
             trimNames: false,
             cacheScope: 'conversation-mode-selfie',
-        }));
+        }, settings);
     } catch (error) {
         console.warn('Conversation Mode: selfie prompt generation failed', error);
     }

--- a/public/scripts/sillybunny-conversation/interface.js
+++ b/public/scripts/sillybunny-conversation/interface.js
@@ -1,4 +1,3 @@
-import { generateRaw } from '../../script.js';
 import { openConversationWorkspaceForAvatar, setConversationInterfaceActive } from './chrome.js';
 import { CHROME_IDS, DEFAULT_BRANCH_ID, DEFAULT_SETTINGS, SETTINGS_FIELDS } from './constants.js';
 import {
@@ -12,7 +11,7 @@ import {
     parsePositiveInt,
     saveGroupConversationSettings,
 } from './context.js';
-import { normalizeConversationOutputText } from './generation.js';
+import { generateConversationRaw, normalizeConversationOutputText } from './generation.js';
 import { getConversationDisplayName, getConversationParticipants, getEffectiveConversationStatus, renderConversationParticipantStack } from './media.js';
 import {
     clearUnreadCount,
@@ -22,7 +21,7 @@ import {
     updateConversationNotificationIndicators,
 } from './notifications.js';
 import { getConversationRailItems } from './pals-rail.js';
-import { getAvailabilityCopy, withConversationConnectionProfile } from './personas.js';
+import { getAvailabilityCopy } from './personas.js';
 import { readChimingPartnersFromList, readWeeklyScheduleFromEditor, updateUserFooter } from './pickers.js';
 import { clamp, getConversationReplyMaxTokens, getCurrentActivityFromSchedule, getStoredSchedule } from './schedule.js';
 import { getSettings, saveSettings } from './settings-store.js';
@@ -532,12 +531,12 @@ export async function handleCharacterMessagePolish(messageId, buttonElement) {
         const systemPrompt = `You are an editor for ${charName}'s messages. Polish ${charName}'s reply in this instant messaging chatroom to make it more expressive, fitting for their personality, and natural. Correct any structural awkwardness while preserving the exact meaning, spelling quirks, and intent of the original text. Output only the polished reply without formatting prefixes or labels.`;
         const prompt = `Polish this message text:\n"${msg.mes}"`;
         const settings = getSettings(avatar, { groupId });
-        const response = await withConversationConnectionProfile(settings, () => generateRaw({
+        const response = await generateConversationRaw({
             prompt,
             systemPrompt,
             responseLength: 300,
             trimNames: true,
-        }));
+        }, settings);
 
         if (response?.trim()) {
             msg.mes = normalizeConversationOutputText(response.trim());

--- a/public/scripts/sillybunny-conversation/personas.js
+++ b/public/scripts/sillybunny-conversation/personas.js
@@ -3,8 +3,6 @@ import { event_types, eventSource } from '../events.js';
 import { extension_settings } from '../extensions.js';
 import { user_avatar } from '../personas.js';
 import { power_user } from '../power-user.js';
-import { executeSlashCommandsWithOptions } from '../slash-commands.js';
-import { getSelectedConnectionProfileName } from './chrome.js';
 import {
     AVAILABILITY_COPY,
     CHROME_IDS,
@@ -15,7 +13,6 @@ import {
 } from './constants.js';
 import { getConversationStore, getConversationThreadKey, getCurrentCharAvatar, persistConversationStore } from './context.js';
 import { updateUserFooter } from './pickers.js';
-import { conversationState } from './state.js';
 
 export function getAvailabilityCopy(status) {
     return AVAILABILITY_COPY[status] ?? AVAILABILITY_COPY.online;
@@ -157,49 +154,4 @@ export function setActiveConversationPersonaAppendixIds(avatarId, ids) {
 
     saveSettingsDebounced();
     void eventSource.emit(event_types.PERSONA_UPDATED, avatarId);
-}
-
-export async function applyConnectionProfileByName(profileName) {
-    if (!profileName) {
-        return;
-    }
-
-    try {
-        await executeSlashCommandsWithOptions(`/profile ${quoteSlashArg(profileName)}`, {});
-    } catch (error) {
-        console.warn('Conversation Mode: could not apply connection profile', profileName, error);
-    }
-}
-
-export function quoteSlashArg(value) {
-    return `"${String(value ?? '').replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\r?\n/g, '\\n')}"`;
-}
-
-export function queueConversationProfileSwitch(task) {
-    const run = conversationState.conversationProfileSwitchQueue.catch(() => {}).then(task);
-    conversationState.conversationProfileSwitchQueue = run.catch(() => {});
-    return run;
-}
-
-export async function withConversationConnectionProfile(settings, task) {
-    const profileName = String(settings?.connection_profile || '').trim();
-    if (!profileName) {
-        return task();
-    }
-
-    return queueConversationProfileSwitch(async () => {
-        const previousProfile = getSelectedConnectionProfileName();
-        const shouldSwitch = previousProfile !== profileName;
-        if (shouldSwitch) {
-            await applyConnectionProfileByName(profileName);
-        }
-
-        try {
-            return await task();
-        } finally {
-            if (shouldSwitch && previousProfile) {
-                await applyConnectionProfileByName(previousProfile);
-            }
-        }
-    });
 }

--- a/public/scripts/sillybunny-conversation/prompt.js
+++ b/public/scripts/sillybunny-conversation/prompt.js
@@ -1,4 +1,4 @@
-import { generateRaw, name1 } from '../../script.js';
+import { name1 } from '../../script.js';
 import { MEDIA_DISPLAY } from '../constants.js';
 import { user_avatar } from '../personas.js';
 import { power_user } from '../power-user.js';
@@ -19,13 +19,13 @@ import {
     getCurrentCharName,
     parsePositiveInt,
 } from './context.js';
+import { generateConversationRaw } from './generation.js';
 import { getCharacterAuthorNote, getCharacterForAvatar, getConversationParticipants, getParticipantNamesForDisplay } from './media.js';
 import {
     composeConversationPersonaDescription,
     getAvailabilityCopy,
     getUserPersonaStatus,
     getUserStatus,
-    withConversationConnectionProfile,
 } from './personas.js';
 import { getCurrentActivityFromSchedule, getStoredSchedule } from './schedule.js';
 import {
@@ -330,13 +330,13 @@ export async function updateConversationMemorySummary(avatar = getCurrentCharAva
             'Return the updated memory summary in concise bullets. No preamble.',
         ].filter(Boolean).join('\n\n');
         const settings = getSettings(avatar, { groupId });
-        const response = await withConversationConnectionProfile(settings, () => generateRaw({
+        const response = await generateConversationRaw({
             prompt,
             systemPrompt: 'You maintain a concise private DM memory summary for realistic ongoing chat continuity.',
             responseLength: MEMORY_SUMMARY_RESPONSE_TOKENS,
             trimNames: false,
             cacheScope: 'conversation-mode-memory',
-        }));
+        }, settings);
 
         if (response?.trim()) {
             saveConversationMemorySummary(avatar, response.trim(), messages.length, { groupId });

--- a/public/scripts/sillybunny-conversation/schedule.js
+++ b/public/scripts/sillybunny-conversation/schedule.js
@@ -1,4 +1,3 @@
-import { generateRaw } from '../../script.js';
 import {
     DEFAULT_CONVERSATION_REPLY_MAX_TOKENS,
     MAX_CONVERSATION_REPLY_MAX_TOKENS,
@@ -13,7 +12,7 @@ import {
     parsePositiveInt,
     persistConversationStore,
 } from './context.js';
-import { withConversationConnectionProfile } from './personas.js';
+import { generateConversationRaw } from './generation.js';
 import { formatPromptText } from './prompt.js';
 import { getSettings } from './settings-store.js';
 import { runtimeStatusOverrides } from './state.js';
@@ -102,13 +101,13 @@ export async function generateCharacterSchedule(character, { groupId = getConver
     promptParts.push('Generate the weekly schedule JSON now.');
 
     const settings = getSettings(character.avatar, { groupId });
-    const response = await withConversationConnectionProfile(settings, () => generateRaw({
+    const response = await generateConversationRaw({
         prompt: promptParts.join('\n\n'),
         systemPrompt,
         responseLength: SCHEDULE_GENERATION_RESPONSE_TOKENS,
         trimNames: false,
         cacheScope: 'conversation-mode-schedule',
-    }));
+    }, settings);
 
     return parseScheduleResponse(response);
 }

--- a/public/scripts/sillybunny-conversation/state.js
+++ b/public/scripts/sillybunny-conversation/state.js
@@ -8,7 +8,6 @@ export const conversationState = {
     conversationUploadActive: false,
     sendQueueProcessing: false,
     sendQueueNeedsProcessing: false,
-    conversationProfileSwitchQueue: Promise.resolve(),
     scheduleGenerationBusy: false,
     conversationWorkspaceOpen: false,
     conversationSelectedAvatar: null,

--- a/public/scripts/sillybunny-conversation/timeline-render.js
+++ b/public/scripts/sillybunny-conversation/timeline-render.js
@@ -1,7 +1,6 @@
 import {
     characters,
     default_user_avatar,
-    generateRaw,
     getThumbnailUrl,
     messageFormatting,
     name1,
@@ -24,11 +23,11 @@ import {
     getCurrentCharName,
     persistConversationStore,
 } from './context.js';
-import { generateSelfieFromContext, normalizeConversationOutputText, reportConversationGenerationError } from './generation.js';
+import { generateConversationRaw, generateSelfieFromContext, normalizeConversationOutputText, reportConversationGenerationError } from './generation.js';
 import { getCharacterForAvatar, getConversationParticipants, getEffectiveConversationStatus } from './media.js';
 import { getConversationMessageAvatar, getConversationMessageReceipt } from './pals-rail.js';
 import { escapeRegExp, getCharacterMentionHandles, parseAvatarList } from './partners.js';
-import { getConnectionProfiles, withConversationConnectionProfile } from './personas.js';
+import { getConnectionProfiles } from './personas.js';
 import { buildConversationPromptMessages, buildConversationSystemPrompt, renderConversationAttachments } from './prompt.js';
 import { registerConversationRenderer, schedulePalsRailRender, scheduleTimelineRender } from './render-scheduler.js';
 import { escapeHtmlAttribute, escapeHtmlText, getConversationMessageExtraFingerprint, hashConversationRenderFingerprint } from './render-utils.js';
@@ -734,7 +733,7 @@ export async function regenerateConversationMessage(messageId) {
     );
 
     try {
-        const response = await withConversationConnectionProfile(settings, () => generateRaw({
+        const response = await generateConversationRaw({
             prompt,
             systemPrompt: buildConversationSystemPrompt(settings, speakerAvatar, {
                 threadAvatar: context.avatar,
@@ -743,7 +742,7 @@ export async function regenerateConversationMessage(messageId) {
             responseLength: getConversationReplyMaxTokens(settings),
             trimNames: true,
             cacheScope: 'conversation-mode',
-        }));
+        }, settings);
 
         const text = normalizeConversationOutputText(response || '');
         if (!text) {

--- a/tests/conversation-mode-scoped-profile.test.js
+++ b/tests/conversation-mode-scoped-profile.test.js
@@ -1,0 +1,83 @@
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const conversationDir = path.join(repoRoot, 'public', 'scripts', 'sillybunny-conversation');
+const normalizeSource = source => source.replace(/\r\n/g, '\n');
+
+function readConversationSource(file) {
+    return normalizeSource(readFileSync(path.join(conversationDir, file), 'utf8'));
+}
+
+function getFunctionSource(source, name) {
+    const marker = `function ${name}(`;
+    const start = source.indexOf(marker);
+    expect(start).toBeGreaterThanOrEqual(0);
+
+    const bodyStart = source.indexOf('{', start);
+    let depth = 0;
+
+    for (let index = bodyStart; index < source.length; index++) {
+        const char = source[index];
+        if (char === '{') {
+            depth++;
+        } else if (char === '}') {
+            depth--;
+            if (depth === 0) {
+                return source.slice(start, index + 1);
+            }
+        }
+    }
+
+    throw new Error(`Unable to find function source for ${name}`);
+}
+
+const generationSource = readConversationSource('generation.js');
+const personasSource = readConversationSource('personas.js');
+const chromeSource = readConversationSource('chrome.js');
+const stateSource = readConversationSource('state.js');
+
+describe('conversation mode scoped connection profile', () => {
+    test('removes the global profile switch wrapper and slash-command helpers', () => {
+        expect(personasSource).not.toContain('withConversationConnectionProfile');
+        expect(personasSource).not.toContain('applyConnectionProfileByName');
+        expect(personasSource).not.toContain('queueConversationProfileSwitch');
+        expect(personasSource).not.toContain('quoteSlashArg');
+        // The old path ran the `/profile` slash command to flip the global profile.
+        expect(personasSource).not.toContain('getSelectedConnectionProfileName');
+        expect(personasSource).not.toContain('/profile ');
+    });
+
+    test('drops the now-unused selected-profile name reader and switch queue', () => {
+        expect(chromeSource).not.toContain('getSelectedConnectionProfileName');
+        expect(stateSource).not.toContain('conversationProfileSwitchQueue');
+    });
+
+    test('exposes a scoped generateConversationRaw helper that never switches the global profile', () => {
+        const helperSource = getFunctionSource(generationSource, 'generateConversationRaw');
+
+        // Resolves the configured profile by name and routes through the scoped
+        // ConnectionManagerRequestService instead of touching the global profile.
+        expect(helperSource).toContain('getConnectionProfiles');
+        expect(helperSource).toContain('ConnectionManagerRequestService');
+        expect(helperSource).toContain('CMRS.sendRequest');
+        expect(helperSource).toContain('extractData: true');
+        expect(helperSource).toContain('includePreset: true');
+        // It must not run the `/profile` slash command or mutate global state.
+        expect(helperSource).not.toContain('/profile ');
+        expect(helperSource).not.toContain('applyConnectionProfileByName');
+        // Falls back to generateRaw (the active profile) when scoped path is unavailable.
+        expect(helperSource).toContain('generateRaw(options)');
+    });
+
+    test('replaces every generation call site with the scoped helper', () => {
+        const consumers = ['generation.js', 'interface.js', 'prompt.js', 'schedule.js', 'timeline-render.js'];
+        for (const file of consumers) {
+            const source = readConversationSource(file);
+            expect(source).toContain('generateConversationRaw');
+            expect(source).not.toContain('withConversationConnectionProfile');
+        }
+    });
+});


### PR DESCRIPTION
## Summary

Conversation Mode flipped the global selected connection profile to the configured Conversation profile around every generation, then restored it afterwards. This made the visible profile dropdown switch back and forth on each generation (reply, selfie, memory summary, schedule, regenerate, prose polish).

## Fix

Replace `withConversationConnectionProfile` (which ran the `/profile` slash command, mutating global `extension_settings.connectionManager.selectedProfile` and the dropdown) with a new `generateConversationRaw` helper that issues a **scoped** request via `ConnectionManagerRequestService.sendRequest`. The global selectedProfile and dropdown are never touched. This mirrors the proven Pathfinder sidecar pattern (`sidecarGenerateWithProfile`).

```
// Before: global profile visibly switches and restores per generation
withConversationConnectionProfile(settings, () => generateRaw({...}))

// After: scoped request, global profile never changes
generateConversationRaw({...}, settings)
```

Behavior:
- Resolves the profile **name** (`settings.connection_profile`) to its **id** via `getConnectionProfiles()`.
- If a profile id resolves and `ConnectionManagerRequestService` is available: builds messages `[{system?}, ...prompt]` and calls `CMRS.sendRequest(id, messages, maxTokens, {extractData, includePreset, stream:false, signal})`, then extracts text.
- Falls back to `generateRaw(options)` (the active profile) when: no profile configured, profile name unresolvable, or CMRS unavailable/errors (non-abort). Abort errors are rethrown.
- Also fixes a latent bug: the old restore was skipped when the previous profile was `None` (empty name).

## Removed dead code

`withConversationConnectionProfile`, `applyConnectionProfileByName`, `queueConversationProfileSwitch`, `quoteSlashArg`, `getSelectedConnectionProfileName`, `conversationProfileSwitchQueue`, plus their now-unused imports.

## Call sites updated (6 direct)

- `generation.js` — `generateConversationReply`, `generateSelfieFromContext`
- `interface.js` — prose polisher
- `prompt.js` — memory summary
- `schedule.js` — weekly schedule generation
- `timeline-render.js` — regenerate reply

## Test

Adds `tests/conversation-mode-scoped-profile.test.js` (source-inspection style) asserting the global-switch path is gone and the scoped helper routes through `ConnectionManagerRequestService`.

## Notes

- `cacheScope` is not passed on the scoped CMRS path (matches the sidecar reference implementation); the fallback `generateRaw` path still carries it.
- `extractProfileResponseText` is reused from the existing `in-chat-agents/llm-utils.js` (same extractor the sidecar uses) to avoid duplication.

## Checklist

- [x] PR targets `staging`
- [x] Conventional Commit prefix (`fix:`)
- [x] KISS / self-contained change
- [x] No base SillyTavern files edited
- [x] `npm run lint` clean
- [x] New + existing conversation tests pass (pre-existing unrelated `in-chat-agents-runner` failures confirmed identical on unmodified `staging`)