### PR TITLE
fix(companion-panel): keep manual Play button visible after first run

### DIFF
--- a/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
+++ b/public/scripts/extensions/in-chat-agents/companion/companion-panel.js
@@ -566,6 +566,7 @@ function buildPanelAgentSection(state) {
                 <span class="ica--tpanel-agent-name"><i class="fa-solid ${escapeHtml(icon)}"></i><span>${escapeHtml(name)}</span></span>
                 <span class="ica--tpanel-agent-when">#${latest.messageIndex}</span>
                 <span class="ica--tpanel-agent-actions">
+                    ${runLatestButton}
                     <button type="button" class="ica--cdash-action" data-action="panel-regenerate" title="Regenerate this state" aria-label="Regenerate state"><i class="fa-solid fa-rotate-right"></i></button>
                     <button type="button" class="ica--cdash-action" data-action="panel-fix" title="Fix: re-run with strict output enforcement (use when the model wrote roleplay instead)" aria-label="Fix state"><i class="fa-solid fa-wrench"></i></button>
                     <button type="button" class="ica--cdash-action" data-action="panel-edit-note" title="Edit this state's text by hand (e.g. type your Plot Compass objective)" aria-label="Edit state text"><i class="fa-solid fa-pen-to-square"></i></button>

--- a/tests/in-chat-agents-companion-panel.test.js
+++ b/tests/in-chat-agents-companion-panel.test.js
@@ -290,6 +290,13 @@ describe('companion tracker panel', () => {
         expect(html).toContain('data-action="panel-regenerate-all"');
         expect(html).toContain('data-message-index="0"');
         expect(html).toContain('No state yet');
+
+        // SillyBunny: the per-companion Play button must remain visible after a companion has
+        // already produced state, otherwise manual companions can only regenerate the first run
+        // and never pick up a newer assistant reply from the draggable panel.
+        const trackerSection = html.match(/<section class="ica--tpanel-agent"[\s\S]*?data-message-index="0"[\s\S]*?<\/section>/)?.[0] ?? '';
+        const playButtonMatches = trackerSection.match(/data-action="panel-run-latest"/g) ?? [];
+        expect(playButtonMatches).toHaveLength(1);
     });
 
     test('renders edit buttons with per-entry message indices on history entries', async () => {


### PR DESCRIPTION
**Summary**
- Manual Companion Agents were only able to re-run their first generated state from the draggable tracker panel. The per-companion Play button (panel-run-latest) was rendered only before any state existed; after the first run the panel exposed regenerate/fix/edit buttons that re-run on the stored message index, so manual companions could never pick up a newer assistant reply.
- Render panel-run-latest alongside the regenerate controls when a companion already has stored state, matching the single-button activation flow already used by the Agents menu and the inline card view.
- Add a regression test asserting the Play button appears inside the existing-state section of the tracker panel.

**Tests**
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.json in-chat-agents-companion.test.js in-chat-agents-companion-dashboard.test.js in-chat-agents-companion-panel.test.js`
- All 42 tests in the affected suites pass.