### PR TITLE
fix: keep mobile shell visible during keyboard viewport shifts

### DIFF
--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -15563,6 +15563,8 @@ function initAll() {
     window.addEventListener('resize', queueMobileViewportStateSync, { passive: true });
     window.addEventListener('orientationchange', queueMobileViewportStateSync);
     window.visualViewport?.addEventListener('resize', queueMobileViewportStateSync, { passive: true });
+    // SillyBunny: iOS can move visualViewport.offsetTop without resizing while the keyboard is open.
+    window.visualViewport?.addEventListener('scroll', queueMobileViewportStateSync, { passive: true });
     window.visualViewport?.addEventListener('resize', syncDesktopShellSizing, { passive: true });
 
     // SillyBunny: re-sync shell width when the chat width slider changes so settings

--- a/tests/mobile-shell-lifecycle-wiring.test.js
+++ b/tests/mobile-shell-lifecycle-wiring.test.js
@@ -203,6 +203,7 @@ describe('mobile shell lifecycle wiring', () => {
         expect(tabsSource).toContain('function syncMobileShellDrawerBounds(');
         expect(tabsSource).toContain('function queueMobileShellDrawerBoundsSync(');
         expect(tabsSource).toContain('setRootViewportProperty(\'--sb-shell-available-height\'');
+        expect(tabsSource).toContain('setRootViewportProperty(\'--sb-shell-viewport-top\', `${viewportSize.top}px`);');
         expect(tabsSource).toContain('function applyMobileDrawerBoundsDecision(');
         expect(tabsSource).toContain('window.visualViewport');
         expect(tabsSource).toContain('function getShellViewportTop(');
@@ -219,6 +220,7 @@ describe('mobile shell lifecycle wiring', () => {
         expect(closeShellSource).toContain('queueMobileShellDrawerBoundsSync();');
         expect(syncMobileViewportStateSource).toContain('syncMobileShellDrawerBounds();');
         expect(tabsSource).toContain('window.visualViewport?.addEventListener(\'resize\', queueMobileViewportStateSync, { passive: true });');
+        expect(tabsSource).toContain('window.visualViewport?.addEventListener(\'scroll\', queueMobileViewportStateSync, { passive: true });');
         expect(tabsSource).toContain('window.addEventListener(\'resize\', queueMobileViewportStateSync, { passive: true });');
         expect(tabsSource).toContain('window.visualViewport?.addEventListener(\'resize\', syncDesktopShellSizing, { passive: true });');
         expect(tabsSource).toContain('window.addEventListener(\'orientationchange\', queueMobileViewportStateSync);');


### PR DESCRIPTION
## Summary
- sync the mobile shell when visualViewport scrolls, not only when it resizes
- keep the existing iOS keyboard offset CSS variable refreshed when the keyboard moves the visual viewport
- pin the viewport-top and scroll-listener wiring with a regression assertion

## Tests
- node --check public/scripts/sillybunny-tabs.js
- npm run test:unit -- mobile-shell-lifecycle-wiring.test.js