### PR TITLE
chore: hard-code Claude Opus 4.8 and GLM-5.2

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3116,12 +3116,13 @@
                             <div>
                                 <h4 data-i18n="Model ID">Model ID</h4>
                                 <div class="flex-container">
-                                    <input id="claude_model_id" class="text_pole wide100p" value="" autocomplete="off" data-i18n="[placeholder]Example: claude-opus-4-7" placeholder="Example: claude-opus-4-7">
+                                    <input id="claude_model_id" class="text_pole wide100p" value="" autocomplete="off" data-i18n="[placeholder]Example: claude-opus-4-8" placeholder="Example: claude-opus-4-8">
                                 </div>
                                 <h4 data-i18n="Available Models">Available Models</h4>
                                 <select id="model_claude_select">
                                     <optgroup label="Versions">
                                         <option value="claude-fable-5">claude-fable-5</option><!-- SillyBunny: claude-fable-5 support -->
+                                        <option value="claude-opus-4-8">claude-opus-4-8</option>
                                         <option value="claude-opus-4-7">claude-opus-4-7</option>
                                         <option value="claude-opus-4-6">claude-opus-4-6</option>
                                         <option value="claude-opus-4-5">claude-opus-4-5</option>
@@ -3968,6 +3969,7 @@
                             <h4 data-i18n="Available Models">Available Models</h4>
                             <select id="model_zai_select">
                                 <optgroup label="GLM Models">
+                                    <option value="glm-5.2">glm-5.2</option>
                                     <option value="glm-5.1">glm-5.1</option>
                                     <option value="glm-5-turbo">glm-5-turbo</option>
                                     <option value="glm-5v-turbo">glm-5v-turbo</option>

--- a/public/scripts/extensions/caption/settings.html
+++ b/public/scripts/extensions/caption/settings.html
@@ -96,6 +96,8 @@
                         <option data-type="openai" value="o4-mini-2025-04-16">o4-mini-2025-04-16</option>
                         <option data-type="openai" value="gpt-4.5-preview">gpt-4.5-preview</option>
                         <option data-type="openai" value="gpt-4.5-preview-2025-02-27">gpt-4.5-preview-2025-02-27</option>
+                        <option data-type="anthropic" value="claude-fable-5">claude-fable-5</option>
+                        <option data-type="anthropic" value="claude-opus-4-8">claude-opus-4-8</option>
                         <option data-type="anthropic" value="claude-opus-4-7">claude-opus-4-7</option>
                         <option data-type="anthropic" value="claude-opus-4-6">claude-opus-4-6</option>
                         <option data-type="anthropic" value="claude-opus-4-5">claude-opus-4-5</option>

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -560,7 +560,7 @@ const default_settings = {
     scenario_format: default_scenario_format,
     personality_format: default_personality_format,
     openai_model: 'gpt-4-turbo',
-    claude_model: 'claude-sonnet-4-5',
+    claude_model: 'claude-opus-4-8',
     claude_disable_temperature: false,
     claude_disable_top_p: false,
     google_model: 'gemini-2.5-pro',
@@ -587,7 +587,7 @@ const default_settings = {
     cometapi_model: 'gpt-4o',
     moonshot_model: 'kimi-latest',
     fireworks_model: 'accounts/fireworks/models/kimi-k2-instruct',
-    zai_model: 'glm-5.1',
+    zai_model: 'glm-5.2',
     zai_endpoint: ZAI_ENDPOINT.COMMON,
     workers_ai_model: '@cf/meta/llama-3.3-70b-instruct-fp8-fast',
     workers_ai_account_id: '',
@@ -7710,6 +7710,7 @@ function getZaiMaxContext(model, isUnlocked) {
     }
 
     const contextMap = {
+        'glm-5.2': max_1mil,
         'glm-5.1': max_200k,
         'glm-5-turbo': max_200k,
         'glm-5v-turbo': max_200k,

--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -344,10 +344,10 @@ async function sendClaudeRequest(request, response) {
         const isFableModel = /claude-fable/.test(request.body.model);
         const useThinking = /^claude-(3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6|opus-4-7|sonnet-4-6)/.test(request.body.model) || (isFableModel && enableAdaptiveThinking);
         const useWebSearch = (/^claude-(3-5|3-7|opus-4|sonnet-4|haiku-4-5|opus-4-5|opus-4-6|opus-4-7|sonnet-4-6)/.test(request.body.model) || isFableModel) && Boolean(request.body.enable_web_search);
-        const isLimitedSampling = /^claude-(opus-4-1|sonnet-4-5|haiku-4-5|opus-4-5|opus-4-6|opus-4-7|sonnet-4-6)/.test(request.body.model);
-        const useVerbosity = /^claude-(opus-4-5|opus-4-6|opus-4-7|sonnet-4-6)/.test(request.body.model) || isFableModel;
-        const noPrefillModel = /^claude-(opus-4-6|opus-4-7|sonnet-4-6)/.test(request.body.model) || isFableModel;
-        const isAdaptiveModel = enableAdaptiveThinking && (/^claude-(opus-4-6|opus-4-7|sonnet-4-6)/.test(request.body.model) || isFableModel);
+        const isLimitedSampling = /^claude-(opus-4-1|sonnet-4-5|haiku-4-5|opus-4-5|opus-4-6|opus-4-7|opus-4-8|sonnet-4-6)/.test(request.body.model);
+        const useVerbosity = /^claude-(opus-4-5|opus-4-6|opus-4-7|opus-4-8|sonnet-4-6)/.test(request.body.model) || isFableModel;
+        const noPrefillModel = /^claude-(opus-4-6|opus-4-7|opus-4-8|sonnet-4-6)/.test(request.body.model) || isFableModel;
+        const isAdaptiveModel = enableAdaptiveThinking && (/^claude-(opus-4-6|opus-4-7|opus-4-8|sonnet-4-6)/.test(request.body.model) || isFableModel);
         let fixThinkingPrefill = false;
         // Add custom stop sequences
         const stopSequences = [];


### PR DESCRIPTION
## Summary

Hard-codes the latest GA backend models into the Claude and ZAI (GLM) connection panels.

### Claude (Anthropic)
- **Opus 4.8** (`claude-opus-4-8`): GA, 1M context, 128k output, adaptive thinking supported. Added to the Claude model dropdown, set as the default `claude_model`, wired into the `opus-4-x` regex groups in `chat-completions.js` (`isLimitedSampling`, `useVerbosity`, `noPrefillModel`, `isAdaptiveModel`), and added to the caption/vision dropdown.
- **Fable 5** (`claude-fable-5`): GA since June 9, 2026. Already present in the main Claude dropdown; this adds it to the caption/vision dropdown as well.

### ZAI (GLM / Zhipu)
- **GLM-5.2** (`glm-5.2`): new flagship, 1M lossless context, 128k output, text-only (no vision). Added to the GLM model dropdown, set as the default `zai_model`, and mapped to `max_1mil` in `getZaiMaxContext`. Reuses the existing GLM 5.1 reasoning preset (identical `thinking` + `reasoning_effort` API), so no new preset is introduced.

## Changed files
- `public/index.html` — Opus 4.8 option + placeholder; GLM-5.2 option
- `public/scripts/openai.js` — `claude_model` / `zai_model` defaults; GLM-5.2 context map entry
- `src/endpoints/backends/chat-completions.js` — `opus-4-8` added to four Claude feature-detection regexes
- `public/scripts/extensions/caption/settings.html` — Opus 4.8 + Fable 5 in the caption model dropdown

## Verification
- `eslint` passes clean on both changed JS files.
- No tests reference the bumped default values.
- Other backends (OpenAI, Gemini, xAI) reviewed and already current — no changes needed.

## Notes
- Follow-up: Opus 4.1 retires Aug 5 2026 (left in place for now; not in scope).
- Self-contained per CONTRIBUTING.md; targets `staging`.