### PR TITLE
fix: block pinch-zoom viewport drift on Android Firefox

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -1,6 +1,15 @@
 /* SillyBunny mobile shell foundation: final sheet contract for modal drawers.
  * Keep this at the end of the shell sheet so it beats older mobile drawer rules. */
 @media screen and (max-width: 768px) {
+    /* SillyBunny: Android Firefox ignores user-scalable=no in the viewport
+       meta, allowing pinch-zoom to drift the visual viewport away from the
+       layout viewport. pan-x pan-y permits touch scrolling but blocks
+       pinch-zoom and double-tap-zoom on the document root. */
+    html,
+    body {
+        touch-action: pan-x pan-y;
+    }
+
     /* SillyBunny: visualViewport-backed height so the shell contracts with
        the software keyboard instead of relying on dvh, which is unreliable
        with body { position: fixed } on Android Chrome. */

--- a/public/scripts/browser-fixes.js
+++ b/public/scripts/browser-fixes.js
@@ -120,11 +120,13 @@ function applyBrowserFixes() {
         let viewportFixScheduled = false;
         let viewportResetScheduled = false;
         let lastViewportHeight = Math.round(viewport?.height || window.innerHeight || 0);
+        let lastOffsetLeft = Math.round(viewport?.offsetLeft || 0);
         let lastSendInteractionAt = 0;
         let lastSendFocusedAt = 0;
 
         const updateViewportBaseline = () => {
             lastViewportHeight = Math.round(viewport?.height || window.innerHeight || 0);
+            lastOffsetLeft = Math.round(viewport?.offsetLeft || 0);
         };
 
         const resetTransientViewportPosition = ({ restoreScroll = false } = {}) => {
@@ -140,7 +142,7 @@ function applyBrowserFixes() {
             document.body.style.bottom = '';
             document.body.style.transform = '';
 
-            if (restoreScroll && (document.scrollingElement?.scrollTop || 0) > 0) {
+            if (restoreScroll && ((document.scrollingElement?.scrollTop || 0) > 0 || (document.scrollingElement?.scrollLeft || 0) > 0)) {
                 window.scrollTo(0, 0);
             }
         };
@@ -209,8 +211,19 @@ function applyBrowserFixes() {
 
             const currentViewportHeight = Math.round(viewport?.height || window.innerHeight || 0);
             const viewportDelta = Math.abs(currentViewportHeight - lastViewportHeight);
+            const currentOffsetLeft = Math.round(viewport?.offsetLeft || 0);
+            const offsetLeftDelta = Math.abs(currentOffsetLeft - lastOffsetLeft);
 
             lastViewportHeight = currentViewportHeight;
+            lastOffsetLeft = currentOffsetLeft;
+
+            // SillyBunny: detect horizontal visual-viewport drift from pinch-zoom
+            // panning (Android Firefox ignores user-scalable=no). Reset scroll and
+            // transient position fixes so the app re-anchors to the layout viewport.
+            if (offsetLeftDelta > 4) {
+                scheduleViewportReset({ restoreScroll: true });
+                return;
+            }
 
             // Ignore tiny viewport twitches from the mobile browser chrome and
             // keyboard suggestion UI. Those do not need the layout workaround.
@@ -222,6 +235,7 @@ function applyBrowserFixes() {
         };
 
         viewport?.addEventListener('resize', fixFunkyPositioning, { passive: true });
+        viewport?.addEventListener('scroll', fixFunkyPositioning, { passive: true });
         window.addEventListener('resize', fixFunkyPositioning, { passive: true });
         document.addEventListener('pointerdown', (event) => {
             if (event.target instanceof HTMLElement && event.target.closest('#send_but')) {


### PR DESCRIPTION
## What?

Add `touch-action: pan-x pan-y` to `html` and `body` on mobile (max-width: 768px) to block pinch-zoom gestures that Android Firefox allows despite `user-scalable=no` in the viewport meta. Add a `visualViewport.scroll` listener and horizontal-offset drift detection in the mobile viewport fix handler so residual viewport drift triggers the existing scroll/position reset.

## Why?

Android Firefox ignores the `user-scalable=no` viewport meta directive. When a user pinch-zooms, the visual viewport drifts away from the layout viewport. Fixed-position elements and viewport-unit-sized elements (top bar, shell, companion panel handle) are anchored to the layout viewport, so they appear shifted with a large blank region. The existing mobile viewport handler only checked height changes (keyboard show/hide) and did not listen to `visualViewport.scroll`, so horizontal drift from pinch-zoom panning went uncorrected.

## How?

**CSS** (`sillybunny-mobile-shell.css`): `touch-action: pan-x pan-y` on `html, body` inside the mobile media query. This permits touch scrolling but blocks pinch-zoom and double-tap-zoom at the gesture level, before the browser can change the visual viewport scale. Applied only on mobile to avoid affecting desktop trackpad or touch-screen behavior.

**JS** (`browser-fixes.js`):
- Track `lastOffsetLeft` alongside the existing `lastViewportHeight` baseline.
- In `fixFunkyPositioning`, detect horizontal visual-viewport drift (`offsetLeftDelta > 4px`) and trigger `scheduleViewportReset({ restoreScroll: true })` to clear document scroll and transient position fixes.
- Add `visualViewport.scroll` listener so drift from pinch-zoom panning is caught in addition to resize events.
- `resetTransientViewportPosition` now also resets horizontal scroll (`scrollLeft`) when `restoreScroll` is true, not just vertical.

## Testing?

- `npm run lint` — passes clean.
- `npm run test:unit -- --testPathPattern="mobile-shell-lifecycle-wiring"` — 20/20 tests pass (all existing `browser-fixes.js` source assertions still hold).
- Manual browser verification on Android Firefox pending (requires physical device or emulator).

## Screenshots

Not available. The bug requires a physical Android device or mobile emulator with Firefox to reproduce the pinch-zoom gesture. Desktop browser devtools cannot trigger real pinch-zoom.

## Anything Else?

Closes #526.