### PR TITLE
fix: restore iOS keyboard shell offset broken by invalid CSS comments

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -831,9 +831,11 @@
     @media screen and (max-width: 768px) {
         /* SillyBunny: iOS 17 WebKit can misresolve dvh for the main shell. */
         body:not(.movingUI) #sheld {
-            // SillyBunny: add visual-viewport top so that when iOS Safari shifts the
-            // viewport up (keyboard open) the shell moves with it instead of floating
-            // mid-screen above the composer.
+            /* SillyBunny: add visual-viewport top so that when iOS Safari shifts the
+               viewport up (keyboard open) the shell moves with it instead of floating
+               mid-screen above the composer. NOTE: must be a CSS block comment, not //,
+               or the parser discards tokens through the next semicolon and silently
+               swallows the top: declaration below (regressed the iOS keyboard offset). */
             top: calc(var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) + var(--sb-shell-viewport-top, 0px)) !important;
             min-height: 100px !important;
             min-width: 0 !important;

--- a/tests/sillybunny-css-comment-hygiene.test.js
+++ b/tests/sillybunny-css-comment-hygiene.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const cssDir = path.join(repoRoot, 'public', 'css');
+
+// SillyBunny layers its own CSS sheets on top of upstream SillyTavern. CSS has no
+// line-comment syntax: a `//` inside a declaration block makes the parser discard
+// tokens through the next semicolon, silently swallowing the declaration that follows.
+// That is exactly how the iOS keyboard shell offset regressed -- a `//` comment ate the
+// `top: calc(... + var(--sb-shell-viewport-top))` rule, so the composer slid back behind
+// the virtual keyboard. Guard every SillyBunny sheet so the whole class of bug stays dead.
+const sillyBunnyCssFiles = readdirSync(cssDir)
+    .filter(name => /^sillybunny.*\.css$/.test(name))
+    .sort();
+
+describe('SillyBunny CSS comment hygiene', () => {
+    test('ships SillyBunny CSS sheets to guard', () => {
+        expect(sillyBunnyCssFiles.length).toBeGreaterThan(0);
+    });
+
+    test('no SillyBunny CSS sheet uses // line-comments', () => {
+        const offenders = [];
+
+        for (const fileName of sillyBunnyCssFiles) {
+            const source = readFileSync(path.join(cssDir, fileName), 'utf8');
+            source.split('\n').forEach((line, index) => {
+                if (/^\s*\/\//.test(line)) {
+                    offenders.push(`${fileName}:${index + 1}: ${line.trim()}`);
+                }
+            });
+        }
+
+        expect(offenders).toEqual([]);
+    });
+
+    test('iOS shell keeps the visual-viewport top offset the keyboard fix depends on', () => {
+        const mobileShellCss = readFileSync(path.join(cssDir, 'sillybunny-mobile-shell.css'), 'utf8');
+
+        // The iOS #sheld rule must shift down by the visual-viewport top so the shell
+        // tracks Safari when the keyboard opens. If a comment ever swallows this again,
+        // the composer hides behind the keyboard (the bug this sheet's fix addresses).
+        expect(mobileShellCss).toMatch(/#sheld\s*\{[^}]*top:\s*calc\([^}]*--sb-shell-viewport-top[^}]*\}/);
+    });
+});


### PR DESCRIPTION
## Summary

When the iOS virtual keyboard is open, the bottom of the chat (the composer) stays hidden behind the keyboard. This restores the visual-viewport offset that keeps the mobile shell tracking Safari while the keyboard is up.

## Root cause

The iOS-specific `#sheld` block in `public/css/sillybunny-mobile-shell.css` used JS-style `//` line comments inside the declaration block:

```css
body:not(.movingUI) #sheld {
    // SillyBunny: add visual-viewport top so that when iOS Safari shifts the
    // viewport up (keyboard open) the shell moves with it ...
    top: calc(var(--sb-shell-measured-top-offset, var(--sb-topbar-layout-offset)) + var(--sb-shell-viewport-top, 0px)) !important;
    ...
}
```

CSS has no `//` comment syntax. The parser treats `//` as an error and discards tokens through the next semicolon, **silently swallowing the `top: calc(...)` declaration** that followed. That `top:` is what shifts `#sheld` down by the visual-viewport top when the keyboard opens, so without it the composer slid back behind the keyboard.

This also explains why the earlier JS scroll-sync fix (#519) had no visible effect: it correctly keeps `--sb-shell-viewport-top` current on `visualViewport` scroll, but there was no surviving CSS rule consuming that variable.

## Fix

- Replace the `//` comment with a `/* ... */` block comment so the `top:` declaration survives the parser. The comment now also notes why `//` must never be used here.
- Add `tests/sillybunny-css-comment-hygiene.test.js`: asserts no SillyBunny CSS sheet contains `//` line-comments, and that the iOS `#sheld` rule keeps its `--sb-shell-viewport-top` offset.

## Testing

```
bun test tests/sillybunny-css-comment-hygiene.test.js tests/mobile-shell-lifecycle-wiring.test.js
# 23 pass / 0 fail
```
ESLint clean on the new test file.