### PR TITLE
fix: scan all Claude content blocks for text, not just content[0]

### DIFF
--- a/src/endpoints/backends/chat-completions.js
+++ b/src/endpoints/backends/chat-completions.js
@@ -514,7 +514,14 @@ async function sendClaudeRequest(request, response) {
 
             /** @type {any} */
             const generateResponseJson = await generateResponse.json();
-            const responseText = generateResponseJson?.content?.[0]?.text || '';
+            // SillyBunny: scan all content blocks for the first text block, not just
+            // content[0]. When adaptive thinking is enabled, content[0] is a thinking
+            // block ({ type: 'thinking', thinking: '...' }) with no .text property,
+            // causing empty responses for Fable and other thinking-enabled models.
+            const textBlock = Array.isArray(generateResponseJson?.content)
+                ? generateResponseJson.content.find(block => block?.type === 'text')
+                : null;
+            const responseText = textBlock?.text || generateResponseJson?.content?.[0]?.text || '';
             console.debug('Claude response:', summarizeLlmPayloadForLog(generateResponseJson));
 
             // Wrap it back to OAI format + save the original content


### PR DESCRIPTION
## What?

Fix the non-streaming Claude response parser to scan all content blocks for the first `{ type: 'text' }` block, instead of only reading `content[0].text`.

## Why?

When adaptive thinking is enabled for Fable models, the Claude API returns content blocks starting with thinking blocks (`{ type: 'thinking', thinking: '...' }`). These blocks have a `.thinking` property, not `.text`. The old code `generateResponseJson?.content?.[0]?.text` returned `undefined` for thinking blocks, producing empty responses.

This caused two reported bugs:
- #525: Empty Fable responses when persona descriptions contain brackets (brackets in system prompts can trigger extended thinking without producing text output).
- #528: Fable fails built-in automatic chat-name generation (auto-name uses `generateRaw` which is non-streaming, hitting the vulnerable `content[0].text` path).

## How?

Replace `content[0].text` with a scan that finds the first `text`-type content block in the response array, falling back to `content[0].text` for backward compatibility. The raw `content` array is still passed through unchanged in `reply.content` so the frontend's `extractMessageFromData()` and `extractJsonFromData()` continue to work.

## Testing?

- `npm run lint` passes clean.
- Manual verification with Fable + adaptive thinking pending (requires API access).

## Anything Else?

Closes #525, closes #528.