### PR TITLE
fix: preserve Bunny Preset Tools section icons

### DIFF
--- a/public/scripts/extensions/third-party/BunnyPresetTools/content.js
+++ b/public/scripts/extensions/third-party/BunnyPresetTools/content.js
@@ -14,6 +14,7 @@ import {
     computeReorderedOrder,
     getSectionLockState,
     setSectionLockState,
+    stripDividerPrefix,
 } from './sectionOrder.js';
 
 const EXTENSION_NAME = 'BunnyPresetTools';
@@ -891,11 +892,6 @@ function createSectionRow(sectionId, title, sectionName, isOpen, isLocked) {
     lockButton.addEventListener('click', activateLockButton);
     lockButton.addEventListener('touchend', activateLockButton);
     return row;
-}
-
-function stripDividerPrefix(title, dividerRegex) {
-    const cleaned = String(title).replace(dividerRegex, '').replace(/^[\s:|~>-]+/, '').trim();
-    return cleaned || String(title).trim();
 }
 
 function refreshPromptSections() {

--- a/public/scripts/extensions/third-party/BunnyPresetTools/sectionOrder.js
+++ b/public/scripts/extensions/third-party/BunnyPresetTools/sectionOrder.js
@@ -22,6 +22,44 @@ function normalizeKey(value) {
     return String(value || '').trim();
 }
 
+const LEADING_DIVIDER_TRIM_REGEX = /^[\s:|~>=*+\-─━—]+/u;
+const DIVIDER_MARKER_REGEX = /[─━—-]\+/u;
+const DIVIDER_DECORATION_REGEX = /[\s:|~>=*+\-─━—]+/gu;
+
+export function stripDividerPrefix(title, dividerRegex) {
+    const rawTitle = String(title);
+    const fallbackTitle = rawTitle.trim();
+    const dividerMatch = rawTitle.match(dividerRegex);
+
+    if (!dividerMatch) {
+        return fallbackTitle;
+    }
+
+    const matchedPrefix = dividerMatch[0] || '';
+    const markerMatch = matchedPrefix.match(DIVIDER_MARKER_REGEX);
+
+    if (markerMatch) {
+        const markerIndex = markerMatch.index ?? 0;
+        const iconPrefix = matchedPrefix
+            .slice(0, markerIndex)
+            .replace(DIVIDER_DECORATION_REGEX, '')
+            .trim();
+        const cleanedTitle = `${matchedPrefix.slice(markerIndex + markerMatch[0].length)}${rawTitle.slice(matchedPrefix.length)}`
+            .replace(LEADING_DIVIDER_TRIM_REGEX, '')
+            .trim();
+        const displayTitle = [iconPrefix, cleanedTitle].filter(Boolean).join(' ');
+
+        return displayTitle || fallbackTitle;
+    }
+
+    const cleanedTitle = rawTitle
+        .replace(dividerRegex, '')
+        .replace(LEADING_DIVIDER_TRIM_REGEX, '')
+        .trim();
+
+    return cleanedTitle || fallbackTitle;
+}
+
 function ensureLockStore(settings) {
     if (!settings || typeof settings !== 'object') {
         return {};

--- a/tests/bpt-section-order.test.js
+++ b/tests/bpt-section-order.test.js
@@ -5,12 +5,23 @@ import {
     computeReorderedOrder,
     getSectionLockState,
     setSectionLockState,
+    stripDividerPrefix,
 } from '../public/scripts/extensions/third-party/BunnyPresetTools/sectionOrder.js';
 
 const sectionRow = sectionId => ({ className: 'bpt-section-row', dataset: { sectionId } });
 const promptRow = (identifier, sectionId) => ({ dataset: { pmIdentifier: identifier, sectionId } });
 
 describe('BunnyPresetTools section order helpers', () => {
+    test('keeps divider section icons in display titles', () => {
+        const dividerRegex = /^(=+|-{3,}|\*{3,}|(?:[^\w\s]+\s*)?[─━—-]\+)/u;
+
+        expect(stripDividerPrefix('🐈‍⬛ ─+ Primary Toggles', dividerRegex)).toBe('🐈‍⬛ Primary Toggles');
+        expect(stripDividerPrefix('🐈‍⬛─+ Main', dividerRegex)).toBe('🐈‍⬛ Main');
+        expect(stripDividerPrefix('⭐─+ Tracker Toggles', dividerRegex)).toBe('⭐ Tracker Toggles');
+        expect(stripDividerPrefix('=== Main Prompts ===', dividerRegex)).toBe('Main Prompts ===');
+        expect(stripDividerPrefix('Main', dividerRegex)).toBe('Main');
+    });
+
     test('defaults new sections to locked and stores id/name keys', () => {
         const settings = {};
 


### PR DESCRIPTION
## Summary
- Preserve emoji/icon prefixes when Bunny Preset Tools turns divider prompts into section headers.
- Keep existing trailing divider decoration behavior for plain divider titles.
- Add focused coverage for icon-prefixed divider titles.

## Tests
- NODE_OPTIONS=--experimental-vm-modules npx jest --config tests/jest.config.json tests/bpt-section-order.test.js
- /home/platinum/SillyBunny/node_modules/.bin/eslint --resolve-plugins-relative-to /home/platinum/SillyBunny "src/**/*.js" "public/**/*.js" "scripts/**/*.js" ./*.js