### PR TITLE
fix: navigate to exact setting from universal search

### DIFF
--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -12786,9 +12786,60 @@ function expandHiddenAccordions(target) {
     }
 }
 
+const SB_SEARCH_HIGHLIGHT_CLASS = 'highlighted-drawer';
+const SB_SEARCH_HIGHLIGHT_DURATION_MS = 1800;
+
 function pulseSearchTarget(target) {
     if (!(target instanceof HTMLElement)) {
         return;
+    }
+
+    const drawer = target.closest('.inline-drawer');
+    const highlightTarget = drawer instanceof HTMLElement ? drawer : target;
+
+    document.querySelectorAll('.' + SB_SEARCH_HIGHLIGHT_CLASS)
+        .forEach(el => el.classList.remove(SB_SEARCH_HIGHLIGHT_CLASS));
+
+    highlightTarget.classList.add(SB_SEARCH_HIGHLIGHT_CLASS);
+    window.setTimeout(() => {
+        highlightTarget.classList.remove(SB_SEARCH_HIGHLIGHT_CLASS);
+    }, SB_SEARCH_HIGHLIGHT_DURATION_MS);
+}
+
+function revealSettingsCategoryFor(target) {
+    if (!(target instanceof HTMLElement)) {
+        return;
+    }
+
+    const settingsContent = document.getElementById('user-settings-block-content');
+    if (!settingsContent || !settingsContent.contains(target)) {
+        return;
+    }
+
+    const taggedDrawer = target.closest('.inline-drawer[data-settings-tab]');
+    if (taggedDrawer instanceof HTMLElement) {
+        const category = taggedDrawer.getAttribute('data-settings-tab');
+        if (category) {
+            settingsContent.setAttribute('data-active-tab', category);
+            const settingsBlock = document.getElementById('user-settings-block');
+            if (settingsBlock) {
+                settingsBlock.setAttribute('data-active-tab', category);
+            }
+            document.querySelectorAll('.sb-settings-tab-btn').forEach(btn => {
+                btn.classList.toggle('active', btn.getAttribute('data-tab') === category);
+            });
+            return;
+        }
+    }
+
+    settingsContent.setAttribute('data-search-active', 'true');
+    const tabNav = document.getElementById('sb-settings-tabs');
+    if (tabNav) {
+        const clearSearchActive = () => {
+            settingsContent.removeAttribute('data-search-active');
+            tabNav.removeEventListener('click', clearSearchActive);
+        };
+        tabNav.addEventListener('click', clearSearchActive);
     }
 }
 
@@ -12821,6 +12872,7 @@ function revealSearchMatch(shellKey, match) {
     openShell(shellKey, match.tabId);
 
     window.setTimeout(() => {
+        revealSettingsCategoryFor(match.element);
         expandHiddenAccordions(match.element);
         match.element.scrollIntoView({
             block: 'center',


### PR DESCRIPTION
## Problem

After the categorized settings tabs redesign (#486), clicking a search result in the universal search only opened the Settings page instead of navigating to the **exact** setting.

## Root cause

The redesign splits the Settings page into 4 inner category tabs (`appearance`, `chat-writing`, `system-device`, `cache-account`). CSS in \`sillybunny-settings-tabs.js\` hides any \`.inline-drawer\` whose category doesn't match the active tab (default \`appearance\`) via \`display: none !important\` — unless \`data-search-active="true"\` is set.

\`revealSearchMatch()\` in \`sillybunny-tabs.js\` opened the Settings shell but never switched the inner category tab, so the matched element's ancestor drawer stayed hidden and \`scrollIntoView()\` was a no-op. Additionally \`pulseSearchTarget()\` was an empty stub, so nothing was highlighted even when visible. The only code that set \`data-search-active\` was wired to the now-hidden legacy \`#settingsSearch\` box.

## Fix

All changes are in \`public/scripts/sillybunny-tabs.js\`:

- **\`revealSettingsCategoryFor()\`** — switches the inner settings category tab to the matched element's \`data-settings-tab\` before scrolling: sets \`data-active-tab\` on both \`#user-settings-block-content\` and \`#user-settings-block\`, and syncs the \`.active\` class on \`.sb-settings-tab-btn\`. Falls back to revealing all categories (\`data-search-active="true"\`, self-clearing on next tab click) for any unmapped setting.
- **\`pulseSearchTarget()\`** — implements the previously-empty stub to flash the existing \`.highlighted-drawer\` class (CSS already defined in \`sillybunny-settings-tabs.js\`) on the target drawer for ~1.8s, clearing any prior pulse first.
- **\`revealSearchMatch()\`** — calls \`revealSettingsCategoryFor()\` before expanding accordions and scrolling, so the target is visible and reachable.

Result: clicking a search result now lands on the correct category tab with the exact setting highlighted and scrolled into view.

## Verification

- \`eslint public/scripts/sillybunny-tabs.js\` — passes clean.
- Mobile + desktop parity: category switch uses the same declarative \`data-active-tab\` mechanism the tab buttons use, so it behaves identically across breakpoints.

## Checklist

- [x] Targets \`staging\` per CONTRIBUTING.md
- [x] Uses \`fix:\` conventional-commit prefix
- [x] Self-contained in a SillyBunny-original file (no upstream files modified)
- [x] KISS — minimal, modular change in a single file
- [x] Allow edits by maintainers enabled