### PR TITLE
fix: bind custom endpoint profiles to saved secrets

### DIFF
--- a/public/scripts/openai-preset-utils.js
+++ b/public/scripts/openai-preset-utils.js
@@ -261,10 +261,11 @@ export function buildReverseProxyPresetForSave(preset, { supportedSources = [] }
  * Normalizes a Custom OpenAI-compatible endpoint profile.
  *
  * @param {Record<string, any>} preset Custom endpoint profile
- * @returns {{name: string, url: string, key: string, model: string}}
+ * @returns {{name: string, url: string, key: string, model: string, secretId: string}}
  */
 export function normalizeCustomEndpointPreset(preset) {
     const name = String(preset?.name ?? 'None');
+    const secretId = String(preset?.secretId ?? preset?.['secret-id'] ?? preset?.secret_id ?? '');
 
     if (name === 'None') {
         return {
@@ -272,6 +273,7 @@ export function normalizeCustomEndpointPreset(preset) {
             url: '',
             key: '',
             model: '',
+            secretId: '',
         };
     }
 
@@ -280,6 +282,7 @@ export function normalizeCustomEndpointPreset(preset) {
         url: String(preset?.url ?? ''),
         key: String(preset?.key ?? ''),
         model: String(preset?.model ?? ''),
+        secretId,
     };
 }
 
@@ -287,7 +290,7 @@ export function normalizeCustomEndpointPreset(preset) {
  * Builds a Custom OpenAI-compatible endpoint profile from the current form.
  *
  * @param {Record<string, any>} preset Custom endpoint profile data
- * @returns {{name: string, url: string, key: string, model: string}}
+ * @returns {{name: string, url: string, key: string, model: string, secretId: string}}
  */
 export function buildCustomEndpointPresetForSave(preset) {
     return normalizeCustomEndpointPreset(preset);

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -45,7 +45,7 @@ import {
 } from './PromptManager.js';
 
 import { forceCharacterEditorTokenize, getCustomStoppingStrings, persona_description_positions, power_user } from './power-user.js';
-import { SECRET_KEYS, secret_state, writeSecret } from './secrets.js';
+import { rotateSecret, SECRET_KEYS, secret_state, writeSecret } from './secrets.js';
 
 import { getEventSourceStream } from './sse-stream.js';
 import {
@@ -698,6 +698,7 @@ export let custom_endpoint_presets = [
         url: '',
         key: '',
         model: '',
+        secretId: '',
     },
 ];
 export let selected_custom_endpoint_preset = custom_endpoint_presets[0];
@@ -5392,7 +5393,13 @@ async function sendOpenAIRequest(type, messages, signal, { jsonSchema = null, ca
 
     const model = getChatCompletionModel(oai_settings);
     const { generate_data, stream, canMultiSwipe } = await createGenerationParameters(oai_settings, model, type, messages, { jsonSchema, cacheScope });
+
     await eventSource.emit(event_types.CHAT_COMPLETION_SETTINGS_READY, generate_data);
+
+    if (generate_data.chat_completion_source === chat_completion_sources.CUSTOM && selected_custom_endpoint_preset?.secretId) {
+        // SillyBunny: Custom endpoint profiles bind chat requests to their saved secret, not the last active CUSTOM key.
+        generate_data.secret_id = selected_custom_endpoint_preset.secretId;
+    }
 
     console.log(`[OpenAI frontend] sendOpenAIRequest: type=${type} source=${generate_data.chat_completion_source} model=${generate_data.model} stream=${generate_data.stream}`);
 
@@ -9338,7 +9345,7 @@ export async function loadCustomEndpointPresets(settings) {
             selected_custom_endpoint_preset.url,
             selected_custom_endpoint_preset.key,
             selected_custom_endpoint_preset.model,
-            { reconnect: false },
+            { secretId: selected_custom_endpoint_preset.secretId, reconnect: false },
         );
     } else {
         $('#custom_endpoint_preset_name').val('None');
@@ -9368,13 +9375,32 @@ function updateCustomEndpointPresetOption(preset) {
     }
 }
 
-async function setCustomEndpointPreset(name, url, key, model, { writeKey = true, reconnect = true } = {}) {
-    const normalizedPreset = normalizeCustomEndpointPreset({ name, url, key, model });
+async function activateCustomEndpointPresetSecret(preset, { forceWrite = false } = {}) {
+    if (!preset || preset.name === 'None') {
+        return;
+    }
+
+    if (preset.secretId && (!forceWrite || !preset.key)) {
+        // SillyBunny: rotate to the bound profile secret instead of writing duplicate or accidental empty keys.
+        await rotateSecret(SECRET_KEYS.CUSTOM, preset.secretId);
+        return;
+    }
+
+    // SillyBunny: legacy/keyless profiles get a stable per-profile secret id, even when the key is intentionally empty.
+    const secretId = await writeSecret(SECRET_KEYS.CUSTOM, preset.key, undefined, { allowEmpty: true });
+    if (secretId) {
+        preset.secretId = secretId;
+    }
+}
+
+async function setCustomEndpointPreset(name, url, key, model, { secretId = '', writeKey = true, reconnect = true } = {}) {
+    const normalizedPreset = normalizeCustomEndpointPreset({ name, url, key, model, secretId });
     const preset = custom_endpoint_presets.find(p => p.name === normalizedPreset.name);
     if (preset) {
         preset.url = normalizedPreset.url;
         preset.key = normalizedPreset.key;
         preset.model = normalizedPreset.model;
+        preset.secretId = normalizedPreset.secretId || preset.secretId || '';
         selected_custom_endpoint_preset = preset;
     } else {
         const newPreset = normalizedPreset;
@@ -9392,7 +9418,7 @@ async function setCustomEndpointPreset(name, url, key, model, { writeKey = true,
     refreshModelIdSearchControlsForSource(chat_completion_sources.CUSTOM);
 
     if (writeKey) {
-        await writeSecret(SECRET_KEYS.CUSTOM, normalizedPreset.key, undefined, { allowEmpty: true });
+        await activateCustomEndpointPresetSecret(selected_custom_endpoint_preset);
     }
     $('#api_key_custom').val(normalizedPreset.key);
 
@@ -9406,7 +9432,7 @@ async function onCustomEndpointPresetChange() {
     const selectedPreset = custom_endpoint_presets.find(preset => preset.name === value);
 
     if (selectedPreset) {
-        await setCustomEndpointPreset(selectedPreset.name, selectedPreset.url, selectedPreset.key, selectedPreset.model);
+        await setCustomEndpointPreset(selectedPreset.name, selectedPreset.url, selectedPreset.key, selectedPreset.model, { secretId: selectedPreset.secretId });
     } else {
         console.error(t`Custom endpoint profile '${value}' not found in custom endpoint profiles array.`);
     }
@@ -9414,14 +9440,18 @@ async function onCustomEndpointPresetChange() {
 }
 
 $('#save_custom_endpoint').on('click', async function () {
+    const presetName = $('#custom_endpoint_preset_name').val();
+    const existingPreset = custom_endpoint_presets.find(preset => preset.name === String(presetName));
     const preset = buildCustomEndpointPresetForSave({
-        name: $('#custom_endpoint_preset_name').val(),
+        name: presetName,
         url: $('#custom_api_url_text').val(),
         key: $('#api_key_custom').val(),
         model: $('#custom_model_id').val(),
+        secretId: existingPreset?.secretId,
     });
 
-    await setCustomEndpointPreset(preset.name, preset.url, preset.key, preset.model);
+    await activateCustomEndpointPresetSecret(preset, { forceWrite: true });
+    await setCustomEndpointPreset(preset.name, preset.url, preset.key, preset.model, { secretId: preset.secretId, writeKey: false });
     saveSettingsDebounced();
     toastr.success(t`Custom Endpoint Profile Saved`);
     updateCustomEndpointPresetOption(preset);
@@ -9448,6 +9478,7 @@ $('#delete_custom_endpoint').on('click', async function () {
             selected_custom_endpoint_preset.url,
             selected_custom_endpoint_preset.key,
             selected_custom_endpoint_preset.model,
+            { secretId: selected_custom_endpoint_preset.secretId },
         );
 
         saveSettingsDebounced();

--- a/tests/openai-preset-utils.test.js
+++ b/tests/openai-preset-utils.test.js
@@ -197,20 +197,47 @@ describe('Chat Completion preset utilities', () => {
             url: 'http://127.0.0.1:1234/v1',
             key: '',
             model: '',
+            secretId: '',
         });
     });
 
-    test('saves Custom endpoint profiles with URL, key, and model', () => {
+    test('normalizes Custom endpoint profile secret ids', () => {
+        expect(normalizeCustomEndpointPreset({
+            name: 'Bound proxy',
+            url: 'https://proxy.example/v1',
+            secretId: 'secret-1',
+        })).toEqual({
+            name: 'Bound proxy',
+            url: 'https://proxy.example/v1',
+            key: '',
+            model: '',
+            secretId: 'secret-1',
+        });
+
+        expect(normalizeCustomEndpointPreset({
+            name: 'Imported proxy',
+            'secret-id': 'secret-2',
+        }).secretId).toBe('secret-2');
+
+        expect(normalizeCustomEndpointPreset({
+            name: 'Request-shaped proxy',
+            secret_id: 'secret-3',
+        }).secretId).toBe('secret-3');
+    });
+
+    test('saves Custom endpoint profiles with URL, key, model, and secret id', () => {
         expect(buildCustomEndpointPresetForSave({
             name: 'Story proxy',
             url: 'https://proxy.example/v1',
             key: 'sk-story',
             model: 'gpt-4o',
+            secretId: 'secret-story',
         })).toEqual({
             name: 'Story proxy',
             url: 'https://proxy.example/v1',
             key: 'sk-story',
             model: 'gpt-4o',
+            secretId: 'secret-story',
         });
     });
 
@@ -225,6 +252,7 @@ describe('Chat Completion preset utilities', () => {
             url: '',
             key: '',
             model: '',
+            secretId: '',
         });
     });
 

--- a/tests/openai-proxy-preset-wiring.test.js
+++ b/tests/openai-proxy-preset-wiring.test.js
@@ -155,21 +155,48 @@ describe('OpenAI proxy preset wiring', () => {
         expect(openAiSource).toContain('url: $(\'#custom_api_url_text\').val()');
         expect(openAiSource).toContain('key: $(\'#api_key_custom\').val()');
         expect(openAiSource).toContain('model: $(\'#custom_model_id\').val()');
+        expect(openAiSource).toContain('secretId: existingPreset?.secretId');
+        expect(openAiSource).toContain('await activateCustomEndpointPresetSecret(preset, { forceWrite: true });');
+        expect(openAiSource).toContain('writeKey: false');
     });
 
     test('applies Custom endpoint profile values before reconnecting', () => {
         const setCustomEndpointSource = getFunctionSource('setCustomEndpointPreset');
         const urlUpdateIndex = setCustomEndpointSource.indexOf('oai_settings.custom_url = normalizedPreset.url;');
         const modelUpdateIndex = setCustomEndpointSource.indexOf('oai_settings.custom_model = normalizedPreset.model;');
-        const secretWriteIndex = setCustomEndpointSource.indexOf('await writeSecret(SECRET_KEYS.CUSTOM, normalizedPreset.key, undefined, { allowEmpty: true });');
+        const secretActivateIndex = setCustomEndpointSource.indexOf('await activateCustomEndpointPresetSecret(selected_custom_endpoint_preset);');
         const keyInputIndex = setCustomEndpointSource.indexOf('$(\'#api_key_custom\').val(normalizedPreset.key);');
         const reconnectIndex = setCustomEndpointSource.indexOf('reconnectOpenAi();');
 
         expect(urlUpdateIndex).toBeGreaterThanOrEqual(0);
         expect(modelUpdateIndex).toBeGreaterThan(urlUpdateIndex);
-        expect(secretWriteIndex).toBeGreaterThan(modelUpdateIndex);
-        expect(keyInputIndex).toBeGreaterThan(secretWriteIndex);
+        expect(secretActivateIndex).toBeGreaterThan(modelUpdateIndex);
+        expect(keyInputIndex).toBeGreaterThan(secretActivateIndex);
         expect(reconnectIndex).toBeGreaterThan(keyInputIndex);
+        expect(setCustomEndpointSource).not.toContain('writeSecret(SECRET_KEYS.CUSTOM, normalizedPreset.key');
+    });
+
+    test('activates Custom endpoint profile secrets by id instead of duplicate writes', () => {
+        const activationSource = getFunctionSource('activateCustomEndpointPresetSecret');
+        const rotateIndex = activationSource.indexOf('await rotateSecret(SECRET_KEYS.CUSTOM, preset.secretId);');
+        const writeIndex = activationSource.indexOf('await writeSecret(SECRET_KEYS.CUSTOM, preset.key, undefined, { allowEmpty: true });');
+
+        expect(openAiSource).toContain('import { rotateSecret, SECRET_KEYS, secret_state, writeSecret } from \'./secrets.js\';');
+        expect(rotateIndex).toBeGreaterThanOrEqual(0);
+        expect(writeIndex).toBeGreaterThan(rotateIndex);
+    });
+
+    test('sends selected Custom endpoint secret id with chat requests', () => {
+        const sendRequestSource = getFunctionSource('sendOpenAIRequest');
+        const settingsReadyIndex = sendRequestSource.indexOf('await eventSource.emit(event_types.CHAT_COMPLETION_SETTINGS_READY, generate_data);');
+        const customSecretGuardIndex = sendRequestSource.indexOf('generate_data.chat_completion_source === chat_completion_sources.CUSTOM && selected_custom_endpoint_preset?.secretId');
+        const secretIdIndex = sendRequestSource.indexOf('generate_data.secret_id = selected_custom_endpoint_preset.secretId;');
+        const fetchIndex = sendRequestSource.indexOf('const response = await fetch(generate_url, {');
+
+        expect(settingsReadyIndex).toBeGreaterThanOrEqual(0);
+        expect(customSecretGuardIndex).toBeGreaterThan(settingsReadyIndex);
+        expect(secretIdIndex).toBeGreaterThan(customSecretGuardIndex);
+        expect(fetchIndex).toBeGreaterThan(secretIdIndex);
     });
 
     test('loads and persists Custom endpoint profiles with settings', () => {


### PR DESCRIPTION
## Summary
- add a `secretId` binding to Custom Endpoint Profiles
- rotate to the selected profile secret instead of rewriting the global CUSTOM secret on profile switches
- send the selected profile `secret_id` with Custom chat-completions requests so generation uses the endpoint's saved key
- avoid accidental empty-key overwrites on already-bound profiles while still supporting keyless profiles

## Tests
- `npm run lint`
- `npm run test:unit --prefix tests -- openai-proxy-preset-wiring.test.js openai-preset-utils.test.js openai-custom-favorites.test.js secrets.test.js`
- `npm run test:unit --prefix tests`
- `npm run check:frontend-budgets`
- `npm run build:frontend`