### PR TITLE
fix: bootstrap bun-termux on Termux

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -225,35 +225,58 @@ SillyBunny includes some extras by default to help you get started right away:
 
 ## Latest Update
 
-### v1.6.4 (2026-06-10)
+### v1.6.5 (2026-06-15)
 
-This update adds a built-in ZIP auto-updater for non-Git installs, token estimates in the chat selector, serialized chat saves, and a round of mobile, chat-backup, and generation-life-cycle fixes on top of 1.6.3.
+This update introduces Companion Agents, sidecar-style auxiliary AI helpers that run alongside the main chat. It also adds an In-Chat Agent expression classifier with Quick Image Gen sprite generation, decoupled sampling settings, categorized settings tabs, more shell styles, and a large round of iOS, Windows, mobile, and stability fixes on top of 1.6.4.
 
 **Added**
-* Built-in ZIP auto-update lets non-Git installs check for and apply new SillyBunny releases directly from Customize > Server.
-* The chat selector now shows an approximate token count for each saved chat so you can see chat sizes at a glance before switching.
+* Added Companion Agents: sidecar-style auxiliary AI helpers that run alongside the main chat, reading the conversation and doing their own background job (tracking plot, watching relationships, drafting worldbuilding notes, summarizing history, and more) without interrupting the story.
+* Companions run on one of two trigger modes, auto (after matching AI replies) or manual, with optional keyword/regex conditions and a probability percentage to fire only some of the time or on specific patterns.
+* Companions can display as inline note cards (with regenerate, edit, copy, and delete actions), in a draggable slide-out side panel that docks to any screen edge, or hidden (feeding future runs without showing). The panel supports regenerate, manual note edits, jump-to-source-message, per-companion run history, a lock-open button, and a regenerate-all action.
+* Added a dedicated Companion Agents dashboard (reachable from the wand menu and an extension toolbar button) to manage every companion across all chats, create new ones, import from file, pick from bundled templates, enable/disable with one tap, and convert eligible inline agents to companion execution.
+* One-click conversion flips agents between inline and companion execution from agent cards and a bulk select-mode action, preserving prompt, regex scripts, injection, and conditions.
+* Trackers converted to companion execution get an automatic loop by default (run after every reply, raw prompt sent verbatim, latest state fed back into the next generation, state shown in the slide-out panel instead of chat cards), with a one-time migration applying the same defaults to already-converted trackers.
+* Companions are configurable per companion: trigger, display mode, output format (markdown/HTML/plain text), context window depth, token thresholds and limits, which context to feed (character card, persona, world info, author's note, system prompt, prior notes), self-feedback depth, raw prompt mode, shared-request batching, and per-companion model, temperature, and reasoning settings. Companions can run in parallel or sequentially.
+* The batch companion selector lists every enabled companion so you can run any combination on demand.
+* Ships 11 ready-to-use companions: Continuity Companion, Relationship Lens, Director's Commentary, Actor Interview, Lorebook Scout, Memory Shard, NPC Motivator, Plot Compass, Chatroom, Message Inbox, and Chat Only.
+* Companions tied to a specific chat are removed automatically when that chat is deleted.
+* Added an In-Chat Agent expression classifier that drives Quick Image Gen sprite generation, so agents can pick a character expression and generate a matching sprite.
+* Added a Fix Trackers button that re-runs tracker agents to rebuild tracker state, with repair controls that stay visible for every enabled tracker, including legacy and pre trackers.
+* Sampling settings can now be decoupled from chat completion presets so model sampling profiles load on their own.
+* Added a quick delete shortcut button to the message actions.
+* Added categorized settings tabs that wrap into a grid on desktop.
+* Added more shell styles and reduced option padding in Customize.
+* Added a hide toggle and a direct hide button for the bottom chat bar.
+* Added ADHDBunny-UI to the Launchpad optional installs.
 
 **Improved**
-* Top bar height, message padding, and mobile chat density were tightened for a cleaner layout on phones and desktops.
-* Mobile shell overlay exclusivity, drawer bounds, and viewport sync were consolidated into the mobile-shell-lifecycle module for steadier narrow-screen behavior.
-* Settings tab now uses a distinct icon for easier recognition in the navigation shell.
-* Optional backup diagnostic logging (`backups.chat.logging`) can trace chat and settings backup writes, skips, and autosave triggers while investigating backup frequency.
+* Prose Polisher maximum output tokens raised to 32000.
+* Synced the bundled Quick Image Gen extension to v2.1.0.
+* World info entry controls are now more compact.
+* Extension load diagnostics give clearer detail when an extension fails to load.
+* Mobile rail and quick-action model selection now route through the mobile-shell-lifecycle module for steadier narrow-screen behavior.
 
 **Fixed**
-* Chat saves are now serialized through a single queue to prevent save corruption when multiple saves fire at once.
-* Stopping an in-flight agent generation now reliably aborts the upstream request and releases the generation lock so the UI returns to its idle state.
-* Creating a new group chat now correctly branches a new chat file and preserves the new chat id during validation.
-* Quick Replies bar is now centered alongside the popout trigger, and the floating edit indicator pill was removed from the message edit UI.
-* Desktop quick actions no longer shift the shell layout while the chat is open.
-* Mobile character panel close button no longer floats above the header.
-* Preset dropdown scroll taps are now guarded so list items cannot be mis-tapped while scrolling on mobile.
-* iOS-specific fixes restore the main screen layout, refresh a stale service worker cache, and revalidate default frontend assets after app updates.
-* Legacy World Info positions are now normalized at scan time.
-* Screenshots now strip hidden content from closed details elements instead of capturing invisible text.
-* Search jumps can no longer shift or clip the fixed viewport by clipping root overflow.
-* Chat backup bloat is reduced: older agent regex snapshots compact on load, interim agent saves defer regular backups until the final post-processed save, and duplicate post-save backups are skipped when only chat integrity changes.
-* Agent profile requests now respect reverse proxy headers so profile resolution works behind proxies.
-* Windows ZIP update guidance is clearer for users running from a ZIP instead of Git.
+* Chat backup count is now capped to 25 by default (`backups.chat.maxTotalBackups`) instead of unlimited, preventing unbounded accumulation over time.
+* Pre-write chat backups now skip writing when the on-disk content is unchanged (duplicate detection), reducing redundant snapshots during rapid save flows like swiping.
+* SillyBunny to SillyTavern version mapping is corrected so extensions check compatibility against the right version.
+* iOS WebKit boot failures are now surfaced instead of failing silently, with hardened frontend boot recovery.
+* Clear cookies and cache now works on iOS WebKit.
+* iOS chat overscroll blanking and keyboard composer displacement are fixed.
+* Public JS revalidation caching is restored, and script.js loads under its bare URL to restore a single module identity.
+* Generated install metadata is restored before updates run.
+* Frontend restart now works on Windows through a unified graceful shutdown, and server.js is self-supervising so restart works everywhere.
+* Windows write fallback is hardened, and direct writes are avoided after Windows temp rename failures.
+* Character saves are protected from a stale frontend, pending saves are canceled when switching characters, and the editor form no longer resets when selecting a character.
+* Stale CSRF tokens are refreshed, and group chat loads retry after a refresh.
+* OpenAI preset selection is preserved on backend switch, and the user backend is preserved on settings load instead of switching to the reverse proxy source.
+* Stale settings overwrites are now prevented.
+* Agent enable and disable toggle now responds on mobile.
+* Mobile keyboard no longer hides the composer, and stuck mobile message updates are force-flushed.
+* MovingUI panels are stabilized on desktop.
+* Mobile cache utility layout is fixed, and profile buttons no longer squish.
+* Guided Generations now honors impersonation perspective prompts.
+* The constant "Model sampling profile loaded" toast is removed.
 
 **Removed**
 * No user-facing features were removed in this release.

--- a/.github/readme.md
+++ b/.github/readme.md
@@ -124,8 +124,9 @@ bash start-termux-node.sh
 
 - `bash start.sh` also defaults to Node.js + npm on native Termux and ARM devices when Node.js is available
 - To force Node.js explicitly: `bash start-termux-node.sh`
-- To force Bun explicitly: `bash start-termux-bun.sh`
-- For shared storage access: `termux-setup-storage` once before starting
+- To force Bun explicitly: `bash start-termux-bun.sh` (this bootstraps `bun-termux` automatically on first run)
+- Keep the repo inside Termux home (for example `~/SillyBunny`), not `~/storage/shared` or `/storage/emulated/0`; Android shared storage blocks the `node_modules` links Bun and npm need
+- Run `termux-setup-storage` once only to grant SillyBunny access to shared files; do not clone the repo into shared storage
   
 ### How to Update
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ When a new, stable upstream SillyTavern version releases:
 2. An IDE or editor of your choice. Visual Studio Code is a safe default.
 3. You can also use GitHub Codespaces which sets up everything for you.
 
-Native Termux contributors should use `bash start-termux-node.sh` for Node.js + npm unless specifically testing Bun behavior; use `bash start-termux-bun.sh` when checking Bun-specific behavior.
+Native Termux contributors should keep the repo inside Termux home (for example `~/SillyBunny`), not Android shared storage. Use `bash start-termux-node.sh` for Node.js + npm unless specifically testing Bun behavior; use `bash start-termux-bun.sh` when checking Bun-specific behavior. The Bun launcher bootstraps `bun-termux` automatically on first run.
 
 ## Getting the code ready
 

--- a/README.md
+++ b/README.md
@@ -122,8 +122,9 @@ bash start-termux-node.sh
 
 - `bash start.sh` also defaults to Node.js + npm on native Termux and ARM devices when Node.js is available
 - To force Node.js explicitly: `bash start-termux-node.sh`
-- To force Bun explicitly: `bash start-termux-bun.sh`
-- For shared storage access: `termux-setup-storage` once before starting
+- To force Bun explicitly: `bash start-termux-bun.sh` (this bootstraps `bun-termux` automatically on first run)
+- Keep the repo inside Termux home (for example `~/SillyBunny`), not `~/storage/shared` or `/storage/emulated/0`; Android shared storage blocks the `node_modules` links Bun and npm need
+- Run `termux-setup-storage` once only to grant SillyBunny access to shared files; do not clone the repo into shared storage
   
 ### How to Update
 

--- a/scripts/install-prerequisites.sh
+++ b/scripts/install-prerequisites.sh
@@ -33,6 +33,9 @@ BUN_INSTALL_DIR="${BUN_INSTALL:-$HOME/.bun}"
 TERMUX_PREFIX_DEFAULT='/data/data/com.termux/files/usr'
 TERMUX_PREFIX="${PREFIX:-$TERMUX_PREFIX_DEFAULT}"
 TERMUX_BUN_WRAPPER_MARKER='SillyBunny Termux Bun wrapper'
+TERMUX_BUN_MANAGER_URL='https://raw.githubusercontent.com/Happ1ness-dev/bun-termux/main/helper_scripts/bun-termux-manager'
+TERMUX_BUN_SOURCE_DIR="${TERMUX_BUN_SOURCE_DIR:-$HOME/bun-termux}"
+TERMUX_BUN_SHIM_PATH="$BUN_INSTALL_DIR/lib/bun-shim.so"
 
 have_command() {
     command -v "$1" >/dev/null 2>&1
@@ -56,6 +59,26 @@ is_termux() {
 
 have_working_bun() {
     have_command bun && bun --version >/dev/null 2>&1
+}
+
+have_working_termux_bun() {
+    local bun_path="$BUN_INSTALL_DIR/bin/bun"
+
+    if ! is_termux; then
+        return 1
+    fi
+
+    if [[ ! -x "$bun_path" ]]; then
+        if ! have_command bun; then
+            return 1
+        fi
+
+        bun_path="$(command -v bun)"
+    fi
+
+    "$bun_path" --version >/dev/null 2>&1 \
+        && [[ -x "$BUN_INSTALL_DIR/bin/buno" ]] \
+        && [[ -f "$TERMUX_BUN_SHIM_PATH" ]]
 }
 
 have_working_git() {
@@ -208,6 +231,21 @@ install_termux_glibc_runner() {
     fi
 }
 
+install_termux_bun_manager() {
+    if ! is_termux; then
+        return 1
+    fi
+
+    echo "Termux detected. Installing Bun through bun-termux..."
+    ensure_download_tool
+
+    if have_command curl; then
+        curl -fsSL "$TERMUX_BUN_MANAGER_URL" | BUN_INSTALL="$BUN_INSTALL_DIR" bash -s install --source "$TERMUX_BUN_SOURCE_DIR"
+    else
+        wget -qO- "$TERMUX_BUN_MANAGER_URL" | BUN_INSTALL="$BUN_INSTALL_DIR" bash -s install --source "$TERMUX_BUN_SOURCE_DIR"
+    fi
+}
+
 is_termux_bun_wrapper() {
     local bun_path="$BUN_INSTALL_DIR/bin/bun"
 
@@ -262,6 +300,15 @@ EOF
 repair_termux_bun() {
     if ! is_termux; then
         return 1
+    fi
+
+    if have_working_termux_bun; then
+        return 0
+    fi
+
+    if install_termux_bun_manager; then
+        refresh_known_paths
+        have_working_termux_bun && return 0
     fi
 
     install_termux_glibc_runner
@@ -356,6 +403,22 @@ install_node_runtime() {
 }
 
 install_bun() {
+    if is_termux; then
+        if have_working_termux_bun; then
+            return
+        fi
+
+        if repair_termux_bun; then
+            return
+        fi
+
+        echo "Termux Bun installation finished, but a Termux-compatible Bun wrapper is still unavailable in this session." >&2
+        echo "SillyBunny uses bun-termux on native Termux so Bun can install packages and run from normal home-directory checkouts." >&2
+        echo "If it still fails, rerun with network access or install manually via:" >&2
+        echo "curl -fsSL '$TERMUX_BUN_MANAGER_URL' | bash -s install" >&2
+        exit 1
+    fi
+
     if have_working_bun; then
         return
     fi

--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 cd "$SCRIPT_DIR"
 
 is_truthy() {
@@ -21,6 +21,21 @@ is_truthy() {
 
 is_termux() {
     [[ -n "${TERMUX_VERSION:-}" || "${PREFIX:-}" == /data/data/com.termux/files/usr ]]
+}
+
+is_termux_shared_storage_repo() {
+    if ! is_termux; then
+        return 1
+    fi
+
+    case "$SCRIPT_DIR" in
+        /storage/*|/sdcard/*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
 }
 
 prefer_node_runtime() {
@@ -139,6 +154,13 @@ while (($#)); do
     esac
     shift
 done
+
+if (( ! self_update_only )) && is_termux_shared_storage_repo; then
+    echo "[SillyBunny] Termux installs must stay in your Termux home, not Android shared storage." >&2
+    echo "[SillyBunny] Android blocks the node_modules links Bun and npm need under paths like /storage/emulated/0." >&2
+    echo "[SillyBunny] Reclone into '$HOME/SillyBunny', then rerun this launcher. Use 'termux-setup-storage' only to grant file access." >&2
+    exit 1
+fi
 
 auto_update_enabled=0
 if (( self_update_requested )); then


### PR DESCRIPTION
## What?
Bootstraps `bun-termux` automatically when `bash start-termux-bun.sh` runs on native Termux, and blocks launches from Android shared storage paths that cannot host the `node_modules` links Bun and npm need.

Also updates the Termux docs in `README.md`, `.github/readme.md`, and `CONTRIBUTING.md` so typical mobile installs stay in `~/SillyBunny` and use the Bun launcher's supported path.

## Why?
Typical Termux Bun installs were still vulnerable to two Android-specific failures:
- plain upstream Bun in Termux home could fail with `CouldntReadCurrentDirectory`
- moving the repo to `/storage/emulated/0` or `~/storage/shared` avoided that cwd bug but then failed because Android shared storage denies the symlinks inside `node_modules/.bin`

That combination made Bun-first mobile installs easy to break even when following otherwise reasonable setup steps.

## How?
- Changes `scripts/install-prerequisites.sh` so Termux Bun installs prefer a full `bun-termux` bootstrap instead of only wrapping stock Bun with `grun`
- Verifies the Termux Bun install by checking for the wrapper layout (`bun`, `buno`, and `bun-shim.so`)
- Adds an early guard in `start.sh` that stops Termux launches from shared storage and tells the user to reclone into Termux home
- Updates Termux documentation to make the supported Bun path explicit and to explain that `termux-setup-storage` is only for granting file access, not for hosting the repo

## Testing?
- `sh -n start.sh`
- `sh -n scripts/install-prerequisites.sh`
- Reviewed the scoped git diff for the launcher and docs changes
- Not run: live Termux validation from an Android device in this environment

## Screenshots (optional)
Not applicable.

## Anything Else?
Recommended recovery command for affected Termux users:

```bash
pkg update && pkg upgrade -y
pkg install -y git curl unzip
termux-setup-storage
rm -rf ~/SillyBunny ~/.bun ~/bun-termux
git clone https://github.com/platberlitz/SillyBunny.git ~/SillyBunny
cd ~/SillyBunny
curl -fsSL "https://raw.githubusercontent.com/Happ1ness-dev/bun-termux/main/helper_scripts/bun-termux-manager" | bash -s install
bash start-termux-bun.sh
```

Keep the repo in Termux home, not `~/storage/shared` or `/storage/emulated/0`.
