### PR TITLE
feat: add custom OpenAI-compatible endpoint profiles

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3824,6 +3824,41 @@
                             </div>
                         </form>
                         <form id="custom_form" data-source="custom">
+                            <div class="inline-drawer wide100p">
+                                <div class="inline-drawer-toggle inline-drawer-header">
+                                    <b data-i18n="Custom Endpoint Profiles">Custom Endpoint Profiles</b>
+                                    <div class="fa-solid fa-circle-chevron-down inline-drawer-icon down"></div>
+                                </div>
+                                <div class="inline-drawer-content">
+                                    <div class="range-block-title justifyLeft" data-i18n="Endpoint Profiles">
+                                        Endpoint Profiles
+                                    </div>
+                                    <div class="toggle-description justifyLeft">
+                                        <span data-i18n="Saved Custom OpenAI-compatible URLs, API keys, and model IDs.">
+                                            Saved Custom OpenAI-compatible URLs, API keys, and model IDs.
+                                        </span>
+                                        <br>
+                                    </div>
+                                    <div class="openai_logit_bias_preset_form">
+                                        <select id="custom_endpoint_preset">
+                                        </select>
+                                        <i id="save_custom_endpoint" class="menu_button fa-solid fa-save" title="Save Custom Endpoint Profile" data-i18n="[title]Save Custom Endpoint Profile"></i>
+                                        <i id="delete_custom_endpoint" class="menu_button fa-solid fa-trash" title="Delete Custom Endpoint Profile" data-i18n="[title]Delete Custom Endpoint Profile"></i>
+                                    </div>
+                                    <div class="range-block-title justifyLeft" data-i18n="Profile Name">
+                                        Profile Name
+                                    </div>
+                                    <div class="toggle-description justifyLeft">
+                                        <span data-i18n="This will show up as your saved endpoint profile.">
+                                            This will show up as your saved endpoint profile.
+                                        </span>
+                                        <br>
+                                    </div>
+                                    <div class="wide100p">
+                                        <input id="custom_endpoint_preset_name" type="text" class="text_pole" placeholder="..." />
+                                    </div>
+                                </div>
+                            </div>
                             <h4 data-i18n="Custom Endpoint (Base URL)">Custom Endpoint (Base URL)</h4>
                             <div class="flex-container">
                                 <input id="custom_api_url_text" class="text_pole wide100p" value="" autocomplete="off" data-i18n="[placeholder]Example: http://localhost:1234/v1" placeholder="Example: http://localhost:1234/v1">

--- a/public/script.js
+++ b/public/script.js
@@ -118,6 +118,9 @@ import {
     proxies,
     loadProxyPresets,
     selected_proxy,
+    custom_endpoint_presets,
+    loadCustomEndpointPresets,
+    selected_custom_endpoint_preset,
     initOpenAI,
     reconnectOpenAi,
 } from './scripts/openai.js';
@@ -11049,6 +11052,9 @@ export async function getSettings(initLoaderHandle = null) {
         // Load proxy presets
         loadProxyPresets(settings);
 
+        // Load Custom OpenAI-compatible endpoint profiles
+        await loadCustomEndpointPresets(settings);
+
         // Allow subscribers to mutate settings
         await eventSource.emit(event_types.SETTINGS_LOADED_AFTER, settings);
 
@@ -11182,6 +11188,8 @@ async function saveSettingsInner(loopCounter = 0) {
         background: background_settings,
         proxies: proxies,
         selected_proxy: selected_proxy,
+        custom_endpoint_presets: custom_endpoint_presets,
+        selected_custom_endpoint_preset: selected_custom_endpoint_preset,
     };
 
     try {

--- a/public/scripts/openai-preset-utils.js
+++ b/public/scripts/openai-preset-utils.js
@@ -256,3 +256,39 @@ export function normalizeReverseProxyPreset(preset, { supportedSources = [] } = 
 export function buildReverseProxyPresetForSave(preset, { supportedSources = [] } = {}) {
     return normalizeReverseProxyPreset(preset, { supportedSources });
 }
+
+/**
+ * Normalizes a Custom OpenAI-compatible endpoint profile.
+ *
+ * @param {Record<string, any>} preset Custom endpoint profile
+ * @returns {{name: string, url: string, key: string, model: string}}
+ */
+export function normalizeCustomEndpointPreset(preset) {
+    const name = String(preset?.name ?? 'None');
+
+    if (name === 'None') {
+        return {
+            name,
+            url: '',
+            key: '',
+            model: '',
+        };
+    }
+
+    return {
+        name,
+        url: String(preset?.url ?? ''),
+        key: String(preset?.key ?? ''),
+        model: String(preset?.model ?? ''),
+    };
+}
+
+/**
+ * Builds a Custom OpenAI-compatible endpoint profile from the current form.
+ *
+ * @param {Record<string, any>} preset Custom endpoint profile data
+ * @returns {{name: string, url: string, key: string, model: string}}
+ */
+export function buildCustomEndpointPresetForSave(preset) {
+    return normalizeCustomEndpointPreset(preset);
+}

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -90,8 +90,10 @@ import {
     buildChatCompletionPresetForSave,
     buildChatCompletionSamplingProfileKey,
     buildChatCompletionSamplingSettingsSnapshot,
+    buildCustomEndpointPresetForSave,
     buildReverseProxyPresetForSave,
     getChatCompletionSamplingProfileLookupKeys,
+    normalizeCustomEndpointPreset,
     normalizeReverseProxyPreset,
     shouldIncludeSamplingFieldsInPreset,
 } from './openai-preset-utils.js';
@@ -688,6 +690,16 @@ export let proxies = [
     },
 ];
 export let selected_proxy = proxies[0];
+
+export let custom_endpoint_presets = [
+    {
+        name: 'None',
+        url: '',
+        key: '',
+        model: '',
+    },
+];
+export let selected_custom_endpoint_preset = custom_endpoint_presets[0];
 
 export let openai_setting_names;
 export let openai_settings;
@@ -9279,6 +9291,164 @@ $('#delete_proxy').on('click', async function () {
     }
 });
 
+/**
+ * Custom OpenAI-compatible endpoint profile stuff
+ */
+export async function loadCustomEndpointPresets(settings) {
+    const hasSavedCustomEndpointPresets = Array.isArray(settings.custom_endpoint_presets) && settings.custom_endpoint_presets.length > 0;
+    let endpointPresets = settings.custom_endpoint_presets;
+
+    if (!hasSavedCustomEndpointPresets) {
+        endpointPresets = custom_endpoint_presets.map(preset => normalizeCustomEndpointPreset(preset));
+    } else {
+        endpointPresets = endpointPresets.map(preset => normalizeCustomEndpointPreset(preset));
+    }
+
+    custom_endpoint_presets = endpointPresets;
+
+    if (!custom_endpoint_presets.some(preset => preset.name === 'None')) {
+        custom_endpoint_presets.unshift(normalizeCustomEndpointPreset({ name: 'None' }));
+    }
+
+    const savedSelectedPreset = settings.selected_custom_endpoint_preset;
+    selected_custom_endpoint_preset = savedSelectedPreset ? normalizeCustomEndpointPreset(savedSelectedPreset) : null;
+    if (selected_custom_endpoint_preset && !custom_endpoint_presets.some(preset => preset.name === selected_custom_endpoint_preset.name)) {
+        custom_endpoint_presets.push(selected_custom_endpoint_preset);
+    }
+
+    $('#custom_endpoint_preset').empty();
+
+    for (const preset of custom_endpoint_presets) {
+        appendCustomEndpointPresetOption(preset);
+    }
+
+    $('#custom_endpoint_preset').val(selected_custom_endpoint_preset?.name || 'None');
+
+    if (selected_custom_endpoint_preset) {
+        await setCustomEndpointPreset(
+            selected_custom_endpoint_preset.name,
+            selected_custom_endpoint_preset.url,
+            selected_custom_endpoint_preset.key,
+            selected_custom_endpoint_preset.model,
+            { reconnect: false },
+        );
+    } else {
+        $('#custom_endpoint_preset_name').val('None');
+    }
+}
+
+function getCustomEndpointPresetOption(name) {
+    return $('#custom_endpoint_preset option').filter((_, option) => option.value === name);
+}
+
+function appendCustomEndpointPresetOption(preset) {
+    const normalizedPreset = normalizeCustomEndpointPreset(preset);
+    const option = document.createElement('option');
+    option.innerText = normalizedPreset.name;
+    option.value = normalizedPreset.name;
+    option.selected = normalizedPreset.name === 'None';
+    $('#custom_endpoint_preset').append(option);
+}
+
+function updateCustomEndpointPresetOption(preset) {
+    const option = getCustomEndpointPresetOption(preset.name);
+
+    if (option.length > 0) {
+        option.text(preset.name);
+    } else {
+        appendCustomEndpointPresetOption(preset);
+    }
+}
+
+async function setCustomEndpointPreset(name, url, key, model, { writeKey = true, reconnect = true } = {}) {
+    const normalizedPreset = normalizeCustomEndpointPreset({ name, url, key, model });
+    const preset = custom_endpoint_presets.find(p => p.name === normalizedPreset.name);
+    if (preset) {
+        preset.url = normalizedPreset.url;
+        preset.key = normalizedPreset.key;
+        preset.model = normalizedPreset.model;
+        selected_custom_endpoint_preset = preset;
+    } else {
+        const newPreset = normalizedPreset;
+        custom_endpoint_presets.push(newPreset);
+        selected_custom_endpoint_preset = newPreset;
+        appendCustomEndpointPresetOption(newPreset);
+    }
+
+    $('#custom_endpoint_preset_name').val(normalizedPreset.name);
+    oai_settings.custom_url = normalizedPreset.url;
+    $('#custom_api_url_text').val(oai_settings.custom_url);
+    oai_settings.custom_model = normalizedPreset.model;
+    $('#custom_model_id').val(oai_settings.custom_model);
+    $('#model_custom_select').val(oai_settings.custom_model);
+
+    if (writeKey) {
+        await writeSecret(SECRET_KEYS.CUSTOM, normalizedPreset.key, undefined, { allowEmpty: true });
+    }
+    $('#api_key_custom').val(normalizedPreset.key);
+
+    if (reconnect && oai_settings.chat_completion_source === chat_completion_sources.CUSTOM) {
+        reconnectOpenAi();
+    }
+}
+
+async function onCustomEndpointPresetChange() {
+    const value = String($('#custom_endpoint_preset').find(':selected').val());
+    const selectedPreset = custom_endpoint_presets.find(preset => preset.name === value);
+
+    if (selectedPreset) {
+        await setCustomEndpointPreset(selectedPreset.name, selectedPreset.url, selectedPreset.key, selectedPreset.model);
+    } else {
+        console.error(t`Custom endpoint profile '${value}' not found in custom endpoint profiles array.`);
+    }
+    saveSettingsDebounced();
+}
+
+$('#save_custom_endpoint').on('click', async function () {
+    const preset = buildCustomEndpointPresetForSave({
+        name: $('#custom_endpoint_preset_name').val(),
+        url: $('#custom_api_url_text').val(),
+        key: $('#api_key_custom').val(),
+        model: $('#custom_model_id').val(),
+    });
+
+    await setCustomEndpointPreset(preset.name, preset.url, preset.key, preset.model);
+    saveSettingsDebounced();
+    toastr.success(t`Custom Endpoint Profile Saved`);
+    updateCustomEndpointPresetOption(preset);
+    $('#custom_endpoint_preset').val(preset.name);
+});
+
+$('#delete_custom_endpoint').on('click', async function () {
+    const presetName = $('#custom_endpoint_preset_name').val();
+    const index = custom_endpoint_presets.findIndex(preset => preset.name === presetName);
+
+    if (index !== -1) {
+        custom_endpoint_presets.splice(index, 1);
+        getCustomEndpointPresetOption(presetName).remove();
+
+        if (custom_endpoint_presets.length > 0) {
+            const newIndex = Math.max(0, index - 1);
+            selected_custom_endpoint_preset = custom_endpoint_presets[newIndex];
+        } else {
+            selected_custom_endpoint_preset = normalizeCustomEndpointPreset({ name: 'None' });
+        }
+
+        await setCustomEndpointPreset(
+            selected_custom_endpoint_preset.name,
+            selected_custom_endpoint_preset.url,
+            selected_custom_endpoint_preset.key,
+            selected_custom_endpoint_preset.model,
+        );
+
+        saveSettingsDebounced();
+        $('#custom_endpoint_preset').val(selected_custom_endpoint_preset.name);
+        toastr.success(t`Custom Endpoint Profile Deleted`);
+    } else {
+        toastr.error(t`Could not find custom endpoint profile with name '${presetName}'`);
+    }
+});
+
 function runProxyCallback(_, value) {
     if (!value) {
         return selected_proxy?.name || '';
@@ -10453,4 +10623,5 @@ export function initOpenAI() {
     $('#openai_proxy_password_show').on('click', onProxyPasswordShowClick);
     $('#customize_additional_parameters').on('click', onCustomizeParametersClick);
     $('#openai_proxy_preset').on('change', onProxyPresetChange);
+    $('#custom_endpoint_preset').on('change', onCustomEndpointPresetChange);
 }

--- a/tests/openai-preset-utils.test.js
+++ b/tests/openai-preset-utils.test.js
@@ -4,11 +4,13 @@ import {
     buildChatCompletionPresetForSave,
     buildChatCompletionSamplingProfileKey,
     buildChatCompletionSamplingSettingsSnapshot,
+    buildCustomEndpointPresetForSave,
     buildReverseProxyPresetForSave,
     getChatCompletionConnectionPresetKeys,
     getChatCompletionSamplingProfileLookupKeys,
     getChatCompletionSamplingPresetKeys,
     getChatCompletionSamplingSettingsKeys,
+    normalizeCustomEndpointPreset,
     normalizeReverseProxyPreset,
     shouldIncludeConnectionFieldsInPreset,
     shouldIncludeSamplingFieldsInPreset,
@@ -182,6 +184,46 @@ describe('Chat Completion preset utilities', () => {
             url: '',
             password: '',
             source: '',
+        });
+    });
+
+    test('normalizes legacy Custom endpoint profiles without keys or models', () => {
+        expect(normalizeCustomEndpointPreset({
+            name: 'Local proxy',
+            url: 'http://127.0.0.1:1234/v1',
+        })).toEqual({
+            name: 'Local proxy',
+            url: 'http://127.0.0.1:1234/v1',
+            key: '',
+            model: '',
+        });
+    });
+
+    test('saves Custom endpoint profiles with URL, key, and model', () => {
+        expect(buildCustomEndpointPresetForSave({
+            name: 'Story proxy',
+            url: 'https://proxy.example/v1',
+            key: 'sk-story',
+            model: 'gpt-4o',
+        })).toEqual({
+            name: 'Story proxy',
+            url: 'https://proxy.example/v1',
+            key: 'sk-story',
+            model: 'gpt-4o',
+        });
+    });
+
+    test('clears Custom endpoint profile fields for None', () => {
+        expect(buildCustomEndpointPresetForSave({
+            name: 'None',
+            url: 'https://proxy.example/v1',
+            key: 'sk-story',
+            model: 'gpt-4o',
+        })).toEqual({
+            name: 'None',
+            url: '',
+            key: '',
+            model: '',
         });
     });
 

--- a/tests/openai-proxy-preset-wiring.test.js
+++ b/tests/openai-proxy-preset-wiring.test.js
@@ -6,6 +6,7 @@ import path from 'node:path';
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const openAiSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'openai.js'), 'utf8');
 const indexHtml = readFileSync(path.join(repoRoot, 'public', 'index.html'), 'utf8');
+const scriptSource = readFileSync(path.join(repoRoot, 'public', 'script.js'), 'utf8');
 
 function getFunctionSource(name) {
     const marker = `function ${name}(`;
@@ -139,5 +140,61 @@ describe('OpenAI proxy preset wiring', () => {
         expect(sourceUpdateIndex).toBeGreaterThan(capturePresetIndex);
         expect(restoreCallIndex).toBeGreaterThan(syncCallIndex);
         expect(saveIndex).toBeGreaterThan(restoreCallIndex);
+    });
+
+    test('shows an explicit Custom endpoint profile selector', () => {
+        expect(indexHtml).toContain('id="custom_endpoint_preset"');
+        expect(indexHtml).toContain('id="save_custom_endpoint"');
+        expect(indexHtml).toContain('id="delete_custom_endpoint"');
+        expect(indexHtml).toContain('id="custom_endpoint_preset_name"');
+        expect(indexHtml).toContain('Saved Custom OpenAI-compatible URLs, API keys, and model IDs.');
+    });
+
+    test('saves Custom endpoint profiles with URL, key, and model fields', () => {
+        expect(openAiSource).toContain('buildCustomEndpointPresetForSave({');
+        expect(openAiSource).toContain('url: $(\'#custom_api_url_text\').val()');
+        expect(openAiSource).toContain('key: $(\'#api_key_custom\').val()');
+        expect(openAiSource).toContain('model: $(\'#custom_model_id\').val()');
+    });
+
+    test('applies Custom endpoint profile values before reconnecting', () => {
+        const setCustomEndpointSource = getFunctionSource('setCustomEndpointPreset');
+        const urlUpdateIndex = setCustomEndpointSource.indexOf('oai_settings.custom_url = normalizedPreset.url;');
+        const modelUpdateIndex = setCustomEndpointSource.indexOf('oai_settings.custom_model = normalizedPreset.model;');
+        const secretWriteIndex = setCustomEndpointSource.indexOf('await writeSecret(SECRET_KEYS.CUSTOM, normalizedPreset.key, undefined, { allowEmpty: true });');
+        const keyInputIndex = setCustomEndpointSource.indexOf('$(\'#api_key_custom\').val(normalizedPreset.key);');
+        const reconnectIndex = setCustomEndpointSource.indexOf('reconnectOpenAi();');
+
+        expect(urlUpdateIndex).toBeGreaterThanOrEqual(0);
+        expect(modelUpdateIndex).toBeGreaterThan(urlUpdateIndex);
+        expect(secretWriteIndex).toBeGreaterThan(modelUpdateIndex);
+        expect(keyInputIndex).toBeGreaterThan(secretWriteIndex);
+        expect(reconnectIndex).toBeGreaterThan(keyInputIndex);
+    });
+
+    test('loads and persists Custom endpoint profiles with settings', () => {
+        expect(scriptSource).toContain('await loadCustomEndpointPresets(settings);');
+        expect(scriptSource).toContain('custom_endpoint_presets: custom_endpoint_presets');
+        expect(scriptSource).toContain('selected_custom_endpoint_preset: selected_custom_endpoint_preset');
+    });
+
+    test('preserves legacy Custom endpoint settings until a profile is selected', () => {
+        const loadCustomEndpointSource = getFunctionSource('loadCustomEndpointPresets');
+        const selectedAssignmentIndex = loadCustomEndpointSource.indexOf('selected_custom_endpoint_preset = savedSelectedPreset ? normalizeCustomEndpointPreset(savedSelectedPreset) : null;');
+        const applyBranchIndex = loadCustomEndpointSource.indexOf('if (selected_custom_endpoint_preset) {');
+        const applyPresetIndex = loadCustomEndpointSource.indexOf('await setCustomEndpointPreset(', applyBranchIndex);
+        const fallbackNameIndex = loadCustomEndpointSource.indexOf('$(\'#custom_endpoint_preset_name\').val(\'None\');');
+
+        expect(selectedAssignmentIndex).toBeGreaterThanOrEqual(0);
+        expect(applyBranchIndex).toBeGreaterThan(selectedAssignmentIndex);
+        expect(applyPresetIndex).toBeGreaterThan(applyBranchIndex);
+        expect(fallbackNameIndex).toBeGreaterThan(applyPresetIndex);
+        expect(loadCustomEndpointSource).not.toContain('savedSelectedPreset ||');
+    });
+
+    test('wires Custom endpoint profile selection from initOpenAI', () => {
+        const initSource = getFunctionSource('initOpenAI');
+
+        expect(initSource).toContain('$(\'#custom_endpoint_preset\').on(\'change\', onCustomEndpointPresetChange);');
     });
 });


### PR DESCRIPTION
## Summary
- Add inline Custom Endpoint Profiles for Custom OpenAI-compatible URLs, API keys, and model IDs.
- Persist custom endpoint profiles and selected profile with settings, then write the selected profile key into the Custom secret slot.
- Preserve legacy Custom endpoint settings until a profile is explicitly selected or saved.

## Tests
- npm run test:unit --prefix tests
- npm run lint
- npm run check:frontend-budgets