### PR TITLE
feat: sort model favorites alphabetically and scope Custom favorites per URL

### DIFF
--- a/public/scripts/openai-preset-utils.js
+++ b/public/scripts/openai-preset-utils.js
@@ -292,3 +292,21 @@ export function normalizeCustomEndpointPreset(preset) {
 export function buildCustomEndpointPresetForSave(preset) {
     return normalizeCustomEndpointPreset(preset);
 }
+
+/**
+ * Builds the storage key for model favorites, scoping Custom endpoint favorites by URL.
+ *
+ * @param {string} source Chat Completion source
+ * @param {string} url Custom OpenAI-compatible endpoint URL
+ * @returns {string} Model favorites storage key
+ */
+export function getCustomEndpointFavoritesKey(source, url) {
+    const normalizedSource = String(source ?? '');
+
+    if (normalizedSource !== 'custom') {
+        return normalizedSource;
+    }
+
+    const normalizedUrl = String(url ?? '').trim().replace(/\/+$/, '');
+    return normalizedUrl ? `${normalizedSource}::${normalizedUrl}` : normalizedSource;
+}

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -93,6 +93,7 @@ import {
     buildCustomEndpointPresetForSave,
     buildReverseProxyPresetForSave,
     getChatCompletionSamplingProfileLookupKeys,
+    getCustomEndpointFavoritesKey,
     normalizeCustomEndpointPreset,
     normalizeReverseProxyPreset,
     shouldIncludeSamplingFieldsInPreset,
@@ -2112,24 +2113,31 @@ function ensureModelFavoritesStore(settings = oai_settings) {
 
 function getModelFavoritesForSource(source = oai_settings.chat_completion_source, settings = oai_settings) {
     const favoritesStore = ensureModelFavoritesStore(settings);
+    const favoritesKey = getCustomEndpointFavoritesKey(source, settings.custom_url);
 
-    if (!Array.isArray(favoritesStore[source])) {
-        favoritesStore[source] = [];
+    if (source === chat_completion_sources.CUSTOM && favoritesKey !== source && !Object.hasOwn(favoritesStore, favoritesKey)) {
+        favoritesStore[favoritesKey] = Array.isArray(favoritesStore[source]) ? [...favoritesStore[source]] : [];
     }
 
-    favoritesStore[source] = [...new Set(
-        favoritesStore[source]
+    if (!Array.isArray(favoritesStore[favoritesKey])) {
+        favoritesStore[favoritesKey] = [];
+    }
+
+    favoritesStore[favoritesKey] = [...new Set(
+        favoritesStore[favoritesKey]
             .filter(model => typeof model === 'string')
             .map(model => model.trim())
             .filter(Boolean),
     )];
 
-    return favoritesStore[source];
+    return favoritesStore[favoritesKey];
 }
 
 function setModelFavoritesForSource(source, favorites, settings = oai_settings) {
     const favoritesStore = ensureModelFavoritesStore(settings);
-    favoritesStore[source] = [...new Set(
+    const favoritesKey = getCustomEndpointFavoritesKey(source, settings.custom_url);
+
+    favoritesStore[favoritesKey] = [...new Set(
         (Array.isArray(favorites) ? favorites : [])
             .filter(model => typeof model === 'string')
             .map(model => model.trim())
@@ -2993,7 +3001,7 @@ function rebuildModelIdSearchControl(control, { preserveQuery = false } = {}) {
     const staticEntries = getModelIdSearchStaticEntries(control);
     const query = preserveQuery ? normalizeModelIdSearchValue(state.query).toLowerCase() : '';
     const selectedValue = normalizeModelIdSearchValue(oai_settings[control.setting] ?? input.value ?? select.value);
-    const favorites = getModelFavoritesForSource(control.source);
+    const favorites = [...getModelFavoritesForSource(control.source)].sort((left, right) => left.localeCompare(right));
     const favoriteValues = new Set(favorites);
     const dynamicOptions = getModelIdSearchDynamicOptions(control);
     const optionMap = new Map();
@@ -9381,6 +9389,7 @@ async function setCustomEndpointPreset(name, url, key, model, { writeKey = true,
     oai_settings.custom_model = normalizedPreset.model;
     $('#custom_model_id').val(oai_settings.custom_model);
     $('#model_custom_select').val(oai_settings.custom_model);
+    refreshModelIdSearchControlsForSource(chat_completion_sources.CUSTOM);
 
     if (writeKey) {
         await writeSecret(SECRET_KEYS.CUSTOM, normalizedPreset.key, undefined, { allowEmpty: true });
@@ -10209,6 +10218,14 @@ export function initOpenAI() {
 
     $('#custom_api_url_text').on('input', function () {
         oai_settings.custom_url = String($(this).val());
+        saveSettingsDebounced();
+    });
+
+    $('#custom_api_url_text').on('change', function () {
+        oai_settings.custom_url = String($(this).val());
+        if (oai_settings.chat_completion_source === chat_completion_sources.CUSTOM) {
+            refreshModelIdSearchControlsForSource(chat_completion_sources.CUSTOM);
+        }
         saveSettingsDebounced();
     });
 

--- a/tests/openai-custom-favorites.test.js
+++ b/tests/openai-custom-favorites.test.js
@@ -1,0 +1,79 @@
+import { describe, expect, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const openAiSource = readFileSync(path.join(repoRoot, 'public', 'scripts', 'openai.js'), 'utf8');
+
+function getFunctionSource(name) {
+    const marker = `function ${name}(`;
+    const start = openAiSource.indexOf(marker);
+
+    expect(start).toBeGreaterThanOrEqual(0);
+
+    const bodyStart = openAiSource.indexOf(') {', start) + 2;
+    let depth = 0;
+
+    for (let index = bodyStart; index < openAiSource.length; index++) {
+        const char = openAiSource[index];
+        if (char === '{') {
+            depth++;
+        } else if (char === '}') {
+            depth--;
+            if (depth === 0) {
+                return openAiSource.slice(start, index + 1);
+            }
+        }
+    }
+
+    throw new Error(`Unable to find function source for ${name}`);
+}
+
+describe('OpenAI custom favorites wiring', () => {
+    test('imports the Custom endpoint favorites key helper', () => {
+        expect(openAiSource).toContain('getCustomEndpointFavoritesKey,');
+        expect(openAiSource).toContain('} from \'./openai-preset-utils.js\';');
+    });
+
+    test('reads model favorites from URL-scoped Custom buckets', () => {
+        const getterSource = getFunctionSource('getModelFavoritesForSource');
+
+        expect(getterSource).toContain('const favoritesKey = getCustomEndpointFavoritesKey(source, settings.custom_url);');
+        expect(getterSource).toContain('source === chat_completion_sources.CUSTOM && favoritesKey !== source && !Object.hasOwn(favoritesStore, favoritesKey)');
+        expect(getterSource).toContain('favoritesStore[favoritesKey] = Array.isArray(favoritesStore[source]) ? [...favoritesStore[source]] : [];');
+        expect(getterSource).toContain('favoritesStore[favoritesKey] = [...new Set(');
+        expect(getterSource).toContain('return favoritesStore[favoritesKey];');
+    });
+
+    test('writes model favorites back to the resolved storage bucket', () => {
+        const setterSource = getFunctionSource('setModelFavoritesForSource');
+
+        expect(setterSource).toContain('const favoritesKey = getCustomEndpointFavoritesKey(source, settings.custom_url);');
+        expect(setterSource).toContain('favoritesStore[favoritesKey] = [...new Set(');
+    });
+
+    test('renders DOM model ID favorites alphabetically without mutating the store', () => {
+        const rebuildSource = getFunctionSource('rebuildModelIdSearchControl');
+
+        expect(rebuildSource).toContain('const favorites = [...getModelFavoritesForSource(control.source)].sort((left, right) => left.localeCompare(right));');
+    });
+
+    test('refreshes Custom model ID favorites after endpoint profile changes', () => {
+        const setCustomEndpointSource = getFunctionSource('setCustomEndpointPreset');
+        const urlUpdateIndex = setCustomEndpointSource.indexOf('oai_settings.custom_url = normalizedPreset.url;');
+        const modelSelectIndex = setCustomEndpointSource.indexOf('$(\'#model_custom_select\').val(oai_settings.custom_model);');
+        const refreshIndex = setCustomEndpointSource.indexOf('refreshModelIdSearchControlsForSource(chat_completion_sources.CUSTOM);');
+        const reconnectIndex = setCustomEndpointSource.indexOf('reconnectOpenAi();');
+
+        expect(urlUpdateIndex).toBeGreaterThanOrEqual(0);
+        expect(modelSelectIndex).toBeGreaterThan(urlUpdateIndex);
+        expect(refreshIndex).toBeGreaterThan(modelSelectIndex);
+        expect(reconnectIndex).toBeGreaterThan(refreshIndex);
+    });
+
+    test('refreshes Custom model ID favorites when manually changing the endpoint URL', () => {
+        expect(openAiSource).toContain('$(\'#custom_api_url_text\').on(\'change\', function () {');
+        expect(openAiSource).toContain('if (oai_settings.chat_completion_source === chat_completion_sources.CUSTOM) {\n            refreshModelIdSearchControlsForSource(chat_completion_sources.CUSTOM);\n        }');
+    });
+});

--- a/tests/openai-preset-utils.test.js
+++ b/tests/openai-preset-utils.test.js
@@ -10,6 +10,7 @@ import {
     getChatCompletionSamplingProfileLookupKeys,
     getChatCompletionSamplingPresetKeys,
     getChatCompletionSamplingSettingsKeys,
+    getCustomEndpointFavoritesKey,
     normalizeCustomEndpointPreset,
     normalizeReverseProxyPreset,
     shouldIncludeConnectionFieldsInPreset,
@@ -359,5 +360,25 @@ describe('Chat Completion sampling profile keys', () => {
     test('returns empty array for missing source or model', () => {
         expect(getChatCompletionSamplingProfileLookupKeys('', 'gpt-4o')).toEqual([]);
         expect(getChatCompletionSamplingProfileLookupKeys('openai', '')).toEqual([]);
+    });
+});
+
+describe('Custom endpoint favorites keys', () => {
+    test('passes through non-Custom sources', () => {
+        expect(getCustomEndpointFavoritesKey('claude', 'https://proxy.example/v1')).toBe('claude');
+        expect(getCustomEndpointFavoritesKey('openai', '')).toBe('openai');
+    });
+
+    test('scopes Custom favorites by endpoint URL', () => {
+        expect(getCustomEndpointFavoritesKey('custom', 'https://proxy.example/v1')).toBe('custom::https://proxy.example/v1');
+    });
+
+    test('normalizes Custom endpoint URL whitespace and trailing slashes', () => {
+        expect(getCustomEndpointFavoritesKey('custom', '  https://proxy.example/v1///  ')).toBe('custom::https://proxy.example/v1');
+    });
+
+    test('keeps legacy Custom key for empty endpoint URLs', () => {
+        expect(getCustomEndpointFavoritesKey('custom', '')).toBe('custom');
+        expect(getCustomEndpointFavoritesKey('custom', '  ///  ')).toBe('custom');
     });
 });


### PR DESCRIPTION
## Summary
- Sort DOM model ID favorites alphabetically across the shared model-ID search controls.
- Scope Custom OpenAI-compatible favorites by normalized endpoint URL while seeding new URL buckets from legacy `model_favorites.custom`.
- Refresh Custom model favorites after endpoint profile changes and committed manual URL changes.

## Tests
- `npm run test:unit --prefix tests -- openai-preset-utils.test.js openai-custom-favorites.test.js openai-proxy-preset-wiring.test.js`
- `npm run lint`
- `npx eslint openai-custom-favorites.test.js openai-preset-utils.test.js` from `tests/`
- Full `npm run test:unit --prefix tests` after dependency install: 140/141 suites passed; existing `tokenizers-runtime.test.js` timed out locally.
- `npm run lint --prefix tests`: fails on existing unrelated test lint issues.