### PR TITLE
fix: use 5-column grid for home action buttons and update TLD site link to BotBooru

### DIFF
--- a/public/css/welcome.css
+++ b/public/css/welcome.css
@@ -354,7 +354,7 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
 
 .welcomeActionGrid {
     display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-columns: repeat(5, minmax(0, 1fr));
     grid-auto-rows: 1fr;
     gap: 14px;
     width: 100%;
@@ -862,6 +862,12 @@ body.hideChatAvatars .welcomePanel .recentChatList .recentChat .avatar {
     .welcomeHeroScene::after {
         width: min(100%, 156px);
         height: 24px;
+    }
+}
+
+@container welcome-home (max-width: 900px) {
+    .welcomeActionGrid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
     }
 }
 

--- a/public/scripts/welcome-screen.js
+++ b/public/scripts/welcome-screen.js
@@ -54,7 +54,7 @@ const STARTER_PACK_CREATOR_NAME = 'purachina';
 const STARTER_PACK_SITE_URL = 'https://platberlitz.github.io/';
 const GEECHAN_PRESET_NAME = 'Geechan - Universal Roleplay (Chat Completions) (v5.2)';
 const GEECHAN_SITE_URL = 'https://rentry.org/geechan';
-const TLD_CHUB_URL = 'https://chub.ai/users/thelonelydevil';
+const TLD_SITE_URL = 'https://botbooru.com/profile/25826';
 const TLD_DISCORD_PALS_URL = 'https://github.com/TheLonelyDevil9/discord-pals/';
 const STARTER_PACK_EXTENSIONS = Object.freeze({
     dialogueColors: Object.freeze({
@@ -912,11 +912,11 @@ function buildTldStarterPackItem() {
         title: 'TheLonelyDevil',
         body: 'SillyBunny bundles the TLD Card Conversion Preset for character card conversions and generations, and the Memory Sharding Quick Reply set for compressing chat history into structured memory shards. We also recommend his Discord Pals program to run LLM characters inside Discord!',
         icon: 'fa-shoe-prints',
-        chips: ['Card converter', 'Memory shards', 'Discord Pals', 'Chub'],
+        chips: ['Card converter', 'Memory shards', 'Discord Pals', 'BotBooru'],
         statusLabel: 'Card Converter',
         statusTone: 'warm',
         actionLabel: 'Visit site',
-        actionValue: TLD_CHUB_URL,
+        actionValue: TLD_SITE_URL,
         secondaryActionLabel: 'Discord Pals',
         secondaryActionValue: TLD_DISCORD_PALS_URL,
     });


### PR DESCRIPTION
## What?

- Switch the welcome home action grid from a 4-column to a 5-column layout so all five action buttons (Temporary Chat, Open/Close Launchpad, Open Assistant, Open Assistant Nahida, Open Conversation) fit on a single row instead of the fifth wrapping to a new line.
- Add a 3-column breakpoint at `900px` so the grid degrades gracefully between desktop and the existing 2-column mobile breakpoint at `760px`.
- Update TheLonelyDevil starter pack site link from the Chub profile to the BotBooru profile (`https://botbooru.com/profile/25826`), and rename the `TLD_CHUB_URL` constant to `TLD_SITE_URL` plus the chip label from `Chub` to `BotBooru`.

## Why?

The home action grid held five buttons but was configured for four columns, so one button always spilled to a second row regardless of viewport or zoom. The available horizontal space was not being used.

The Chub profile is no longer the active public home for TheLonelyDevil cards; BotBooru is. The starter pack card should point visitors to the current profile.

## How?

- `welcome.css`: `grid-template-columns` changed from `repeat(4, minmax(0, 1fr))` to `repeat(5, minmax(0, 1fr))` on `.welcomeActionGrid`. A new `@container welcome-home (max-width: 900px)` rule drops to 3 columns before the existing `760px` rule drops to 2.
- `welcome-screen.js`: constant renamed and URL updated; chip label updated. No logic changes.

## Testing?

- `bun run lint` passes clean (exit 0) against the full eslint config.
- No automated tests cover this grid; the change is CSS-only plus a constant rename.
- Manual visual verification in a browser is recommended before merge, particularly at widths around the new 900px breakpoint.

## Anything Else?

Two separate PRs are being opened for these related but independent fixes; this one covers the welcome-screen UI and link, the other covers the bundled TLD Card Conversion Preset update to v8.