### PR TITLE
fix: block multi-touch pinch-zoom on Firefox mobile

### DIFF
--- a/public/scripts/browser-fixes.js
+++ b/public/scripts/browser-fixes.js
@@ -121,12 +121,14 @@ function applyBrowserFixes() {
         let viewportResetScheduled = false;
         let lastViewportHeight = Math.round(viewport?.height || window.innerHeight || 0);
         let lastOffsetLeft = Math.round(viewport?.offsetLeft || 0);
+        let lastScale = viewport?.scale || 1;
         let lastSendInteractionAt = 0;
         let lastSendFocusedAt = 0;
 
         const updateViewportBaseline = () => {
             lastViewportHeight = Math.round(viewport?.height || window.innerHeight || 0);
             lastOffsetLeft = Math.round(viewport?.offsetLeft || 0);
+            lastScale = viewport?.scale || 1;
         };
 
         const resetTransientViewportPosition = ({ restoreScroll = false } = {}) => {
@@ -213,9 +215,21 @@ function applyBrowserFixes() {
             const viewportDelta = Math.abs(currentViewportHeight - lastViewportHeight);
             const currentOffsetLeft = Math.round(viewport?.offsetLeft || 0);
             const offsetLeftDelta = Math.abs(currentOffsetLeft - lastOffsetLeft);
+            const currentScale = viewport?.scale || 1;
+            const scaleDelta = Math.abs(currentScale - lastScale);
 
             lastViewportHeight = currentViewportHeight;
             lastOffsetLeft = currentOffsetLeft;
+            lastScale = currentScale;
+
+            // SillyBunny: detect visual-viewport scale change from pinch-zoom
+            // or double-tap-zoom (Firefox mobile ignores user-scalable=no and
+            // touch-action). Reset scroll and transient position fixes so the
+            // app re-anchors to the layout viewport.
+            if (scaleDelta > 0.01) {
+                scheduleViewportReset({ restoreScroll: true });
+                return;
+            }
 
             // SillyBunny: detect horizontal visual-viewport drift from pinch-zoom
             // panning (Android Firefox ignores user-scalable=no). Reset scroll and
@@ -272,6 +286,18 @@ function applyBrowserFixes() {
             }
         }, true);
         window.addEventListener('sb-mobile-viewport-reset', handleMobileViewportReset);
+
+        // SillyBunny: Firefox mobile ignores touch-action CSS and user-scalable=no
+        // in the viewport meta for pinch-zoom. Intercept multi-touch events at the
+        // touch level and preventDefault to block the browser's zoom gesture before
+        // it can change visualViewport.scale and drift the app layout.
+        const blockMultiTouchZoom = (event) => {
+            if (event.touches.length > 1) {
+                event.preventDefault();
+            }
+        };
+        document.addEventListener('touchstart', blockMultiTouchZoom, { passive: false });
+        document.addEventListener('touchmove', blockMultiTouchZoom, { passive: false });
     }
 
     addMacOSPatch();


### PR DESCRIPTION
## What?

Add JavaScript-level multi-touch event interception that calls `preventDefault()` when 2+ touches are detected, blocking pinch-zoom gestures on Firefox mobile. Also add `visualViewport.scale` drift detection to the existing viewport reset handler so any scale change (including double-tap-zoom) triggers a re-anchor.

## Why?

The previous fix (#536) added `touch-action: pan-x pan-y` in CSS and `visualViewport.scroll`/`offsetLeft` drift detection in JS. Firefox mobile ignores `touch-action` for pinch-zoom and ignores `user-scalable=no` in the viewport meta. The offsetLeft detection only caught horizontal panning after zoom, not the zoom itself. The viewport still becomes small and shifted when the user pinch-zooms on Firefox mobile.

The only reliable way to block pinch-zoom on Firefox mobile is to intercept multi-touch `touchstart`/`touchmove` events with `passive: false` and call `preventDefault()`, which Firefox respects at the touch event level.

## How?

**Multi-touch prevention** (`browser-fixes.js`): Two non-passive document-level listeners on `touchstart` and `touchmove`. When `event.touches.length > 1`, call `event.preventDefault()`. This blocks the browser from initiating or continuing the pinch-zoom gesture. Single-touch interactions (taps, scrolling, swipes) are unaffected. Element-specific multi-touch handlers (e.g. image cropper) fire first in bubble phase and are not broken.

**Scale drift detection** (`browser-fixes.js`): Track `lastScale` alongside the existing `lastViewportHeight` and `lastOffsetLeft` baselines. In `fixFunkyPositioning`, detect `scaleDelta > 0.01` and trigger `scheduleViewportReset({ restoreScroll: true })`. This catches double-tap-zoom or any zoom that slips through the touch interception.

## Testing?

- `npm run lint` — passes clean.
- `npm run test:unit -- --testPathPattern="mobile-shell-lifecycle-wiring"` — 20/20 tests pass.
- Manual browser verification on Android Firefox mobile pending (requires physical device).

## Anything Else?

Follow-up to #536. The CSS `touch-action: pan-x pan-y` from #536 remains as a first line of defense on Chrome mobile. This PR adds the Firefox-mobile-specific JS interception that was missing.