### PR TITLE
fix: coalesce consecutive user messages in conversation mode

### DIFF
--- a/public/scripts/sillybunny-conversation/attachments.js
+++ b/public/scripts/sillybunny-conversation/attachments.js
@@ -36,6 +36,7 @@ import {
 import { handleConversationSlashAction } from './timeline-slash-commands.js';
 import { getConversationActivityContext, maybePostDelayedReplyNotice, splitChatroomMessages, withTypingParticipant } from './typing.js';
 import { appendConversationMessage } from './message-writer.js';
+import { coalesceConversationQueueItems } from './send-queue-utils.js';
 
 export { appendConversationMessage };
 
@@ -520,45 +521,10 @@ export async function processQueuedConversationReply(queueItem) {
     }
 }
 
-function isSameConversationQueueThread(left, right) {
-    return Boolean(
-        left
-        && right
-        && !left.force
-        && !right.force
-        && left.avatar === right.avatar
-        && String(left.groupId || '') === String(right.groupId || ''),
-    );
-}
-
-function mergeConversationQueueItems(items) {
-    if (items.length <= 1) {
-        return items[0] || null;
-    }
-
-    const first = items[0];
-    return {
-        ...first,
-        text: items.map(item => item.text).filter(Boolean).join('\n\n'),
-        attachmentContext: items.map(item => item.attachmentContext).filter(Boolean).join('\n\n'),
-        createdAt: first.createdAt,
-        latestQueuedAt: items[items.length - 1]?.createdAt || first.createdAt,
-        messageCount: items.length,
-    };
-}
-
 async function collectConversationQueueItem(firstItem) {
-    if (!firstItem || firstItem.force || SEND_QUEUE_COALESCE_MS <= 0) {
-        return firstItem || null;
-    }
-
-    await new Promise(resolve => setTimeout(resolve, SEND_QUEUE_COALESCE_MS));
-    const items = [firstItem];
-    while (sendQueue.length && isSameConversationQueueThread(firstItem, sendQueue[0])) {
-        items.push(sendQueue.shift());
-    }
-
-    return mergeConversationQueueItems(items);
+    return coalesceConversationQueueItems(firstItem, sendQueue, {
+        windowMs: SEND_QUEUE_COALESCE_MS,
+    });
 }
 
 export async function processSendQueue() {

--- a/public/scripts/sillybunny-conversation/constants.js
+++ b/public/scripts/sillybunny-conversation/constants.js
@@ -88,7 +88,10 @@ export const DEFAULT_MAX_FOLLOWUPS = 3;
 export const DEFAULT_REPLY_DELAY_MULTIPLIER = 100;
 export const DEFAULT_AUTO_CHAT_COOLDOWN = 10;
 export const SEND_QUEUE_BATCH_MS = 900;
-export const SEND_QUEUE_COALESCE_MS = 600;
+// SillyBunny: idle window (ms) waited after the last same-thread user send before a
+// conversation reply starts generating. Previously 600ms, which was too short for a
+// human to send a follow-up message, so consecutive user messages were never merged.
+export const SEND_QUEUE_COALESCE_MS = 1500;
 export const MIN_CONVERSATION_REPLY_MAX_TOKENS = 64;
 export const DEFAULT_CONVERSATION_REPLY_MAX_TOKENS = 16000;
 export const MAX_CONVERSATION_REPLY_MAX_TOKENS = 64000;

--- a/public/scripts/sillybunny-conversation/send-queue-utils.js
+++ b/public/scripts/sillybunny-conversation/send-queue-utils.js
@@ -1,0 +1,115 @@
+/**
+ * SillyBunny: pure, dependency-free helpers for the conversation-mode send queue.
+ * Extracted from attachments.js so the coalescing/merging logic can be unit-tested
+ * without the heavy DOM + jQuery imports that attachments.js pulls in.
+ *
+ * See CONTRIBUTING.md "Best Code Practices" — fork-specific helpers live in their
+ * own self-contained files where possible.
+ */
+
+/**
+ * Two queue items belong to the same conversation thread when they target the same
+ * avatar + group and neither is a forced (non-coalescable) item.
+ */
+export function isSameConversationQueueThread(left, right) {
+    return Boolean(
+        left
+        && right
+        && !left.force
+        && !right.force
+        && left.avatar === right.avatar
+        && String(left.groupId || '') === String(right.groupId || ''),
+    );
+}
+
+/**
+ * Merge multiple same-thread queue items into a single item. User texts and
+ * attachment contexts are joined with a blank line. The earliest `createdAt` is
+ * preserved, the latest is recorded in `latestQueuedAt`, and `messageCount` reflects
+ * how many sends were grouped.
+ */
+export function mergeConversationQueueItems(items) {
+    if (items.length <= 1) {
+        return items[0] || null;
+    }
+
+    const first = items[0];
+    return {
+        ...first,
+        text: items.map(item => item.text).filter(Boolean).join('\n\n'),
+        attachmentContext: items.map(item => item.attachmentContext).filter(Boolean).join('\n\n'),
+        createdAt: first.createdAt,
+        latestQueuedAt: items[items.length - 1]?.createdAt || first.createdAt,
+        messageCount: items.length,
+    };
+}
+
+/**
+ * Shift every consecutive same-thread item off the front of `queue` (mutating it),
+ * starting with `firstItem`. Stops at the first item that belongs to a different
+ * thread. Returns the collected items.
+ */
+export function drainSameThreadItems(firstItem, queue) {
+    const items = [firstItem];
+    while (queue.length && isSameConversationQueueThread(firstItem, queue[0])) {
+        items.push(queue.shift());
+    }
+    return items;
+}
+
+/**
+ * SillyBunny: debounce-from-last-arrival coalescing for the conversation send queue.
+ *
+ * Before this fix the window was a single 600ms `setTimeout` measured from when an
+ * item was *shifted off* the queue. That left two gaps: (1) 600ms is too short for a
+ * human to type a follow-up, and (2) the window only opened in the narrow gap before
+ * a generation started, so messages typed *while the character was replying* were
+ * never merged — each got its own sequential generation ("delay not firing off").
+ *
+ * The new behaviour: wait the coalesce window, then drain same-thread items from
+ * `queue`. If a new item arrived during the wait, restart the window so a rapid
+ * burst of messages keeps extending it until the user goes quiet for the full window.
+ * This also merges messages that piled up during the previous generation, because
+ * they are already sitting in `queue` when the next coalesce starts.
+ *
+ * On `force` items or when the window is disabled (`windowMs <= 0`) we skip waiting.
+ *
+ * @param {object} firstItem - The item already shifted off the front of the queue.
+ * @param {Array} queue - The live queue array (mutated as items are drained).
+ * @param {object} [options]
+ * @param {number} [options.windowMs=1500] - Idle window per round.
+ * @param {function} [options.timeoutRef=setTimeout] - Injectable timer (for tests).
+ * @returns {Promise<object|null>} The (possibly merged) queue item, or null.
+ */
+export async function coalesceConversationQueueItems(firstItem, queue, options = {}) {
+    if (!firstItem || firstItem.force) {
+        return firstItem || null;
+    }
+
+    const timeout = typeof options.timeoutRef === 'function' ? options.timeoutRef : setTimeout;
+    const windowMs = typeof options.windowMs === 'number' ? options.windowMs : 1500;
+
+    if (windowMs <= 0) {
+        return firstItem;
+    }
+
+    let items = [firstItem];
+
+    // Wait the idle window. Restart it whenever new same-thread messages land during
+    // the wait, so a burst of user messages stays grouped until the user goes quiet
+    // for the full window.
+    while (true) {
+        await new Promise(resolve => timeout(resolve, windowMs));
+
+        const beforeLength = items.length;
+        while (queue.length && isSameConversationQueueThread(firstItem, queue[0])) {
+            items.push(queue.shift());
+        }
+
+        if (items.length === beforeLength) {
+            break; // nothing new arrived; stop extending
+        }
+    }
+
+    return mergeConversationQueueItems(items);
+}

--- a/tests/sillybunny-conversation-send-queue.test.js
+++ b/tests/sillybunny-conversation-send-queue.test.js
@@ -1,0 +1,214 @@
+import { describe, expect, test, jest, beforeEach, afterEach } from '@jest/globals';
+
+import {
+    coalesceConversationQueueItems,
+    drainSameThreadItems,
+    isSameConversationQueueThread,
+    mergeConversationQueueItems,
+} from '../public/scripts/sillybunny-conversation/send-queue-utils.js';
+
+function makeItem(text, overrides = {}) {
+    return {
+        avatar: 'charA.png',
+        groupId: '',
+        text,
+        attachmentContext: '',
+        createdAt: Date.now(),
+        ...overrides,
+    };
+}
+
+describe('sillybunny conversation send-queue utils', () => {
+    describe('isSameConversationQueueThread', () => {
+        test('matches same avatar and group', () => {
+            const a = makeItem('hi');
+            const b = makeItem('yo');
+            expect(isSameConversationQueueThread(a, b)).toBe(true);
+        });
+
+        test('differs on avatar', () => {
+            expect(isSameConversationQueueThread(makeItem('a'), makeItem('b', { avatar: 'charB.png' }))).toBe(false);
+        });
+
+        test('differs on groupId', () => {
+            expect(isSameConversationQueueThread(makeItem('a', { groupId: 'g1' }), makeItem('b', { groupId: 'g2' }))).toBe(false);
+        });
+
+        test('differs when either is forced', () => {
+            expect(isSameConversationQueueThread(makeItem('a', { force: true }), makeItem('b'))).toBe(false);
+            expect(isSameConversationQueueThread(makeItem('a'), makeItem('b', { force: true }))).toBe(false);
+        });
+
+        test('handles null inputs', () => {
+            expect(isSameConversationQueueThread(null, makeItem('a'))).toBe(false);
+            expect(isSameConversationQueueThread(makeItem('a'), null)).toBe(false);
+        });
+    });
+
+    describe('mergeConversationQueueItems', () => {
+        test('returns the single item as-is for a one-element array', () => {
+            const item = makeItem('only');
+            expect(mergeConversationQueueItems([item])).toBe(item);
+        });
+
+        test('returns null for an empty array', () => {
+            expect(mergeConversationQueueItems([])).toBe(null);
+        });
+
+        test('joins texts and attachment contexts with a blank line', () => {
+            const merged = mergeConversationQueueItems([
+                makeItem('one', { attachmentContext: 'att1' }),
+                makeItem('two', { attachmentContext: 'att2' }),
+                makeItem('three', { attachmentContext: '' }),
+            ]);
+            expect(merged.text).toBe('one\n\ntwo\n\nthree');
+            expect(merged.attachmentContext).toBe('att1\n\natt2');
+            expect(merged.messageCount).toBe(3);
+        });
+
+        test('preserves earliest createdAt and records latest as latestQueuedAt', () => {
+            const merged = mergeConversationQueueItems([
+                makeItem('one', { createdAt: 1000 }),
+                makeItem('two', { createdAt: 3000 }),
+                makeItem('three', { createdAt: 2000 }),
+            ]);
+            expect(merged.createdAt).toBe(1000);
+            expect(merged.latestQueuedAt).toBe(2000);
+        });
+    });
+
+    describe('drainSameThreadItems', () => {
+        test('shifts consecutive same-thread items off the queue front', () => {
+            const queue = [makeItem('b'), makeItem('c')];
+            const items = drainSameThreadItems(makeItem('a'), queue);
+            expect(items.map(i => i.text)).toEqual(['a', 'b', 'c']);
+            expect(queue).toHaveLength(0);
+        });
+
+        test('stops at a different-thread item, leaving it in the queue', () => {
+            const queue = [makeItem('b'), makeItem('c', { avatar: 'charB.png' }), makeItem('d')];
+            const items = drainSameThreadItems(makeItem('a'), queue);
+            expect(items.map(i => i.text)).toEqual(['a', 'b']);
+            expect(queue.map(i => i.text)).toEqual(['c', 'd']);
+        });
+    });
+
+    describe('coalesceConversationQueueItems', () => {
+        test('returns null for falsy first item', async () => {
+            const result = await coalesceConversationQueueItems(null, [], { timeoutRef: () => 0 });
+            expect(result).toBe(null);
+        });
+
+        test('returns force items immediately without waiting', async () => {
+            let waited = false;
+            const timeoutRef = () => { waited = true; return 0; };
+            const item = makeItem('forced', { force: true });
+            const result = await coalesceConversationQueueItems(item, [], { timeoutRef });
+            expect(result).toBe(item);
+            expect(waited).toBe(false);
+        });
+
+        test('skips waiting when windowMs <= 0', async () => {
+            let waited = false;
+            const timeoutRef = () => { waited = true; return 0; };
+            const item = makeItem('a');
+            const result = await coalesceConversationQueueItems(item, [], { windowMs: 0, timeoutRef });
+            expect(result).toBe(item);
+            expect(waited).toBe(false);
+        });
+
+        test('returns a single item when no follow-ups arrive within the window', async () => {
+            const timeoutRef = (resolve) => { setTimeout(resolve, 0); return 0; };
+            const result = await coalesceConversationQueueItems(makeItem('only'), [], { timeoutRef });
+            expect(result.text).toBe('only');
+            expect(result.messageCount).toBeUndefined();
+        });
+
+        test('merges follow-up messages that are already queued (accumulated during generation)', async () => {
+            const timeoutRef = (resolve) => { setTimeout(resolve, 0); return 0; };
+            const queue = [makeItem('second'), makeItem('third')];
+            const result = await coalesceConversationQueueItems(makeItem('first'), queue, { timeoutRef });
+            expect(result.text).toBe('first\n\nsecond\n\nthird');
+            expect(result.messageCount).toBe(3);
+            expect(queue).toHaveLength(0);
+        });
+
+        test('does not merge items from a different thread', async () => {
+            const timeoutRef = (resolve) => { setTimeout(resolve, 0); return 0; };
+            const queue = [makeItem('other', { avatar: 'charB.png' })];
+            const result = await coalesceConversationQueueItems(makeItem('first'), queue, { timeoutRef });
+            expect(result.text).toBe('first');
+            expect(queue).toHaveLength(1);
+        });
+
+        test('extends the window when a new message arrives mid-wait', async () => {
+            let rounds = 0;
+            const timeoutRef = (resolve) => {
+                rounds++;
+                setTimeout(resolve, 0);
+                return 0;
+            };
+
+            const queue = [];
+            const firstItem = makeItem('first');
+            const promise = coalesceConversationQueueItems(firstItem, queue, { windowMs: 1500, timeoutRef });
+
+            queue.push(makeItem('second'));
+            const result = await promise;
+
+            expect(result.text).toBe('first\n\nsecond');
+            expect(result.messageCount).toBe(2);
+            expect(rounds).toBeGreaterThanOrEqual(2);
+        });
+    });
+
+    describe('coalesceConversationQueueItems with fake timers', () => {
+        beforeEach(() => jest.useFakeTimers());
+        afterEach(() => {
+            jest.runOnlyPendingTimers();
+            jest.useRealTimers();
+        });
+
+        test('waits the full window when no follow-ups arrive', async () => {
+            const queue = [];
+            const promise = coalesceConversationQueueItems(makeItem('only'), queue, { windowMs: 1500 });
+            await jest.advanceTimersByTimeAsync(1500);
+            const result = await promise;
+            expect(result.text).toBe('only');
+            expect(queue).toHaveLength(0);
+        });
+
+        test('coalesces a message that arrives during the window and extends it', async () => {
+            const queue = [];
+            const promise = coalesceConversationQueueItems(makeItem('first'), queue, { windowMs: 1500 });
+
+            await jest.advanceTimersByTimeAsync(500);
+            queue.push(makeItem('second'));
+
+            await jest.advanceTimersByTimeAsync(1000);
+            await jest.advanceTimersByTimeAsync(1500);
+
+            const result = await promise;
+            expect(result.text).toBe('first\n\nsecond');
+            expect(result.messageCount).toBe(2);
+        });
+
+        test('coalesces a burst of messages arriving during successive windows', async () => {
+            const queue = [];
+            const promise = coalesceConversationQueueItems(makeItem('msg1'), queue, { windowMs: 1500 });
+
+            await jest.advanceTimersByTimeAsync(300);
+            queue.push(makeItem('msg2'));
+
+            await jest.advanceTimersByTimeAsync(1500);
+            queue.push(makeItem('msg3'));
+
+            await jest.advanceTimersByTimeAsync(1500);
+            await jest.advanceTimersByTimeAsync(1500);
+
+            const result = await promise;
+            expect(result.text).toBe('msg1\n\nmsg2\n\nmsg3');
+            expect(result.messageCount).toBe(3);
+        });
+    });
+});


### PR DESCRIPTION
## Problem

In Conversation Mode, the delay that checks for multiple consecutive user messages either wasn't long enough or wasn't firing off, so rapid follow-up messages each triggered their own character generation instead of being batched into one reply.

## Root cause

The only mechanism merging consecutive user messages was `collectConversationQueueItem` in `attachments.js`, which waited a fixed **600ms** (`SEND_QUEUE_COALESCE_MS`) measured from when an item was *shifted off the queue*. Two compounding defects:

1. **Window too short (600ms)** — a human can't compose and send a second message within 600ms, so the window almost always closed empty.
2. **Didn't fire during generation** — the window only opened in the narrow gap between shifting an item and starting its generation. Once the LLM call began (several seconds), messages typed *while the character was replying* piled up in `sendQueue`. The re-entrant `processSendQueue` guard meant these were processed one-by-one as separate generations rather than being merged.

There were no tests covering this path and no existing notes acknowledging the limitation.

## Fix

Replace the single fixed-delay coalesce with a **debounce-from-last-arrival loop**:
- Wait the idle window, then drain all same-thread items from the queue front.
- If new items arrived during the wait, **restart the window** so a burst of messages stays grouped until the user goes quiet for the full window.
- Messages that accumulated during the previous generation are naturally merged, since they sit in the queue when the next coalesce starts.

Bump `SEND_QUEUE_COALESCE_MS` **600 → 1500** so a quick follow-up can land before the reply starts.

## Changes

- `public/scripts/sillybunny-conversation/send-queue-utils.js` (new) — pure, dependency-free coalesce/merge/drain helpers (follows existing `-utils.js` pattern so the logic is unit-testable without the heavy DOM/jQuery imports in `attachments.js`).
- `public/scripts/sillybunny-conversation/attachments.js` — `collectConversationQueueItem` now delegates to `coalesceConversationQueueItems`; removed the now-duplicated inline helpers.
- `public/scripts/sillybunny-conversation/constants.js` — `SEND_QUEUE_COALESCE_MS = 1500`.
- `tests/sillybunny-conversation-send-queue.test.js` (new) — 21 tests covering single-message, coalesced follow-ups, burst messages across successive windows, messages accumulated during generation, cross-thread isolation, force items, and disabled-window edge cases.

## Verification

- `npm run lint` — clean (eslint 8.57)
- `npm run test:unit --prefix tests` — **1259 tests pass** (135 suites), including 21 new + 25 existing conversation tests
- Maintains Bun + Node.js compatibility (no runtime-specific APIs)

- [x] Allow edits from maintainers
- [x] Targets `staging`
- [x] Conventional Commits title (`fix:`)