### PR TITLE
feat: regenerate character thumbnail from editor menu

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6675,6 +6675,9 @@
                                                                             <option id="import_character_info" data-i18n="Import Card Lore">
                                                                                 Import Card Lore
                                                                             </option>
+                                                                            <option id="regenerate_thumbnail" data-i18n="Regenerate Thumbnail">
+                                                                                Regenerate Thumbnail
+                                                                            </option>
                                                                             <option id="set_chat_character_settings" data-i18n="Character Settings Overrides">
                                                                                 Character Settings Overrides
                                                                             </option>

--- a/public/script.js
+++ b/public/script.js
@@ -17194,6 +17194,33 @@ jQuery(async function () {
                 await importEmbeddedWorldInfo();
                 saveCharacterDebounced();
                 break;
+            case 'regenerate_thumbnail': {
+                if (this_chid === undefined || this_chid === -1 || !characters[this_chid]) {
+                    break;
+                }
+                const avatarKey = characters[this_chid].avatar;
+                if (!avatarKey || avatarKey === 'none') {
+                    toastr.warning(t`This character has no avatar to regenerate a thumbnail from.`);
+                    break;
+                }
+                try {
+                    const regenResponse = await fetch('/api/characters/regenerate-thumbnail', {
+                        method: 'POST',
+                        headers: getRequestHeaders(),
+                        body: JSON.stringify({ avatar_url: avatarKey }),
+                        cache: 'no-cache',
+                    });
+                    if (!regenResponse.ok) {
+                        toastr.error(t`Failed to regenerate thumbnail (${regenResponse.status})`);
+                        break;
+                    }
+                    await refreshCharacterAvatar(avatarKey);
+                    toastr.success(t`Thumbnail regenerated successfully.`, t`Thumbnail Refreshed`);
+                } catch (error) {
+                    console.error('Failed to regenerate thumbnail:', error);
+                    toastr.error(t`An error occurred while regenerating the thumbnail.`);
+                }
+            } break;
             case 'character_source': {
                 const source = getCharacterSource(this_chid);
                 if (source && isValidUrl(source)) {

--- a/src/endpoints/characters.js
+++ b/src/endpoints/characters.js
@@ -18,7 +18,7 @@ import { deepMerge, humanizedDateTime, tryParse, MemoryLimitedMap, getConfigValu
 import { TavernCardValidator } from '../validator/TavernCardValidator.js';
 import { parse, read, write } from '../character-card-parser.js';
 import { readWorldInfoFile } from './worldinfo.js';
-import { invalidateThumbnail } from './thumbnails.js';
+import { invalidateThumbnail, generateThumbnail } from './thumbnails.js';
 import { importRisuSprites } from './sprites.js';
 import { getUserDirectories } from '../users.js';
 import { getChatInfo } from './chats.js';
@@ -1429,6 +1429,43 @@ router.post('/delete', validateAvatarUrlMiddleware, async function (request, res
     }
 
     return response.sendStatus(200);
+});
+
+/**
+ * HTTP POST endpoint for the "/api/characters/regenerate-thumbnail" route.
+ *
+ * Invalidates the cached avatar thumbnail for a character and regenerates it from the original avatar file.
+ *
+ * @param {import("express").Request} request The HTTP request object. Body: `{ avatar_url: string }`
+ * @param {import("express").Response} response The HTTP response object.
+ */
+router.post('/regenerate-thumbnail', validateAvatarUrlMiddleware, async function (request, response) {
+    if (!request.body || !request.body.avatar_url) {
+        return response.sendStatus(400);
+    }
+
+    if (request.body.avatar_url !== sanitize(request.body.avatar_url)) {
+        console.error('Malicious filename prevented');
+        return response.sendStatus(403);
+    }
+
+    const avatarPath = path.join(request.user.directories.characters, request.body.avatar_url);
+    if (!fs.existsSync(avatarPath)) {
+        return response.status(404).json({ error: 'Character avatar file not found.' });
+    }
+
+    try {
+        invalidateThumbnail(request.user.directories, 'avatar', request.body.avatar_url);
+        const result = await generateThumbnail(request.user.directories, 'avatar', request.body.avatar_url, true);
+        return response.json({
+            ok: true,
+            regenerated: result.path !== null,
+            aspectRatio: result.aspectRatio,
+        });
+    } catch (error) {
+        console.error('Failed to regenerate thumbnail for', request.body.avatar_url, error);
+        return response.status(500).json({ error: 'Failed to regenerate thumbnail.' });
+    }
 });
 
 /**


### PR DESCRIPTION
## What?

Add a `Regenerate Thumbnail` option to the character editor `More...` dropdown that invalidates the cached avatar thumbnail and regenerates it from the original avatar file, then refreshes all visible thumbnail references in the UI.

## Why?

Character thumbnails can become stale after avatar changes, imports, or cache issues. The existing admin `POST /api/admin/thumbnails/clear-cache` endpoint clears all thumbnails for the user, which is too broad for targeting a single character. Issue #535 requests a per-character refresh action accessible from the character editor.

## How?

- **Backend** (`src/endpoints/characters.js`): New `POST /api/characters/regenerate-thumbnail` endpoint. Uses the same `validateAvatarUrlMiddleware` as other character endpoints. Calls `invalidateThumbnail()` to delete the cached file, then `generateThumbnail(forceGenerate=true)` to regenerate from the original avatar. Returns `{ ok, regenerated, aspectRatio }`. If the avatar is an animated/nonstandard format (GIF, APNG, animated WebP), `generateThumbnail` returns `path: null` and `regenerated: false` — the client continues serving the original file, preserving current behavior.
- **Frontend HTML** (`public/index.html`): New `<option id="regenerate_thumbnail">` in `#char-management-dropdown`, placed after `Import Card Lore`.
- **Frontend JS** (`public/script.js`): New case in the dropdown `change` handler. POSTs to the endpoint with `{ avatar_url }`, then calls the existing `refreshCharacterAvatar(avatarKey)` function which reloads the browser cache via `fetch(url, { cache: 'reload' })` and updates all matching `<img>` elements and `.mes` avatar CSS variables with cache-busted URLs.

## Testing?

- `npm run lint` — clean
- `npm run test:unit --prefix tests` — 138 suites, 1293 tests pass (no regressions)
- Not tested: live browser interaction (dropdown selection, thumbnail visual refresh) — requires manual verification with a running instance

## Screenshots

Not available — the dropdown option and thumbnail refresh require a running instance to screenshot.

## Anything Else?

- Closes #535
- Single `Regenerate Thumbnail` action chosen over separate refresh/delete — simpler UX, and the endpoint always invalidates before regenerating so the result is the same
- The `refreshCharacterAvatar()` function already handles updating `<img>` elements in the character list, chat messages, and CSS avatar variables — no additional UI refresh logic needed
- Animated/nonstandard avatar formats (GIF, APNG, animated WebP) are handled gracefully: the endpoint returns `regenerated: false` and the client continues serving the original file as before
