### PR TITLE
fix: make swipe DOM updates instant

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -14758,7 +14758,9 @@ export async function swipe(event, direction, { source, repeated, message = chat
             //Update the chat.
             await loadFromSwipeId(mesId, newSwipeId);
             //Transition to the new chat.
-            await animateSwipe();
+            // SillyBunny: skip the slide-out so the target swipe's content renders to the DOM instantly,
+            // rather than lagging behind the previous message until the slide-out completes.
+            await animateSwipe(false, true);
         }
         await endSwipe();
     }
@@ -14918,7 +14920,8 @@ export async function swipe(event, direction, { source, repeated, message = chat
     /**
      * Anime a swipe, optionally running a generation.
      * @param {boolean} run_generate
-     * @param {boolean} [skipSwipeOut=false]
+     * @param {boolean} [skipSwipeOut=false] SillyBunny: callers now pass `true` so the DOM swaps instantly
+     *     (the message is blanked/replaced immediately), keeping only the slide-in enter animation.
      */
     async function animateSwipe(run_generate = false, skipSwipeOut = false) {
         let swipeViewportUpdate = null;
@@ -15069,7 +15072,9 @@ export async function swipe(event, direction, { source, repeated, message = chat
                 clearMessageData(chat[mesId]);
                 let run_generate = true;
                 //Generate.
-                await animateSwipe(run_generate);
+                // SillyBunny: skip the slide-out so the message blanks to "..." instantly on regenerate,
+                // instead of keeping the previous generation visible during the slide-out animation.
+                await animateSwipe(run_generate, true);
                 await endSwipe();
                 return;
             } else if (overswipe == OVERSWIPE_BEHAVIOR.LOOP || overswipe == OVERSWIPE_BEHAVIOR.PRISTINE_GREETING) {


### PR DESCRIPTION
## Summary

Makes swipe DOM changes instant. When swiping (browsing saved candidates or regenerating), the message content now swaps in the DOM **immediately**, instead of lingering on the previous message until the slide-out animation finishes.

## Problem

In `animateSwipe()` (`public/script.js`), the DOM content swap was awaited **after** the slide-out animation:

\`\`\`js
if (!skipSwipeOut) {
    //Swipe out.   ← previous message stays visible during this whole animation
    await animateSwipeTransition(mesId, { xEnd: \`\${swipeRange}px\`, duration: swipeDuration });
}
// ...
if (run_generate) {
    thisMesDiv.find('.mes_text').html('...');   // ← DOM only blanks AFTER slide-out finishes
} else {
    addOneMessage(chat[mesId], { type: 'swipe', ... }); // ← target text only after slide-out
}
\`\`\`

So during \`swipeDuration\` (~125ms by default, longer if \`animation_duration\` is raised), the previous message remained on screen — the exact lag described in the bug report.

Upstream already has a \`skipSwipeOut\` parameter on \`animateSwipe\`, but **no caller ever passed \`true\`**. This PR wires it up.

## Fix

Single-file change to \`public/script.js\`:

- **Regenerate path** (overswipe → \`OVERSWIPE_BEHAVIOR.REGENERATE\`): \`animateSwipe(run_generate)\` → \`animateSwipe(run_generate, true)\` — message now blanks to \`...\` instantly.
- **Navigation path** (\`standardSwipe\`, browsing saved candidates): \`animateSwipe()\` → \`animateSwipe(false, true)\` — target swipe's text renders instantly.
- Updated the \`skipSwipeOut\` docstring to note SillyBunny now uses it for instant swaps.

The slide-**in** enter animation is preserved, so the transition still feels animated — just snappier, with no lag behind the previous message.

Inline \`// SillyBunny:\` comments mark each divergence point per CONTRIBUTING.md.

## Behavior change

The slide-**out** animation (old content sliding off-screen) is removed for all swipes. The slide-in is kept. Net effect: content appears instantly, then the new content animates in from the opposite side.

## Verification

- \`eslint public/script.js\` — passes (exit 0).
- No existing tests cover swipe animation timing; manual verification recommended on both desktop and mobile.

No platform-specific code touched; desktop/mobile parity is automatic.

## Checklist

- [x] Targets \`staging\` (CONTRIBUTING.md L29)
- [x] \`fix:\` Conventional Commit prefix (L40)
- [x] Single self-contained file change (L19-20)
- [x] Inline comments marking divergence from upstream (L21)
- [x] Allow edits from maintainers — enabled
- [x] KISS — two call sites, no new settings/state (L19)