### PR TITLE
fix: stop token counter truncation in narrow avatar column (#531)

### DIFF
--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -1497,14 +1497,13 @@ select.text_pole:where(:not([multiple]):not([size]):not(.select2-hidden-accessib
 }
 
 #chat .mes .mesAvatarWrapper > :is(.mesIDDisplay, .mes_timer, .tokenCounterDisplay) {
-    inline-size: 100%;
+    inline-size: max-content;
+    max-inline-size: 100%;
     min-block-size: calc(var(--mainFontSize) * var(--sb-message-meta-line-height));
     padding: 0 2px;
     box-sizing: border-box;
     line-height: var(--sb-message-meta-line-height);
     white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
 }
 
 #chat .mes .mesAvatarWrapper > .mesIDDisplay {


### PR DESCRIPTION
## What

Token counter, message ID, and timer text truncated when the avatar column was narrow (default chat style). Only echo/whisper/hush/tide styles were unaffected because they auto-size the avatar wrapper.

## Why

`.mesAvatarWrapper` has a fixed `inline-size: var(--avatar-base-width)` (~42px). Metadata items (`.tokenCounterDisplay`, `.mesIDDisplay`, `.mes_timer`) were set to `inline-size: 100%` with `overflow: hidden` + `text-overflow: ellipsis`, clipping any text wider than the avatar column. Token counts like `12345t` or longer were cut off.

## How

Changed metadata item sizing in `sillybunny-theme.css`:
- `inline-size: 100%` → `max-content` (items size to their text)
- `max-inline-size: 100%` added (items don't exceed column when content fits)
- Removed `overflow: hidden` and `text-overflow: ellipsis`
- `white-space: nowrap` kept (prevents wrapping)

## Testing

- `npm run lint` passes
- `npm run test:unit` passes (1275 tests)
- CSS-only change; no JS touched

## Related

Closes #531.