### PR TITLE
fix: hide unused STscript controls in mobile composer

### DIFF
--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -128,6 +128,15 @@
         display: none !important;
     }
 
+    /* SillyBunny: the STscript execution play/pause/stop controls (.stscript_btn)
+       are unused by this fork's roleplay-focused audience. mobile-styles.css
+       forces them to display:flex (see #533), which lets them overlap the
+       composer textarea on mobile. Hide them unconditionally here -- this sheet
+       loads after mobile-styles.css so the !important wins. */
+    #rightSendForm > .stscript_btn {
+        display: none !important;
+    }
+
     #leftSendForm > div,
     #rightSendForm > div:not(.stscript_btn),
     #send_but,

--- a/tests/mobile-composer-stscript-buttons.test.js
+++ b/tests/mobile-composer-stscript-buttons.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const mobileShellCss = readFileSync(path.join(repoRoot, 'public', 'css', 'sillybunny-mobile-shell.css'), 'utf8');
+const mobileStylesCss = readFileSync(path.join(repoRoot, 'public', 'css', 'mobile-styles.css'), 'utf8');
+const indexHtml = readFileSync(path.join(repoRoot, 'public', 'index.html'), 'utf8');
+
+describe('mobile composer STscript controls', () => {
+    test('hides the unused stscript play/pause/stop buttons unconditionally', () => {
+        // #533 forced .stscript_btn to display:flex !important in mobile-styles.css,
+        // which let the unused script execution controls overlap the textarea.
+        // sillybunny-mobile-shell.css loads later (verified below) so its
+        // display:none !important wins and keeps them hidden.
+        expect(mobileShellCss).toMatch(/#rightSendForm\s*>\s*\.stscript_btn\s*\{[^}]*display:\s*none\s*!important/);
+    });
+
+    test('the override sheet still loads after the sheet that forces display:flex', () => {
+        const mobileStylesIdx = indexHtml.indexOf('css/mobile-styles.css');
+        const mobileShellIdx = indexHtml.indexOf('css/sillybunny-mobile-shell.css');
+
+        expect(mobileStylesIdx).toBeGreaterThan(-1);
+        expect(mobileShellIdx).toBeGreaterThan(-1);
+        expect(mobileShellIdx).toBeGreaterThan(mobileStylesIdx);
+    });
+
+    test('documents why the override is needed', () => {
+        // Keep the explanatory comment so a future cleanup does not delete the
+        // rule without understanding the #533 interaction.
+        expect(mobileShellCss).toContain('stscript_btn');
+        expect(mobileShellCss).toContain('#533');
+    });
+
+    test('mobile-styles.css still forces the controls visible (the thing being overridden)', () => {
+        // Guards against #533 being reverted upstream: if it ever is, this test
+        // flips and the override rule above can be simplified.
+        expect(mobileStylesCss).toMatch(/#rightSendForm\s*>\s*\.stscript_btn\s*\{[^}]*display:\s*flex\s*!important/);
+    });
+});

--- a/tests/mobile-css-budgets.test.js
+++ b/tests/mobile-css-budgets.test.js
@@ -28,8 +28,13 @@ function getMediaQueryPxValues(cssSource) {
 // Ratchet budgets: ceilings match the measured state of staging when this
 // test landed. Lower them as cleanup PRs land; never raise them without a
 // review note explaining the regression.
+//
+// sillybunny-mobile-shell.css raised 664 -> 665: one display:none !important
+// added to unconditionally hide the unused STscript play/pause/stop controls
+// (.stscript_btn) in the mobile composer, overriding the display:flex !important
+// that mobile-styles.css added in #533.
 const FORK_SHEET_IMPORTANT_BUDGETS = Object.freeze({
-    'sillybunny-mobile-shell.css': 664,
+    'sillybunny-mobile-shell.css': 665,
     'sillybunny-tabs.css': 386,
     'sillybunny-chat-styles.css': 225,
     'sillybunny-theme.css': 158,


### PR DESCRIPTION
## What

The STscript execution play/pause/stop controls (`.stscript_btn` — `#stscript_continue`, `#stscript_pause`, `#stscript_stop`) sit behind the composer text box on mobile and are unused by this fork's roleplay-focused audience.

## Why

`mobile-styles.css` (in #533) forces these buttons to `display: flex !important` with explicit composer-action sizing, so they render in the mobile composer and overlap the `#send_textarea`. They are advanced STscript-execution controls that the target audience does not use, so they should be hidden in the mobile composer.

## How

Adds an unconditional hide rule in `sillybunny-mobile-shell.css`:

```css
#rightSendForm > .stscript_btn {
    display: none !important;
}
```

This sheet loads after `mobile-styles.css` (verified by the existing load-order test in `mobile-css-budgets.test.js`), so the equal-specificity `!important` here wins. Desktop behaviour is untouched — the buttons still appear there during script execution.

## Scope

- Only touches SillyBunny-owned files (`public/css/sillybunny-mobile-shell.css`, tests). No upstream SillyTavern files are modified.
- Self-contained single-rule change per the KISS guideline.

## Tests

- New `tests/mobile-composer-stscript-buttons.test.js`: guards the override rule, the load order it depends on, the explanatory comment, and the #533 `display: flex !important` it overrides.
- Bumps the `sillybunny-mobile-shell.css` `!important` ratchet budget `664 -> 665` in `tests/mobile-css-budgets.test.js` with a review note.
- All 14 tests across `mobile-composer-stscript-buttons`, `mobile-css-budgets`, and `sillybunny-css-comment-hygiene` pass.

## Manual verification

`bun start` (or `npm start`), DevTools mobile emulation, and confirm the play/pause/stop controls never appear in the composer (including during STscript execution).

- [x] Allow edits from maintainers
- [x] Targets `staging`