### PR TITLE
fix: scroll mobile drawer inputs above the keyboard

### DIFF
--- a/public/scripts/sillybunny-tabs.js
+++ b/public/scripts/sillybunny-tabs.js
@@ -2333,6 +2333,52 @@ function syncShellViewportBounds() {
     setRootViewportProperty('--sb-shell-viewport-top', `${viewportSize.top}px`);
 }
 
+/**
+ * SillyBunny: on mobile the body is fixed/clip, so the browser cannot scroll a
+ * focused input above the virtual keyboard the way a normal page would. When
+ * focus enters an input inside a shell panel or drawer scroller, manually scroll
+ * that scroller so the input sits above the keyboard. The chat composer itself
+ * is already handled by the --sb-shell-viewport-height shell sizing; this covers
+ * the remaining settings/drawer inputs (e.g. "Enter a Model ID").
+ */
+function scrollMobileFocusedInputIntoView(event) {
+    if (!isMobileViewport()) {
+        return;
+    }
+
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) {
+        return;
+    }
+
+    if (!['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName) && !target.isContentEditable) {
+        return;
+    }
+
+    const scroller = target.closest('.sb-shell-panel-scroller, .scrollableInner, .scrollableInnerFull');
+    if (!(scroller instanceof HTMLElement)) {
+        return;
+    }
+
+    function tryScroll() {
+        // visualViewport tracks the keyboard: top grows and height shrinks as the
+        // keyboard rises, so (top + height) is the bottom of the visible area.
+        const viewportSize = getShellViewportSize();
+        const viewportBottom = viewportSize.top + viewportSize.height;
+        const rect = target.getBoundingClientRect();
+        const overflow = rect.bottom - viewportBottom + 16;
+
+        if (overflow > 0) {
+            scroller.scrollTop += overflow;
+        }
+    }
+
+    // Run once immediately (keyboard may already be open) and again after the
+    // keyboard animation / visualViewport resize has settled.
+    window.requestAnimationFrame(tryScroll);
+    window.setTimeout(tryScroll, 200);
+}
+
 function getMobileShellBoundDrawers() {
     return Array.from(new Set([
         ...document.querySelectorAll('#left-nav-panel, #user-settings-block, .sb-shell-root, #right-nav-panel'),
@@ -15566,6 +15612,11 @@ function initAll() {
     // SillyBunny: iOS can move visualViewport.offsetTop without resizing while the keyboard is open.
     window.visualViewport?.addEventListener('scroll', queueMobileViewportStateSync, { passive: true });
     window.visualViewport?.addEventListener('resize', syncDesktopShellSizing, { passive: true });
+
+    // SillyBunny: keep focused inputs in mobile settings drawers above the
+    // virtual keyboard. The fixed/clipped body blocks native scrolling, so the
+    // scroller is nudged manually (see scrollMobileFocusedInputIntoView).
+    document.addEventListener('focusin', scrollMobileFocusedInputIntoView);
 
     // SillyBunny: re-sync shell width when the chat width slider changes so settings
     // panels narrow alongside the chat container (matches standard ST behaviour).

--- a/tests/mobile-keyboard-focused-input-scroll.test.js
+++ b/tests/mobile-keyboard-focused-input-scroll.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tabsSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'sillybunny-tabs.js'), 'utf8');
+
+describe('mobile keyboard focused-input scroll wiring', () => {
+    test('defines the focusin scroll helper', () => {
+        expect(tabsSource).toContain('function scrollMobileFocusedInputIntoView(');
+    });
+
+    test('only runs inside the mobile viewport', () => {
+        expect(tabsSource).toMatch(/function scrollMobileFocusedInputIntoView\([\s\S]*?if \(!isMobileViewport\(\)\)/);
+    });
+
+    test('targets shell panel and drawer scrollers', () => {
+        expect(tabsSource).toMatch(/\.closest\('\.sb-shell-panel-scroller, \.scrollableInner, \.scrollableInnerFull'\)/);
+    });
+
+    test('scrolls against the visual-viewport bottom so the input clears the keyboard', () => {
+        // The visible area ends at (visualViewport.offsetTop + height); the helper
+        // must push the scroller so the focused input's rect.bottom clears it.
+        expect(tabsSource).toMatch(/viewportSize\.top \+ viewportSize\.height/);
+        expect(tabsSource).toMatch(/scroller\.scrollTop \+= overflow/);
+    });
+
+    test('wires the helper on a document focusin listener inside initAll', () => {
+        expect(tabsSource).toContain('document.addEventListener(\'focusin\', scrollMobileFocusedInputIntoView)');
+    });
+});


### PR DESCRIPTION
## Problem

On mobile, the body uses `position: fixed; overflow: clip` (`public/css/mobile-styles.css` ~line 948-955), which blocks the browser\'s native behavior of scrolling a focused input above the virtual keyboard. The chat composer itself is already handled by the shell sizing (`--sb-shell-viewport-height`, from #480/#519/#523), but inputs inside settings drawers and shell panels remained hidden behind the keyboard.

Repro: open a settings drawer (e.g. API / Connection settings) on a mobile device, scroll to a lower field such as **Enter a Model ID** (`#custom_model_id`), and focus it — the input is obscured by the keyboard.

## Fix

Add `scrollMobileFocusedInputIntoView` to `public/scripts/sillybunny-tabs.js` and wire it on `document focusin` in `initAll()`. When focus enters an `INPUT`/`TEXTAREA`/`SELECT`/`contentEditable` inside a shell or drawer scroller (`.sb-shell-panel-scroller`, `.scrollableInner`, `.scrollableInnerFull`), the helper bumps the scroller\'s `scrollTop` so the focused input\'s `rect.bottom` clears the visible viewport bottom (`visualViewport.offsetTop + height`, +16px padding). It runs once on `requestAnimationFrame` and again after 200ms to cover the keyboard animation.

Guarded by `isMobileViewport()` so it is a no-op on desktop and for non-input targets.

## Files changed

- `public/scripts/sillybunny-tabs.js`: new `scrollMobileFocusedInputIntoView` helper (after `syncShellViewportBounds`) + `focusin` wiring in `initAll()`.
- `tests/mobile-keyboard-focused-input-scroll.test.js` (new): asserts the helper definition, mobile-viewport guard, scroller `closest` selector, viewport-bottom overflow math, and the `focusin` wiring.

No upstream SillyTavern files are modified.

## Verification

- `node --check public/scripts/sillybunny-tabs.js` → SYNTAX OK
- `npx eslint public/scripts/sillybunny-tabs.js tests/mobile-keyboard-focused-input-scroll.test.js` → clean
- `cd tests && node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.json mobile-keyboard-focused-input-scroll mobile-shell-lifecycle-wiring mobile-shell-lifecycle-viewport-sync` → **33 passed**