### PR TITLE
fix: store Guided Generations profile by id instead of name (#529)

### DIFF
--- a/public/scripts/extensions/guided-generations/index.js
+++ b/public/scripts/extensions/guided-generations/index.js
@@ -1,6 +1,6 @@
-import { saveSettingsDebounced } from '../../../script.js';
+import { saveSettingsDebounced, eventSource, event_types } from '../../../script.js';
 import { extensionNames, extension_settings, renderExtensionTemplateAsync } from '../../extensions.js';
-import { extensionName, getPresetsForApiType, getProfileApiType, getProfileList } from './scripts/shared.js';
+import { extensionName, getPresetsForApiType, getProfileApiType, getProfileList, resolveStoredProfile } from './scripts/shared.js';
 import { guidedCorrection } from './scripts/guidedCorrection.js';
 import { guidedImpersonate } from './scripts/guidedImpersonate.js';
 import { guidedResponse } from './scripts/guidedResponse.js';
@@ -145,11 +145,28 @@ async function populateProfiles(container) {
     profileSelect.innerHTML = '<option value="">Current profile</option>';
     for (const profile of profiles) {
         const option = document.createElement('option');
-        option.value = profile;
-        option.textContent = profile;
+        // SillyBunny: use profile id as the option value so retention survives
+        // profile renames. Display name is shown to the user. (#529)
+        option.value = profile.id;
+        option.textContent = profile.name;
         profileSelect.append(option);
     }
-    profileSelect.value = settings.profileImpersonate1st ?? '';
+
+    // SillyBunny: resolve the stored value to a valid profile id. Existing
+    // settings may store a legacy profile name instead of an id, so use
+    // resolveStoredProfile which accepts both. (#529)
+    const storedValue = settings.profileImpersonate1st ?? '';
+    if (storedValue) {
+        const resolved = resolveStoredProfile(storedValue);
+        profileSelect.value = resolved?.id ?? '';
+        // Migrate the stored value to an id if it was a name.
+        if (resolved && resolved.id !== storedValue) {
+            settings.profileImpersonate1st = resolved.id;
+            saveSettingsDebounced();
+        }
+    } else {
+        profileSelect.value = '';
+    }
 }
 
 async function populatePresets(container) {
@@ -398,6 +415,27 @@ export async function init() {
     await loadSettingsPanel();
     updateExtensionButtons();
     startQrIntegration();
+
+    // SillyBunny: re-populate profile/preset dropdowns when Connection Manager
+    // profiles change, so the UI stays in sync without requiring a manual
+    // refresh click. Fixes the race condition where dropdowns populate before
+    // Connection Manager data is ready. (#529)
+    const refreshDropdowns = async () => {
+        const container = document.getElementById(`extension_settings_${extensionName}`);
+        if (container) {
+            await updateSettingsUI();
+        }
+    };
+
+    if (event_types?.CONNECTION_PROFILE_CREATED) {
+        eventSource.on(event_types.CONNECTION_PROFILE_CREATED, refreshDropdowns);
+    }
+    if (event_types?.CONNECTION_PROFILE_UPDATED) {
+        eventSource.on(event_types.CONNECTION_PROFILE_UPDATED, refreshDropdowns);
+    }
+    if (event_types?.CONNECTION_PROFILE_DELETED) {
+        eventSource.on(event_types.CONNECTION_PROFILE_DELETED, refreshDropdowns);
+    }
 }
 
 export {

--- a/public/scripts/extensions/guided-generations/scripts/guidedImpersonate.js
+++ b/public/scripts/extensions/guided-generations/scripts/guidedImpersonate.js
@@ -4,7 +4,7 @@ import {
     extensionName,
     extension_settings,
     getContext,
-    getCurrentProfile,
+    getCurrentProfileId,
     getLastImpersonateResult,
     getPreviousImpersonateInput,
     handleSwitching,
@@ -69,7 +69,7 @@ async function guidedImpersonate() {
     const settings = extension_settings[extensionName] ?? {};
     const profileValue = settings.profileImpersonate1st ?? '';
     const presetValue = settings.presetImpersonate1st ?? '';
-    const originalProfile = await getCurrentProfile();
+    const originalProfile = await getCurrentProfileId();
     const switching = await handleSwitching(profileValue, presetValue, originalProfile);
     const promptTemplate = settings.promptImpersonate1st ?? '';
     const filledPrompt = applyPromptTemplate(promptTemplate, currentInputText);

--- a/public/scripts/extensions/guided-generations/scripts/presetUtils.js
+++ b/public/scripts/extensions/guided-generations/scripts/presetUtils.js
@@ -54,6 +54,33 @@ function getProfileByName(profileName) {
     return profiles.find(profile => profile.name === profileName) ?? null;
 }
 
+function getProfileById(profileId) {
+    const profiles = getConnectionManagerSettings().profiles;
+    if (!Array.isArray(profiles)) {
+        return null;
+    }
+
+    return profiles.find(profile => profile.id === profileId) ?? null;
+}
+
+/**
+ * Resolves a stored profile identifier to a profile object.
+ * Accepts both id-based (new) and name-based (legacy) values so existing
+ * settings migrate transparently without an explicit migration step. (#529)
+ */
+function resolveStoredProfile(storedValue) {
+    if (!storedValue) {
+        return null;
+    }
+
+    const byId = getProfileById(storedValue);
+    if (byId) {
+        return byId;
+    }
+
+    return getProfileByName(storedValue);
+}
+
 async function getCurrentProfile() {
     const settings = getConnectionManagerSettings();
     const profiles = settings.profiles;
@@ -64,17 +91,26 @@ async function getCurrentProfile() {
     return profiles.find(profile => profile.id === settings.selectedProfile)?.name ?? '';
 }
 
-async function getProfileList() {
-    const profiles = getConnectionManagerSettings().profiles;
-    return Array.isArray(profiles) ? profiles.map(profile => profile.name).filter(Boolean) : [];
+async function getCurrentProfileId() {
+    const settings = getConnectionManagerSettings();
+    return settings.selectedProfile ?? '';
 }
 
-async function getProfileApiType(profileName) {
-    if (!profileName) {
+async function getProfileList() {
+    const profiles = getConnectionManagerSettings().profiles;
+    return Array.isArray(profiles)
+        ? profiles.filter(profile => profile.id && profile.name).map(profile => ({ id: profile.id, name: profile.name }))
+        : [];
+}
+
+async function getProfileApiType(profileIdentifier) {
+    if (!profileIdentifier) {
         return normalizeApiType();
     }
 
-    const profile = getProfileByName(profileName);
+    // SillyBunny: accept both profile id (new) and profile name (legacy) so
+    // existing settings migrate transparently. (#529)
+    const profile = getProfileById(profileIdentifier) ?? getProfileByName(profileIdentifier);
     if (!profile) {
         return normalizeApiType();
     }
@@ -144,21 +180,27 @@ async function switchToProfile(profileName) {
     return true;
 }
 
-async function handleSwitching(targetProfile = '', targetPreset = '', originalProfile = '') {
-    const profileToRestore = originalProfile ?? await getCurrentProfile();
+async function handleSwitching(targetProfileId = '', targetPreset = '', originalProfileId = '') {
+    const profileToRestoreId = originalProfileId || await getCurrentProfileId();
     const apiToRestore = normalizeApiType();
     const presetToRestore = getCurrentPresetName(apiToRestore);
 
+    // Resolve ids to names for the /profile slash command which accepts names.
+    const restoreProfile = getProfileById(profileToRestoreId);
+    const profileToRestoreName = restoreProfile?.name ?? '';
+
     async function switchToTarget() {
-        if (targetProfile && targetProfile !== profileToRestore) {
-            debugLog(`[${extensionName}] Switching profile to: ${targetProfile}`);
-            await switchToProfile(targetProfile);
+        if (targetProfileId && targetProfileId !== profileToRestoreId) {
+            const targetProfile = getProfileById(targetProfileId);
+            const targetName = targetProfile?.name ?? targetProfileId;
+            debugLog(`[${extensionName}] Switching profile to: ${targetName}`);
+            await switchToProfile(targetName);
         }
 
         if (targetPreset) {
-            const apiType = await getProfileApiType(targetProfile || await getCurrentProfile());
+            const apiType = await getProfileApiType(targetProfileId || await getCurrentProfileId());
             debugLog(`[${extensionName}] Switching preset to: ${targetPreset} (${apiType})`);
-            if (targetProfile && targetPreset) {
+            if (targetProfileId && targetPreset) {
                 await getContext().executeSlashCommandsWithOptions(`/preset ${makeCommandArg(targetPreset)}`);
             } else {
                 await selectPresetByName(targetPreset, apiType);
@@ -168,10 +210,10 @@ async function handleSwitching(targetProfile = '', targetPreset = '', originalPr
 
     async function restore() {
         try {
-            const currentProfile = await getCurrentProfile();
-            if (targetProfile && currentProfile !== profileToRestore) {
-                debugLog(`[${extensionName}] Restoring profile to: ${profileToRestore || NONE_PROFILE}`);
-                await switchToProfile(profileToRestore);
+            const currentId = await getCurrentProfileId();
+            if (targetProfileId && currentId !== profileToRestoreId) {
+                debugLog(`[${extensionName}] Restoring profile to: ${profileToRestoreName || NONE_PROFILE}`);
+                await switchToProfile(profileToRestoreName);
             }
 
             if (targetPreset && presetToRestore) {
@@ -186,15 +228,18 @@ async function handleSwitching(targetProfile = '', targetPreset = '', originalPr
     return {
         switch: switchToTarget,
         restore,
-        originalProfile: profileToRestore,
+        originalProfile: profileToRestoreName,
         originalPreset: presetToRestore,
     };
 }
 
 export {
     getCurrentProfile,
+    getCurrentProfileId,
     getPresetsForApiType,
     getProfileApiType,
+    getProfileById,
     getProfileList,
     handleSwitching,
+    resolveStoredProfile,
 };

--- a/public/scripts/extensions/guided-generations/scripts/shared.js
+++ b/public/scripts/extensions/guided-generations/scripts/shared.js
@@ -1,10 +1,13 @@
 import { extension_settings, getContext } from '../../../extensions.js';
 import {
     getCurrentProfile,
+    getCurrentProfileId,
     getPresetsForApiType,
     getProfileApiType,
+    getProfileById,
     getProfileList,
     handleSwitching,
+    resolveStoredProfile,
 } from './presetUtils.js';
 
 const extensionName = 'guided-generations';
@@ -75,14 +78,17 @@ export {
     extension_settings,
     getContext,
     getCurrentProfile,
+    getCurrentProfileId,
     getLastAiMessage,
     getLastImpersonateResult,
     getPresetsForApiType,
     getPreviousImpersonateInput,
     getProfileApiType,
+    getProfileById,
     getProfileList,
     handleSwitching,
     isGroupChat,
+    resolveStoredProfile,
     setLastImpersonateResult,
     setPreviousImpersonateInput,
 };

--- a/tests/guided-generations-settings.test.js
+++ b/tests/guided-generations-settings.test.js
@@ -12,6 +12,8 @@ describe('Guided Generations settings migration', () => {
 
         await jest.unstable_mockModule('../public/script.js', () => ({
             saveSettingsDebounced,
+            eventSource: { on: jest.fn() },
+            event_types: {},
         }));
         await jest.unstable_mockModule('../public/scripts/extensions.js', () => ({
             extensionNames: [],
@@ -23,6 +25,7 @@ describe('Guided Generations settings migration', () => {
             getPresetsForApiType: jest.fn(async () => []),
             getProfileApiType: jest.fn(async () => ''),
             getProfileList: jest.fn(async () => []),
+            resolveStoredProfile: jest.fn(() => null),
         }));
         await jest.unstable_mockModule('../public/scripts/extensions/guided-generations/scripts/guidedCorrection.js', () => ({
             guidedCorrection: jest.fn(),

--- a/tests/guided-generations-steering.test.js
+++ b/tests/guided-generations-steering.test.js
@@ -102,10 +102,13 @@ describe('Guided Generations steering commands', () => {
         }));
         await jest.unstable_mockModule('../public/scripts/extensions/guided-generations/scripts/presetUtils.js', () => ({
             getCurrentProfile: jest.fn(async () => ''),
+            getCurrentProfileId: jest.fn(async () => ''),
             getPresetsForApiType: jest.fn(async () => []),
             getProfileApiType: jest.fn(async () => ''),
+            getProfileById: jest.fn(() => null),
             getProfileList: jest.fn(async () => []),
             handleSwitching: jest.fn(async () => ({ switch: jest.fn(), restore: jest.fn() })),
+            resolveStoredProfile: jest.fn(() => null),
         }));
     });
 


### PR DESCRIPTION
## What

Guided Generations profile dropdowns did not retain the selected profile after renaming/reordering profiles in Connection Manager, and sometimes appeared empty on first load due to a race condition between dropdown population and Connection Manager data loading.

## Why

Profiles were stored by display name, not by id. Renaming a profile orphaned the stored setting. The dropdown also populated during extension init, before Connection Manager had loaded its profile list — so the dropdown appeared empty until the user manually refreshed settings.

## How

**Id-based storage** (`presetUtils.js`, `index.js`):
- `getProfileList()` returns `{ id, name }` objects instead of name strings
- `populateProfiles()` uses `profile.id` as the `<option>` value
- `getProfileApiType()` and `handleSwitching()` accept profile ids, resolving to names only when calling the `/profile` slash command (which uses names)
- `guidedImpersonate.js` passes `getCurrentProfileId()` to `handleSwitching()`

**Legacy migration** (`presetUtils.js`, `index.js`):
- `resolveStoredProfile()` accepts both id-based (new) and name-based (legacy) values
- On dropdown populate, legacy name-based settings are transparently migrated to ids and saved

**Reactive refresh** (`index.js`):
- Listeners on `CONNECTION_PROFILE_CREATED`, `CONNECTION_PROFILE_UPDATED`, `CONNECTION_PROFILE_DELETED` re-populate dropdowns when Connection Manager profiles change
- Eliminates the race condition — dropdowns stay in sync without manual refresh

## Testing

- `npm run lint` passes
- Manual testing pending (mobile/Android Firefox)

## Related

Closes #529.