### PR TITLE
fix: surface custom-category templates (HTML Toggle, etc.) in the templates browser

### DIFF
--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -763,8 +763,10 @@ const TEMPLATE_BROWSER_CATEGORY_LABELS = {
 };
 
 function getTemplateBrowserCategoryOrder(templateList = templates) {
+    // SillyBunny: include 'custom' so bundled custom-category templates (e.g. HTML Toggle,
+    // Friction Mode) render in the templates browser. Upstream-only behaviour excluded it,
+    // which silently dropped these templates from the pills, sections, and search results.
     return Object.keys(AGENT_CATEGORIES)
-        .filter(category => category !== 'custom')
         .filter(category => templateList.some(template => template.category === category));
 }
 

--- a/tests/in-chat-agents-templates.test.js
+++ b/tests/in-chat-agents-templates.test.js
@@ -47,6 +47,30 @@ function readIndexSetBody(name) {
     return match[1];
 }
 
+function readIndexFunctionBody(name) {
+    const source = fs.readFileSync(indexSourceUrl, 'utf8');
+    const start = source.indexOf(`function ${name}(`);
+
+    if (start === -1) {
+        throw new Error(`Missing function definition: ${name}`);
+    }
+
+    const bodyStart = source.indexOf('{', start);
+    let depth = 0;
+    for (let i = bodyStart; i < source.length; i++) {
+        if (source[i] === '{') {
+            depth++;
+        } else if (source[i] === '}') {
+            depth--;
+            if (depth === 0) {
+                return source.slice(start, i + 1);
+            }
+        }
+    }
+
+    throw new Error(`Unterminated function: ${name}`);
+}
+
 async function importAgentStore() {
     jest.resetModules();
 
@@ -420,5 +444,31 @@ describe('in-chat agent bundled templates', () => {
         expect(readIndexSetBody('INTERNAL_BUNDLED_TEMPLATE_IDS')).toContain(pathfinderTemplateId);
         expect(readIndexSetBody('REMOVED_BUNDLED_TEMPLATE_IDS')).not.toContain(pathfinderTemplateId);
         expect(readIndexSetBody('DEFAULT_BUNDLED_TEMPLATE_IDS')).not.toContain(pathfinderTemplateId);
+    });
+
+    test('keeps every catalog template category renderable in the browser', async () => {
+        const { AGENT_CATEGORIES } = await importAgentStore();
+        const catalog = readTemplate('index.json');
+        const knownCategories = Object.keys(AGENT_CATEGORIES);
+
+        const unknownCategories = catalog
+            .map(template => template.category)
+            .filter(category => !knownCategories.includes(category));
+
+        expect(unknownCategories).toEqual([]);
+    });
+
+    test('surfaces bundled custom-category templates such as HTML Toggle in the browser', () => {
+        const catalog = readTemplate('index.json');
+        const htmlToggle = findCatalogTemplate(catalog, 'tpl-html-toggle');
+
+        expect(htmlToggle.category).toBe('custom');
+
+        const customTemplates = catalog.filter(template => template.category === 'custom');
+        expect(customTemplates.length).toBeGreaterThan(0);
+
+        const orderSource = readIndexFunctionBody('getTemplateBrowserCategoryOrder');
+        expect(orderSource).not.toContain('category !== \'custom\'');
+        expect(orderSource).toContain('AGENT_CATEGORIES');
     });
 });


### PR DESCRIPTION
## Problem

The **HTML Agent** (the _HTML Toggle_ template, `tpl-html-toggle`) is no longer showing up in the Templates browser, even though it's installed and present in the agent list.

## Root cause

Introduced in `3c401054a` (_feat: categorise templates browser, retire Pathfinder agent_). `getTemplateBrowserCategoryOrder()` explicitly excluded the `custom` category:

```js
return Object.keys(AGENT_CATEGORIES)
    .filter(category => category !== 'custom')   // dropped all custom-category templates
    .filter(category => templateList.some(template => template.category === category));
```

The pills builder (`index.js:3430`), the render loop (`renderTemplateResults`, `index.js:3566`), and the pill counts (`updateTemplatePills`) all iterate only over `categoryOrder`, which never contained `custom`. So every `category: "custom"` template was silently dropped — even on the **All** pill and **even when searching**.

Installed agents still appeared in the agent list (a separate render path that doesn't filter by `categoryOrder`), which is exactly the reported symptom: "It says I have it on my current setup too but it's not showing up."

This affected **six** bundled templates:
- HTML Toggle (`tpl-html-toggle`)
- Friction Mode (`tpl-friction-mode`)
- NPC Profile Cards (`tpl-npc-profiles`)
- Nightmare Difficulty Increase (`tpl-nightmare-difficulty-increase`)
- Don't Write for User (`tpl-dont-write-for-user`)
- Write for User (`tpl-write-for-user`)

## Fix

Drop the `custom` exclusion in `getTemplateBrowserCategoryOrder()` so a **Custom** pill and section are rendered. `AGENT_CATEGORIES.custom` already defines the icon (`fa-puzzle-piece`) and label, and `getTemplateCategoryLabel` falls back to _Custom_, so no other changes are needed.

## Testing

- `npm run lint` — clean on changed files.
- `jest tests/in-chat-agents-templates.test.js` — 15/15 pass, including two new guards:
  - _keeps every catalog template category renderable in the browser_ — every `category` in `index.json` is a key in `AGENT_CATEGORIES` (data guard).
  - _surfaces bundled custom-category templates such as HTML Toggle in the browser_ — asserts `tpl-html-toggle` is `custom` and that `getTemplateBrowserCategoryOrder` no longer excludes `custom` (render-logic guard, mirroring the existing `readIndexSetBody` source-parsing pattern).

## Notes

- Self-contained one-line behavioral fix, following KISS / modular guidance from `CONTRIBUTING.md`.
- Inline divergence comment added on the upstream-adjacent code to aid future upstream merges.