### PR TITLE
fix: persist Pathfinder section collapse state

### DIFF
--- a/public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js
@@ -37,6 +37,7 @@ const MODULE_NAME = 'in-chat-agents';
 const PATHFINDER_LOG_PREFIX = '[Pathfinder]';
 const PATHFINDER_LOG_MODE_KEY = 'pathfinder-retrieval-log-mode';
 const PATHFINDER_QUICKSTART_DISMISSED_KEY = 'pathfinder-quickstart-dismissed';
+const PATHFINDER_COLLAPSED_SECTIONS_KEY = 'pathfinder-collapsed-sections';
 const DEFAULT_PIPELINE_MAX_TOKENS = 64000;
 
 let settingsEl = null;
@@ -56,6 +57,62 @@ function applyQuickstartDismissalState() {
     if (isQuickstartDismissed()) {
         settingsEl.find('#pf--quickstart').hide();
     }
+}
+
+function getCollapsedSectionStates() {
+    const rawValue = localStorage.getItem(PATHFINDER_COLLAPSED_SECTIONS_KEY);
+    if (!rawValue) {
+        return {};
+    }
+
+    try {
+        const parsed = JSON.parse(rawValue);
+        return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+    } catch (err) {
+        console.warn(`${PATHFINDER_LOG_PREFIX} Failed to read Pathfinder collapsed section preferences.`, err);
+        return {};
+    }
+}
+
+function getCollapseSectionKey(section) {
+    const sectionId = section.attr('id');
+    if (sectionId) {
+        return sectionId;
+    }
+
+    return section.children('.pf--collapsible-header').first().find('strong').first().text().trim();
+}
+
+function setSectionCollapsedPreference(sectionKey, collapsed) {
+    if (!sectionKey) {
+        return;
+    }
+
+    const states = getCollapsedSectionStates();
+    states[sectionKey] = collapsed;
+    localStorage.setItem(PATHFINDER_COLLAPSED_SECTIONS_KEY, JSON.stringify(states));
+}
+
+function setSectionChevronState(section, collapsed) {
+    const chevron = section.children('.pf--collapsible-header').first().find('.pf--chevron').first();
+    chevron.toggleClass('fa-chevron-down', !collapsed);
+    chevron.toggleClass('fa-chevron-right', collapsed);
+}
+
+function applyPersistedCollapseStates() {
+    const states = getCollapsedSectionStates();
+
+    settingsEl.find('.pf--section-collapsible').each(function () {
+        const section = $(this);
+        const sectionKey = getCollapseSectionKey(section);
+        if (!sectionKey || !Object.prototype.hasOwnProperty.call(states, sectionKey)) {
+            return;
+        }
+
+        const collapsed = states[sectionKey] === true;
+        section.children('.pf--section-body').first().toggle(!collapsed);
+        setSectionChevronState(section, collapsed);
+    });
 }
 
 function ensureEnabledLorebooks(settings) {
@@ -266,6 +323,7 @@ export async function openPathfinderSettings(agent) {
     await refreshLorebookList();
     applyQuickstartDismissalState();
     loadSettingsIntoUI();
+    applyPersistedCollapseStates();
     bindEvents();
     settingsEl.find('#pf--log-mode').val(retrievalLogMode);
     updateStatusBanner();
@@ -1029,13 +1087,13 @@ function bindEvents() {
     // Collapsible sections
     settingsEl.find('.pf--collapsible-header').on('click', function () {
         const section = $(this).closest('.pf--section-collapsible');
-        const body = section.find('.pf--section-body');
-        const chevron = $(this).find('.pf--chevron');
+        const body = section.children('.pf--section-body').first();
         const sectionTitle = $(this).find('strong').text().trim() || 'Unnamed section';
         const willOpen = !body.is(':visible');
 
         body.slideToggle(200);
-        chevron.toggleClass('fa-chevron-down fa-chevron-right');
+        setSectionChevronState(section, !willOpen);
+        setSectionCollapsedPreference(getCollapseSectionKey(section), !willOpen);
         logPathfinder(`${willOpen ? 'Opened' : 'Collapsed'} Pathfinder section "${sectionTitle}".`);
     });
 

--- a/public/scripts/extensions/in-chat-agents/pathfinder-settings.html
+++ b/public/scripts/extensions/in-chat-agents/pathfinder-settings.html
@@ -81,61 +81,64 @@
     </div>
 
     <!-- Step 2: Choose Mode -->
-    <div class="pf--section">
-        <div class="pf--section-header">
+    <div id="pf--mode-section" class="pf--section pf--section-collapsible">
+        <div class="pf--section-header pf--collapsible-header">
+            <i class="fa-solid fa-chevron-down pf--chevron"></i>
             <span class="pf--step-badge">2</span>
             <strong>Choose How Pathfinder Works</strong>
         </div>
 
-        <!-- Warning banner when both modes enabled -->
-        <div id="pf--dual-mode-warning" class="pf--dual-mode-warning" style="display: none;">
-            <i class="fa-solid fa-triangle-exclamation"></i>
-            <span>Both modes enabled — this uses more tokens but gives the AI both automatic context and active lorebook control.</span>
-        </div>
-
-        <div class="pf--mode-cards">
-            <!-- Tool Mode Card -->
-            <div class="pf--mode-card" data-mode="tools">
-                <div class="pf--mode-card-header">
-                    <label class="checkbox_label">
-                        <input type="checkbox" id="pf--enable-tools" />
-                        <span><i class="fa-solid fa-wrench"></i> Tool Mode</span>
-                    </label>
-                </div>
-                <div class="pf--mode-card-body">
-                    <p>The AI can actively <b>browse, search, and modify</b> your lorebook using function tools.</p>
-                    <ul>
-                        <li><i class="fa-solid fa-search"></i> Search & navigate waypoints</li>
-                        <li><i class="fa-solid fa-brain"></i> Remember new information</li>
-                        <li><i class="fa-solid fa-pen"></i> Update existing entries</li>
-                        <li><i class="fa-solid fa-book"></i> Private AI notebook</li>
-                    </ul>
-                    <div class="pf--mode-requirement">
-                        <i class="fa-solid fa-triangle-exclamation"></i>
-                        Requires an API that supports tool/function calling (OpenAI, Claude, etc.)
-                    </div>
-                </div>
+        <div class="pf--section-body">
+            <!-- Warning banner when both modes enabled -->
+            <div id="pf--dual-mode-warning" class="pf--dual-mode-warning" style="display: none;">
+                <i class="fa-solid fa-triangle-exclamation"></i>
+                <span>Both modes enabled — this uses more tokens but gives the AI both automatic context and active lorebook control.</span>
             </div>
 
-            <!-- Pipeline Mode Card -->
-            <div class="pf--mode-card" data-mode="pipeline">
-                <div class="pf--mode-card-header">
-                    <label class="checkbox_label">
-                        <input type="checkbox" id="pf--enable-pipeline" />
-                        <span><i class="fa-solid fa-wand-magic-sparkles"></i> Predictive Pipeline</span>
-                    </label>
+            <div class="pf--mode-cards">
+                <!-- Tool Mode Card -->
+                <div class="pf--mode-card" data-mode="tools">
+                    <div class="pf--mode-card-header">
+                        <label class="checkbox_label">
+                            <input type="checkbox" id="pf--enable-tools" />
+                            <span><i class="fa-solid fa-wrench"></i> Tool Mode</span>
+                        </label>
+                    </div>
+                    <div class="pf--mode-card-body">
+                        <p>The AI can actively <b>browse, search, and modify</b> your lorebook using function tools.</p>
+                        <ul>
+                            <li><i class="fa-solid fa-search"></i> Search & navigate waypoints</li>
+                            <li><i class="fa-solid fa-brain"></i> Remember new information</li>
+                            <li><i class="fa-solid fa-pen"></i> Update existing entries</li>
+                            <li><i class="fa-solid fa-book"></i> Private AI notebook</li>
+                        </ul>
+                        <div class="pf--mode-requirement">
+                            <i class="fa-solid fa-triangle-exclamation"></i>
+                            Requires an API that supports tool/function calling (OpenAI, Claude, etc.)
+                        </div>
+                    </div>
                 </div>
-                <div class="pf--mode-card-body">
-                    <p><b>Automatically</b> predicts and injects relevant lore before each AI response.</p>
-                    <ul>
-                        <li><i class="fa-solid fa-bolt"></i> Works with any API</li>
-                        <li><i class="fa-solid fa-brain"></i> AI predicts what's relevant</li>
-                        <li><i class="fa-solid fa-filter"></i> Two-stage filtering</li>
-                        <li><i class="fa-solid fa-sliders"></i> Fully customizable prompts</li>
-                    </ul>
-                    <div class="pf--mode-info">
-                        <i class="fa-solid fa-circle-info"></i>
-                        Uses a separate AI call to select entries before generation
+
+                <!-- Pipeline Mode Card -->
+                <div class="pf--mode-card" data-mode="pipeline">
+                    <div class="pf--mode-card-header">
+                        <label class="checkbox_label">
+                            <input type="checkbox" id="pf--enable-pipeline" />
+                            <span><i class="fa-solid fa-wand-magic-sparkles"></i> Predictive Pipeline</span>
+                        </label>
+                    </div>
+                    <div class="pf--mode-card-body">
+                        <p><b>Automatically</b> predicts and injects relevant lore before each AI response.</p>
+                        <ul>
+                            <li><i class="fa-solid fa-bolt"></i> Works with any API</li>
+                            <li><i class="fa-solid fa-brain"></i> AI predicts what's relevant</li>
+                            <li><i class="fa-solid fa-filter"></i> Two-stage filtering</li>
+                            <li><i class="fa-solid fa-sliders"></i> Fully customizable prompts</li>
+                        </ul>
+                        <div class="pf--mode-info">
+                            <i class="fa-solid fa-circle-info"></i>
+                            Uses a separate AI call to select entries before generation
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- make the Pathfinder mode selection section collapsible
- persist collapsed and expanded preferences for Pathfinder collapsible sections in localStorage
- preserve template defaults unless the user has toggled a section

## Tests
- bun run lint
- bun run check:frontend-budgets