### PR TITLE
chore: guard all first-party CSS against invalid // comments

### DIFF
--- a/tests/sillybunny-css-comment-hygiene.test.js
+++ b/tests/sillybunny-css-comment-hygiene.test.js
@@ -6,28 +6,34 @@ import path from 'node:path';
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const cssDir = path.join(repoRoot, 'public', 'css');
 
-// SillyBunny layers its own CSS sheets on top of upstream SillyTavern. CSS has no
-// line-comment syntax: a `//` inside a declaration block makes the parser discard
-// tokens through the next semicolon, silently swallowing the declaration that follows.
-// That is exactly how the iOS keyboard shell offset regressed -- a `//` comment ate the
-// `top: calc(... + var(--sb-shell-viewport-top))` rule, so the composer slid back behind
-// the virtual keyboard. Guard every SillyBunny sheet so the whole class of bug stays dead.
-const sillyBunnyCssFiles = readdirSync(cssDir)
-    .filter(name => /^sillybunny.*\.css$/.test(name))
+// CSS has no line-comment syntax: a `//` inside a declaration block makes the parser
+// discard tokens through the next semicolon, silently swallowing the declaration that
+// follows. That is exactly how the iOS keyboard shell offset regressed -- a `//` comment
+// ate the `top: calc(... + var(--sb-shell-viewport-top))` rule, so the composer slid back
+// behind the virtual keyboard. Guard first-party sheets so the whole class stays dead.
+const firstPartyCssFiles = readdirSync(cssDir)
+    .filter(name => name.endsWith('.css') && !name.endsWith('.min.css'))
     .sort();
 
+function stripCssBlockComments(source) {
+    return source.replace(/\/\*[\s\S]*?\*\//g, match => match.replace(/[^\n]/g, ' '));
+}
+
 describe('SillyBunny CSS comment hygiene', () => {
-    test('ships SillyBunny CSS sheets to guard', () => {
-        expect(sillyBunnyCssFiles.length).toBeGreaterThan(0);
+    test('ships first-party CSS sheets to guard', () => {
+        expect(firstPartyCssFiles.length).toBeGreaterThan(0);
     });
 
-    test('no SillyBunny CSS sheet uses // line-comments', () => {
+    test('no first-party CSS sheet uses invalid // comments', () => {
         const offenders = [];
 
-        for (const fileName of sillyBunnyCssFiles) {
-            const source = readFileSync(path.join(cssDir, fileName), 'utf8');
+        for (const fileName of firstPartyCssFiles) {
+            const source = stripCssBlockComments(readFileSync(path.join(cssDir, fileName), 'utf8'));
             source.split('\n').forEach((line, index) => {
-                if (/^\s*\/\//.test(line)) {
+                // Allow URL schemes such as http:// and https://, but flag line-start,
+                // inline, and trailing `//` comments. Protocol-relative URLs would need
+                // an explicit exception if the project ever intentionally adds one.
+                if (/(^|[^:])\/\//.test(line)) {
                     offenders.push(`${fileName}:${index + 1}: ${line.trim()}`);
                 }
             });


### PR DESCRIPTION
## Summary
- Expand the CSS comment hygiene guard from SillyBunny-prefixed sheets to every first-party non-minified CSS sheet.
- Strip valid CSS block comments before scanning so explanatory `/* */` comments are ignored.
- Flag line-start, inline, and trailing `//` comments while allowing URL schemes such as `http://` and `https://`.

## Testing
- `bun test tests/sillybunny-css-comment-hygiene.test.js`
- `npx eslint tests/sillybunny-css-comment-hygiene.test.js`