### PR TITLE
fix: prevent empty conversation replies when persona description uses brackets

### DIFF
--- a/public/scripts/personas.js
+++ b/public/scripts/personas.js
@@ -259,7 +259,10 @@ function composePersonaDescription(avatarId = user_avatar) {
     for (const appendix of getActivePersonaAppendices(avatarId)) {
         const description = String(appendix.description ?? '').trim();
         if (description) {
-            chunks.push(`[${appendix.name}]\n${description}`);
+            // SillyBunny: wrap the appendix label in parentheses instead of square brackets.
+            // Mirrors the Conversation Mode change so the persona shape is consistent across
+            // modes and avoids colliding with any square-bracket command grammar downstream.
+            chunks.push(`(${appendix.name})\n${description}`);
         }
     }
 

--- a/public/scripts/sillybunny-conversation/generation-utils.js
+++ b/public/scripts/sillybunny-conversation/generation-utils.js
@@ -39,7 +39,8 @@ export function normalizeConversationOutputText(rawText) {
 }
 
 export function extractCharacterReplyCommandParts(rawText, settings = {}) {
-    let text = String(rawText || '');
+    const originalText = String(rawText || '');
+    let text = originalText;
     const scheduleUpdates = [];
     const selfieRequests = [];
     const reminders = [];
@@ -65,5 +66,13 @@ export function extractCharacterReplyCommandParts(rawText, settings = {}) {
 
     text = text.replace(/[ \t]{2,}/g, ' ').replace(/\n{3,}/g, '\n\n').trim();
     text = normalizeConversationOutputText(text);
+
+    // SillyBunny: bracket-command stripping must never blank a real reply. If the strip
+    // pass consumed everything (e.g. the model echoed bracket labels it saw in the persona),
+    // fall back to the original text so the user always sees a response.
+    if (!text && originalText.trim()) {
+        text = normalizeConversationOutputText(originalText.trim());
+    }
+
     return { text, selfieRequests, scheduleUpdates, reminders };
 }

--- a/public/scripts/sillybunny-conversation/personas.js
+++ b/public/scripts/sillybunny-conversation/personas.js
@@ -125,7 +125,11 @@ export function composeConversationPersonaDescription(avatarId) {
     const activeIds = new Set(getActiveConversationPersonaAppendixIds(avatarId));
     for (const appendix of getConversationPersonaAppendices(avatarId)) {
         if (activeIds.has(appendix.id) && appendix.description.trim()) {
-            chunks.push(`[${appendix.name}]\n${appendix.description.trim()}`);
+            // SillyBunny: wrap the appendix label in parentheses instead of square brackets.
+            // Square brackets collide with Conversation Mode's reply command grammar
+            // ([selfie], [schedule_update:], [reminder:]); echoing them in a reply caused
+            // the strip pass to blank it entirely.
+            chunks.push(`(${appendix.name})\n${appendix.description.trim()}`);
         }
     }
 

--- a/tests/sillybunny-conversation-generation-utils.test.js
+++ b/tests/sillybunny-conversation-generation-utils.test.js
@@ -44,4 +44,32 @@ describe('sillybunny conversation generation utils', () => {
     test('normalizes repeated wrapper quotes and punctuation spacing', () => {
         expect(normalizeConversationOutputText('""Hello ?!""')).toBe('Hello?!');
     });
+
+    test('does not blank a reply when bracket-stripping consumes all visible content', () => {
+        const original = '[selfie: context="smiling"]';
+        const result = extractCharacterReplyCommandParts(original, {
+            schedule_command_enabled: true,
+            selfie_command_enabled: true,
+        });
+
+        expect(result.selfieRequests).toEqual(['smiling']);
+        expect(result.scheduleUpdates).toEqual([]);
+        expect(result.reminders).toEqual([]);
+        // SillyBunny: even though the only content was a stripped command, the reply is
+        // never blanked back to the original text instead.
+        expect(result.text.length).toBeGreaterThan(0);
+    });
+
+    test('does not blank a reply composed entirely of reminder commands', () => {
+        const original = '[reminder: 15m | check back]';
+        const result = extractCharacterReplyCommandParts(original, {});
+
+        expect(result.reminders).toEqual([{ delay: '15m', memo: 'check back' }]);
+        expect(result.text.length).toBeGreaterThan(0);
+    });
+
+    test('returns empty text when input is empty or whitespace only', () => {
+        expect(extractCharacterReplyCommandParts('   \n  ', {}).text).toBe('');
+        expect(extractCharacterReplyCommandParts('', {}).text).toBe('');
+    });
 });


### PR DESCRIPTION
## Problem

If a persona description (or persona appendix) contains **square brackets**, Conversation Mode generations can come back **completely empty**.

## Root cause

Conversation Mode teaches the model a square-bracket reply-command grammar in its system prompt:

- `[selfie]` / `[selfie: context="..."]`
- `[schedule_update: status="...", activity="...", duration="..."]`
- `[reminder: delay_or_time | memo]`

These commands are **stripped** from the visible reply in `extractCharacterReplyCommandParts` (`public/scripts/sillybunny-conversation/generation-utils.js`).

Persona appendices were *also* wrapped in `[name]` (`sillybunny-conversation/personas.js:128`, mirrored in main-chat `personas.js:262`), and the default persona placeholder in the UI literally reads `[{{user}} is a 28-year-old Romanian cat girl.]`. So a bracket-heavy persona primed the model to wrap its reply in the same bracket grammar, and the strip pass then consumed the entire reply → `text === ''` → nothing posted (the regenerate path even surfaces `Regenerate returned no message.`).

Bug has been present since Conversation Mode landed in #503.

## Fix

**1. Stop wrapping persona appendix labels in square brackets.** Changed to parentheses in both Conversation Mode (`sillybunny-conversation/personas.js`) and main chat (`personas.js`) so the persona shape can no longer collide with the command grammar. Mirrored across both modes for a consistent persona shape; inline comments mark where SillyBunny diverges.

**2. Defensive fallback** in `extractCharacterReplyCommandParts`: if bracket-command stripping consumes all visible content but the original reply was non-empty, restore the original text. This guarantees a reply is never blanked, even if the model echoes a bracket label verbatim.

## Verification

- `npm run lint` — clean
- `npm run test:unit --prefix tests` — 135 suites / 1262 tests pass
- Added 3 regression tests to `tests/sillybunny-conversation-generation-utils.test.js` covering: selfie-only reply, reminder-only reply, and empty/whitespace input.

## Notes

- Targets `staging` per CONTRIBUTING.md.
- Conventional Commit prefix `fix:`.
- Self-contained: edits are in SillyBunny-specific files (`sillybunny-conversation/`) plus the fork's appendix wrapping in `personas.js`, with inline comments where code diverges.
- "Allow edits from maintainers" is enabled.