### PR TITLE
fix: improve WebKit prefix parity and iOS guards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ BEFORE submitting a pull request, keep the following project goals and best prac
 - While Bun is the default runtime, Node.js backwards compatibility is required. Do not use Bun-exclusive APIs (such as Bun.file() or Bun.serve()) unless a standard Node.js fallback is included. Test all structural changes in both runtime environments.
 - Keep fork-specific feature additions and upstream synchronization merges in separate pull requests. Mixing upstream code updates with SillyBunny feature logic complicates the review process.
 - Make sure new features work elegantly with parity on both mobile and desktop environments.
+- Frontend code may target Safari/WebKit 16.4+ for modern selectors and color functions, but still include required WebKit-prefixed companions for shipped Safari properties such as `backdrop-filter`, `appearance`, `user-select`, and `position: sticky`.
 
 #### Correct target branch
 

--- a/public/css/backgrounds.css
+++ b/public/css/backgrounds.css
@@ -282,6 +282,7 @@
     border-radius: 5px;
     padding: 3px 3px;
     z-index: 3;
+    -webkit-backdrop-filter: blur(4px);
     backdrop-filter: blur(4px);
     border: 1px solid var(--SmartThemeBorderColor);
     justify-items: center;
@@ -567,6 +568,7 @@
     border-radius: 5px;
     padding: 3px;
     z-index: 3;
+    -webkit-backdrop-filter: blur(4px);
     backdrop-filter: blur(4px);
     border: 1px solid var(--SmartThemeBorderColor);
     align-items: center;

--- a/public/css/extensions-panel.css
+++ b/public/css/extensions-panel.css
@@ -138,6 +138,7 @@ label[for="extensions_notify_updates"] input[type="checkbox"] {
 }
 
 .extensions_info .third_party_toolbar {
+    -webkit-user-select: none;
     user-select: none;
 }
 
@@ -241,6 +242,7 @@ input.extension_missing[type="checkbox"] {
 
 .extensions_toolbar {
     top: 0;
+    position: -webkit-sticky;
     position: sticky;
     display: flex;
     flex-direction: row;

--- a/public/css/loader.css
+++ b/public/css/loader.css
@@ -12,6 +12,7 @@
     background-color: var(--SmartThemeBlurTintColor);
     color: var(--SmartThemeBodyColor);
     /*for some reason the full screen blur does not work on iOS*/
+    -webkit-backdrop-filter: blur(30px);
     backdrop-filter: blur(30px);
     opacity: 1;
 }

--- a/public/css/logprobs.css
+++ b/public/css/logprobs.css
@@ -53,6 +53,7 @@
 }
 
 #logprobs_generation_output {
+    -webkit-user-select: none;
     user-select: none;
     height: 100%;
     overflow-y: auto;

--- a/public/css/macros.css
+++ b/public/css/macros.css
@@ -70,6 +70,7 @@
 
 .macroBrowser .macro-details-panel {
     flex: 0 0 40%;
+    position: -webkit-sticky;
     position: sticky;
     top: 0;
     max-height: 60vh;
@@ -96,6 +97,7 @@
     border-bottom: 1px solid var(--SmartThemeBorderColor);
     border-radius: 10px 10px 0 0;
     color: var(--SmartThemeQuoteColor);
+    position: -webkit-sticky;
     position: sticky;
     top: 0;
     background: var(--SmartThemeChatTintColor);

--- a/public/css/mobile-styles.css
+++ b/public/css/mobile-styles.css
@@ -664,6 +664,7 @@
         border-radius: 6px;
         z-index: 3;
         cursor: pointer;
+        -webkit-backdrop-filter: blur(2px);
         backdrop-filter: blur(2px);
     }
 
@@ -828,6 +829,7 @@
         border-radius: 6px;
         z-index: 3;
         cursor: pointer;
+        -webkit-backdrop-filter: blur(2px);
         backdrop-filter: blur(2px);
     }
 
@@ -1094,6 +1096,7 @@
 
     #send_form {
         border: 1px solid var(--SmartThemeBorderColor);
+        -webkit-backdrop-filter: blur(20px);
         backdrop-filter: blur(20px);
         max-width: 100dvw;
     }
@@ -1217,6 +1220,7 @@
         border-radius: 0 0 20px 20px;
         top: var(--topBarBlockSize) !important;
         left: 0 !important;
+        -webkit-backdrop-filter: blur(calc(var(--SmartThemeBlurStrength) * 2));
         backdrop-filter: blur(calc(var(--SmartThemeBlurStrength) * 2));
 
         @starting-style {
@@ -1450,6 +1454,7 @@
         max-width: unset;
         min-height: unset;
         max-height: unset;
+        -webkit-backdrop-filter: blur(calc(var(--SmartThemeBlurStrength) * 2));
         backdrop-filter: blur(calc(var(--SmartThemeBlurStrength) * 2));
         left: 0;
         right: 0;
@@ -1538,6 +1543,7 @@
         z-index: var(--sb-z-loader) !important;
         overflow-y: auto !important;
         border-radius: 0 !important;
+        -webkit-backdrop-filter: blur(20px);
         backdrop-filter: blur(20px);
         background: var(--SmartThemeBlurTintColor);
     }

--- a/public/css/personas.css
+++ b/public/css/personas.css
@@ -854,6 +854,7 @@
 
 @media screen and (max-width: 760px) {
     #PersonaManagement .persona-workspace-tabs {
+        position: -webkit-sticky;
         position: sticky;
         top: 0;
         z-index: 3;

--- a/public/css/promptmanager.css
+++ b/public/css/promptmanager.css
@@ -614,6 +614,7 @@
     flex-direction: column;
     z-index: var(--sb-z-loader) !important;
     border-radius: 0;
+    -webkit-backdrop-filter: blur(20px);
     backdrop-filter: blur(20px);
     background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 94%, black 6%);
     min-width: 0;
@@ -859,6 +860,7 @@
         border-radius: 0;
         box-shadow: none;
         background: transparent;
+        -webkit-backdrop-filter: none;
         backdrop-filter: none;
         overflow: visible;
     }

--- a/public/css/rm-groups.css
+++ b/public/css/rm-groups.css
@@ -51,6 +51,7 @@
 #rm_group_buttons>input {
 
     cursor: pointer;
+    -webkit-user-select: none;
     user-select: none;
 }
 

--- a/public/css/select2-overrides.css
+++ b/public/css/select2-overrides.css
@@ -15,9 +15,11 @@
     border-radius: 10px;
     box-shadow: 0 0 5px black;
     text-shadow: 0px 0px calc(var(--shadowWidth) * 1px) var(--SmartThemeShadowColor);
+    -webkit-backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)*2));
     backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)*2));
     color: var(--SmartThemeBodyColor);
     z-index: var(--sb-z-critical);
+    -webkit-user-select: none;
     user-select: none;
     pointer-events: auto;
 }

--- a/public/css/sillybunny-chat-styles.css
+++ b/public/css/sillybunny-chat-styles.css
@@ -729,6 +729,7 @@ body.ripplestyle #chat {
         }
 
         .mesAvatarWrapper {
+            position: -webkit-sticky;
             position: sticky;
             top: 0;
             padding-bottom: 45px;
@@ -1522,6 +1523,7 @@ body:is(.echostyle, .whisperstyle, .hushstyle, .ripplestyle, .tidestyle) #chat .
         min-width: 0 !important;
         overflow: visible !important;
         padding: 0 0 var(--moonlit-sb-ripple-left-bottom-gap) 0 !important;
+        position: -webkit-sticky !important;
         position: sticky !important;
         top: 0 !important;
         z-index: 2;

--- a/public/css/sillybunny-chat-styles.css
+++ b/public/css/sillybunny-chat-styles.css
@@ -1523,7 +1523,7 @@ body:is(.echostyle, .whisperstyle, .hushstyle, .ripplestyle, .tidestyle) #chat .
         min-width: 0 !important;
         overflow: visible !important;
         padding: 0 0 var(--moonlit-sb-ripple-left-bottom-gap) 0 !important;
-        position: -webkit-sticky !important;
+        position: -webkit-sticky;
         position: sticky !important;
         top: 0 !important;
         z-index: 2;

--- a/public/css/sillybunny-conversation.css
+++ b/public/css/sillybunny-conversation.css
@@ -1813,6 +1813,7 @@
     border-radius: 999px;
     cursor: pointer;
     font-size: var(--sb-type-meta);
+    -webkit-user-select: none;
     user-select: none;
     transition: background-color 160ms ease-out, border-color 160ms ease-out;
 }
@@ -2310,6 +2311,7 @@
         width: 100%;
         margin-block-start: 8px;
         box-shadow: none;
+        -webkit-backdrop-filter: none;
         backdrop-filter: none;
         border: 1px solid color-mix(in srgb, var(--sb-shell-border) 42%, transparent);
         background: color-mix(in srgb, var(--SmartThemeBlurTintColor) 50%, var(--SmartThemeBodyColor) 4%);

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -112,6 +112,10 @@
         gap: 3px !important;
     }
 
+    #leftSendForm::-webkit-scrollbar {
+        display: none !important;
+    }
+
     #rightSendForm {
         grid-area: action !important;
         width: 100% !important;
@@ -1746,6 +1750,7 @@
     }
 
     .sb-mobile-panel-close {
+        -webkit-appearance: none;
         appearance: none;
         width: var(--sb-mobile-touch-target, 44px);
         height: var(--sb-mobile-touch-target, 44px);
@@ -1782,6 +1787,7 @@
     }
 
     .sb-nav-item {
+        -webkit-appearance: none;
         appearance: none;
         position: relative;
         isolation: isolate;

--- a/public/css/sillybunny-mobile-shell.css
+++ b/public/css/sillybunny-mobile-shell.css
@@ -113,7 +113,7 @@
     }
 
     #leftSendForm::-webkit-scrollbar {
-        display: none !important;
+        display: none;
     }
 
     #rightSendForm {

--- a/public/css/sillybunny-tabs.css
+++ b/public/css/sillybunny-tabs.css
@@ -282,6 +282,7 @@
 }
 
 body.sb-topbar-dragging {
+    -webkit-user-select: none;
     user-select: none;
 }
 
@@ -603,6 +604,7 @@ body.sb-topbar-compact #sb-chatbar-layer {
 }
 
 .sb-chatbar-button {
+    -webkit-appearance: none;
     appearance: none;
     position: relative;
     isolation: isolate;
@@ -846,6 +848,7 @@ body.sb-topbar-compact #sb-chatbar-layer {
 }
 
 .sb-connection-strip-connect {
+    -webkit-appearance: none;
     appearance: none;
     position: relative;
     isolation: isolate;
@@ -1161,6 +1164,7 @@ body:not(.movingUI) .drawer-content.maximized {
 }
 
 .sb-proxy-button {
+    -webkit-appearance: none;
     appearance: none;
     position: relative;
     overflow: hidden;
@@ -1607,6 +1611,7 @@ body.movingUI #right-nav-panel.openDrawer > .sb-shell-resize-handle {
 body.sb-shell-resizing,
 body.sb-shell-resizing * {
     cursor: nwse-resize !important;
+    -webkit-user-select: none !important;
     user-select: none !important;
 }
 
@@ -1769,6 +1774,7 @@ body.sb-shell-resizing * {
 }
 
 .sb-shell-tab {
+    -webkit-appearance: none;
     appearance: none;
     border: 1px solid transparent;
     border-radius: var(--sb-radius-button, 14px);
@@ -2359,6 +2365,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 }
 
 .sb-character-import-action {
+    -webkit-appearance: none;
     appearance: none;
     width: 100%;
     min-height: 92px;
@@ -2735,6 +2742,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 }
 
 .sb-search-result {
+    -webkit-appearance: none;
     appearance: none;
     width: 100%;
     padding: 12px 14px;
@@ -3621,6 +3629,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 }
 
 .sb-theme-option {
+    -webkit-appearance: none;
     appearance: none;
     border-radius: var(--sb-radius-md, 16px);
     border: 1px solid color-mix(in srgb, var(--sb-shell-border) 84%, transparent);
@@ -3763,6 +3772,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 }
 
 .sb-compact-mode-option {
+    -webkit-appearance: none;
     appearance: none;
     position: relative;
     isolation: isolate;
@@ -3861,6 +3871,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 }
 
 .sb-mobile-nav-choice {
+    -webkit-appearance: none;
     appearance: none;
     position: relative;
     isolation: isolate;
@@ -4313,6 +4324,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
     background: color-mix(in srgb, var(--SmartThemeBodyColor) 4%, var(--sb-composer-surface-base, var(--SmartThemeBlurTintColor)));
     border: 1px solid color-mix(in srgb, var(--SmartThemeBorderColor) 40%, transparent);
     border-radius: calc(10px * var(--sb-bottom-bar-scale));
+    -webkit-appearance: none;
     appearance: none;
     cursor: pointer;
     overflow: hidden;
@@ -4404,6 +4416,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 }
 
 .sb-bottom-chat-btn {
+    -webkit-appearance: none;
     appearance: none;
     position: relative;
     border: none;
@@ -4908,6 +4921,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 }
 
 .sb-persona-option {
+    -webkit-appearance: none;
     appearance: none;
     width: 100%;
     border: 0;
@@ -6704,6 +6718,7 @@ body #right-nav-panel #HotSwapWrapper .hotswap > :is(.avatar, .character_select,
 }
 
 .sb-topbar-label-option {
+    -webkit-appearance: none;
     appearance: none;
     position: relative;
     isolation: isolate;

--- a/public/css/sillybunny-theme.css
+++ b/public/css/sillybunny-theme.css
@@ -142,6 +142,15 @@
     --sb-message-radius: 22px;
 }
 
+a,
+button,
+[role="button"],
+.menu_button,
+input[type="button"],
+input[type="submit"] {
+    -webkit-tap-highlight-color: transparent;
+}
+
 .zoomed_avatar_container,
 .avatar_zoom_container,
 .zoomed_avatar,

--- a/public/css/streaming-display.css
+++ b/public/css/streaming-display.css
@@ -23,6 +23,7 @@
     transition: opacity var(--sb-transition-fast), transform var(--sb-transition-fast);
     overflow: hidden;
     box-shadow: 0 4px 24px rgba(0, 0, 0, 0.25);
+    -webkit-backdrop-filter: blur(12px);
     backdrop-filter: blur(12px);
 }
 
@@ -39,6 +40,7 @@
     display: flex;
     align-items: center;
     gap: 8px;
+    -webkit-user-select: none;
     user-select: none;
 }
 

--- a/public/css/toggle-dependent.css
+++ b/public/css/toggle-dependent.css
@@ -371,6 +371,7 @@ body.documentstyle #chat .mes_block .ch_name {
 /*FastUI blur removal*/
 
 body.no-blur * {
+    -webkit-backdrop-filter: unset !important;
     backdrop-filter: unset !important;
 }
 

--- a/public/css/welcome.css
+++ b/public/css/welcome.css
@@ -1130,6 +1130,7 @@ body.big-avatars .welcomeRecent .recentChatList .recentChat .chatMessageContaine
     --sb-welcome-surface-bg: color-mix(in srgb, var(--SmartThemeBlurTintColor) 76%, transparent);
     align-self: center;
     min-width: 44px;
+    position: -webkit-sticky;
     position: sticky;
     bottom: 0;
     z-index: 1;

--- a/public/css/world-info.css
+++ b/public/css/world-info.css
@@ -195,6 +195,7 @@
 
 #world_popup_bottom_holder div {
     width: fit-content;
+    -webkit-user-select: none;
     user-select: none;
 }
 

--- a/public/lib/polyfill.js
+++ b/public/lib/polyfill.js
@@ -12,6 +12,15 @@ if (!Array.prototype.findLastIndex) {
     };
 }
 
+if (!Array.prototype.at) {
+    Array.prototype.at = function (index) {
+        const length = this.length;
+        let relativeIndex = Math.trunc(index) || 0;
+        if (relativeIndex < 0) relativeIndex += length;
+        return relativeIndex < 0 || relativeIndex >= length ? undefined : this[relativeIndex];
+    };
+}
+
 if (!Array.prototype.toSorted) {
     Array.prototype.toSorted = function (compareFunction) {
         return this.slice().sort(compareFunction);

--- a/public/script.js
+++ b/public/script.js
@@ -15737,8 +15737,13 @@ function addDebugFunctions() {
         alert(message);
     });
     registerDebugFunction('toggleEventTracing', 'Toggle event tracing', 'Useful to see what triggered a certain event.', () => {
-        localStorage.setItem('eventTracing', localStorage.getItem('eventTracing') === 'true' ? 'false' : 'true');
-        toastr.info('Event tracing is now ' + (localStorage.getItem('eventTracing') === 'true' ? 'enabled' : 'disabled'));
+        try {
+            const nextEventTracing = localStorage.getItem('eventTracing') === 'true' ? 'false' : 'true';
+            localStorage.setItem('eventTracing', nextEventTracing);
+            toastr.info('Event tracing is now ' + (nextEventTracing === 'true' ? 'enabled' : 'disabled'));
+        } catch {
+            toastr.warning('Event tracing could not be persisted in this browser session.');
+        }
     });
 
     registerDebugFunction('toggleRegenerateWarning', 'Toggle Ctrl+Enter regeneration confirmation', 'Toggle the warning when regenerating a message with a Ctrl+Enter hotkey.', () => {

--- a/public/scripts/RossAscends-mods.js
+++ b/public/scripts/RossAscends-mods.js
@@ -516,7 +516,11 @@ function restoreUserInput() {
 
 function saveUserInput() {
     const userInput = String($('#send_textarea').val());
-    localStorage.setItem(getUserInputKey(), userInput);
+    try {
+        localStorage.setItem(getUserInputKey(), userInput);
+    } catch {
+        // Ignore storage write failures in Safari Private Browsing.
+    }
     console.debug('User Input -- ', userInput);
 }
 const saveUserInputDebounced = debounce(saveUserInput);

--- a/public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder-settings-ui.js
@@ -42,15 +42,31 @@ const DEFAULT_PIPELINE_MAX_TOKENS = 64000;
 
 let settingsEl = null;
 let currentAgent = null;
-let retrievalLogMode = localStorage.getItem(PATHFINDER_LOG_MODE_KEY) === 'detailed' ? 'detailed' : 'summary';
+let retrievalLogMode = safeGetLocalStorageItem(PATHFINDER_LOG_MODE_KEY) === 'detailed' ? 'detailed' : 'summary';
 let summaryMemoryUnsubscribe = null;
+
+function safeGetLocalStorageItem(key) {
+    try {
+        return localStorage.getItem(key);
+    } catch {
+        return null;
+    }
+}
+
+function safeSetLocalStorageItem(key, value) {
+    try {
+        localStorage.setItem(key, value);
+    } catch {
+        // Ignore storage write failures in Safari Private Browsing.
+    }
+}
 
 function logPathfinder(message, ...details) {
     console.log(`${PATHFINDER_LOG_PREFIX} ${message}`, ...details);
 }
 
 function isQuickstartDismissed() {
-    return localStorage.getItem(PATHFINDER_QUICKSTART_DISMISSED_KEY) === 'true';
+    return safeGetLocalStorageItem(PATHFINDER_QUICKSTART_DISMISSED_KEY) === 'true';
 }
 
 function applyQuickstartDismissalState() {
@@ -60,7 +76,7 @@ function applyQuickstartDismissalState() {
 }
 
 function getCollapsedSectionStates() {
-    const rawValue = localStorage.getItem(PATHFINDER_COLLAPSED_SECTIONS_KEY);
+    const rawValue = safeGetLocalStorageItem(PATHFINDER_COLLAPSED_SECTIONS_KEY);
     if (!rawValue) {
         return {};
     }
@@ -90,7 +106,7 @@ function setSectionCollapsedPreference(sectionKey, collapsed) {
 
     const states = getCollapsedSectionStates();
     states[sectionKey] = collapsed;
-    localStorage.setItem(PATHFINDER_COLLAPSED_SECTIONS_KEY, JSON.stringify(states));
+    safeSetLocalStorageItem(PATHFINDER_COLLAPSED_SECTIONS_KEY, JSON.stringify(states));
 }
 
 function setSectionChevronState(section, collapsed) {
@@ -818,7 +834,7 @@ ${recentChat}`;
  */
 function bindEvents() {
     settingsEl.find('#pf--quickstart-dismiss').on('click', () => {
-        localStorage.setItem(PATHFINDER_QUICKSTART_DISMISSED_KEY, 'true');
+        safeSetLocalStorageItem(PATHFINDER_QUICKSTART_DISMISSED_KEY, 'true');
         settingsEl.find('#pf--quickstart').slideUp(180);
         logPathfinder('Dismissed Pathfinder introduction card.');
     });
@@ -1157,7 +1173,7 @@ function bindEvents() {
 
     settingsEl.find('#pf--log-mode').on('change', function () {
         retrievalLogMode = String($(this).val()) === 'detailed' ? 'detailed' : 'summary';
-        localStorage.setItem(PATHFINDER_LOG_MODE_KEY, retrievalLogMode);
+        safeSetLocalStorageItem(PATHFINDER_LOG_MODE_KEY, retrievalLogMode);
         renderRetrievalLog();
     });
 

--- a/public/scripts/extensions/in-chat-agents/pathfinder/summary-memory-store.js
+++ b/public/scripts/extensions/in-chat-agents/pathfinder/summary-memory-store.js
@@ -38,7 +38,11 @@ function loadState() {
 }
 
 function persistState() {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch {
+        // Ignore storage write failures in Safari Private Browsing.
+    }
     for (const listener of listeners) {
         listener(getSummaryMemoryState());
     }

--- a/public/scripts/extensions/in-chat-agents/style.css
+++ b/public/scripts/extensions/in-chat-agents/style.css
@@ -220,6 +220,7 @@
 .ica--quick-chip-apply {
     border: none;
     color: inherit;
+    -webkit-appearance: none;
     appearance: none;
     font: inherit;
 }
@@ -335,6 +336,7 @@
     align-items: center;
     gap: 8px;
     cursor: pointer;
+    -webkit-user-select: none;
     user-select: none;
     font-size: calc(var(--mainFontSize) * 0.78);
     font-weight: 600;
@@ -805,6 +807,7 @@ button.ica--card-pill--version-update {
     background: transparent;
     border: none;
     color: inherit;
+    -webkit-appearance: none;
     appearance: none;
     font: inherit;
     text-decoration: none;
@@ -1226,6 +1229,7 @@ button.ica--card-pill--version-update {
     min-height: 40px;
     padding: 8px 10px;
     cursor: pointer;
+    -webkit-user-select: none;
     user-select: none;
     list-style: none;
 }
@@ -1407,6 +1411,10 @@ button.ica--card-pill--version-update {
     overflow-x: auto;
     scrollbar-width: none;
     padding-bottom: 2px;
+}
+
+.ica--agent-tabs::-webkit-scrollbar {
+    display: none;
 }
 
 .ica--agent-tab {
@@ -1950,6 +1958,7 @@ button.ica--card-pill--version-update {
     cursor: pointer;
     font-size: calc(var(--mainFontSize) * 0.8);
     opacity: 0.65;
+    -webkit-user-select: none;
     user-select: none;
     min-height: 32px;
     display: flex;
@@ -2087,6 +2096,7 @@ button.ica--card-pill--version-update {
 }
 
 .ica--template-filter-bar {
+    position: -webkit-sticky;
     position: sticky;
     top: 0;
     z-index: 2;

--- a/public/scripts/extensions/input-history/index.js
+++ b/public/scripts/extensions/input-history/index.js
@@ -285,10 +285,18 @@ eventSource.on(event_types.GENERATION_STARTED, () => {
 
 let inputHistoryIdx = -1;
 export function getInputHistory() {
-    return JSON.parse(localStorage.getItem('st--inputHistory') ?? '[]');
+    try {
+        return JSON.parse(localStorage.getItem('st--inputHistory') ?? '[]');
+    } catch {
+        return [];
+    }
 }
 export function setInputHistory(inputHistory) {
-    localStorage.setItem('st--inputHistory', JSON.stringify(inputHistory));
+    try {
+        localStorage.setItem('st--inputHistory', JSON.stringify(inputHistory));
+    } catch {
+        // Ignore storage write failures in Safari Private Browsing.
+    }
 }
 export function addToInputHistory(text) {
     text = text?.trim();

--- a/public/scripts/extensions/prompt-inspector/index.js
+++ b/public/scripts/extensions/prompt-inspector/index.js
@@ -53,13 +53,29 @@ function addLaunchButton() {
     });
 }
 
-let inspectEnabled = localStorage.getItem('promptInspectorEnabled') === 'true' || false;
-let inspectFormat = localStorage.getItem('promptInspectorFormat') || 'json';
+let inspectEnabled = safeGetLocalStorageItem('promptInspectorEnabled') === 'true' || false;
+let inspectFormat = safeGetLocalStorageItem('promptInspectorFormat') || 'json';
+
+function safeGetLocalStorageItem(key) {
+    try {
+        return localStorage.getItem(key);
+    } catch {
+        return null;
+    }
+}
+
+function safeSetLocalStorageItem(key, value) {
+    try {
+        localStorage.setItem(key, value);
+    } catch {
+        // Ignore storage write failures in Safari Private Browsing.
+    }
+}
 
 function toggleInspectNext() {
     inspectEnabled = !inspectEnabled;
     toastr.info(`Prompt inspection is now ${inspectEnabled ? 'enabled' : 'disabled'}`);
-    localStorage.setItem('promptInspectorEnabled', String(inspectEnabled));
+    safeSetLocalStorageItem('promptInspectorEnabled', String(inspectEnabled));
 }
 
 eventSource.on(event_types.CHAT_COMPLETION_PROMPT_READY, async (data) => {
@@ -164,7 +180,7 @@ async function showPromptInspector(input) {
     formatSelect.toggle(isChatCompletion());
     formatSelect.on('change', () => {
         inspectFormat = formatSelect.val();
-        localStorage.setItem('promptInspectorFormat', inspectFormat);
+        safeSetLocalStorageItem('promptInspectorFormat', inspectFormat);
 
         const currentValue = prompt.val();
         prompt.val(inspectFormat === 'yaml' ? jsonToYaml(currentValue) : yamlToJson(currentValue));

--- a/public/scripts/extensions/quick-image-gen/style.css
+++ b/public/scripts/extensions/quick-image-gen/style.css
@@ -95,6 +95,7 @@
 }
 
 .qig-action-bar {
+    position: -webkit-sticky;
     position: sticky;
     top: 0;
     z-index: 20;
@@ -991,6 +992,7 @@
 
 .qig-filter-drag-handle {
     cursor: grab;
+    -webkit-user-select: none;
     user-select: none;
 }
 
@@ -1072,6 +1074,7 @@
 }
 
 .qig-resizing #qig-result-img {
+    -webkit-user-select: none;
     user-select: none;
     pointer-events: none;
 }
@@ -1364,6 +1367,7 @@
     border: 1px solid var(--SmartThemeBorderColor);
     background: var(--SmartThemeBlurTintColor, rgba(20, 20, 20, 0.96));
     box-shadow: 0 10px 32px rgba(0, 0, 0, 0.35);
+    -webkit-backdrop-filter: blur(12px);
     backdrop-filter: blur(12px);
 }
 

--- a/public/scripts/extensions/quick-reply/style.css
+++ b/public/scripts/extensions/quick-reply/style.css
@@ -498,6 +498,7 @@
   padding: 0;
 }
 .popup:has(#qr--modalEditor):has(.qr--isExecuting.qr--minimized)::backdrop {
+  -webkit-backdrop-filter: unset;
   backdrop-filter: unset;
   background-color: transparent;
 }
@@ -673,6 +674,7 @@
 .popup:has(#qr--modalEditor) .popup-content > #qr--modalEditor > #qr--main > .qr--labels > .label .qr--modal-switcherList {
   background-color: var(--stcdx--bgColor);
   border: 1px solid var(--SmartThemeBorderColor);
+  -webkit-backdrop-filter: blur(var(--SmartThemeBlurStrength));
   backdrop-filter: blur(var(--SmartThemeBlurStrength));
   border-radius: 10px;
   font-size: smaller;

--- a/public/scripts/extensions/stable-diffusion/style.css
+++ b/public/scripts/extensions/stable-diffusion/style.css
@@ -1,5 +1,6 @@
 #sd_dropdown {
     z-index: 30000;
+    -webkit-backdrop-filter: blur(var(--SmartThemeBlurStrength));
     backdrop-filter: blur(var(--SmartThemeBlurStrength));
 }
 

--- a/public/scripts/extensions/third-party/BunnyPresetTools/styles.css
+++ b/public/scripts/extensions/third-party/BunnyPresetTools/styles.css
@@ -127,6 +127,7 @@
 }
 
 #completion_prompt_manager_list.bpt-section-reordering {
+    -webkit-user-select: none;
     user-select: none;
 }
 

--- a/public/scripts/f-localStorage.js
+++ b/public/scripts/f-localStorage.js
@@ -4,7 +4,11 @@
  * @deprecated THIS FUNCTION IS OBSOLETE. DO NOT USE
  */
 export function SaveLocal(target, val) {
-    localStorage.setItem(target, val);
+    try {
+        localStorage.setItem(target, val);
+    } catch {
+        // Ignore storage write failures in Safari Private Browsing.
+    }
     console.debug('SaveLocal -- ' + target + ' : ' + val);
 }
 /**

--- a/public/scripts/i18n.js
+++ b/public/scripts/i18n.js
@@ -18,6 +18,30 @@ function getStoredLanguage() {
     }
 }
 
+function safeSetLocalStorageItem(key, value) {
+    try {
+        localStorage.setItem(key, value);
+    } catch {
+        // Ignore storage write failures in Safari Private Browsing.
+    }
+}
+
+function safeGetLocalStorageItem(key) {
+    try {
+        return localStorage.getItem(key);
+    } catch {
+        return null;
+    }
+}
+
+function safeRemoveLocalStorageItem(key) {
+    try {
+        localStorage.removeItem(key);
+    } catch {
+        // Ignore storage write failures in Safari Private Browsing.
+    }
+}
+
 /** @type {Set<string>|null} Array of translations keys if they should be tracked - if not tracked then null */
 let trackMissingDynamicTranslate = null;
 
@@ -296,9 +320,9 @@ export async function initLocales() {
         const language = String($(this).val());
 
         if (language) {
-            localStorage.setItem(storageKey, language);
+            safeSetLocalStorageItem(storageKey, language);
         } else {
-            localStorage.removeItem(storageKey);
+            safeRemoveLocalStorageItem(storageKey);
         }
 
         location.reload();
@@ -324,8 +348,8 @@ export async function initLocales() {
         'This includes things translated via the t`...` function and translate(). It will only track strings translated <b>after</b> this is toggled on, '
         + 'and when they actually pop up, so refreshing the page and opening popups, etc, is needed. Will only track if the current locale is not English.',
         () => {
-            const isTracking = localStorage.getItem('trackDynamicTranslate') !== 'true';
-            localStorage.setItem('trackDynamicTranslate', isTracking ? 'true' : 'false');
+            const isTracking = safeGetLocalStorageItem('trackDynamicTranslate') !== 'true';
+            safeSetLocalStorageItem('trackDynamicTranslate', isTracking ? 'true' : 'false');
             if (isTracking && isSupportedNonEnglish()) {
                 trackMissingDynamicTranslate = new Set();
                 toastr.success('Dynamic translation tracking enabled.');

--- a/public/scripts/sillybunny-conversation/chrome.js
+++ b/public/scripts/sillybunny-conversation/chrome.js
@@ -1,6 +1,7 @@
 import { characters } from '../../script.js';
 import { loadStylesheetAsync } from '../dynamic-styles.js';
 import { selected_group } from '../group-chats.js';
+import { isIOSWebKitPlatform } from '../mobile-send-button.js';
 import { setUserAvatar } from '../personas.js';
 import { shouldSendOnEnter } from '../RossAscends-mods.js';
 import { addConversationFilesToInput, clearConversationAttachmentInput, processSendQueue, submitConversationInput, updateConversationAttachmentPreview } from './attachments.js';
@@ -101,6 +102,33 @@ function requestConversationRuntimeStart() {
     window.dispatchEvent(new CustomEvent('sb:conversation-runtime-needed'));
 }
 
+function getConversationToolsVisible() {
+    try {
+        return localStorage.getItem('sb_conv_tools_visible') === 'true';
+    } catch {
+        return false;
+    }
+}
+
+function setConversationToolsVisible(visible) {
+    try {
+        localStorage.setItem('sb_conv_tools_visible', String(visible));
+    } catch {
+        // Ignore storage write failures in Safari Private Browsing.
+    }
+}
+
+function focusConversationInput({ skipIOS = false } = {}) {
+    if (skipIOS && isIOSWebKitPlatform()) {
+        return;
+    }
+
+    const input = document.getElementById(CHROME_IDS.input);
+    if (input instanceof HTMLTextAreaElement) {
+        input.focus();
+    }
+}
+
 export function bindConversationChromeControls(sheld) {
     if (sheld.dataset.sbConversationChromeBound === 'true') {
         return;
@@ -155,8 +183,8 @@ export function bindConversationChromeControls(sheld) {
 
         switch (target.dataset.sbConversationAction) {
             case 'toggle-tools': {
-                const currentVisible = localStorage.getItem('sb_conv_tools_visible') === 'true';
-                localStorage.setItem('sb_conv_tools_visible', String(!currentVisible));
+                const currentVisible = getConversationToolsVisible();
+                setConversationToolsVisible(!currentVisible);
                 syncConversationToolsVisibility();
                 break;
             }
@@ -234,6 +262,10 @@ export function bindConversationChromeControls(sheld) {
                 if (index >= 0) {
                     const char = characters[index];
                     if (char?.avatar) {
+                        if (isIOSWebKitPlatform()) {
+                            focusConversationInput();
+                        }
+
                         const charSettings = getSettings(char.avatar, { groupId: '' });
                         charSettings.enabled = true;
                         saveSettings(char.avatar, charSettings, { groupId: '' });
@@ -245,10 +277,7 @@ export function bindConversationChromeControls(sheld) {
                         });
                         schedulePalsRailRender();
                         setTimeout(() => {
-                            const input = document.getElementById(CHROME_IDS.input);
-                            if (input instanceof HTMLTextAreaElement) {
-                                input.focus();
-                            }
+                            focusConversationInput({ skipIOS: true });
                         }, 100);
                     }
                 }

--- a/public/scripts/textgen-settings.js
+++ b/public/scripts/textgen-settings.js
@@ -689,7 +689,11 @@ export async function loadTextGenSettings(data, loadedSettings) {
         const result = prompt(`Enter Mancer base URL\nDefault: ${MANCER_SERVER_DEFAULT}`, MANCER_SERVER);
 
         if (result) {
-            localStorage.setItem(MANCER_SERVER_KEY, result);
+            try {
+                localStorage.setItem(MANCER_SERVER_KEY, result);
+            } catch {
+                // Ignore storage write failures in Safari Private Browsing.
+            }
             MANCER_SERVER = result;
         }
     });

--- a/public/scripts/welcome-screen.js
+++ b/public/scripts/welcome-screen.js
@@ -29,6 +29,7 @@ import { deleteGroupChatByName, getGroupAvatar, groups, is_group_generating, ope
 import { enableExtension, extension_settings, findExtension, installExtension } from './extensions.js';
 import { t } from './i18n.js';
 import { getPresetManager } from './preset-manager.js';
+import { isIOSWebKitPlatform } from './mobile-send-button.js';
 import { callGenericPopup, POPUP_TYPE } from './popup.js';
 import { renderTemplateAsync } from './templates.js';
 import { isAdmin } from './user.js';
@@ -1168,14 +1169,24 @@ function openShellTab(route) {
     document.querySelector(fallbackSelector)?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 }
 
-function prefillSendTextarea(sendTextArea, value) {
+function focusSendTextarea(sendTextArea, { skipIOS = false } = {}) {
+    if (skipIOS && isIOSWebKitPlatform()) {
+        return;
+    }
+
+    if (sendTextArea instanceof HTMLTextAreaElement) {
+        sendTextArea.focus();
+    }
+}
+
+function prefillSendTextarea(sendTextArea, value, { skipIOSFocus = false } = {}) {
     if (!(sendTextArea instanceof HTMLTextAreaElement)) {
         return;
     }
 
     sendTextArea.value = value;
     sendTextArea.dispatchEvent(new Event('input', { bubbles: true }));
-    sendTextArea.focus();
+    focusSendTextarea(sendTextArea, { skipIOS: skipIOSFocus });
 }
 
 async function refreshCharacterAvatarCache(avatar) {
@@ -1387,14 +1398,14 @@ async function handleWelcomeAction(button, sendTextArea) {
             }
             break;
         case 'assistant-prompt':
+            focusSendTextarea(sendTextArea);
             await openBundledAssistantCard(assistantId);
-            prefillSendTextarea(sendTextArea, value);
+            prefillSendTextarea(sendTextArea, value, { skipIOSFocus: true });
             break;
         case 'open-assistant':
+            focusSendTextarea(sendTextArea);
             await openBundledAssistantCard(assistantId);
-            if (sendTextArea instanceof HTMLTextAreaElement) {
-                sendTextArea.focus();
-            }
+            focusSendTextarea(sendTextArea, { skipIOS: true });
             break;
         case 'open-conversation': {
             const conversationModule = await import('./sillybunny-conversation.js');
@@ -1629,10 +1640,9 @@ async function sendWelcomePanel(chats, expand = false) {
         });
         fragment.querySelectorAll('button.openTemporaryChat').forEach((button) => {
             button.addEventListener('click', async () => {
+                focusSendTextarea(sendTextArea);
                 await newAssistantChat({ temporary: true });
-                if (sendTextArea instanceof HTMLTextAreaElement) {
-                    sendTextArea.focus();
-                }
+                focusSendTextarea(sendTextArea, { skipIOS: true });
             });
         });
         fragment.querySelectorAll('.recentChat.group').forEach((groupChat) => {

--- a/public/style.css
+++ b/public/style.css
@@ -503,7 +503,7 @@ input[type='checkbox']:focus-visible {
     padding: 5px 5px 5px 14px;
     margin-bottom: 0.5em;
     overflow-y: auto;
-    color: hsl(from var(--reasoning-body-color) h calc(s * var(--reasoning-saturation)) l);
+    color: var(--reasoning-body-color);
 }
 
 .mes_reasoning_details {
@@ -530,6 +530,7 @@ input[type='checkbox']:focus-visible {
 .mes_reasoning_header {
     cursor: pointer;
     position: relative;
+    -webkit-user-select: none;
     user-select: none;
     margin: 0.5em 2px;
     padding: 7px 14px;
@@ -604,7 +605,7 @@ input[type='checkbox']:focus-visible {
 
 .mes_reasoning i,
 .mes_reasoning em {
-    color: hsl(from var(--reasoning-em-color) h calc(s * var(--reasoning-saturation)) l);
+    color: var(--reasoning-em-color);
 }
 
 .mes_text q i,
@@ -614,7 +615,7 @@ input[type='checkbox']:focus-visible {
 
 .mes_reasoning q i,
 .mes_reasoning q em {
-    color: hsl(from var(--SmartThemeQuoteColor) h calc(s * var(--reasoning-saturation)) l);
+    color: var(--SmartThemeQuoteColor);
 }
 
 .mes_text u {
@@ -622,7 +623,7 @@ input[type='checkbox']:focus-visible {
 }
 
 .mes_reasoning u {
-    color: hsl(from var(--SmartThemeUnderlineColor) h calc(s * var(--reasoning-saturation)) l);
+    color: var(--SmartThemeUnderlineColor);
 }
 
 .mes_text q {
@@ -646,6 +647,7 @@ input[type='checkbox']:focus-visible {
     line-height: 1.35;
     min-height: 44px;
     padding: 0.75em;
+    -webkit-user-select: none;
     user-select: none;
 }
 
@@ -665,7 +667,31 @@ input[type='checkbox']:focus-visible {
 }
 
 .mes_reasoning q {
-    color: hsl(from var(--SmartThemeQuoteColor) h calc(s * var(--reasoning-saturation)) l);
+    color: var(--SmartThemeQuoteColor);
+}
+
+@supports (color: rgb(from black r g b / 1)) {
+    .mes_reasoning {
+        color: hsl(from var(--reasoning-body-color) h calc(s * var(--reasoning-saturation)) l);
+    }
+
+    .mes_reasoning i,
+    .mes_reasoning em {
+        color: hsl(from var(--reasoning-em-color) h calc(s * var(--reasoning-saturation)) l);
+    }
+
+    .mes_reasoning q i,
+    .mes_reasoning q em {
+        color: hsl(from var(--SmartThemeQuoteColor) h calc(s * var(--reasoning-saturation)) l);
+    }
+
+    .mes_reasoning u {
+        color: hsl(from var(--SmartThemeUnderlineColor) h calc(s * var(--reasoning-saturation)) l);
+    }
+
+    .mes_reasoning q {
+        color: hsl(from var(--SmartThemeQuoteColor) h calc(s * var(--reasoning-saturation)) l);
+    }
 }
 
 .mes_text font[color] em,
@@ -999,6 +1025,7 @@ body .panelControlBar {
     border: 1px solid var(--SmartThemeBorderColor);
     border-radius: 0 0 1.65rem 1.65rem;
     background-color: var(--SmartThemeBlurTintColor);
+    -webkit-backdrop-filter: blur(20px);
     backdrop-filter: blur(20px);
 }
 
@@ -1436,6 +1463,7 @@ body .panelControlBar {
 }
 
 .swipe_picker_header {
+    position: -webkit-sticky;
     position: sticky;
     top: 0;
     z-index: 1;
@@ -2085,6 +2113,7 @@ body {
 
     --bottom: 50vh;
     background: var(--ac-color-background);
+    -webkit-backdrop-filter: blur(var(--SmartThemeBlurStrength));
     backdrop-filter: blur(var(--SmartThemeBlurStrength));
     border: 1px solid var(--ac-color-border);
     border-radius: 3px;
@@ -2891,6 +2920,7 @@ input[type="file"] {
     background: color-mix(in srgb, var(--color-surface-strong, color-mix(in srgb, var(--SmartThemeBlurTintColor) 90%, var(--SmartThemeBodyColor) 10%)) 80%, transparent);
     border-bottom: 1px solid var(--color-border, var(--SmartThemeBorderColor));
     border-radius: 1.65rem 1.65rem 0 0;
+    position: -webkit-sticky;
     position: sticky;
     top: 0;
     z-index: 10;
@@ -3225,6 +3255,7 @@ input[type="file"] {
 /*#################################################################*/
 
 select {
+    -webkit-appearance: none;
     appearance: none;
     padding: 3px 5px;
     background-color: var(--black30a);
@@ -4270,6 +4301,7 @@ grammarly-extension {
     cursor: grab;
     transition: background-color var(--animation-duration-2x) ease-in-out;
     position: relative;
+    -webkit-user-select: none;
     user-select: none;
     display: flex;
     align-items: center;
@@ -4373,6 +4405,7 @@ grammarly-extension {
 .drag-handle {
     cursor: grab;
     /* Make the drag handle not selectable in most browsers */
+    -webkit-user-select: none;
     user-select: none;
 }
 
@@ -4677,6 +4710,7 @@ input[type='checkbox'].del_checkbox {
 }
 
 .neo-range-slider {
+    -webkit-appearance: none !important;
     appearance: none !important;
     margin: 7px 0 0 !important;
     padding: 0 !important;
@@ -5322,6 +5356,7 @@ body:is([data-generating="true"], [data-swiping="true"]) :is(
 
 .swipe_picker_block {
     cursor: pointer;
+    -webkit-user-select: none;
     user-select: none;
 }
 
@@ -5532,6 +5567,7 @@ body .ui-widget-content {
     border-radius: 10px;
     box-shadow: 0 0 3px var(--black50a);
     text-shadow: 0px 0px calc(var(--shadowWidth) * 1px) var(--SmartThemeShadowColor);
+    -webkit-backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)*2));
     backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)*2));
     color: var(--SmartThemeBodyColor);
 }
@@ -5712,6 +5748,7 @@ a:hover {
     margin-top: 0;
     overflow: hidden;
     background-color: var(--SmartThemeBlurTintColor);
+    -webkit-backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)*2));
     backdrop-filter: blur(calc(var(--SmartThemeBlurStrength)*2));
     border: 1px solid var(--SmartThemeBorderColor);
     border-radius: 10px;
@@ -6519,6 +6556,7 @@ body:not(.movingUI) .drawer-content.maximized {
     border-radius: 10px;
     border: 1px solid var(--SmartThemeBorderColor);
     aspect-ratio: unset;
+    -webkit-backdrop-filter: blur(var(--SmartThemeBlurStrength));
     backdrop-filter: blur(var(--SmartThemeBlurStrength));
     background-color: var(--SmartThemeBlurTintColor);
     padding: 5px;
@@ -6634,6 +6672,7 @@ body:not(.movingUI) .drawer-content.maximized {
     justify-content: center;
     align-items: center;
     gap: 5px;
+    -webkit-user-select: none;
     user-select: none;
 }
 
@@ -7327,6 +7366,7 @@ body:not(.movingUI) .drawer-content.maximized {
     height: 22px;
     margin-left: 4px;
     padding: 0;
+    -webkit-appearance: none;
     appearance: none;
     border: 1px solid color-mix(in srgb, var(--SmartThemeBorderColor, #555) 50%, transparent);
     border-radius: 999px;


### PR DESCRIPTION
## Summary
- Adds WebKit-prefixed companions for backdrop-filter, appearance, user-select, sticky positioning, hidden scrollbars, and tap highlight resets across app and bundled extension CSS.
- Guards relative-color reasoning text styles with plain fallbacks while documenting the Safari/WebKit 16.4+ floor.
- Adds Array.prototype.at polyfill, iOS synchronous focus handling, and safe localStorage writes for Safari Private Browsing paths.

## Testing
- bun install --frozen-lockfile
- bun run lint
- bun run check:frontend-budgets
- git diff --check