### PR TITLE
feat: lock and reorder BunnyPresetTools section dropdowns

### DIFF
--- a/public/scripts/extensions/third-party/BunnyPresetTools/content.js
+++ b/public/scripts/extensions/third-party/BunnyPresetTools/content.js
@@ -8,12 +8,21 @@ import {
 import { extension_settings, saveMetadataDebounced } from '../../../extensions.js';
 import { background_settings } from '../../../backgrounds.js';
 import { promptManager } from '../../../openai.js';
+import { power_user } from '../../../power-user.js';
+import {
+    buildSectionBlocks,
+    computeReorderedOrder,
+    getSectionLockState,
+    setSectionLockState,
+} from './sectionOrder.js';
 
 const EXTENSION_NAME = 'BunnyPresetTools';
 const LEGACY_EXTENSION_NAME = 'NemoPresetExt';
 const BUILT_IN_DIVIDER_PATTERNS = ['=+', '-{3,}', '\\*{3,}', '(?:[^\\w\\s]+\\s*)?[─━—-]\\+'];
 const VIDEO_EXTENSIONS = new Set(['mp4', 'webm', 'ogv', 'm4v']);
 const BACKGROUND_LOCK_KEY = 'custom_background';
+const SECTION_DRAG_HOLD_MS = 2500;
+const SECTION_DRAG_MOVE_THRESHOLD_PX = 8;
 
 let promptListElement = null;
 let promptListObserver = null;
@@ -32,6 +41,9 @@ let backgroundCardObserversAttached = false;
 let backgroundSyncTimer = null;
 let backgroundLifecycleHandlersAttached = false;
 let legacySettingsMigrationChecked = false;
+let activeSectionDrag = null;
+let sectionDropIndicator = null;
+let suppressSectionToggleUntil = 0;
 
 function migrateLegacySettings() {
     if (legacySettingsMigrationChecked) {
@@ -70,6 +82,9 @@ function ensureSettings() {
     }
     if (!settings.promptSectionStates || typeof settings.promptSectionStates !== 'object') {
         settings.promptSectionStates = {};
+    }
+    if (!settings.promptSectionLocks || typeof settings.promptSectionLocks !== 'object') {
+        settings.promptSectionLocks = {};
     }
     if (!settings.openSectionStates || typeof settings.openSectionStates !== 'object') {
         settings.openSectionStates = {};
@@ -273,7 +288,10 @@ function injectPromptToolbar(promptList) {
         const settings = ensureSettings();
         const sections = Array.from(promptList.querySelectorAll('.bpt-section-row'));
         sections.forEach(section => {
-            setPromptSectionOpenState(settings, section.dataset.sectionId, section.dataset.sectionName || section.dataset.sectionId, false);
+            const sectionName = section.dataset.sectionName || section.dataset.sectionId;
+            if (!getSectionLockState(settings, section.dataset.sectionId, sectionName)) {
+                setPromptSectionOpenState(settings, section.dataset.sectionId, sectionName, false);
+            }
         });
         saveSettingsDebounced();
         schedulePromptRefresh();
@@ -282,7 +300,10 @@ function injectPromptToolbar(promptList) {
         const settings = ensureSettings();
         const sections = Array.from(promptList.querySelectorAll('.bpt-section-row'));
         sections.forEach(section => {
-            setPromptSectionOpenState(settings, section.dataset.sectionId, section.dataset.sectionName || section.dataset.sectionId, true);
+            const sectionName = section.dataset.sectionName || section.dataset.sectionId;
+            if (!getSectionLockState(settings, section.dataset.sectionId, sectionName)) {
+                setPromptSectionOpenState(settings, section.dataset.sectionId, sectionName, true);
+            }
         });
         saveSettingsDebounced();
         schedulePromptRefresh();
@@ -405,8 +426,12 @@ function applySectionRowStyles(row, isOpen) {
         return;
     }
 
-    row.style.setProperty('display', 'block', 'important');
+    const isLocked = row.classList.contains('is-locked');
+
+    row.style.setProperty('display', 'grid', 'important');
     row.style.setProperty('width', '100%', 'important');
+    row.style.gridTemplateColumns = 'minmax(0, 1fr) auto';
+    row.style.alignItems = 'stretch';
     row.style.setProperty('min-height', '48px', 'important');
     row.style.boxSizing = 'border-box';
     row.style.padding = '0';
@@ -425,17 +450,17 @@ function applySectionRowStyles(row, isOpen) {
         trigger.style.setProperty('display', 'flex', 'important');
         trigger.style.setProperty('align-items', 'center', 'important');
         trigger.style.setProperty('width', '100%', 'important');
-        trigger.style.setProperty('grid-column', '1 / -1', 'important');
+        trigger.style.setProperty('grid-column', '1', 'important');
         trigger.style.setProperty('min-height', '48px', 'important');
         trigger.style.setProperty('gap', '10px', 'important');
         trigger.style.setProperty('padding', '10px 12px', 'important');
         trigger.style.border = '0';
-        trigger.style.borderRadius = 'inherit';
+        trigger.style.borderRadius = '14px 0 0 14px';
         trigger.style.background = 'transparent';
         trigger.style.color = 'inherit';
         trigger.style.font = 'inherit';
         trigger.style.textAlign = 'left';
-        trigger.style.cursor = 'pointer';
+        trigger.style.cursor = isLocked ? 'default' : 'pointer';
         trigger.style.touchAction = 'manipulation';
         trigger.style.appearance = 'none';
         trigger.style.webkitAppearance = 'none';
@@ -467,26 +492,350 @@ function applySectionRowStyles(row, isOpen) {
         count.style.fontSize = '0.9em';
         count.style.whiteSpace = 'nowrap';
     }
+
+    const lockButton = row.querySelector('.bpt-section-lock');
+    if (lockButton instanceof HTMLElement) {
+        lockButton.style.display = 'flex';
+        lockButton.style.alignItems = 'center';
+        lockButton.style.justifyContent = 'center';
+        lockButton.style.alignSelf = 'stretch';
+        lockButton.style.minWidth = '46px';
+        lockButton.style.minHeight = '48px';
+        lockButton.style.padding = '0 12px';
+        lockButton.style.border = '0';
+        lockButton.style.borderLeft = '1px solid color-mix(in srgb, var(--SmartThemeBorderColor) 72%, transparent)';
+        lockButton.style.borderRadius = '0 14px 14px 0';
+        lockButton.style.background = isLocked
+            ? 'color-mix(in srgb, var(--SmartThemeQuoteColor) 20%, transparent)'
+            : 'color-mix(in srgb, var(--SmartThemeBlurTintColor) 52%, transparent)';
+        lockButton.style.color = isLocked ? 'var(--SmartThemeBodyColor)' : 'var(--SmartThemeEmColor)';
+        lockButton.style.cursor = 'pointer';
+        lockButton.style.touchAction = 'manipulation';
+        lockButton.style.appearance = 'none';
+        lockButton.style.webkitAppearance = 'none';
+    }
 }
 
-function createSectionRow(sectionId, title, sectionName, isOpen) {
+function getSectionRowsForDrag() {
+    if (!promptListElement) {
+        return [];
+    }
+
+    return Array.from(promptListElement.querySelectorAll(':scope > li.bpt-section-row'))
+        .filter(row => row instanceof HTMLElement && row.style.display !== 'none' && row.getClientRects().length > 0);
+}
+
+function ensureSectionDropIndicator() {
+    if (!sectionDropIndicator) {
+        sectionDropIndicator = document.createElement('li');
+        sectionDropIndicator.className = 'bpt-drop-indicator';
+        sectionDropIndicator.setAttribute('aria-hidden', 'true');
+        sectionDropIndicator.setAttribute('role', 'presentation');
+    }
+
+    return sectionDropIndicator;
+}
+
+function clearSectionDropIndicator() {
+    sectionDropIndicator?.remove();
+    sectionDropIndicator = null;
+}
+
+function clearSectionDropTarget() {
+    promptListElement?.querySelectorAll('.bpt-section-drop-target').forEach(row => {
+        row.classList.remove('bpt-section-drop-target');
+    });
+}
+
+function placeSectionDropIndicator(targetSectionId) {
+    if (!promptListElement || !activeSectionDrag?.isDragging) {
+        return;
+    }
+
+    const indicator = ensureSectionDropIndicator();
+    const rows = getSectionRowsForDrag().filter(row => row !== activeSectionDrag.row);
+    const targetRow = targetSectionId
+        ? rows.find(row => row.dataset.sectionId === targetSectionId)
+        : null;
+
+    clearSectionDropTarget();
+
+    if (targetRow) {
+        targetRow.classList.add('bpt-section-drop-target');
+        promptListElement.insertBefore(indicator, targetRow);
+        return;
+    }
+
+    promptListElement.append(indicator);
+}
+
+function resolveSectionDropTarget(clientX, clientY) {
+    const rows = getSectionRowsForDrag().filter(row => row !== activeSectionDrag?.row);
+    if (!rows.length) {
+        return null;
+    }
+
+    const rowAtPoint = document.elementsFromPoint?.(clientX, clientY)
+        .map(element => element.closest?.('.bpt-section-row'))
+        .find(row => row instanceof HTMLElement && row !== activeSectionDrag?.row && rows.includes(row));
+
+    if (rowAtPoint) {
+        const rect = rowAtPoint.getBoundingClientRect();
+        if (clientY <= rect.top + rect.height / 2) {
+            return rowAtPoint.dataset.sectionId || null;
+        }
+
+        const nextRow = rows[rows.indexOf(rowAtPoint) + 1];
+        return nextRow?.dataset.sectionId || null;
+    }
+
+    for (const row of rows) {
+        const rect = row.getBoundingClientRect();
+        if (clientY <= rect.top + rect.height / 2) {
+            return row.dataset.sectionId || null;
+        }
+    }
+
+    return null;
+}
+
+function updateSectionDropTarget(clientX, clientY) {
+    if (!activeSectionDrag?.isDragging) {
+        return;
+    }
+
+    const targetSectionId = resolveSectionDropTarget(clientX, clientY);
+    activeSectionDrag.dropTargetSectionId = targetSectionId;
+    placeSectionDropIndicator(targetSectionId);
+}
+
+function hasSamePromptOrder(previousOrder, nextOrder) {
+    if (!Array.isArray(previousOrder) || !Array.isArray(nextOrder) || previousOrder.length !== nextOrder.length) {
+        return false;
+    }
+
+    return previousOrder.every((entry, index) => entry?.identifier === nextOrder[index]?.identifier);
+}
+
+function commitSectionReorder(fromSectionId, toSectionId) {
+    const activeCharacter = promptManager?.activeCharacter;
+    const promptOrder = promptManager?.getPromptOrderForCharacter?.(activeCharacter);
+
+    if (!promptListElement || !activeCharacter || !Array.isArray(promptOrder)) {
+        return false;
+    }
+
+    const rows = Array.from(promptListElement.querySelectorAll(':scope > li.bpt-section-row, :scope > li.completion_prompt_manager_prompt[data-pm-identifier]'));
+    const blocks = buildSectionBlocks(rows);
+    const updatedPromptOrder = computeReorderedOrder(promptOrder, blocks, fromSectionId, toSectionId);
+
+    if (hasSamePromptOrder(promptOrder, updatedPromptOrder)) {
+        return false;
+    }
+
+    promptManager.removePromptOrderForCharacter(activeCharacter);
+    promptManager.addPromptOrderForCharacter(activeCharacter, updatedPromptOrder);
+    promptManager.log?.(`Prompt sections reordered for ${activeCharacter.name}.`);
+
+    const renderUpdatedOrder = () => {
+        promptManager.render?.(false);
+        schedulePromptRefresh();
+    };
+    const saveResult = promptManager.saveServiceSettings?.();
+
+    if (saveResult?.then) {
+        saveResult.then(renderUpdatedOrder).catch(error => {
+            console.warn('[BunnyPresetTools] Failed to save section reorder.', error);
+            renderUpdatedOrder();
+        });
+    } else {
+        saveSettingsDebounced();
+        renderUpdatedOrder();
+    }
+
+    return true;
+}
+
+function removeSectionDragListeners() {
+    document.removeEventListener('pointermove', handleSectionDragPointerMove, true);
+    document.removeEventListener('pointerup', handleSectionDragPointerUp, true);
+    document.removeEventListener('pointercancel', handleSectionDragPointerCancel, true);
+    document.removeEventListener('contextmenu', handleSectionDragContextMenu, true);
+}
+
+function finishSectionDrag({ suppressClick = false } = {}) {
+    if (!activeSectionDrag) {
+        return;
+    }
+
+    window.clearTimeout(activeSectionDrag.holdTimer);
+    removeSectionDragListeners();
+
+    if (suppressClick || activeSectionDrag.isDragging) {
+        suppressSectionToggleUntil = Date.now() + 450;
+    }
+
+    activeSectionDrag.row.classList.remove('bpt-section-dragging');
+    activeSectionDrag.trigger?.removeAttribute('aria-grabbed');
+    promptListElement?.classList.remove('bpt-section-reordering');
+    clearSectionDropTarget();
+    clearSectionDropIndicator();
+
+    try {
+        activeSectionDrag.trigger?.releasePointerCapture?.(activeSectionDrag.pointerId);
+    } catch {
+        // Pointer capture may already be released by the browser.
+    }
+
+    activeSectionDrag = null;
+}
+
+function beginSectionDrag() {
+    if (!activeSectionDrag || activeSectionDrag.isDragging) {
+        return;
+    }
+
+    const settings = ensureSettings();
+    if (getSectionLockState(settings, activeSectionDrag.sectionId, activeSectionDrag.sectionName) || power_user.prompt_manager_drag_locked) {
+        finishSectionDrag();
+        return;
+    }
+
+    activeSectionDrag.isDragging = true;
+    activeSectionDrag.row.classList.add('bpt-section-dragging');
+    activeSectionDrag.trigger?.setAttribute('aria-grabbed', 'true');
+    promptListElement?.classList.add('bpt-section-reordering');
+
+    try {
+        activeSectionDrag.trigger?.setPointerCapture?.(activeSectionDrag.pointerId);
+    } catch {
+        // Pointer capture is a progressive enhancement for this reorder gesture.
+    }
+
+    updateSectionDropTarget(activeSectionDrag.lastX, activeSectionDrag.lastY);
+}
+
+function armSectionDrag(event, row, sectionId, sectionName) {
+    if (!(event instanceof PointerEvent) || !event.isPrimary || (event.button !== undefined && event.button !== 0)) {
+        return;
+    }
+
+    const settings = ensureSettings();
+    if (getSectionLockState(settings, sectionId, sectionName) || power_user.prompt_manager_drag_locked || !promptManager?.activeCharacter) {
+        return;
+    }
+
+    finishSectionDrag();
+
+    activeSectionDrag = {
+        row,
+        trigger: event.currentTarget instanceof HTMLElement ? event.currentTarget : row.querySelector('.bpt-section-trigger'),
+        sectionId,
+        sectionName,
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        lastX: event.clientX,
+        lastY: event.clientY,
+        dropTargetSectionId: sectionId,
+        holdTimer: window.setTimeout(beginSectionDrag, SECTION_DRAG_HOLD_MS),
+        isDragging: false,
+    };
+
+    document.addEventListener('pointermove', handleSectionDragPointerMove, true);
+    document.addEventListener('pointerup', handleSectionDragPointerUp, true);
+    document.addEventListener('pointercancel', handleSectionDragPointerCancel, true);
+    document.addEventListener('contextmenu', handleSectionDragContextMenu, true);
+}
+
+function handleSectionDragPointerMove(event) {
+    if (!activeSectionDrag || event.pointerId !== activeSectionDrag.pointerId) {
+        return;
+    }
+
+    activeSectionDrag.lastX = event.clientX;
+    activeSectionDrag.lastY = event.clientY;
+
+    const distance = Math.hypot(event.clientX - activeSectionDrag.startX, event.clientY - activeSectionDrag.startY);
+    if (!activeSectionDrag.isDragging && distance > SECTION_DRAG_MOVE_THRESHOLD_PX) {
+        finishSectionDrag();
+        return;
+    }
+
+    if (activeSectionDrag.isDragging) {
+        event.preventDefault();
+        event.stopPropagation();
+        updateSectionDropTarget(event.clientX, event.clientY);
+    }
+}
+
+function handleSectionDragPointerUp(event) {
+    if (!activeSectionDrag || event.pointerId !== activeSectionDrag.pointerId) {
+        return;
+    }
+
+    if (!activeSectionDrag.isDragging) {
+        finishSectionDrag();
+        return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const { sectionId, dropTargetSectionId } = activeSectionDrag;
+    commitSectionReorder(sectionId, dropTargetSectionId);
+    finishSectionDrag({ suppressClick: true });
+}
+
+function handleSectionDragPointerCancel(event) {
+    if (!activeSectionDrag || event.pointerId !== activeSectionDrag.pointerId) {
+        return;
+    }
+
+    finishSectionDrag({ suppressClick: activeSectionDrag.isDragging });
+}
+
+function handleSectionDragContextMenu(event) {
+    if (!activeSectionDrag) {
+        return;
+    }
+
+    event.preventDefault();
+    if (!activeSectionDrag.isDragging) {
+        finishSectionDrag();
+    }
+}
+
+function createSectionRow(sectionId, title, sectionName, isOpen, isLocked) {
     const row = document.createElement('li');
-    row.className = `bpt-section-row ${isOpen ? '' : 'is-collapsed'}`.trim();
+    row.className = `bpt-section-row ${isOpen ? '' : 'is-collapsed'} ${isLocked ? 'is-locked' : 'is-unlocked'}`.trim();
     row.dataset.sectionId = sectionId;
     row.dataset.sectionName = sectionName;
+    const triggerTitle = isLocked
+        ? 'Unlock this section before changing its open state or position.'
+        : power_user.prompt_manager_drag_locked
+            ? 'Tap to open or close. Unlock Prompt Manager reordering to move this section.'
+            : 'Tap to open or close. Hold for 2.5 seconds to move this section.';
     row.innerHTML = `
-        <button class="bpt-section-trigger" type="button" aria-expanded="${String(isOpen)}" aria-label="Toggle ${title}">
+        <button class="bpt-section-trigger" type="button" aria-expanded="${String(isOpen)}" aria-disabled="${String(isLocked)}" aria-label="Toggle section">
             <span class="bpt-section-toggle" aria-hidden="true">
                 <i class="fa-solid ${isOpen ? 'fa-chevron-down' : 'fa-chevron-right'}"></i>
             </span>
             <span class="bpt-section-title"></span>
             <span class="bpt-section-count"></span>
         </button>
+        <button class="bpt-section-lock" type="button" aria-pressed="${String(isLocked)}" aria-label="Toggle section lock">
+            <i class="fa-solid ${isLocked ? 'fa-lock' : 'fa-unlock'}" aria-hidden="true"></i>
+        </button>
     `;
     applySectionRowStyles(row, isOpen);
     row.querySelector('.bpt-section-title').textContent = title;
     const toggleSection = () => {
         const settings = ensureSettings();
+        if (getSectionLockState(settings, sectionId, sectionName)) {
+            return;
+        }
+
         const nextIsOpen = !getPromptSectionOpenState(settings, sectionId, sectionName);
         setPromptSectionOpenState(settings, sectionId, sectionName, nextIsOpen);
         saveSettingsDebounced();
@@ -494,10 +843,16 @@ function createSectionRow(sectionId, title, sectionName, isOpen) {
     };
 
     const trigger = row.querySelector('.bpt-section-trigger');
+    trigger.setAttribute('aria-label', `Toggle ${title}`);
+    trigger.setAttribute('title', triggerTitle);
     let lastToggleAt = 0;
     const activateTrigger = event => {
         event.preventDefault();
         event.stopPropagation();
+
+        if (Date.now() < suppressSectionToggleUntil) {
+            return;
+        }
 
         const now = Date.now();
         if (now - lastToggleAt < 180) {
@@ -507,8 +862,34 @@ function createSectionRow(sectionId, title, sectionName, isOpen) {
         lastToggleAt = now;
         toggleSection();
     };
+    trigger.addEventListener('pointerdown', event => armSectionDrag(event, row, sectionId, sectionName));
     trigger.addEventListener('click', activateTrigger);
     trigger.addEventListener('touchend', activateTrigger);
+
+    const lockButton = row.querySelector('.bpt-section-lock');
+    const lockLabel = isLocked ? `Unlock ${title} section` : `Lock ${title} section open or closed`;
+    lockButton.setAttribute('aria-label', lockLabel);
+    lockButton.setAttribute('title', lockLabel);
+    let lastLockToggleAt = 0;
+    const activateLockButton = event => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        const now = Date.now();
+        if (now - lastLockToggleAt < 180) {
+            return;
+        }
+
+        lastLockToggleAt = now;
+
+        const settings = ensureSettings();
+        const nextLocked = !getSectionLockState(settings, sectionId, sectionName);
+        setSectionLockState(settings, sectionId, sectionName, nextLocked);
+        saveSettingsDebounced();
+        schedulePromptRefresh();
+    };
+    lockButton.addEventListener('click', activateLockButton);
+    lockButton.addEventListener('touchend', activateLockButton);
     return row;
 }
 
@@ -563,8 +944,9 @@ function refreshPromptSections() {
 
                 const sectionId = row.dataset.pmIdentifier || promptName || `bpt-section-${sections.length}`;
                 const isOpen = getPromptSectionOpenState(settings, sectionId, promptName);
+                const isLocked = getSectionLockState(settings, sectionId, promptName);
                 const sectionTitle = stripDividerPrefix(promptName, dividerRegex);
-                const sectionRow = createSectionRow(sectionId, sectionTitle, promptName, isOpen);
+                const sectionRow = createSectionRow(sectionId, sectionTitle, promptName, isOpen, isLocked);
                 const isSourcePrompt = hasPromptRowContent(row);
 
                 row.before(sectionRow);
@@ -574,6 +956,7 @@ function refreshPromptSections() {
                     id: sectionId,
                     title: sectionTitle,
                     isOpen,
+                    isLocked,
                     row: sectionRow,
                     prompts: [],
                 };
@@ -621,7 +1004,11 @@ function refreshPromptSections() {
             section.row.querySelector('.bpt-section-count').textContent = `${enabledCount}/${countablePrompts.length}`;
             section.row.style.display = query.length === 0 || titleMatches || matchedCount > 0 ? '' : 'none';
             section.row.classList.toggle('is-collapsed', !section.isOpen && query.length === 0);
-            section.row.querySelector('.bpt-section-trigger')?.setAttribute('aria-expanded', String(section.isOpen || query.length > 0));
+            section.row.classList.toggle('is-locked', section.isLocked);
+            section.row.classList.toggle('is-unlocked', !section.isLocked);
+            const sectionTrigger = section.row.querySelector('.bpt-section-trigger');
+            sectionTrigger?.setAttribute('aria-expanded', String(section.isOpen || query.length > 0));
+            sectionTrigger?.setAttribute('aria-disabled', String(section.isLocked));
             applySectionRowStyles(section.row, section.isOpen || query.length > 0);
 
             const icon = section.row.querySelector('.bpt-section-toggle i');

--- a/public/scripts/extensions/third-party/BunnyPresetTools/manifest.json
+++ b/public/scripts/extensions/third-party/BunnyPresetTools/manifest.json
@@ -1,7 +1,7 @@
 {
     "display_name": "Bunny Preset Tools",
     "author": "SillyBunny",
-    "version": "1.5.3",
+    "version": "1.5.4",
     "description": "Prompt sections and animated backgrounds tailored for SillyBunny.",
     "requires": [],
     "optional": [],

--- a/public/scripts/extensions/third-party/BunnyPresetTools/sectionOrder.js
+++ b/public/scripts/extensions/third-party/BunnyPresetTools/sectionOrder.js
@@ -1,0 +1,156 @@
+function getDatasetValue(row, key) {
+    return row?.dataset?.[key] ?? row?.[key] ?? '';
+}
+
+function hasClass(row, className) {
+    if (row?.classList?.contains?.(className)) {
+        return true;
+    }
+
+    if (typeof row?.className === 'string') {
+        return row.className.split(/\s+/u).includes(className);
+    }
+
+    if (Array.isArray(row?.classes)) {
+        return row.classes.includes(className);
+    }
+
+    return row?.classes instanceof Set && row.classes.has(className);
+}
+
+function normalizeKey(value) {
+    return String(value || '').trim();
+}
+
+function ensureLockStore(settings) {
+    if (!settings || typeof settings !== 'object') {
+        return {};
+    }
+
+    if (!settings.promptSectionLocks || typeof settings.promptSectionLocks !== 'object') {
+        settings.promptSectionLocks = {};
+    }
+
+    return settings.promptSectionLocks;
+}
+
+export function getSectionLockState(settings, sectionId, sectionName, defaultValue = true) {
+    const locks = ensureLockStore(settings);
+    const idKey = normalizeKey(sectionId);
+    const nameKey = normalizeKey(sectionName);
+    const stateById = idKey ? locks[idKey] : undefined;
+    const stateByName = nameKey ? locks[nameKey] : undefined;
+    const resolvedState = typeof stateById === 'boolean'
+        ? stateById
+        : typeof stateByName === 'boolean'
+            ? stateByName
+            : Boolean(defaultValue);
+
+    if (idKey) {
+        locks[idKey] = resolvedState;
+    }
+    if (nameKey) {
+        locks[nameKey] = resolvedState;
+    }
+
+    return resolvedState;
+}
+
+export function setSectionLockState(settings, sectionId, sectionName, isLocked) {
+    const locks = ensureLockStore(settings);
+    const idKey = normalizeKey(sectionId);
+    const nameKey = normalizeKey(sectionName);
+    const nextState = Boolean(isLocked);
+
+    if (idKey) {
+        locks[idKey] = nextState;
+    }
+    if (nameKey) {
+        locks[nameKey] = nextState;
+    }
+}
+
+export function buildSectionBlocks(rows) {
+    const blocks = [];
+    const blockBySectionId = new Map();
+    let currentBlock = null;
+
+    Array.from(rows || []).forEach(row => {
+        const sectionId = normalizeKey(getDatasetValue(row, 'sectionId'));
+        const identifier = normalizeKey(getDatasetValue(row, 'pmIdentifier') || getDatasetValue(row, 'identifier'));
+        const isSectionRow = Boolean(row?.isSection) || hasClass(row, 'bpt-section-row');
+
+        if (isSectionRow && sectionId) {
+            currentBlock = { sectionId, promptIds: [] };
+            blocks.push(currentBlock);
+            blockBySectionId.set(sectionId, currentBlock);
+            return;
+        }
+
+        if (!identifier || !sectionId) {
+            return;
+        }
+
+        const block = currentBlock?.sectionId === sectionId
+            ? currentBlock
+            : blockBySectionId.get(sectionId) ?? { sectionId, promptIds: [] };
+
+        if (!blockBySectionId.has(sectionId)) {
+            blocks.push(block);
+            blockBySectionId.set(sectionId, block);
+        }
+
+        if (!block.promptIds.includes(identifier)) {
+            block.promptIds.push(identifier);
+        }
+    });
+
+    return blocks;
+}
+
+export function computeReorderedOrder(order, blocks, fromSectionId, toSectionId) {
+    const promptOrder = Array.isArray(order) ? order : [];
+    const sectionBlocks = Array.isArray(blocks) ? blocks : [];
+    const fromId = normalizeKey(fromSectionId);
+    const toId = toSectionId === null || toSectionId === undefined ? null : normalizeKey(toSectionId);
+
+    if (!fromId || fromId === toId) {
+        return promptOrder.slice();
+    }
+
+    const fromBlock = sectionBlocks.find(block => normalizeKey(block?.sectionId) === fromId);
+    const toBlock = toId ? sectionBlocks.find(block => normalizeKey(block?.sectionId) === toId) : null;
+
+    if (!fromBlock || (toId && !toBlock)) {
+        return promptOrder.slice();
+    }
+
+    const entryById = new Map(promptOrder.map(entry => [normalizeKey(entry?.identifier), entry]));
+    const movingIds = Array.from(fromBlock.promptIds || [])
+        .map(normalizeKey)
+        .filter(identifier => identifier && entryById.has(identifier));
+
+    if (!movingIds.length) {
+        return promptOrder.slice();
+    }
+
+    const movingIdSet = new Set(movingIds);
+    const movingEntries = movingIds.map(identifier => entryById.get(identifier));
+    const remainingEntries = promptOrder.filter(entry => !movingIdSet.has(normalizeKey(entry?.identifier)));
+    let targetIndex = remainingEntries.length;
+
+    if (toBlock) {
+        const targetIds = new Set(Array.from(toBlock.promptIds || []).map(normalizeKey).filter(Boolean));
+        targetIndex = remainingEntries.findIndex(entry => targetIds.has(normalizeKey(entry?.identifier)));
+
+        if (targetIndex === -1) {
+            return promptOrder.slice();
+        }
+    }
+
+    return [
+        ...remainingEntries.slice(0, targetIndex),
+        ...movingEntries,
+        ...remainingEntries.slice(targetIndex),
+    ];
+}

--- a/public/scripts/extensions/third-party/BunnyPresetTools/styles.css
+++ b/public/scripts/extensions/third-party/BunnyPresetTools/styles.css
@@ -19,8 +19,9 @@
 }
 
 #completion_prompt_manager #completion_prompt_manager_list li.bpt-section-row {
-    display: block;
-    grid-template-columns: minmax(0, 1fr);
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: stretch;
     min-height: 48px;
     padding: 0;
     margin: 8px 0 4px;
@@ -40,7 +41,7 @@
 .bpt-section-trigger {
     appearance: none;
     -webkit-appearance: none;
-    grid-column: 1 / -1;
+    grid-column: 1;
     min-height: 48px;
     width: 100%;
     display: flex;
@@ -48,13 +49,17 @@
     gap: 10px;
     padding: 10px 12px;
     border: 0;
-    border-radius: inherit;
+    border-radius: 14px 0 0 14px;
     background: transparent;
     color: inherit;
     font: inherit;
     text-align: left;
     cursor: pointer;
     touch-action: manipulation;
+}
+
+.bpt-section-row.is-locked .bpt-section-trigger {
+    cursor: default;
 }
 
 .bpt-section-trigger > * {
@@ -88,6 +93,61 @@
     color: var(--SmartThemeEmColor);
     font-size: 0.9em;
     white-space: nowrap;
+}
+
+.bpt-section-lock {
+    appearance: none;
+    -webkit-appearance: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    align-self: stretch;
+    min-width: 46px;
+    min-height: 48px;
+    padding: 0 12px;
+    border: 0;
+    border-left: 1px solid color-mix(in srgb, var(--SmartThemeBorderColor) 72%, transparent);
+    border-radius: 0 14px 14px 0;
+    background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 52%, transparent);
+    color: var(--SmartThemeEmColor);
+    cursor: pointer;
+    touch-action: manipulation;
+}
+
+.bpt-section-row.is-locked .bpt-section-lock {
+    background: color-mix(in srgb, var(--SmartThemeQuoteColor) 20%, transparent);
+    color: var(--SmartThemeBodyColor);
+}
+
+.bpt-section-lock:hover,
+.bpt-section-lock:focus-visible {
+    outline: none;
+    color: var(--SmartThemeBodyColor);
+    box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--SmartThemeQuoteColor) 72%, transparent);
+}
+
+#completion_prompt_manager_list.bpt-section-reordering {
+    user-select: none;
+}
+
+#completion_prompt_manager_list li.bpt-section-row.bpt-section-dragging {
+    opacity: 0.72;
+    transform: scale(0.995);
+    box-shadow: 0 14px 28px color-mix(in srgb, var(--SmartThemeShadowColor) 16%, transparent);
+}
+
+#completion_prompt_manager_list li.bpt-section-row.bpt-section-drop-target {
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--SmartThemeQuoteColor) 48%, transparent);
+}
+
+#completion_prompt_manager_list li.bpt-drop-indicator {
+    display: block;
+    height: 8px;
+    margin: 6px 0;
+    border-radius: 999px;
+    list-style: none;
+    background: color-mix(in srgb, var(--SmartThemeQuoteColor) 70%, transparent);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--SmartThemeQuoteColor) 16%, transparent);
 }
 
 #completion_prompt_manager #completion_prompt_manager_list .completion_prompt_manager_prompt.bpt-section-item .prompt_manager_prompt_name {
@@ -356,6 +416,12 @@ body.bpt-animated-bg-active #bg1 {
     .bpt-section-trigger {
         padding: 14px 16px;
         min-height: 48px;
+    }
+
+    .bpt-section-lock {
+        min-width: 52px;
+        min-height: 52px;
+        padding: 0 14px;
     }
 
     .bpt-section-toggle {

--- a/tests/bpt-section-order.test.js
+++ b/tests/bpt-section-order.test.js
@@ -1,0 +1,142 @@
+import { describe, expect, test } from '@jest/globals';
+
+import {
+    buildSectionBlocks,
+    computeReorderedOrder,
+    getSectionLockState,
+    setSectionLockState,
+} from '../public/scripts/extensions/third-party/BunnyPresetTools/sectionOrder.js';
+
+const sectionRow = sectionId => ({ className: 'bpt-section-row', dataset: { sectionId } });
+const promptRow = (identifier, sectionId) => ({ dataset: { pmIdentifier: identifier, sectionId } });
+
+describe('BunnyPresetTools section order helpers', () => {
+    test('defaults new sections to locked and stores id/name keys', () => {
+        const settings = {};
+
+        expect(getSectionLockState(settings, 'section-1', 'Main')).toBe(true);
+        expect(settings.promptSectionLocks).toEqual({
+            'section-1': true,
+            Main: true,
+        });
+    });
+
+    test('uses section-name fallback for existing lock state', () => {
+        const settings = { promptSectionLocks: { Main: false } };
+
+        expect(getSectionLockState(settings, 'section-1', 'Main')).toBe(false);
+        expect(settings.promptSectionLocks['section-1']).toBe(false);
+    });
+
+    test('sets lock state by id and name', () => {
+        const settings = {};
+
+        setSectionLockState(settings, 'section-1', 'Main', false);
+
+        expect(getSectionLockState(settings, 'section-1', 'Main')).toBe(false);
+        expect(settings.promptSectionLocks).toEqual({
+            'section-1': false,
+            Main: false,
+        });
+    });
+
+    test('builds section blocks from mixed section and prompt rows', () => {
+        expect(buildSectionBlocks([
+            sectionRow('main'),
+            promptRow('main-divider', 'main'),
+            promptRow('main-child', 'main'),
+            sectionRow('prefills'),
+            promptRow('prefill-divider', 'prefills'),
+            promptRow('prefill-child', 'prefills'),
+            promptRow('unsectioned', ''),
+        ])).toEqual([
+            { sectionId: 'main', promptIds: ['main-divider', 'main-child'] },
+            { sectionId: 'prefills', promptIds: ['prefill-divider', 'prefill-child'] },
+        ]);
+    });
+
+    test('moves a section block before a later section', () => {
+        const order = [
+            { identifier: 'a-divider', enabled: true },
+            { identifier: 'a-child', enabled: false },
+            { identifier: 'b-divider', enabled: true },
+            { identifier: 'b-child', enabled: true },
+            { identifier: 'c-divider', enabled: false },
+        ];
+        const blocks = [
+            { sectionId: 'a', promptIds: ['a-divider', 'a-child'] },
+            { sectionId: 'b', promptIds: ['b-divider', 'b-child'] },
+            { sectionId: 'c', promptIds: ['c-divider'] },
+        ];
+
+        const result = computeReorderedOrder(order, blocks, 'a', 'c');
+
+        expect(result.map(entry => entry.identifier)).toEqual(['b-divider', 'b-child', 'a-divider', 'a-child', 'c-divider']);
+        expect(result[2]).toBe(order[0]);
+        expect(result[3].enabled).toBe(false);
+    });
+
+    test('moves a section block before an earlier section', () => {
+        const order = [
+            { identifier: 'a-divider' },
+            { identifier: 'b-divider' },
+            { identifier: 'b-child' },
+            { identifier: 'c-divider' },
+        ];
+        const blocks = [
+            { sectionId: 'a', promptIds: ['a-divider'] },
+            { sectionId: 'b', promptIds: ['b-divider', 'b-child'] },
+            { sectionId: 'c', promptIds: ['c-divider'] },
+        ];
+
+        expect(computeReorderedOrder(order, blocks, 'c', 'a').map(entry => entry.identifier)).toEqual([
+            'c-divider',
+            'a-divider',
+            'b-divider',
+            'b-child',
+        ]);
+    });
+
+    test('moves a section block to the end when target is null', () => {
+        const order = [
+            { identifier: 'a-divider' },
+            { identifier: 'b-divider' },
+            { identifier: 'c-divider' },
+        ];
+        const blocks = [
+            { sectionId: 'a', promptIds: ['a-divider'] },
+            { sectionId: 'b', promptIds: ['b-divider'] },
+            { sectionId: 'c', promptIds: ['c-divider'] },
+        ];
+
+        expect(computeReorderedOrder(order, blocks, 'b', null).map(entry => entry.identifier)).toEqual([
+            'a-divider',
+            'c-divider',
+            'b-divider',
+        ]);
+    });
+
+    test('leaves self drops and missing sections unchanged', () => {
+        const order = [{ identifier: 'a-divider' }, { identifier: 'b-divider' }];
+        const blocks = [
+            { sectionId: 'a', promptIds: ['a-divider'] },
+            { sectionId: 'b', promptIds: ['b-divider'] },
+        ];
+
+        expect(computeReorderedOrder(order, blocks, 'a', 'a')).toEqual(order);
+        expect(computeReorderedOrder(order, blocks, 'missing', 'a')).toEqual(order);
+        expect(computeReorderedOrder(order, blocks, 'a', 'missing')).toEqual(order);
+    });
+
+    test('does not move empty source or anchor to empty target sections', () => {
+        const order = [{ identifier: 'a-divider' }, { identifier: 'b-divider' }];
+        const blocks = [
+            { sectionId: 'empty', promptIds: [] },
+            { sectionId: 'a', promptIds: ['a-divider'] },
+            { sectionId: 'b', promptIds: ['b-divider'] },
+        ];
+
+        expect(computeReorderedOrder(order, blocks, 'empty', 'a')).toEqual(order);
+        expect(computeReorderedOrder(order, blocks, 'a', 'empty')).toEqual(order);
+    });
+});


### PR DESCRIPTION
## Summary
- add per-section lock buttons for BunnyPresetTools Prompt Manager sections, defaulting new sections to locked
- keep locked section open/closed state out of bulk expand/collapse actions
- add 2.5s hold-to-reorder for unlocked sections, moving divider prompts with their child prompts through the existing PromptManager order APIs
- add pure section-order helpers and focused Jest coverage

## Tests
- NODE_OPTIONS=--experimental-vm-modules npx jest --config tests/jest.config.json tests/bpt-section-order.test.js
- npm run lint
- npm run check:frontend-budgets
- git diff --check
- git diff --cached --check