### PR TITLE
fix: lazy-load Conversation Mode runtime

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -49,7 +49,6 @@
     <link rel="stylesheet" type="text/css" href="css/mobile-styles.css?v=20260610a" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-theme.css?v=20260609a">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-tabs.css?v=20260609a">
-    <link rel="stylesheet" type="text/css" href="css/sillybunny-conversation.css?v=20260618g">
     <link rel="stylesheet" type="text/css" href="css/sillybunny-mobile-shell.css?v=20260609d" media="(max-width: 768px)">
     <link rel="stylesheet" type="text/css" href="css/user.css">
     <!-- Scripts are loaded at the end of the body to improve page load speed -->

--- a/public/scripts/sillybunny-conversation/auto-engine.js
+++ b/public/scripts/sillybunny-conversation/auto-engine.js
@@ -87,6 +87,7 @@ export function stopConversationAutoWorker() {
     globalThis[AUTO_WORKER_INTERVAL_GLOBAL_KEY] = null;
     conversationState.autoWorkerAbortController?.abort?.();
     conversationState.autoWorkerAbortController = null;
+    conversationState.autoWorkerStarted = false;
     clearConversationTimeouts();
 }
 
@@ -99,6 +100,7 @@ export function startConversationAutoWorker() {
         void conversationModeAutoMessageWorker({ signal: controller.signal });
     }, AUTO_WORKER_INTERVAL_MS);
     globalThis[AUTO_WORKER_INTERVAL_GLOBAL_KEY] = conversationState.autoWorkerIntervalId;
+    conversationState.autoWorkerStarted = true;
 }
 
 export function buildAutoMessageDirective(directive) {

--- a/public/scripts/sillybunny-conversation/chrome.js
+++ b/public/scripts/sillybunny-conversation/chrome.js
@@ -1,4 +1,5 @@
 import { characters } from '../../script.js';
+import { loadStylesheetAsync } from '../dynamic-styles.js';
 import { selected_group } from '../group-chats.js';
 import { setUserAvatar } from '../personas.js';
 import { shouldSendOnEnter } from '../RossAscends-mods.js';
@@ -79,6 +80,26 @@ import {
     updateConversationSearchQuery,
 } from './timeline-render.js';
 import { setLastConversationPreview } from './typing.js';
+
+const CONVERSATION_STYLESHEET_HREF = 'css/sillybunny-conversation.css?v=20260618g';
+const CONVERSATION_STYLESHEET_ID = 'sb-conversation-css';
+
+function ensureConversationStylesheet() {
+    if (conversationState.conversationCssLoaded) {
+        return;
+    }
+
+    conversationState.conversationCssLoaded = true;
+    loadStylesheetAsync(CONVERSATION_STYLESHEET_HREF, { id: CONVERSATION_STYLESHEET_ID })
+        .catch(error => {
+            conversationState.conversationCssLoaded = false;
+            console.warn('Conversation Mode: stylesheet failed to load', error);
+        });
+}
+
+function requestConversationRuntimeStart() {
+    window.dispatchEvent(new CustomEvent('sb:conversation-runtime-needed'));
+}
 
 export function bindConversationChromeControls(sheld) {
     if (sheld.dataset.sbConversationChromeBound === 'true') {
@@ -707,6 +728,7 @@ export function openConversationWorkspaceForAvatar(avatar, { groupId = null, sho
         conversationState.conversationTimelineChannel = 'main';
         conversationState.conversationTimelineSearchQuery = '';
     }
+    ensureConversationStylesheet();
 
     if (!targetAvatar) {
         scheduleInterfaceRefresh({ syncControls: false });
@@ -720,6 +742,7 @@ export function openConversationWorkspaceForAvatar(avatar, { groupId = null, sho
     const wasEnabled = Boolean(settings.enabled);
     settings.enabled = true;
     saveSettings(targetAvatar, settings, { groupId: targetGroupId });
+    requestConversationRuntimeStart();
     applySettingsToPanel(settings);
     scheduleInterfaceRefresh({ syncControls: true });
     if (showToast && !wasEnabled) {
@@ -769,6 +792,15 @@ export function setConversationInterfaceActive(active) {
             if (element instanceof HTMLElement) {
                 element.hidden = true;
             }
+        }
+        const timeline = document.getElementById(CHROME_IDS.timeline);
+        if (timeline instanceof HTMLElement) {
+            // Mobile Safari keeps hidden DOM expensive; rebuild the timeline lazily on next open.
+            timeline.replaceChildren();
+            timeline.removeAttribute('data-sb-conversation-fingerprint');
+            conversationState.lastTimelineFingerprint = '';
+            conversationState.lastRenderedAvatar = null;
+            conversationState.lastRenderedMessageCount = 0;
         }
         return;
     }

--- a/public/scripts/sillybunny-conversation/init.js
+++ b/public/scripts/sillybunny-conversation/init.js
@@ -16,9 +16,28 @@ import { loadCurrentPanelSettings } from './interface.js';
 import { sanitizeConversationUnreadCounts, updateConversationNotificationIndicators } from './notifications.js';
 import { getCharacterForGroupChatMessage, getCurrentGroupConversationMembers } from './pals-rail.js';
 import { scheduleInterfaceRefresh } from './render-scheduler.js';
-import { getSettings } from './settings-store.js';
+import { getSettings, hasAnyConversationModeUsage } from './settings-store.js';
 import { conversationState } from './state.js';
 import { setConversationTimeout } from './timers.js';
+
+function hasConversationRuntimeUsage() {
+    return conversationState.conversationWorkspaceOpen || hasAnyConversationModeUsage();
+}
+
+function scheduleInterfaceRefreshIfOpen() {
+    if (conversationState.conversationWorkspaceOpen) {
+        scheduleInterfaceRefresh({ syncControls: false });
+    }
+}
+
+function ensureConversationRuntimeStarted() {
+    if (conversationState.autoWorkerStarted || !hasConversationRuntimeUsage()) {
+        return;
+    }
+
+    startConversationAutoWorker();
+    updateConversationNotificationIndicators();
+}
 
 export function init() {
     if (conversationState.initialized) {
@@ -29,13 +48,21 @@ export function init() {
     migrateConversationLocalStorage();
     sanitizeConversationUnreadCounts();
     eventSource.on(event_types.USER_MESSAGE_RENDERED, (messageId) => {
-        scheduleInterfaceRefresh({ syncControls: false });
+        if (!hasConversationRuntimeUsage()) {
+            return;
+        }
+
+        scheduleInterfaceRefreshIfOpen();
         if (selected_group) {
             checkGroupChatMention(messageId);
         }
     });
     eventSource.on(event_types.CHARACTER_MESSAGE_RENDERED, (messageId) => {
-        scheduleInterfaceRefresh({ syncControls: false });
+        if (!hasConversationRuntimeUsage()) {
+            return;
+        }
+
+        scheduleInterfaceRefreshIfOpen();
 
         // Occasional private asides keep Conversation Mode feeling connected
         // without forcing a public group-chat reply.
@@ -63,18 +90,30 @@ export function init() {
         }
 
         conversationState.generationActive = true;
-        scheduleInterfaceRefresh({ syncControls: false });
+        if (!hasConversationRuntimeUsage()) {
+            return;
+        }
+
+        scheduleInterfaceRefreshIfOpen();
     });
     eventSource.on(event_types.GENERATION_ENDED, () => {
         conversationState.generationActive = false;
-        scheduleInterfaceRefresh({ syncControls: false });
+        scheduleInterfaceRefreshIfOpen();
     });
     eventSource.on(event_types.GENERATION_STOPPED, () => {
         conversationState.generationActive = false;
-        scheduleInterfaceRefresh({ syncControls: false });
+        scheduleInterfaceRefreshIfOpen();
     });
-    eventSource.on(event_types.CHAT_CHANGED, handleChatChanged);
-    eventSource.on(event_types.CHAT_LOADED, handleChatChanged);
+    eventSource.on(event_types.CHAT_CHANGED, () => {
+        if (conversationState.conversationWorkspaceOpen) {
+            handleChatChanged();
+        }
+    });
+    eventSource.on(event_types.CHAT_LOADED, () => {
+        if (conversationState.conversationWorkspaceOpen) {
+            handleChatChanged();
+        }
+    });
 
     window.addEventListener('sb:open-conversation-workspace', (event) => {
         const detail = event instanceof CustomEvent ? event.detail : null;
@@ -83,11 +122,13 @@ export function init() {
         openConversationWorkspaceForAvatar(avatar, { groupId, showToast: detail?.showToast !== false });
     });
     window.addEventListener('sb:close-conversation-workspace', () => disableConversationModeForCurrentCharacter({ focusRoleplay: false }));
+    window.addEventListener('sb:conversation-runtime-needed', ensureConversationRuntimeStarted);
     window.addEventListener('beforeunload', stopConversationAutoWorker);
 
-    startConversationAutoWorker();
-    loadCurrentPanelSettings();
-    updateConversationNotificationIndicators();
+    if (hasAnyConversationModeUsage()) {
+        ensureConversationRuntimeStarted();
+        loadCurrentPanelSettings();
+    }
 }
 
 eventSource.on(event_types.APP_READY, init);

--- a/public/scripts/sillybunny-conversation/settings-store.js
+++ b/public/scripts/sillybunny-conversation/settings-store.js
@@ -37,6 +37,35 @@ const GROUP_CONVERSATION_FORCED_SETTINGS = Object.freeze({
     auto_character_chat: true,
 });
 
+let conversationUsageCache = null;
+
+function threadStoreHasConversationUsage(storeKey, threadStore) {
+    if (!threadStore || typeof threadStore !== 'object') {
+        return false;
+    }
+
+    if (threadStore.settings?.enabled === true) {
+        return true;
+    }
+
+    const parsed = parseConversationThreadKey(storeKey);
+    return Boolean(parsed.groupId && parsed.avatar);
+}
+
+export function invalidateConversationUsageCache() {
+    conversationUsageCache = null;
+}
+
+export function hasAnyConversationModeUsage() {
+    if (conversationUsageCache !== null) {
+        return conversationUsageCache;
+    }
+
+    const charactersStore = getConversationStore().characters || {};
+    conversationUsageCache = Object.entries(charactersStore).some(([storeKey, threadStore]) => threadStoreHasConversationUsage(storeKey, threadStore));
+    return conversationUsageCache;
+}
+
 /**
  * Conversation settings are stored in separate persisted scopes. Keep this
  * precedence stable unless a migration updates existing saved data:
@@ -76,6 +105,7 @@ export function getGlobalConversationSettings() {
 export function saveGlobalConversationSettings(settings) {
     const store = getConversationStore();
     store.settings = normalizeGlobalConversationSettings(settings);
+    invalidateConversationUsageCache();
     persistConversationStore();
 }
 
@@ -199,6 +229,7 @@ export function saveSettings(avatar, settings, { groupId = getConversationGroupI
             ? pickConversationSettings(normalizedSettings, CHARACTER_CONVERSATION_SETTINGS_KEYS)
             : pickConversationSettings(normalizedSettings, THREAD_CONVERSATION_SETTINGS_KEYS);
     }
+    invalidateConversationUsageCache();
     persistConversationStore();
 }
 

--- a/public/scripts/sillybunny-conversation/state.js
+++ b/public/scripts/sillybunny-conversation/state.js
@@ -1,5 +1,7 @@
 export const conversationState = {
     initialized: false,
+    autoWorkerStarted: false,
+    conversationCssLoaded: false,
     autoWorkerIntervalId: null,
     autoWorkerAbortController: null,
     autoWorkerBusy: false,


### PR DESCRIPTION
## Summary
- remove Conversation Mode CSS from the parser-blocking startup path and load it on first workspace open
- gate Conversation Mode listeners, notification startup, and auto-worker startup behind persisted usage / active workspace
- stop refreshing hidden Conversation Mode UI while in main mode and release hidden timeline nodes when closing the workspace

## Why
The Conversation Mode module was imposing runtime cost in regular/main mode. On mobile/iOS this showed up as lag during startup/warmup and lag that persisted after returning to main mode.

## Details
- Adds a cached `hasAnyConversationModeUsage()` store scan and invalidates it when Conversation settings are saved.
- Starts the auto-worker/notification runtime only when existing usage is present or when the workspace is first opened.
- Keeps reaction/mention hooks available for persisted Conversation Mode users but avoids scheduling interface refreshes unless the workspace is open.
- Clears the hidden timeline DOM on deactivate and resets timeline fingerprints so the next open rebuilds lazily.

## Verification
- `node --check public/scripts/sillybunny-conversation/init.js public/scripts/sillybunny-conversation/chrome.js public/scripts/sillybunny-conversation/settings-store.js public/scripts/sillybunny-conversation/state.js public/scripts/sillybunny-conversation/auto-engine.js`
- `./node_modules/.bin/eslint public/scripts/sillybunny-conversation/init.js public/scripts/sillybunny-conversation/chrome.js public/scripts/sillybunny-conversation/settings-store.js public/scripts/sillybunny-conversation/state.js public/scripts/sillybunny-conversation/auto-engine.js`
- `git diff --check`
- `node scripts/check-frontend-budgets.js`