### PR TITLE
fix: guarantee send buttons reactivated after quiet generation

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -5301,6 +5301,11 @@ export async function generateQuietPrompt({ quietPrompt = '', quietToLoud = fals
             TempResponseLength.restore(main_api);
             TempResponseLength.removeEventHook(main_api, eventHook);
         }
+        // SillyBunny: guarantee the send buttons are reactivated after quiet
+        // generation, regardless of whether Generate succeeded, failed, threw,
+        // or returned null data. Without this, memory refresh and other quiet
+        // generation callers can leave the chat input locked. (#527)
+        activateSendButtons();
     }
 }
 
@@ -6889,6 +6894,9 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
     // assemble the prompt so we can count its tokens regardless of whether a chat is active.)
     if (!dryRun && !hasBackendConnection) {
         is_send_press = false;
+        // SillyBunny: reactivate send buttons on early exit so the UI is not
+        // left locked when there is no backend connection. (#527)
+        activateSendButtons();
         return Promise.resolve();
     }
 
@@ -8003,7 +8011,12 @@ export async function Generate(type, { automatic_trigger, force_name2, quiet_pro
      * @throws {Error} Throws an error if the response data contains an error message
      */
     async function onSuccess(data) {
-        if (!data) return;
+        if (!data) {
+            // SillyBunny: unblock generation on null/falsy data so the send
+            // buttons are not left locked. (#527)
+            unblockGeneration(type, { force: true });
+            return;
+        }
 
         if (data?.fromStream) {
             return data;


### PR DESCRIPTION
## What?

Guarantee `activateSendButtons()` runs after quiet generation completes, fails, or is interrupted, so the chat input is never left locked.

## Why?

Memory refresh (force-summarize) uses `generateQuietPrompt()` which calls `Generate('quiet')`. Inside `Generate`, `deactivateSendButtons()` locks the UI, but `activateSendButtons()` was not guaranteed to run on all exit paths. Three specific leak paths left the send button hidden and the stop button as a no-op:

1. `generateQuietPrompt()` finally block cleaned up signal listeners and temp response length but never called `activateSendButtons()`.
2. `onSuccess()` returned silently on null/falsy data without calling `unblockGeneration()`.
3. No-backend-connection early return set `is_send_press = false` but never reactivated the send buttons.

## How?

1. Add `activateSendButtons()` to `generateQuietPrompt()` finally block — guarantees cleanup for all quiet generation callers (memory, auto-name, regex testing, etc.).
2. Add `unblockGeneration(type, { force: true })` to the `onSuccess` null-data early return.
3. Add `activateSendButtons()` to the no-backend-connection early return.

## Testing?

- `npm run lint` passes clean.
- Manual verification: trigger memory refresh with a failing API, then confirm chat input accepts typing.

## Anything Else?

Closes #527.