### PR TITLE
chore: reclassify custom in-chat agent templates into content and tracker

### DIFF
--- a/public/scripts/extensions/in-chat-agents/index.js
+++ b/public/scripts/extensions/in-chat-agents/index.js
@@ -763,9 +763,10 @@ const TEMPLATE_BROWSER_CATEGORY_LABELS = {
 };
 
 function getTemplateBrowserCategoryOrder(templateList = templates) {
-    // SillyBunny: include 'custom' so bundled custom-category templates (e.g. HTML Toggle,
-    // Friction Mode) render in the templates browser. Upstream-only behaviour excluded it,
-    // which silently dropped these templates from the pills, sections, and search results.
+    // SillyBunny: 'custom' stays in AGENT_CATEGORIES as a fallback for user/saved
+    // agents even though no bundled templates ship in that category anymore.
+    // Former custom-category templates (HTML Toggle, Friction Mode, NPC Profile
+    // Cards, etc.) have been reclassified into content and tracker.
     return Object.keys(AGENT_CATEGORIES)
         .filter(category => templateList.some(template => template.category === category));
 }

--- a/public/scripts/extensions/in-chat-agents/templates/dont-write-for-user.json
+++ b/public/scripts/extensions/in-chat-agents/templates/dont-write-for-user.json
@@ -3,7 +3,8 @@
     "name": "Don't Write for User",
     "description": "Never write {{user}}'s actions or dialogue -- only {{char}} and NPCs",
     "icon": "",
-    "category": "custom",
+    "category": "content",
+    "subcategory": "pov",
     "tags": [
         "pov",
         "user"

--- a/public/scripts/extensions/in-chat-agents/templates/friction-mode.json
+++ b/public/scripts/extensions/in-chat-agents/templates/friction-mode.json
@@ -3,7 +3,8 @@
     "name": "Friction Mode",
     "description": "Combats positivity bias -- characters resist, protect their pride, and take time to warm up",
     "icon": "",
-    "category": "custom",
+    "category": "content",
+    "subcategory": "behaviour",
     "tags": [
         "realism",
         "difficulty",

--- a/public/scripts/extensions/in-chat-agents/templates/html-toggle.json
+++ b/public/scripts/extensions/in-chat-agents/templates/html-toggle.json
@@ -3,7 +3,8 @@
     "name": "HTML Toggle",
     "description": "Use inline HTML for diegetic in-world objects (signs, letters, screens)",
     "icon": "",
-    "category": "custom",
+    "category": "content",
+    "subcategory": "behaviour",
     "tags": [
         "html",
         "artifacts",

--- a/public/scripts/extensions/in-chat-agents/templates/index.json
+++ b/public/scripts/extensions/in-chat-agents/templates/index.json
@@ -220,7 +220,8 @@
         "name": "Nightmare Difficulty Increase",
         "description": "Aggressively hostile environment -- maximum difficulty and consequences",
         "icon": "",
-        "category": "custom",
+        "category": "content",
+        "subcategory": "behaviour",
         "tags": [
             "difficulty",
             "challenge",
@@ -311,7 +312,8 @@
         "name": "Don't Write for User",
         "description": "Never write {{user}}'s actions or dialogue -- only {{char}} and NPCs",
         "icon": "",
-        "category": "custom",
+        "category": "content",
+        "subcategory": "pov",
         "tags": [
             "pov",
             "user"
@@ -397,7 +399,8 @@
         "name": "Friction Mode",
         "description": "Combats positivity bias -- characters resist, protect their pride, and take time to warm up",
         "icon": "",
-        "category": "custom",
+        "category": "content",
+        "subcategory": "behaviour",
         "tags": [
             "realism",
             "difficulty",
@@ -626,7 +629,8 @@
         "name": "HTML Toggle",
         "description": "Use inline HTML for diegetic in-world objects (signs, letters, screens)",
         "icon": "",
-        "category": "custom",
+        "category": "content",
+        "subcategory": "behaviour",
         "tags": [
             "html",
             "artifacts",
@@ -754,7 +758,8 @@
         "name": "NPC Profile Cards",
         "description": "Generate brief profile cards when introducing new named NPCs",
         "icon": "",
-        "category": "custom",
+        "category": "tracker",
+        "subcategory": "characters",
         "tags": [
             "npc",
             "characters",
@@ -789,6 +794,9 @@
                 "normal",
                 "continue"
             ]
+        },
+        "companion": {
+            "includeSystemPrompt": false
         }
     },
     {
@@ -1314,7 +1322,8 @@
         "name": "Write for User",
         "description": "Include {{user}} as a fully realized character -- write their actions, dialogue, and reactions",
         "icon": "",
-        "category": "custom",
+        "category": "content",
+        "subcategory": "pov",
         "tags": [
             "pov",
             "user"

--- a/public/scripts/extensions/in-chat-agents/templates/nightmare-difficulty-increase.json
+++ b/public/scripts/extensions/in-chat-agents/templates/nightmare-difficulty-increase.json
@@ -3,7 +3,8 @@
     "name": "Nightmare Difficulty Increase",
     "description": "Aggressively hostile environment -- maximum difficulty and consequences",
     "icon": "",
-    "category": "custom",
+    "category": "content",
+    "subcategory": "behaviour",
     "tags": [
         "difficulty",
         "challenge",

--- a/public/scripts/extensions/in-chat-agents/templates/npc-profiles.json
+++ b/public/scripts/extensions/in-chat-agents/templates/npc-profiles.json
@@ -3,7 +3,8 @@
     "name": "NPC Profile Cards",
     "description": "Generate brief profile cards when introducing new named NPCs",
     "icon": "",
-    "category": "custom",
+    "category": "tracker",
+    "subcategory": "characters",
     "tags": [
         "npc",
         "characters",
@@ -38,5 +39,8 @@
             "normal",
             "continue"
         ]
+    },
+    "companion": {
+        "includeSystemPrompt": false
     }
 }

--- a/public/scripts/extensions/in-chat-agents/templates/write-for-user.json
+++ b/public/scripts/extensions/in-chat-agents/templates/write-for-user.json
@@ -3,7 +3,8 @@
     "name": "Write for User",
     "description": "Include {{user}} as a fully realized character -- write their actions, dialogue, and reactions",
     "icon": "",
-    "category": "custom",
+    "category": "content",
+    "subcategory": "pov",
     "tags": [
         "pov",
         "user"

--- a/tests/in-chat-agents-templates.test.js
+++ b/tests/in-chat-agents-templates.test.js
@@ -458,15 +458,15 @@ describe('in-chat agent bundled templates', () => {
         expect(unknownCategories).toEqual([]);
     });
 
-    test('surfaces bundled custom-category templates such as HTML Toggle in the browser', () => {
+    test('surfaces bundled content templates such as HTML Toggle in the browser', () => {
         const catalog = readTemplate('index.json');
         const htmlToggle = findCatalogTemplate(catalog, 'tpl-html-toggle');
 
-        expect(htmlToggle.category).toBe('custom');
+        expect(htmlToggle.category).toBe('content');
+        expect(htmlToggle.subcategory).toBe('behaviour');
 
-        const customTemplates = catalog.filter(template => template.category === 'custom');
-        expect(customTemplates.length).toBeGreaterThan(0);
-
+        // 'custom' stays in AGENT_CATEGORIES as a fallback for user/saved agents
+        // even though no bundled templates ship in that category anymore.
         const orderSource = readIndexFunctionBody('getTemplateBrowserCategoryOrder');
         expect(orderSource).not.toContain('category !== \'custom\'');
         expect(orderSource).toContain('AGENT_CATEGORIES');


### PR DESCRIPTION
## Summary

Moves the six bundled templates out of the `custom` category into their semantically correct homes. All six were already Pre-generation (`phase: "pre"`), so no phase changes were needed — only category/subcategory reassignment.

### Reclassification

| Template | Old | New |
|---|---|---|
| Don't Write for User | `custom` | `content` / `pov` |
| Write for User | `custom` | `content` / `pov` |
| Friction Mode | `custom` | `content` / `behaviour` |
| Nightmare Difficulty Increase | `custom` | `content` / `behaviour` |
| HTML Toggle | `custom` | `content` / `behaviour` |
| NPC Profile Cards | `custom` | `tracker` / `characters` |

NPC Profile Cards lands in `tracker` because it already ships an `extract` postProcess and is already a member of the `grp-pura-trackers` group in `groups.json`. It also picks up `companion.includeSystemPrompt: false` to satisfy the tracker template invariant enforced in `tests/in-chat-agents-templates.test.js`.

### Why keep `custom` at all?

`custom` stays defined in `AGENT_CATEGORIES` as the fallback bucket for user-created and saved agents. No bundled templates ship in that category anymore, but the browser-order helper (`getTemplateBrowserCategoryOrder`) still surfaces it whenever a user/saved agent lands there. The stale comment on that helper has been refreshed to reflect the new reality.

## Changes

- `templates/index.json`: 6 catalog entries recategorized; NPC Profile Cards gets the `companion.includeSystemPrompt: false` block.
- 6 per-template source mirrors updated to match (catalog/source sync enforced by tests for `npc-profiles.json`; the other five are kept in sync manually).
- `index.js`: refreshed the now-stale SillyBunny comment on `getTemplateBrowserCategoryOrder`.
- `tests/in-chat-agents-templates.test.js`: replaced the `htmlToggle.category === 'custom'` assertion with a `content` / `behaviour` assertion while preserving the structural checks that keep `custom` renderable in the browser.

## Verification

- `npm run test:unit --prefix tests -- in-chat-agents-templates` → 15/15 passing
- `npm run lint` → clean
- `npm run check:frontend-budgets` → within budget

Generated with AI assistance.