### PR TITLE
fix: exclude hidden messages from companion context threshold so the memory shard waits for fresh context

### DIFF
--- a/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-runner.js
@@ -970,6 +970,15 @@ export function getChatTokenEstimate(beforeMessageIndex = chat.length) {
     let total = 0;
     for (let index = 0; index < Math.min(beforeMessageIndex, chat.length); index++) {
         const message = chat[index];
+        // SillyBunny divergence: skip messages hidden from prompts (is_system). The memory shard
+        // companion hides the history it summarizes, so counting hidden messages would keep its
+        // minContextTokens threshold permanently satisfied and make it regenerate on every reply.
+        // Match how the rest of the codebase sizes context (token-counter/world-info/memory/vectors
+        // all filter out is_system). With the history hidden, the estimate drops back to ~0 and the
+        // shard waits until another minContextTokens worth of fresh, visible context accrues.
+        if (message?.is_system) {
+            continue;
+        }
         const counted = Number(message?.extra?.token_count);
         total += Number.isFinite(counted) && counted > 0
             ? counted

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -1285,6 +1285,31 @@ describe('in-chat agent post-processing runner', () => {
         expect(companionRunner.meetsCompanionContextThreshold(ungated, 0)).toBe(true);
     });
 
+    test('excludes hidden messages from the context threshold so the memory shard waits for fresh context', async () => {
+        const companionRunner = await import('../public/scripts/extensions/in-chat-agents/companion/companion-runner.js');
+
+        // Chat grows past the shard's 30k threshold: two 15k assistant replies plus a user turn.
+        const shard = createCompanionAgent({ id: 'memory-shard', companion: { minContextTokens: 30000 } });
+        chat.push(
+            { mes: 'Reply one', name: 'Assistant', is_user: false, is_system: false, extra: { token_count: 15000 } },
+            { mes: 'Keep going.', name: 'User', is_user: true, is_system: false, extra: { token_count: 100 } },
+            { mes: 'Reply two', name: 'Assistant', is_user: false, is_system: false, extra: { token_count: 15000 } },
+        );
+
+        expect(companionRunner.getChatTokenEstimate()).toBe(30100);
+        expect(companionRunner.meetsCompanionContextThreshold(shard, 2)).toBe(true);
+
+        // The shard runs and hides everything above it (0..1), mirroring the panel's
+        // "Hide story above this shard" action via hideChatMessageRange(...).
+        chat[0].is_system = true;
+        chat[1].is_system = true;
+
+        // Hidden messages no longer count: the estimate drops to the single visible reply,
+        // so the threshold is unmet again until fresh context accrues.
+        expect(companionRunner.getChatTokenEstimate()).toBe(15000);
+        expect(companionRunner.meetsCompanionContextThreshold(shard, 2)).toBe(false);
+    });
+
     test('appends the repair instruction on fix runs', async () => {
         const fixCompanion = createCompanionAgent({ id: 'fix-companion' });
         enabledAgents = [fixCompanion];


### PR DESCRIPTION
## Bug

For Companion Agents, the Memory Shard agent has a `minContextTokens` threshold (30k by default) that gates when it auto-runs. After a shard generates and the user clicks **`Hide story above this shard`` (which sets `is_system: true` on everything above it via `hideChatMessageRange`), the shard kept **regenerating on every single reply** instead of waiting for the next 30k of fresh context.

## Root cause

`meetsCompanionContextThreshold` gates auto-run companions on `getChatTokenEstimate`, which summed the token count of **every** message in the chat — including ones hidden from prompts (`is_system`). Hiding the summarized history did not lower the estimate, so the threshold stayed permanently satisfied and the shard ran again every reply.

This is also inconsistent with how the rest of the codebase sizes context (`token-counter`, `world-info`, `memory`, `vectors` all filter out `is_system`).

## Fix

`getChatTokenEstimate` now skips messages hidden from prompts (`is_system === true`). After a shard hides its history, the estimate drops back to ~0, so the shard waits until another `minContextTokens` worth of fresh, visible context accrues before running again.

General fix (applies to all auto-trigger companions) — but the Memory Shard is the only companion that actually hides messages, so it is the only one behaviorally affected.

```diff
 export function getChatTokenEstimate(beforeMessageIndex = chat.length) {
     let total = 0;
     for (let index = 0; index < Math.min(beforeMessageIndex, chat.length); index++) {
         const message = chat[index];
+        if (message?.is_system) {
+            continue;
+        }
         const counted = Number(message?.extra?.token_count);
```

## Verification

- `npm run lint` — clean
- `jest in-chat-agents-runner in-chat-agents-companion-panel in-chat-agents-store` — 136/136 passing
- Added a test reproduating the hide-before flow: estimate is met at 30k, drops to 15k after `is_system` is applied, threshold unmet again.

## Notes

- Targets `staging` per CONTRIBUTING.md.
- Default `minContextTokens` is `0` (ungated), so only companions with an explicit threshold are affected — i.e. the Memory Shard.
- Inline divergence comment added per CONTRIBUTING.md §Best Code Practices.