### PR TITLE
chore: sync stale test expectations to current source

### DIFF
--- a/tests/in-chat-agents-store.test.js
+++ b/tests/in-chat-agents-store.test.js
@@ -303,7 +303,7 @@ describe('in-chat agent scoped enabled state', () => {
             wrapSuffix: 'suffix',
             patchStartTag: '<context_patch>',
             patchEndTag: '<done>',
-            maxTokens: 16000,
+            maxTokens: 64000,
         }));
 
         store.loadAgents([{
@@ -353,7 +353,7 @@ describe('in-chat agent scoped enabled state', () => {
             },
             batch: false,
             batchAgentIds: [],
-            maxTokens: 32000,
+            maxTokens: 64000,
         });
         expect(store.isCompanionAgent(agent)).toBe(false);
     });
@@ -394,7 +394,7 @@ describe('in-chat agent scoped enabled state', () => {
             },
             batch: true,
             batchAgentIds: ['continuity-companion', 'director-commentary'],
-            maxTokens: 32000,
+            maxTokens: 64000,
         }));
 
         expect(store.normalizeCompanionConfig({

--- a/tests/in-chat-agents-templates.test.js
+++ b/tests/in-chat-agents-templates.test.js
@@ -142,7 +142,7 @@ describe('in-chat agent bundled templates', () => {
             rawPrompt: true,
             inlinePhase: 'pre',
             feedback: { enabled: true, depth: 1 },
-            maxTokens: 32000,
+            maxTokens: 64000,
         }));
         expect(template.conditions.generationTypes).toEqual(['normal', 'continue', 'impersonate']);
     });
@@ -200,7 +200,7 @@ describe('in-chat agent bundled templates', () => {
             format: 'markdown',
             feedback: { enabled: true, depth: 2 },
             batch: false,
-            maxTokens: 32000,
+            maxTokens: 64000,
         }));
         expect(relationship.companion).toEqual(expect.objectContaining({
             trigger: 'manual',
@@ -247,7 +247,7 @@ describe('in-chat agent bundled templates', () => {
             contextMessages: 30,
             includeHistory: true,
             feedback: { enabled: true, depth: 1 },
-            maxTokens: 32000,
+            maxTokens: 64000,
         }));
         expect(chatroom.companion).toEqual(expect.objectContaining({
             trigger: 'auto',
@@ -258,7 +258,7 @@ describe('in-chat agent bundled templates', () => {
             includeHistory: true,
             historyDepth: 1,
             feedback: { enabled: false, depth: 1 },
-            maxTokens: 32000,
+            maxTokens: 64000,
         }));
         expect(chatroom.regexScripts).toHaveLength(6);
         expect(chatroom.prompt).toContain('chatroom-style|active-style');
@@ -288,7 +288,7 @@ describe('in-chat agent bundled templates', () => {
             includeHistory: true,
             historyDepth: 6,
             feedback: { enabled: false, depth: 1 },
-            maxTokens: 32000,
+            maxTokens: 64000,
         }));
         expect(chatOnly.prompt).toContain('private side-channel conversation');
         expect(chatOnly.prompt).toContain('[Your previous notes]');
@@ -317,7 +317,7 @@ describe('in-chat agent bundled templates', () => {
             includeAuthorsNote: true,
             includeHistory: false,
             feedback: { enabled: false, depth: 1 },
-            maxTokens: 32000,
+            maxTokens: 64000,
         }));
         expect(messageInbox.regexScripts).toHaveLength(6);
         expect(messageInbox.prompt).toContain('phone-none');
@@ -345,7 +345,7 @@ describe('in-chat agent bundled templates', () => {
             includeHistory: true,
             historyDepth: 1,
             feedback: { enabled: true, depth: 1 },
-            maxTokens: 32000,
+            maxTokens: 64000,
         }));
         expect(plotCompass.prompt).toContain('[Plot Compass Objective]');
         expect(plotCompass.prompt).not.toContain('first line of [Your previous notes]');
@@ -360,7 +360,7 @@ describe('in-chat agent bundled templates', () => {
         expect(saved.category).toBe('companion');
         expect(saved.execution).toBe('companion');
         expect(isCompanionAgent(saved)).toBe(true);
-        expect(saved.companion.maxTokens).toBe(32000);
+        expect(saved.companion.maxTokens).toBe(64000);
     });
 
     test('renders orphan greentext continuation lines inside the Chatroom interface', () => {

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -202,7 +202,7 @@ describe('mobile shell lifecycle wiring', () => {
         expect(tabsSource).toContain('function syncShellViewportBounds(');
         expect(tabsSource).toContain('function syncMobileShellDrawerBounds(');
         expect(tabsSource).toContain('function queueMobileShellDrawerBoundsSync(');
-        expect(tabsSource).toContain('root.style.setProperty(\'--sb-shell-available-height\'');
+        expect(tabsSource).toContain('setRootViewportProperty(\'--sb-shell-available-height\'');
         expect(tabsSource).toContain('function applyMobileDrawerBoundsDecision(');
         expect(tabsSource).toContain('window.visualViewport');
         expect(tabsSource).toContain('function getShellViewportTop(');
@@ -218,10 +218,10 @@ describe('mobile shell lifecycle wiring', () => {
         expect(closeShellSource).toContain('syncMobileShellDrawerBounds();');
         expect(closeShellSource).toContain('queueMobileShellDrawerBoundsSync();');
         expect(syncMobileViewportStateSource).toContain('syncMobileShellDrawerBounds();');
-        expect(tabsSource).toContain('window.visualViewport?.addEventListener(\'resize\', syncMobileViewportState, { passive: true });');
-        expect(tabsSource).toContain('window.visualViewport?.addEventListener(\'scroll\', syncMobileViewportState, { passive: true });');
+        expect(tabsSource).toContain('window.visualViewport?.addEventListener(\'resize\', queueMobileViewportStateSync, { passive: true });');
+        expect(tabsSource).toContain('window.addEventListener(\'resize\', queueMobileViewportStateSync, { passive: true });');
         expect(tabsSource).toContain('window.visualViewport?.addEventListener(\'resize\', syncDesktopShellSizing, { passive: true });');
-        expect(tabsSource).toContain('window.visualViewport?.addEventListener(\'scroll\', syncDesktopShellSizing, { passive: true });');
+        expect(tabsSource).toContain('window.addEventListener(\'orientationchange\', queueMobileViewportStateSync);');
         expect(mobileShellCssSource).toMatch(/#left-nav-panel\.openDrawer,[\s\S]*#right-nav-panel\.openDrawer\s*\{[\s\S]*top:\s*calc\(var\(--sb-shell-measured-top-offset,[\s\S]*bottom:\s*auto\s*!important;[\s\S]*box-sizing:\s*border-box\s*!important;[\s\S]*height:\s*calc\(var\(--sb-shell-available-height/);
         expect(mobileShellCssSource.lastIndexOf('bottom: auto !important;')).toBeGreaterThan(
             mobileShellCssSource.lastIndexOf('bottom: env(safe-area-inset-bottom, 0px) !important;'),
@@ -238,7 +238,7 @@ describe('mobile shell lifecycle wiring', () => {
         expect(syncMobileViewportStateSource).toContain('[viewportSyncStep.SCHEDULE_TOPBAR_CONTEXT_REFRESH]: () => scheduleTopbarContextRefresh(0),');
         expect(queueMobileShellDrawerBoundsSyncSource).toContain('sbMobileShellLifecycle.viewportSync.resolveDrawerBoundsSchedule({');
         expect(queueMobileShellDrawerBoundsSyncSource).toContain('followupDelayMs: SB_MOBILE_VIEWPORT_RESET_FOLLOWUP_MS,');
-        expect(queueMobileShellDrawerBoundsSyncSource).toContain('window.setTimeout(sync, schedule.followupDelayMs);');
+        expect(queueMobileShellDrawerBoundsSyncSource).toContain('sbMobileShellDrawerBoundsFollowupId = window.setTimeout(() => {');
         expect(syncMobileViewportStateSource).not.toContain('if (!isMobileViewport()) {');
         expect(queueMobileShellDrawerBoundsSyncSource).not.toContain('if (!isMobileViewport()) {');
         expect(queueMobileShellDrawerBoundsSyncSource).not.toContain('if (typeof window.requestAnimationFrame === \'function\') {');

--- a/tests/sillybunny-conversation-settings-keys.test.js
+++ b/tests/sillybunny-conversation-settings-keys.test.js
@@ -11,6 +11,9 @@ import {
 describe('sillybunny conversation settings keys', () => {
     test('scopes custom instructions and connection profile globally', () => {
         expect(GLOBAL_CONVERSATION_SETTINGS_KEYS).toEqual([
+            'idle_action',
+            'idle_followup',
+            'idle_spontaneous',
             'custom_instructions',
             'connection_profile',
         ]);


### PR DESCRIPTION
## Summary

Test-only PR. Syncs expectations that drifted from prior source evolution (no source changes). Resolves 8 failing tests across 4 suites. Complements #507 (which fixes the other 18 via mock-export fixes); together they clear the full 26-failure pre-existing baseline.

## Changes

**`sillybunny-conversation-settings-keys.test.js`** — `GLOBAL_CONVERSATION_SETTINGS_KEYS` now includes `idle_action`/`idle_followup`/`idle_spontaneous` alongside `custom_instructions`/`connection_profile`.

**`mobile-shell-lifecycle-wiring.test.js`** — viewport property writes moved into a `setRootViewportProperty` helper; drawer bounds sync now uses a followup closure (`sbMobileShellDrawerBoundsFollowupId`); mobile viewport listeners switched from direct `syncMobileViewportState` to debounced `queueMobileViewportStateSync` on resize/orientationchange (visualViewport scroll listeners removed).

**`in-chat-agents-templates.test.js`** — companion template `maxTokens` raised `32000`->`64000` across npc-motivator, continuity, memory-shard, chatroom, chat-only, message-inbox, and the normalized saved-agent assertion (all companion JSONs are now 64000).

**`in-chat-agents-store.test.js`** — `createDefaultAgent`/`normalizeCompanionConfig` and preProcess `maxTokens` clamp ceiling raised to `MAX_AGENT_MAX_TOKENS` (64000).

## Verification

- 4 affected suites: 69 passed, 0 failed
- Full suite: 18 remaining failures are exactly #507 scope (mock-export fix) — disjoint from this PR
- `npm run lint` clean (no source files changed)
- Tests lint: 0 errors

## Notes

- Test-only change; no source/behavior changes.
- Disjoint file set from #507; both branch from latest `staging` and can merge independently.