### PR TITLE
feat: batch import embedded lorebooks for visible characters

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4924,6 +4924,7 @@
                             </div>
                             <div class="world_popup_action_group world_popup_action_group--library">
                                 <div id="world_import_button" class="menu_button fa-solid fa-file-import" title="Import World Info" data-i18n="[title]Import World Info"></div>
+                                <div id="world_batch_import_embedded" class="menu_button fa-solid fa-cubes-stacked" title="Batch Import Embedded Lorebooks&#10;&#10;Imports embedded lorebooks from all visible character cards" data-i18n="[title]Batch Import Embedded Lorebooks"></div>
                                 <div id="world_popup_export" class="menu_button fa-solid fa-file-export" title="Export World Info" data-i18n="[title]Export World Info"></div>
                                 <div id="world_popup_name_button" class="menu_button fa-pencil fa-solid" title="Rename World Info" data-i18n="[title]Rename World Info"></div>
                                 <div id="world_duplicate" class="menu_button fa-solid fa-paste" title="Duplicate World Info" data-i18n="[title]Duplicate World Info"></div>

--- a/public/scripts/world-info-batch-helpers.js
+++ b/public/scripts/world-info-batch-helpers.js
@@ -1,0 +1,41 @@
+/**
+ * Pure helpers for batch embedded lorebook import.
+ * Separated from world-info.js for testability.
+ */
+
+/**
+ * Detects which characters have embedded lorebooks and whether their book names collide with existing worlds.
+ * @param {Array<{chid: number, character: object}>} charList - Characters to check
+ * @param {string[]} existingWorldNames - Currently saved world/lorebook names
+ * @returns {Array<{chid: number, characterName: string, bookName: string, collision: boolean}>} Candidates with embedded lorebooks
+ */
+export function detectEmbeddedLorebookCandidates(charList, existingWorldNames) {
+    const result = [];
+    for (const { chid, character } of charList) {
+        if (!character?.data?.character_book) {
+            continue;
+        }
+        const bookName = character.data.character_book.name || `${character.name}'s Lorebook`;
+        result.push({
+            chid,
+            characterName: character.name,
+            bookName,
+            collision: existingWorldNames.includes(bookName),
+        });
+    }
+    return result;
+}
+
+/**
+ * Returns the list of auxiliary world book names already linked to a character file name.
+ * @param {Array<{name: string, extraBooks?: string[]}>} charLore - The charLore settings array
+ * @param {string} fileName - The character file name (avatar without extension)
+ * @returns {string[]} Already linked auxiliary book names
+ */
+export function getLinkedAuxBooks(charLore, fileName) {
+    if (!Array.isArray(charLore) || !fileName) {
+        return [];
+    }
+    const entry = charLore.find(e => e.name === fileName);
+    return Array.isArray(entry?.extraBooks) ? entry.extraBooks : [];
+}

--- a/public/scripts/world-info.js
+++ b/public/scripts/world-info.js
@@ -1,6 +1,6 @@
 import { Fuse } from '../lib.js';
 
-import { saveSettings, substituteParams, getRequestHeaders, chat_metadata, this_chid, characters, saveCharacterDebounced, menu_type, eventSource, event_types, getExtensionPromptByName, saveMetadata, getCurrentChatId, extension_prompt_roles, create_save, createOrEditCharacter, name1, getOneCharacter, select_selected_character } from '../script.js';
+import { saveSettings, substituteParams, getRequestHeaders, chat_metadata, this_chid, characters, saveCharacterDebounced, menu_type, eventSource, event_types, getExtensionPromptByName, saveMetadata, getCurrentChatId, extension_prompt_roles, create_save, createOrEditCharacter, name1, getOneCharacter, select_selected_character, getEntitiesList } from '../script.js';
 import { download, debounce, initScrollHeight, resetScrollHeight, parseJsonFile, extractDataFromPng, getFileBuffer, getCharaFilename, getSortableDelay, escapeRegex, PAGINATION_TEMPLATE, navigation_option, waitUntilCondition, isTrueBoolean, setValueByPath, flashHighlight, select2ModifyOptions, getSelect2OptionId, dynamicSelect2DataViaAjax, highlightRegex, select2ChoiceClickSubscribe, isFalseBoolean, getSanitizedFilename, checkOverwriteExistingData, getStringHash, parseStringArray, cancelDebounce, findChar, onlyUnique, equalsIgnoreCaseAndAccents, uuidv4, normalizeArray, getUniqueName, logSlashCommandWarn, addLongPressEvent, escapeHtml } from './utils.js';
 import { extension_settings, getContext } from './extensions.js';
 import { NOTE_MODULE_NAME, metadata_keys, shouldWIAddPrompt } from './authors-note.js';
@@ -24,6 +24,7 @@ import { t } from './i18n.js';
 import { accountStorage } from './util/AccountStorage.js';
 import { getOrCreatePersonaDescriptor, setPersonaDescription, user_avatar } from './personas.js';
 import { normalizeCharacterBookPosition, normalizeWorldInfoPosition } from './world-info-character-book.js';
+import { detectEmbeddedLorebookCandidates, getLinkedAuxBooks } from './world-info-batch-helpers.js';
 
 export const world_info_insertion_strategy = {
     evenly: 0,
@@ -5959,9 +5960,7 @@ export async function importEmbeddedWorldInfo(skipPopup = false) {
         }
     }
 
-    const convertedBook = convertCharacterBook(characters[chid].data.character_book);
-
-    await saveWorldInfo(bookName, convertedBook, true);
+    await importEmbeddedWorldInfoForCharacter(chid);
     await updateWorldInfoList();
     $('#character_world').val(bookName).trigger('change');
 
@@ -5976,6 +5975,124 @@ export async function importEmbeddedWorldInfo(skipPopup = false) {
     }
 
     setWorldInfoButtonClass(chid, true);
+}
+
+/**
+ * Imports the embedded lorebook for a single character by chid.
+ * Pure helper — saves the world info but does not touch the active-character UI.
+ * @param {number} chid - Character hash id
+ * @returns {Promise<{chid: number, characterName: string, bookName: string, status: 'imported'|'skipped', collision: boolean}>}
+ */
+export async function importEmbeddedWorldInfoForCharacter(chid) {
+    const character = characters[chid];
+
+    if (!character?.data?.character_book) {
+        return { chid, characterName: character?.name ?? 'Unknown', bookName: '', status: 'skipped', collision: false };
+    }
+
+    const bookName = character.data.character_book.name || `${character.name}'s Lorebook`;
+    const collision = world_names.includes(bookName);
+    const convertedBook = convertCharacterBook(character.data.character_book);
+
+    await saveWorldInfo(bookName, convertedBook, true);
+
+    return { chid, characterName: character.name, bookName, status: 'imported', collision };
+}
+
+/**
+ * Batch-imports embedded lorebooks for all visible loaded character cards.
+ * Detects embedded books, shows a confirmation dialog with collision warnings,
+ * imports each book, links via auxiliary world books (settings-only, safe for non-active chars),
+ * and reports a summary.
+ */
+export async function importEmbeddedWorldInfoBatch() {
+    const entities = getEntitiesList({ doFilter: true });
+    const visibleCharList = entities
+        .filter(e => e.type === 'character' && e.id !== undefined && e.id !== -1)
+        .map(e => ({ chid: e.id, character: e.item }));
+
+    const candidates = detectEmbeddedLorebookCandidates(visibleCharList, world_names);
+
+    if (candidates.length === 0) {
+        toastr.info(t`No visible character cards have embedded lorebooks.`, t`Batch Import`);
+        return;
+    }
+
+    const collisionCount = candidates.filter(c => c.collision).length;
+
+    let collisionNote = '';
+    if (collisionCount > 0) {
+        const collisionNames = candidates.filter(c => c.collision).map(c => escapeHtml(c.bookName));
+        collisionNote = `<div class="m-b-1">${t`Warning:`} <b>${collisionCount}</b> ${t`will overwrite existing lorebook(s):`} ${collisionNames.join(', ')}</div>`;
+    }
+
+    const html = `<h3>${t`Import embedded lorebooks for ${candidates.length} visible character(s)?`}</h3>${collisionNote}`;
+    const confirm = await callGenericPopup(html, POPUP_TYPE.CONFIRM, '', { okButton: t`Import` });
+
+    if (!confirm) {
+        return;
+    }
+
+    const results = [];
+    for (const candidate of candidates) {
+        try {
+            const result = await importEmbeddedWorldInfoForCharacter(candidate.chid);
+
+            if (result.status === 'imported') {
+                const characterKey = characters[candidate.chid]?.avatar;
+                if (characterKey) {
+                    const fileName = getCharaFilename(null, { manualAvatarKey: characterKey });
+                    const linkedBooks = getLinkedAuxBooks(world_info.charLore, fileName);
+                    if (!linkedBooks.includes(result.bookName)) {
+                        await charUpdateAddAuxWorld(characterKey, result.bookName);
+                    }
+                }
+            }
+
+            results.push(result);
+        } catch (error) {
+            console.error('[Batch WI Import] Failed for', candidate.characterName, error);
+            results.push({ ...candidate, status: 'skipped', collision: false, error: error.message });
+        }
+    }
+
+    await updateWorldInfoList();
+
+    const imported = results.filter(r => r.status === 'imported');
+    const skipped = results.filter(r => r.status === 'skipped');
+    const collisions = imported.filter(r => r.collision);
+
+    let summary = `<h3>${t`Batch import complete`}</h3>`;
+    summary += `<div>${imported.length} ${t`imported`}`;
+
+    if (collisions.length > 0) {
+        summary += `, ${collisions.length} ${t`overwrote existing`}`;
+    }
+
+    if (skipped.length > 0) {
+        summary += `, ${skipped.length} ${t`skipped`}`;
+    }
+
+    summary += '.</div>';
+
+    if (imported.length > 0) {
+        summary += '<ul>';
+        for (const r of imported) {
+            summary += `<li>${escapeHtml(r.characterName)} → ${escapeHtml(r.bookName)}${r.collision ? ` (${t`overwrote`})` : ''}</li>`;
+        }
+        summary += '</ul>';
+    }
+
+    if (skipped.length > 0) {
+        summary += `<div class="m-t-1"><b>${t`Skipped:`}</b></div><ul>`;
+        for (const r of skipped) {
+            summary += `<li>${escapeHtml(r.characterName)}${r.error ? `: ${escapeHtml(r.error)}` : ` (${t`no embedded lorebook`})`}</li>`;
+        }
+        summary += '</ul>';
+    }
+
+    await callGenericPopup(summary, POPUP_TYPE.TEXT, '', { okButton: t`Close` });
+    toastr.success(t`Imported ${imported.length} lorebook(s) from ${candidates.length} character(s).`, t`Batch Import Complete`);
 }
 
 export function onWorldInfoChange(args, text) {
@@ -6419,6 +6536,8 @@ export function initWorldInfo() {
         // Will allow to select the same file twice in a row
         e.target.value = '';
     });
+
+    $('#world_batch_import_embedded').on('click', importEmbeddedWorldInfoBatch);
 
     $('#world_create_button').on('click', async () => {
         const tempName = getFreeWorldName();

--- a/tests/world-info-batch-helpers.test.js
+++ b/tests/world-info-batch-helpers.test.js
@@ -1,0 +1,87 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { detectEmbeddedLorebookCandidates, getLinkedAuxBooks } from '../public/scripts/world-info-batch-helpers.js';
+
+describe('detectEmbeddedLorebookCandidates', () => {
+    test('returns empty array when no characters have embedded lorebooks', () => {
+        const charList = [
+            { chid: 0, character: { name: 'Alice', data: {} } },
+            { chid: 1, character: { name: 'Bob', data: { character_book: null } } },
+        ];
+        const result = detectEmbeddedLorebookCandidates(charList, []);
+        expect(result).toEqual([]);
+    });
+
+    test('detects characters with embedded lorebooks', () => {
+        const charList = [
+            { chid: 0, character: { name: 'Alice', data: { character_book: { name: 'Alice Lore', entries: [] } } } },
+            { chid: 1, character: { name: 'Bob', data: {} } },
+            { chid: 2, character: { name: 'Carol', data: { character_book: { name: 'Carol Lore', entries: [] } } } },
+        ];
+        const result = detectEmbeddedLorebookCandidates(charList, []);
+        expect(result).toHaveLength(2);
+        expect(result[0]).toEqual({ chid: 0, characterName: 'Alice', bookName: 'Alice Lore', collision: false });
+        expect(result[1]).toEqual({ chid: 2, characterName: 'Carol', bookName: 'Carol Lore', collision: false });
+    });
+
+    test('uses character name fallback when book has no name', () => {
+        const charList = [
+            { chid: 0, character: { name: 'Alice', data: { character_book: { entries: [] } } } },
+        ];
+        const result = detectEmbeddedLorebookCandidates(charList, []);
+        expect(result[0].bookName).toBe(`Alice's Lorebook`);
+    });
+
+    test('detects name collisions with existing worlds', () => {
+        const charList = [
+            { chid: 0, character: { name: 'Alice', data: { character_book: { name: 'Existing World', entries: [] } } } },
+            { chid: 1, character: { name: 'Bob', data: { character_book: { name: 'New World', entries: [] } } } },
+        ];
+        const result = detectEmbeddedLorebookCandidates(charList, ['Existing World', 'Other World']);
+        expect(result).toHaveLength(2);
+        expect(result[0].collision).toBe(true);
+        expect(result[1].collision).toBe(false);
+    });
+
+    test('skips characters with undefined character_book', () => {
+        const charList = [
+            { chid: 0, character: { name: 'Alice', data: {} } },
+            { chid: 1, character: { name: 'Bob', data: { character_book: undefined } } },
+            { chid: 2, character: { name: 'Carol', data: { character_book: { name: 'Carol Lore', entries: [] } } } },
+        ];
+        const result = detectEmbeddedLorebookCandidates(charList, []);
+        expect(result).toHaveLength(1);
+        expect(result[0].characterName).toBe('Carol');
+    });
+
+    test('handles empty charList', () => {
+        const result = detectEmbeddedLorebookCandidates([], ['Existing']);
+        expect(result).toEqual([]);
+    });
+});
+
+describe('getLinkedAuxBooks', () => {
+    test('returns empty array when charLore is null', () => {
+        expect(getLinkedAuxBooks(null, 'alice')).toEqual([]);
+    });
+
+    test('returns empty array when fileName is empty', () => {
+        expect(getLinkedAuxBooks([{ name: 'alice', extraBooks: ['book1'] }], '')).toEqual([]);
+    });
+
+    test('returns empty array when character not found', () => {
+        expect(getLinkedAuxBooks([{ name: 'bob', extraBooks: ['book1'] }], 'alice')).toEqual([]);
+    });
+
+    test('returns extraBooks for matching character', () => {
+        const charLore = [
+            { name: 'alice', extraBooks: ['book1', 'book2'] },
+            { name: 'bob', extraBooks: ['book3'] },
+        ];
+        expect(getLinkedAuxBooks(charLore, 'alice')).toEqual(['book1', 'book2']);
+    });
+
+    test('returns empty array when extraBooks is undefined', () => {
+        expect(getLinkedAuxBooks([{ name: 'alice' }], 'alice')).toEqual([]);
+    });
+});


### PR DESCRIPTION
## What?

Add a one-click batch import that detects embedded lorebooks on all visible loaded character cards, imports each one, links it to the correct character, and reports a summary with any skipped characters or name collisions.

## Why?

The existing embedded lorebook import (`Import Card Lore` in the character panel `More...` dropdown) is oriented around the active character. For users with many loaded character cards that each contain an embedded lorebook, importing them one at a time is repetitive and easy to miss. Issue #534 requests a batch workflow that operates on the visible roster.

## How?

- **Pure helper `importEmbeddedWorldInfoForCharacter(chid)`**: Extracts the import logic (detect embedded book, convert via `convertCharacterBook`, save via `saveWorldInfo`) into a function that takes a chid and returns a result object `{ chid, characterName, bookName, status, collision }`. Does not touch the active-character UI (`#character_world`, WI panel, `#import_character_info`).
- **Batch orchestrator `importEmbeddedWorldInfoBatch()`**: Gathers visible character chids via `getEntitiesList({ doFilter: true })`, detects candidates with embedded books, shows a confirmation dialog listing the count and any name collisions, imports each via the pure helper, links each imported book as an **auxiliary world book** via `charUpdateAddAuxWorld()` (settings-only `world_info.charLore` update — safe for non-active characters, avoids `createOrEditCharacter()` active-form coupling), and shows a summary popup.
- **Auxiliary vs primary linking**: The single-character flow sets the primary world (`#character_world` → `charUpdatePrimaryWorld()` → `createOrEditCharacter()`), which is correct for the active character but would corrupt non-active characters in a batch. The batch flow uses auxiliary linking instead, which only updates `world_info.charLore` in settings and calls `saveSettingsDebounced()`. Both primary and auxiliary books are loaded during generation.
- **Dedup**: Before linking, checks `getLinkedAuxBooks()` to avoid duplicate entries if the batch is run multiple times.
- **Refactor**: `importEmbeddedWorldInfo()` now delegates the actual import to the pure helper while keeping its active-character UI behavior (primary world link, WI panel open, button class).
- **UI entry point**: Adds a `Batch Import Embedded Lorebooks` button (`fa-cubes-stacked` icon) to the World Info popup library action group, next to the existing `Import World Info` button.
- **Pure helpers file**: `world-info-batch-helpers.js` contains `detectEmbeddedLorebookCandidates()` and `getLinkedAuxBooks()` — both pure functions with no side-effect imports, extracted for testability.

## Testing?

- `npm run lint` — clean
- `npm run test:unit --prefix tests -- world-info` — 29 tests pass (11 new + 18 existing)
- New tests in `world-info-batch-helpers.test.js` cover: no embedded books, detection with mixed roster, name fallback when book has no name, collision detection, undefined `character_book` skip, empty list, aux book lookup edge cases
- Not tested: live browser interaction (confirmation dialog, summary popup, WI panel button) — requires manual verification

## Screenshots

Not available — UI button placement is in the WI popup which requires a running instance to screenshot.

## Anything Else?

- Closes #534
- The batch flow does not switch the active chat or active character — it only reads `getEntitiesList` and writes world info + `charLore` settings
- Name collisions overwrite existing lorebooks (same behavior as the single-character import with `skipPopup=true`); collisions are listed in the confirmation dialog before proceeding
- Characters without embedded lorebooks are skipped silently in the batch (reported in the summary)