### PR TITLE
fix: reset Pathfinder auto-summary counter on tool success, not injection

### DIFF
--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -55,7 +55,7 @@ import {
 import { getPathfinderToolDefinitions } from './pathfinder/tool-definitions.js';
 import { getContextualLorebooks } from './pathfinder/pathfinder-tool-bridge.js';
 import { PATHFINDER_RETRIEVAL_PROMPT_KEYS, runSidecarRetrieval } from './pathfinder/sidecar-retrieval.js';
-import { markAutoSummaryComplete, shouldAutoSummarize } from './pathfinder/auto-summary.js';
+import { shouldAutoSummarize } from './pathfinder/auto-summary.js';
 import { buildRegexScriptRefsForAgent, cacheAgentRegexScripts, migrateLegacyRegexSnapshotsInMessages } from './regex-snapshot-store.js';
 
 const PROMPT_KEY_PREFIX = 'inchat_agent_';
@@ -3594,7 +3594,11 @@ async function onGenerationAfterCommands(generationType, _options, dryRun) {
                 false,
                 extension_prompt_roles.SYSTEM,
             );
-            markAutoSummaryComplete();
+            // SillyBunny: do NOT reset the counter here. The counter is reset
+            // only after the Pathfinder_Summarize tool actually writes a summary.
+            // Resetting at injection time caused the interval to be consumed even
+            // when the model skipped or failed the tool call, preventing future
+            // summaries from triggering. (#530)
         }
     }
 

--- a/public/scripts/extensions/in-chat-agents/pathfinder/tools/summarize.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/tools/summarize.js
@@ -4,6 +4,7 @@ import { getWritableBooks, resolveTargetBook, TOOL_NAMES } from '../pathfinder-t
 import { registerToolAction, registerToolFormatter } from '../../tool-action-registry.js';
 import { logToolCallStarted, logToolCallCompleted, logToolCallError } from '../activity-feed.js';
 import { setSummaryMemoryCreated } from '../summary-memory-store.js';
+import { markAutoSummaryComplete } from '../auto-summary.js';
 
 const COMPACT_DESCRIPTION = 'Create a scene or event summary with significance level and optional narrative arc.';
 const GENERIC_SUMMARY_TITLE_PATTERN = /^(recent scene summary|scene summary|memory summary|summary|untitled summary)$/i;
@@ -160,6 +161,11 @@ export async function createSeparateSummaryMemoryEntry(args = {}) {
 async function summarizeAction(args) {
     try {
         const result = await createSummaryMemoryEntry(args);
+        // SillyBunny: reset the auto-summary counter only after a summary is
+        // successfully written, not when the prompt is injected. This ensures
+        // the interval is not consumed when the model skips or fails the tool
+        // call. (#530)
+        markAutoSummaryComplete();
         return `📝 Summary "${result.title}" saved in "${result.targetBook}" (UID: ${result.uid}). Significance: ${result.significance}. ${result.arc ? `Filed under arc "${result.arc}".` : ''}`;
     } catch (err) {
         return `❌ Failed to summarize: ${err.message}`;

--- a/tests/pathfinder-summary-tool.test.js
+++ b/tests/pathfinder-summary-tool.test.js
@@ -27,6 +27,7 @@ await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/path
 await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/pathfinder-tool-bridge.js', () => ({
     TOOL_NAMES: { SUMMARIZE: 'Pathfinder_Summarize' },
     getWritableBooks: jest.fn(() => mockWritableBooks),
+    getActiveTunnelVisionBooks: jest.fn(() => mockWritableBooks),
     resolveTargetBook: jest.fn((requestedBook, writableBooks) => {
         if (requestedBook && writableBooks.includes(requestedBook)) {
             return requestedBook;
@@ -51,6 +52,10 @@ await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/path
     setSummaryMemoryCreated: jest.fn(payload => {
         mockSummaryState = payload;
     }),
+}));
+
+await jest.unstable_mockModule('../public/scripts/extensions/in-chat-agents/pathfinder/auto-summary.js', () => ({
+    markAutoSummaryComplete: jest.fn(),
 }));
 
 const {


### PR DESCRIPTION
## What?

Move the Pathfinder auto-summary counter reset from prompt-injection time to tool-success time, so skipped or failed summaries do not consume the interval.

## Why?

The counter was reset synchronously at `agent-runner.js` immediately after `setExtensionPrompt()` injected the "summary is due" prompt, before the LLM generation ran. The injected prompt explicitly allows the model to skip the tool call ("If nothing important happened, do not call it"). When the model skipped or the generation was interrupted, the counter was already zeroed, and the next summary would not trigger for another full interval. This caused the reported "summarize once then stops" behavior.

## How?

- Remove `markAutoSummaryComplete()` from `agent-runner.js` at the prompt injection site.
- Add `markAutoSummaryComplete()` to `summarize.js` inside `summarizeAction()`, after `createSummaryMemoryEntry()` succeeds.
- Clean up the now-unused `markAutoSummaryComplete` import in `agent-runner.js`.

If the model skips the tool call, the counter stays above the threshold, so the prompt fires again on the next generation. This is the correct behavior: the interval should only reset when a summary is actually written.

## Testing?

- `npm run lint` passes clean.
- Manual verification: set interval to 2, send 4+ messages, confirm summaries trigger repeatedly.

## Anything Else?

Closes #530.