### PR TITLE
fix(ica): regenerate extract trackers from Fix Trackers

### DIFF
--- a/public/scripts/extensions/in-chat-agents/agent-runner.js
+++ b/public/scripts/extensions/in-chat-agents/agent-runner.js
@@ -4854,6 +4854,27 @@ export async function runTrackerFixOnMessage(messageIndex) {
     let chatStateChanged = false;
     let messageDisplayChanged = false;
     const promptRuns = [];
+    let trackerRegenerations = 0;
+    let trackerRegenerationErrors = 0;
+    const applyExtractPostProcess = (agent, sourceText) => {
+        const postProcess = agent.postProcess;
+        if (!postProcess?.extractPattern || !postProcess.extractVariable) {
+            return false;
+        }
+
+        try {
+            const regex = new RegExp(postProcess.extractPattern, 'g');
+            const matches = String(sourceText ?? '').match(regex);
+            if (matches) {
+                chat_metadata[`agent_${postProcess.extractVariable}`] = matches.join('\n');
+                return true;
+            }
+        } catch (error) {
+            console.warn(`[InChatAgents] Extract error in agent "${agent.name}":`, error);
+        }
+
+        return false;
+    };
     let currentPromptTransformText = unwrapAssistantResponseWrapper(message.mes);
 
     if (currentPromptTransformText !== normalizeContentText(message.mes)) {
@@ -4928,8 +4949,53 @@ export async function runTrackerFixOnMessage(messageIndex) {
         messageDisplayChanged = true;
     }
 
+    const extractRegenerationAgents = trackerAgents.filter(agent =>
+        agent.postProcess?.enabled &&
+        agent.postProcess.type === 'extract' &&
+        !agent.postProcess.promptTransformEnabled &&
+        String(agent.prompt ?? '').trim() &&
+        agent.postProcess.extractPattern &&
+        agent.postProcess.extractVariable,
+    );
+    const extractRegenerationAgentIds = new Set(extractRegenerationAgents.map(agent => agent.id));
+
+    // SillyBunny divergence: repair inline extract trackers by regenerating their
+    // block; re-extraction alone cannot recover a missing [TAG|...] payload.
+    for (const agent of extractRegenerationAgents) {
+        try {
+            const result = await runPromptTransformAgent(agent, message, generationType, currentPromptTransformText, messageIndex, {
+                applyToMessage: false,
+            });
+            const regenerated = String(result.outputText ?? '').trim()
+                ? applyExtractPostProcess(agent, result.outputText)
+                : false;
+            const extracted = regenerated || applyExtractPostProcess(agent, message.mes);
+
+            if (result.status === 'error') {
+                trackerRegenerationErrors++;
+            }
+
+            if (extracted) {
+                chatStateChanged = true;
+            }
+
+            if (regenerated) {
+                trackerRegenerations++;
+            }
+        } catch (error) {
+            trackerRegenerationErrors++;
+            console.warn(`[InChatAgents] Tracker regeneration failed in agent "${agent.name}":`, error);
+
+            if (applyExtractPostProcess(agent, message.mes)) {
+                chatStateChanged = true;
+            }
+        }
+    }
+
     const utilityAgents = trackerAgents.filter(agent =>
-        agent.postProcess?.enabled && agent.postProcess.type !== 'regex',
+        agent.postProcess?.enabled &&
+        agent.postProcess.type !== 'regex' &&
+        !extractRegenerationAgentIds.has(agent.id),
     );
 
     for (const agent of utilityAgents) {
@@ -4937,19 +5003,8 @@ export async function runTrackerFixOnMessage(messageIndex) {
 
         switch (postProcess.type) {
             case 'extract': {
-                if (!postProcess.extractPattern || !postProcess.extractVariable) {
-                    break;
-                }
-
-                try {
-                    const regex = new RegExp(postProcess.extractPattern, 'g');
-                    const matches = message.mes.match(regex);
-                    if (matches) {
-                        chat_metadata[`agent_${postProcess.extractVariable}`] = matches.join('\n');
-                        chatStateChanged = true;
-                    }
-                } catch (error) {
-                    console.warn(`[InChatAgents] Extract error in agent "${agent.name}":`, error);
+                if (applyExtractPostProcess(agent, message.mes)) {
+                    chatStateChanged = true;
                 }
                 break;
             }
@@ -4999,11 +5054,14 @@ export async function runTrackerFixOnMessage(messageIndex) {
 
     const changedRuns = promptRuns.filter(r => r.changed);
     const failedRuns = promptRuns.filter(r => r.status === 'error');
+    const postProcessRuns = utilityAgents.length + extractRegenerationAgents.length;
+    const errorRuns = failedRuns.length + trackerRegenerationErrors;
     const parts = [];
+    if (trackerRegenerations > 0) parts.push(`${trackerRegenerations} tracker${trackerRegenerations > 1 ? 's' : ''} regenerated`);
     if (changedRuns.length > 0) parts.push(`${changedRuns.length} prompt transform${changedRuns.length > 1 ? 's' : ''} applied`);
-    if (utilityAgents.length > 0) parts.push(`${utilityAgents.length} post-process${utilityAgents.length > 1 ? 'es' : ''} run`);
+    if (postProcessRuns > 0) parts.push(`${postProcessRuns} post-process${postProcessRuns > 1 ? 'es' : ''} run`);
     if (regexSnapshotChanged) parts.push('regex snapshot updated');
-    if (failedRuns.length > 0) parts.push(`${failedRuns.length} error${failedRuns.length > 1 ? 's' : ''}`);
+    if (errorRuns > 0) parts.push(`${errorRuns} error${errorRuns > 1 ? 's' : ''}`);
 
     if (parts.length > 0) {
         toastr.success(parts.join(', '), 'Trackers fixed');

--- a/tests/in-chat-agents-runner.test.js
+++ b/tests/in-chat-agents-runner.test.js
@@ -2523,6 +2523,28 @@ describe('in-chat agent post-processing runner', () => {
         expect(globalThis.toastr.success).toHaveBeenCalledWith('1 post-process run', 'Trackers fixed');
     });
 
+    test('manual tracker fix regenerates missing extract tracker blocks', async () => {
+        usePreExtractTracker();
+        generateQuietPrompt.mockResolvedValueOnce('[STATUS|Alice|Tired|Moderate]');
+
+        const { runTrackerFixOnMessage } = await import('../public/scripts/extensions/in-chat-agents/agent-runner.js');
+        chat.push({
+            name: 'Assistant',
+            mes: 'Fresh reply without an inline tracker block.',
+            is_user: false,
+            is_system: false,
+            extra: {},
+        });
+
+        await runTrackerFixOnMessage(0);
+
+        expect(chatMetadata.agent_status_data).toBe('[STATUS|Alice|Tired|Moderate]');
+        expect(chat[0].mes).toBe('Fresh reply without an inline tracker block.');
+        expect(generateQuietPrompt).toHaveBeenCalledTimes(1);
+        expect(saveChatDebounced).toHaveBeenCalledTimes(1);
+        expect(globalThis.toastr.success).toHaveBeenCalledWith('1 tracker regenerated, 1 post-process run', 'Trackers fixed');
+    });
+
     test('snapshots regex-only agents on streamed tokens before final message events', async () => {
         useRegexOnlyAgent();
 


### PR DESCRIPTION
Summary
- Regenerate prompt-bearing inline extract trackers via a non-destructive sidecar run when Fix Trackers is pressed.
- Extract regenerated tracker blocks into chat_metadata, with existing message text as fallback.
- Add Jest coverage for missing inline tracker blocks.

Tests
- NODE_OPTIONS=--experimental-vm-modules npx jest --config tests/jest.config.json tests/in-chat-agents-runner.test.js --runInBand
- npm run lint
- npx eslint tests/in-chat-agents-runner.test.js