### PR TITLE
chore: add missing MAX_AGENT_MAX_TOKENS export to agent-store test mocks

### DIFF
--- a/tests/in-chat-agents-pre-intercept-summary.test.js
+++ b/tests/in-chat-agents-pre-intercept-summary.test.js
@@ -73,6 +73,7 @@ beforeAll(async () => {
         AGENT_CATEGORIES: {},
         AGENT_SUBCATEGORIES: {},
         DEFAULT_AGENT_MAX_TOKENS: 8192,
+        MAX_AGENT_MAX_TOKENS: 64000,
         LEGACY_AGENT_MAX_TOKENS: 2048,
         areAgentsGloballyEnabled: jest.fn(() => true),
         getAgents: jest.fn(() => []),

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -300,6 +300,7 @@ describe('in-chat agent post-processing runner', () => {
 
         await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/agent-store.js', () => ({
             DEFAULT_AGENT_MAX_TOKENS: 8192,
+            MAX_AGENT_MAX_TOKENS: 64000,
             areAgentsGloballyEnabled: jest.fn(() => true),
             getAgentById: jest.fn(id => enabledAgents.find(agent => agent.id === id)),
             getCompanionConfig: jest.fn(agent => ({


### PR DESCRIPTION
## Summary

Fixes 18 pre-existing test failures across 2 suites caused by stale test mocks.

`agent-store.js` exports `MAX_AGENT_MAX_TOKENS` (64000), which `index.js` and `companion-runner.js` import. The mocks in two test files omitted this export, so importing those modules threw:

```
SyntaxError: The requested module "./agent-store.js" does not provide an export named "MAX_AGENT_MAX_TOKENS"
```

## Changes

Added `MAX_AGENT_MAX_TOKENS: 64000,` to the `jest.unstable_mockModule` factory in:
- `tests/in-chat-agents-runner.test.js` (15 tests fixed)
- `tests/in-chat-agents-pre-intercept-summary.test.js` (3 tests fixed)

## Verification

- `npm run test:unit --prefix tests` for these 2 suites: **83 passed, 83 total** (was 18 failed)
- `npm run lint --prefix tests`: clean

No source changes — test maintenance only. Part of a cleanup split across two PRs (this is the mock-export fix; the other syncs stale expectations).