### PR TITLE
fix: block horizontal touch-panning on mobile document root (#526)

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -3,11 +3,13 @@
 @media screen and (max-width: 768px) {
     /* SillyBunny: Android Firefox ignores user-scalable=no in the viewport
        meta, allowing pinch-zoom to drift the visual viewport away from the
-       layout viewport. pan-x pan-y permits touch scrolling but blocks
-       pinch-zoom and double-tap-zoom on the document root. */
+       layout viewport. pan-y permits vertical touch scrolling but blocks
+       horizontal panning, pinch-zoom, and double-tap-zoom on the document
+       root. Horizontal panning is never desired at the document level;
+       specific horizontal rails set their own touch-action. (#526) */
     html,
     body {
-        touch-action: pan-x pan-y;
+        touch-action: pan-y;
     }
 
     /* SillyBunny: visualViewport-backed height so the shell contracts with


### PR DESCRIPTION
## What

Mobile users could drag the screen horizontally, pulling the viewport off focus. This is a residual bug from the #526 pinch-zoom fix.

## Why

The document root used `touch-action: pan-x pan-y`, which explicitly permits horizontal touch panning. Horizontal panning is never desired at the document level in this app — it only lets users drag the layout sideways. Vertical scrolling is the only panning the root needs.

## How

Changed `touch-action` on `html, body` (mobile media query) from `pan-x pan-y` to `pan-y`:
- Keeps vertical touch scrolling
- Blocks horizontal panning (the reported bug)
- Blocks pinch-zoom and double-tap-zoom (unchanged from before)

Specific horizontal rails (e.g. the character shell shortcut rail) set their own `touch-action: pan-x` and are unaffected. The JS visual-viewport drift detection in `browser-fixes.js` remains as a safety net for browsers that ignore `touch-action` (e.g. Firefox mobile).

## Testing

- `npm run lint` passes
- CSS-only change; no JS touched

## Related

Follow-up to #526 (PRs #536, #537).