### PR TITLE
fix: detect Node.js in standard install paths in Start-Node.bat

### DIFF
--- a/Start-Node.bat
+++ b/Start-Node.bat
@@ -4,10 +4,18 @@ REM Use this if Bun causes high CPU usage on your platform.
 setlocal enabledelayedexpansion
 pushd %~dp0
 
+REM Prepend common Node.js install locations so double-click launches still find
+REM Node when the launching shell inherited a stale PATH (e.g. right after install,
+REM before Explorer refreshes environment variables). Mirrors the PATH augmentation
+REM Start.bat applies for Bun/Git discovery.
+set "PATH=%ProgramFiles%\nodejs;%ProgramFiles(x86)%\nodejs;%APPDATA%\npm;%LocalAppData%\Volta\bin;%USERPROFILE%\scoop\shims;%PATH%"
+
 where node > nul 2>&1
 if %errorlevel% neq 0 (
     echo Node.js was not found in PATH.
     echo Install Node.js from https://nodejs.org/ or use Start.bat for Bun.
+    echo If you just installed Node.js, restart your PC or relaunch from a fresh
+    echo Command Prompt so the updated PATH is picked up.
     goto end
 )
 


### PR DESCRIPTION
## Summary

`Start-Node.bat` ran `where node` against the inherited PATH without augmenting it — unlike `Start.bat`, which prepends common Bun/Git locations before its `where bun` check. When a user double-clicks the launcher right after installing Node (or after adding it to PATH), the launching shell often inherits a **stale PATH** that doesn't yet include the Node directory. `where node` then fails and the launcher prints `Node.js was not found in PATH` — even though Node is correctly installed, on PATH, and found by other freshly-launched apps. The window flashes and closes.

This blocks the documented workaround (switching from Bun to Node.js) for users hitting the Bun-runtime streaming-abort issue.

## Changes

- Prepend standard Node.js install locations to `PATH` before the `where node` check, mirroring the proven pattern in `Start.bat:5`:
  - `%ProgramFiles%\nodejs` / `%ProgramFiles(x86)%\nodejs` — MSI installers
  - `%APPDATA%\npm` — npm global bin
  - `%LocalAppData%\Volta\bin` — Volta
  - `%USERPROFILE%\scoop\shims` — Scoop
- Extend the not-found message with guidance to restart the PC / relaunch from a fresh Command Prompt when Node was just added to PATH.

The `%ProgramFiles(x86)%` parens are safe inside the quoted `set` — `Start.bat` already uses the identical idiom.

## Why this is the right fix

This is the same approach the project already ships for Bun/Git discovery in `Start.bat`. It is self-contained to the launcher (no backend/frontend changes) and directly unblocks the known-working abort path.

## Test plan

- [x] Verified the batch syntax mirrors the existing `Start.bat` pattern (no new idioms).
- [ ] Maintainer sanity-check on Windows: with Node not in a stale inherited PATH but present under `%ProgramFiles%\nodejs`, `Start-Node.bat` finds Node and boots.
- [ ] Negative path: with Node genuinely absent, the launcher still prints the (improved) not-found message and exits cleanly.

This is a Windows-only launcher change; no unit tests or lint apply (`.bat` is not covered by `npm run lint`).

Follow-up: the root cause of the abort-not-propagating-under-Bun issue is tracked in a separate sibling PR targeting `src/connection-state-checker.js`.